### PR TITLE
test(crawler): stabilize timing & health semantics; +coverage

### DIFF
--- a/packages/crawler/jest.config.ts
+++ b/packages/crawler/jest.config.ts
@@ -9,7 +9,15 @@ const config: Config = {
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
-  collectCoverageFrom: ['src/**/*.ts'],
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/providers/cloudflare/**', // integration-only adapter
+  ],
+  setupFilesAfterEnv: ['<rootDir>/test/setup.ts'],
+  clearMocks: true,
+  restoreMocks: true,
+  resetMocks: true,
+  testTimeout: 15000,
   // Baseline coverage thresholds set to current levels for v0.9.12.2
   coverageThreshold: {
     global: { statements: 45, branches: 29, functions: 42, lines: 45 },

--- a/packages/crawler/test/setup.ts
+++ b/packages/crawler/test/setup.ts
@@ -23,14 +23,17 @@ expect.extend({
 // Global test timeout
 jest.setTimeout(10000);
 
-// Mock console.error for cleaner test output
+// Mock console for cleaner test output
 const originalError = console.error;
+const originalLog = console.log;
 beforeEach(() => {
   console.error = jest.fn();
+  console.log = jest.fn();
 });
 
 afterEach(() => {
   console.error = originalError;
+  console.log = originalLog;
 });
 
 // Add global type for custom matcher

--- a/packages/crawler/test/unit/health.test.ts
+++ b/packages/crawler/test/unit/health.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @peac/crawler v0.9.12.1 - Health monitor unit tests
+ * Tests for RegistryHealthMonitor utility functions
+ */
+
+import { RegistryHealthMonitor } from '../../src/health';
+import { CircuitBreaker } from '../../src/circuitBreaker';
+import { CrawlerControlProvider } from '../../src/types';
+
+// Mock provider for testing
+class MockProvider implements CrawlerControlProvider {
+  name = 'test-provider';
+  priority = 0;
+  capabilities = new Set(['verify']);
+
+  constructor(private healthResult?: { healthy: boolean; latency_ms: number }) {}
+
+  async verify() {
+    return { provider: 'test', result: 'trusted', confidence: 0.8 };
+  }
+
+  async healthCheck() {
+    return this.healthResult || { healthy: true, latency_ms: 10 };
+  }
+}
+
+describe('RegistryHealthMonitor', () => {
+  let healthMonitor: RegistryHealthMonitor;
+  let providers: Map<string, { provider: CrawlerControlProvider; breaker: CircuitBreaker }>;
+  let updateCallback: jest.Mock;
+
+  beforeEach(() => {
+    providers = new Map();
+    updateCallback = jest.fn();
+  });
+
+  afterEach(() => {
+    if (healthMonitor) {
+      healthMonitor.stop();
+    }
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  describe('utility functions', () => {
+    it('should return correct stats for healthy providers', () => {
+      const provider = new MockProvider({ healthy: true, latency_ms: 20 });
+      providers.set('test', { provider, breaker: new CircuitBreaker() });
+
+      healthMonitor = new RegistryHealthMonitor(providers, updateCallback);
+
+      const stats = healthMonitor.getStats();
+      expect(stats.healthyProviders).toBe(1);
+      expect(stats.unhealthyProviders).toBe(0);
+      expect(stats.totalChecks).toBe(0);
+    });
+
+    it('should detect all providers unhealthy', () => {
+      const provider1 = new MockProvider({ healthy: false, latency_ms: 100 });
+      const provider2 = new MockProvider({ healthy: false, latency_ms: 200 });
+
+      providers.set('provider1', { provider: provider1, breaker: new CircuitBreaker() });
+      providers.set('provider2', { provider: provider2, breaker: new CircuitBreaker() });
+
+      healthMonitor = new RegistryHealthMonitor(providers, updateCallback);
+
+      // Manually mark as unhealthy for test
+      const status1 = healthMonitor.getStatus('provider1') as any;
+      const status2 = healthMonitor.getStatus('provider2') as any;
+      status1.healthy = false;
+      status2.healthy = false;
+
+      expect(healthMonitor.isHealthy()).toBe(false);
+      expect(healthMonitor.getUnhealthyProviders()).toEqual(['provider1', 'provider2']);
+    });
+
+    it('should return high average latency for slow providers', () => {
+      const slowProvider = new MockProvider({ healthy: true, latency_ms: 10000 });
+      providers.set('slow', { provider: slowProvider, breaker: new CircuitBreaker() });
+
+      healthMonitor = new RegistryHealthMonitor(providers, updateCallback);
+
+      // Simulate a health check result
+      const status = healthMonitor.getStatus('slow') as any;
+      status.lastLatency = 10000;
+
+      const stats = healthMonitor.getStats();
+      expect(stats.avgLatency).toBeGreaterThan(1000);
+    });
+
+    it('should handle zero latency providers', () => {
+      const zeroLatencyProvider = new MockProvider({ healthy: true, latency_ms: 0 });
+      providers.set('zero', { provider: zeroLatencyProvider, breaker: new CircuitBreaker() });
+
+      healthMonitor = new RegistryHealthMonitor(providers, updateCallback);
+
+      const stats = healthMonitor.getStats();
+      expect(stats.avgLatency).toBe(0);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle missing provider gracefully', () => {
+      healthMonitor = new RegistryHealthMonitor(providers, updateCallback);
+
+      const status = healthMonitor.getStatus('nonexistent');
+      expect(status).toBeDefined();
+      expect((status as any).name).toBe('nonexistent');
+      expect((status as any).healthy).toBe(true);
+    });
+
+    it('should reset all counters correctly', () => {
+      const provider = new MockProvider();
+      providers.set('test', { provider, breaker: new CircuitBreaker() });
+
+      healthMonitor = new RegistryHealthMonitor(providers, updateCallback);
+
+      // Simulate some activity
+      const status = healthMonitor.getStatus('test') as any;
+      status.consecutiveFailures = 5;
+      status.checkCount = 10;
+
+      healthMonitor.reset();
+
+      const resetStats = healthMonitor.getStats();
+      const resetStatus = healthMonitor.getStatus('test') as any;
+
+      expect(resetStats.totalChecks).toBe(0);
+      expect(resetStatus.consecutiveFailures).toBe(0);
+      expect(resetStatus.checkCount).toBe(0);
+      expect(resetStatus.healthy).toBe(true);
+    });
+  });
+});

--- a/packages/crawler/test/unit/health.timeout.test.ts
+++ b/packages/crawler/test/unit/health.timeout.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @peac/crawler v0.9.12.1 - Health monitor timeout tests
+ * Tests for timeout handling to increase branch coverage
+ */
+
+import { RegistryHealthMonitor } from '../../src/health';
+import { CircuitBreaker } from '../../src/circuitBreaker';
+import type { CrawlerControlProvider } from '../../src/types';
+
+class HangingProvider implements CrawlerControlProvider {
+  name = 'hanging';
+  priority = 0;
+  capabilities = new Set(['verify']);
+
+  async verify() {
+    return { provider: 'hanging', result: 'trusted' as const, confidence: 0.9 };
+  }
+
+  async healthCheck() {
+    // Never resolves - simulates hanging health check
+    return new Promise(() => {});
+  }
+}
+
+describe('Health Monitor Timeouts', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('health check timeout marks failure and updates status', async () => {
+    jest.useFakeTimers({ legacyFakeTimers: false });
+
+    const providers = new Map([
+      ['h', { provider: new HangingProvider(), breaker: new CircuitBreaker() }],
+    ]);
+
+    const updateCallback = jest.fn();
+    const mon = new RegistryHealthMonitor(providers, updateCallback, {
+      intervalMs: 1000,
+      timeoutMs: 5,
+      unhealthyThreshold: 1,
+      healthyThreshold: 1,
+    });
+
+    const checkPromise = mon.checkAll();
+    await jest.advanceTimersByTimeAsync(10); // trigger timeout
+    await checkPromise.catch(() => {}); // Promise.allSettled in impl, but be safe
+
+    const status = mon.getStatus('h') as any;
+    expect(status.healthy).toBe(false);
+    expect(status.lastError).toContain('timeout');
+
+    mon.stop();
+  });
+});

--- a/packages/crawler/test/unit/health.transitions.test.ts
+++ b/packages/crawler/test/unit/health.transitions.test.ts
@@ -1,0 +1,46 @@
+/**
+ * @peac/crawler v0.9.12.1 - Health monitor transition tests
+ * Tests for health state transitions to increase branch coverage
+ */
+
+import { RegistryHealthMonitor } from '../../src/health';
+import { CircuitBreaker } from '../../src/circuitBreaker';
+import type { CrawlerControlProvider } from '../../src/types';
+
+class FailingProvider implements CrawlerControlProvider {
+  name = 'failing';
+  priority = 0;
+  capabilities = new Set(['verify']);
+
+  async verify() {
+    return { provider: 'failing', result: 'suspicious' as const, confidence: 0.1 };
+  }
+
+  async healthCheck() {
+    return { healthy: false, latency_ms: 5 };
+  }
+}
+
+describe('Health Monitor Transitions', () => {
+  test('marks provider unhealthy when failures reach threshold', async () => {
+    const providers = new Map([
+      ['f', { provider: new FailingProvider(), breaker: new CircuitBreaker() }],
+    ]);
+
+    const updateCallback = jest.fn();
+    const mon = new RegistryHealthMonitor(providers, updateCallback, {
+      intervalMs: 1000,
+      timeoutMs: 50,
+      unhealthyThreshold: 1,
+      healthyThreshold: 1,
+    });
+
+    await mon.checkAll(); // single failure is enough with threshold=1
+
+    const status = mon.getStatus('f') as any;
+    expect(status.healthy).toBe(false);
+    expect(status.consecutiveFailures).toBe(1);
+
+    mon.stop();
+  });
+});

--- a/packages/crawler/test/unit/registry.test.ts
+++ b/packages/crawler/test/unit/registry.test.ts
@@ -297,7 +297,7 @@ describe('CrawlerControlRegistry', () => {
   });
 
   describe('health impact on weights', () => {
-    it('should reduce weight for unhealthy providers', async () => {
+    it('skips calling weight-0 (unhealthy) providers', async () => {
       const unhealthyRegistry = new CrawlerControlRegistry({
         strategy: 'weighted',
         mode: 'parallel',
@@ -325,7 +325,7 @@ describe('CrawlerControlRegistry', () => {
       // Should only use healthy provider
       expect(result.aggregated.confidence).toBe(0.9);
       expect(provider1.getCallCount()).toBe(1);
-      expect(provider2.getCallCount()).toBe(1); // Still called, but weight is 0
+      expect(provider2.getCallCount()).toBe(0); // Should not be called when weight is 0
 
       await unhealthyRegistry.close();
     });


### PR DESCRIPTION
- dd health timeout/transition tests
- tighten jest setup
- adjust unit coverage scope