### PR TITLE
chore: remove duplicate .prettierrc

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,8 +1,0 @@
-{
-  "printWidth": 100,
-  "singleQuote": true,
-  "trailingComma": "all",
-  "semi": true,
-  "arrowParens": "always",
-  "endOfLine": "lf"
-}


### PR DESCRIPTION
The repo has both .prettierrc and .prettierrc.json with identical content. Keeping .prettierrc.json as the canonical config