### PR TITLE
fix(nightly): use pnpm recursive run to properly exclude crawler

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,12 +42,13 @@ jobs:
           PEAC_WEBHOOK_SECRET: test_secret
         run: |
           echo "Running complete test suite with coverage (excluding crawler)..."
-          pnpm -w -r --filter=!@peac/crawler run test
+          pnpm -r --filter='!@peac/crawler' run test
 
       - name: Crawler system tests with coverage
         run: |
           echo "Running crawler tests with coverage..."
-          pnpm --filter @peac/crawler run test:ci
+          pnpm --filter @peac/crawler exec jest \
+            --config jest.config.ts --coverage --ci --runInBand --forceExit
 
       - name: Upload coverage reports
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
- Change from 'pnpm -w test' to 'pnpm -r --filter="!@peac/crawler" run test'
- Root script ignores filters, recursive run respects them
- Crawler tests now truly excluded from general test step
- Explicit jest exec command for crawler step with all CI flags