### PR TITLE
fix(pay402): use correct glob pattern for CI test runner

### DIFF
--- a/packages/pay402/package.json
+++ b/packages/pay402/package.json
@@ -25,9 +25,9 @@
   "scripts": {
     "build": "tsup",
     "pretest": "pnpm build",
-    "test": "node --test src/**/*.test.js",
-    "test:coverage": "node --test --experimental-test-coverage src/**/*.test.js",
-    "test:watch": "node --test --watch src/**/*.test.js",
+    "test": "node --test src/*.test.js",
+    "test:coverage": "node --test --experimental-test-coverage src/*.test.js",
+    "test:watch": "node --test --watch src/*.test.js",
     "lint": "echo 'Lint temporarily disabled due to workspace dependencies - run from root'",
     "typecheck": "tsc --noEmit",
     "dev": "tsup --watch",


### PR DESCRIPTION
- Change src/**/*.test.js to src/*.test.js to fix CI globbing
- Avoids shell expansion issues in GitHub Actions
- Tests are at src/ root, so ** pattern is unnecessary