### PR TITLE
fix(ci): resolve Bun shell escaping and Deno imports

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -192,7 +192,7 @@ jobs:
             "
           elif [ "${{ matrix.runtime }}" == "bun" ]; then
             bun -e "
-              const m = await import('file://${process.env.CORE_PATH}');
+              const m = await import('file://' + process.env.CORE_PATH);
               const { signDetached, verifyDetached, generateEdDSAKeyPair, validateKidFormat } = m;
               console.log('Testing with Bun...');
               const { privateKey, publicKey, kid } = await generateEdDSAKeyPair();

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
   splitting: false,
   treeshake: true,
   minify: false,
-  target: 'es2022',
-  external: ['node:*'],
+  target: 'esnext',
+  platform: 'neutral',
+  external: ['node:crypto', 'jose'],
+  esbuildOptions(options) {
+    options.conditions = ['node'];
+  },
 });


### PR DESCRIPTION
- Use string concatenation for Bun file path to avoid shell escaping
- Fix node:crypto import preservation in built ESM modules
- Update tsup config for improved cross-runtime compatibility