### PR TITLE
test(pay402): run tests with Node's built-in test runner

### DIFF
--- a/packages/pay402/package.json
+++ b/packages/pay402/package.json
@@ -24,9 +24,10 @@
   },
   "scripts": {
     "build": "tsup",
-    "test": "jest",
-    "test:coverage": "jest --coverage",
-    "test:watch": "jest --watch",
+    "pretest": "pnpm build",
+    "test": "node --test src/**/*.test.js",
+    "test:coverage": "node --test --experimental-test-coverage src/**/*.test.js",
+    "test:watch": "node --test --watch src/**/*.test.js",
     "lint": "echo 'Lint temporarily disabled due to workspace dependencies - run from root'",
     "typecheck": "tsc --noEmit",
     "dev": "tsup --watch",

--- a/packages/pay402/tsup.config.ts
+++ b/packages/pay402/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/handler.ts', 'src/negotiator.ts'],
   format: ['cjs', 'esm'],
   dts: false, // Temporarily disable declaration generation
   sourcemap: true,


### PR DESCRIPTION
  Pay402 tests are written for Node's test runner (ESM + node:test) but CI ran them with Jest, causing "Cannot use import statement outside a module".

## Changes
  - Use Node's built-in test runner for pay402
  - Provide coverage/watch equivalents
  - Build individual source files (handler.js, negotiator.js)
  for tests
  - Add pretest build step

## Impact
  - Nightly unblocks (pay402 no longer fails in the shared test
  matrix)
  - Aligns runner with test source without touching other
  packages