### PR TITLE
ci: ignore pnpm-lock.yaml in Prettier; clean ci-lite logs

### DIFF
--- a/.github/workflows/ci-lite.yml
+++ b/.github/workflows/ci-lite.yml
@@ -36,27 +36,27 @@ jobs:
 
       - name: Format check
         run: |
-          echo "🔍 Prettier format check..."
+          echo "Prettier format check..."
           pnpm -w format:check
 
       - name: Lint
         run: |
-          echo "🔍 ESLint validation..."
+          echo "ESLint validation..."
           pnpm -w lint
 
       - name: TypeScript check
         run: |
-          echo "🔍 TypeScript compilation check..."
+          echo "TypeScript compilation check..."
           pnpm -w typecheck
 
       - name: Build all packages
         run: |
-          echo "🔨 Building all packages..."
+          echo "Building all packages..."
           pnpm -w build
 
       - name: Smoke tests
         run: |
-          echo "💨 Running smoke tests for critical packages..."
+          echo "Running smoke tests for critical packages..."
           # SDK smoke tests (only working tests)
           pnpm --filter @peac/sdk test:smoke || echo "::warning::SDK smoke tests had issues"
 
@@ -75,14 +75,14 @@ jobs:
     steps:
       - name: Summary
         run: |
-          echo "🚀 CI Lite completed for PR/push validation"
+          echo "CI Lite completed for PR/push validation"
           echo ""
-          echo "✅ Quality gates enforced:"
-          echo "  • Code formatting (Prettier)"
-          echo "  • Code quality (ESLint)" 
-          echo "  • Type safety (TypeScript)"
-          echo "  • Build compilation"
-          echo "  • Critical smoke tests"
+          echo "Quality gates enforced:"
+          echo "  - Code formatting (Prettier)"
+          echo "  - Code quality (ESLint)" 
+          echo "  - Type safety (TypeScript)"
+          echo "  - Build compilation"
+          echo "  - Critical smoke tests"
           echo ""
-          echo "🌙 Full test suite runs in nightly workflow"
-          echo "📦 Ready for merge when all checks pass"
+          echo "Full test suite runs in nightly workflow"
+          echo "Ready for merge when all checks pass"

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,6 +9,8 @@
 **/*.bom.json
 **/*.lock
 package-lock.json
+.pnpm-store
+pnpm-lock.yaml
 
 # test artifacts
 **/__snapshots__/**


### PR DESCRIPTION
  Fix Dependabot CI failures that were tripping on Prettier
  
  ## Changes
  - Add explicit pnpm-lock.yaml and .pnpm-store to
  .prettierignore
  - Replace non-ASCII echo lines in ci-lite with plain ASCII
  text

 ## Impact
  - Dependabot PRs clear the Prettier gate
  - Logs comply with our ASCII-only policy