### PR TITLE
docs(core): add canonicalization rules comment to policy hash

### DIFF
--- a/packages/core/src/hash.ts
+++ b/packages/core/src/hash.ts
@@ -1,6 +1,14 @@
 /**
  * Normative policy hash implementation per v0.9.12.4
  * RFC 8785 JCS + URL normalization rules
+ *
+ * Canonicalization rules:
+ * - Scheme/host: lowercase
+ * - Ports: drop default (80 for HTTP, 443 for HTTPS)
+ * - Paths: resolve dot-segments, percent-encode
+ * - Query: preserve original order, normalize encoding
+ * - Fragments: drop entirely
+ * - JSON: JCS recursive key sorting
  */
 
 import { createHash } from 'node:crypto';


### PR DESCRIPTION
Adds explicit documentation of the canonicalization rules applied in the policy hash implementation.

No functional changes - only documentation improvement.