### PR TITLE
chore: fix malformed docs/peips.md

### DIFF
--- a/archive/0.9.0-0.9.14/INDEX.md
+++ b/archive/0.9.0-0.9.14/INDEX.md
@@ -24,6 +24,7 @@ This directory contains documentation and materials from PEAC Protocol versions
 - `perf/` - v0.9.12 performance benchmarks
 - `interop.md` - v0.9.14 wire protocol interoperability guide
 - `problems.md` - Early RFC 7807 problem-details examples
+- `peips-malformed.md` - Malformed PEIP doc (heredoc artifact)
 
 ### docs/onboarding/
 

--- a/archive/0.9.0-0.9.14/docs/peips-malformed.md
+++ b/archive/0.9.0-0.9.14/docs/peips-malformed.md
@@ -1,0 +1,31 @@
+# PEIPs (PEAC Improvement Proposals)
+
+Use PEIPs to propose changes, adapters, or extensions to PEAC.
+
+- Start with the template in `docs/peips/PEIP-TEMPLATE.md`.
+- Discuss proposals in GitHub Discussions; open a PR when ready.
+  EOF
+
+# docs/peips/PEIP-TEMPLATE.md
+
+cat > docs/peips/PEIP-TEMPLATE.md <<'EOF'
+
+# PEIP-XXX: Title
+
+Status: Draft
+Author: <you>
+Created: <date>
+
+## Abstract
+
+## Motivation
+
+## Specification
+
+## Rationale
+
+## Backwards Compatibility
+
+## Security Considerations
+
+## Reference Implementation (optional)

--- a/docs/peips.md
+++ b/docs/peips.md
@@ -1,31 +1,16 @@
 # PEIPs (PEAC Improvement Proposals)
 
-Use PEIPs to propose changes, adapters, or extensions to PEAC.
+PEIPs are the mechanism for proposing changes, extensions, or new features to the PEAC Protocol.
 
-- Start with the template in `docs/peips/PEIP-TEMPLATE.md`.
-- Discuss proposals in GitHub Discussions; open a PR when ready.
-  EOF
+## Documentation
 
-# docs/peips/PEIP-TEMPLATE.md
+- [PEIP Process](peip/README.md) - Workflow and submission guidelines
+- [PEIP Template](peip/PEIP-0000.md) - Template for new proposals
+- [PEIP Registry](peip/index.json) - Index of all PEIPs
 
-cat > docs/peips/PEIP-TEMPLATE.md <<'EOF'
+## Quick Start
 
-# PEIP-XXX: Title
-
-Status: Draft
-Author: <you>
-Created: <date>
-
-## Abstract
-
-## Motivation
-
-## Specification
-
-## Rationale
-
-## Backwards Compatibility
-
-## Security Considerations
-
-## Reference Implementation (optional)
+1. Fork the repository
+2. Copy `docs/peip/PEIP-0000.md` to `docs/peip/PEIP-XXXX.md`
+3. Fill in all sections
+4. Submit a PR titled "PEIP-XXXX: Your Title"


### PR DESCRIPTION
- Archive malformed peips.md (contained heredoc shell syntax)
- Create clean peips.md pointing to docs/peip/ system
- Update archive INDEX.md