### PR TITLE
docs: align HTTP header docs with PEAC-Receipt naming

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,7 +2,17 @@
 
 Common HTTP headers and endpoints used alongside PEAC.
 
-- On wire, headers are lowercase: `x-peac-*`.
-- Version negotiation: `x-peac-protocol-version`, `x-peac-protocol-version-supported`.
-- Receipts: `x-peac-receipt` (presented by agents after settlement).
-- Negotiation endpoint: defined by the `negotiate` URL in `peac.txt`.
+## HTTP Headers
+
+PEAC uses a single canonical HTTP header for receipts:
+
+- `PEAC-Receipt`: JWS-encoded receipt envelope (see `specs/kernel/constants.json`)
+
+HTTP header names are case-insensitive per RFC 7230. Implementations MUST accept `PEAC-Receipt` and SHOULD tolerate lowercase variants (e.g., `peac-receipt`) as seen in HTTP/2 or gRPC metadata.
+
+**Note:** All legacy `X-PEAC-*` headers were removed in v0.9.15. Do not use or implement them.
+
+## Endpoints
+
+- Discovery: `/.well-known/peac.json` (see `docs/specs/` for format)
+- Verification: Defined by the `verify` URL in discovery response

--- a/docs/engineering-guide.md
+++ b/docs/engineering-guide.md
@@ -3,6 +3,7 @@
 Operational notes for implementers:
 
 - Prefer HTTPS; disallow clear-text negotiation/receipts.
-- Cache `peac.txt` with strong `ETag`.
-- Treat negotiation endpoints as abuse-sensitive; rate-limit and log.
-- Emit lowercase `x-peac-*`; parse case-insensitively.
+- Cache discovery responses with strong `ETag`.
+- Treat verification endpoints as abuse-sensitive; rate-limit and log.
+- Use the `PEAC-Receipt` header for receipts. Accept case-insensitive variants (e.g., `peac-receipt`) per HTTP/2 norms.
+- Do not emit or depend on legacy `X-PEAC-*` headers (removed in v0.9.15).


### PR DESCRIPTION
Update engineering guide and API reference to use the canonical PEAC-Receipt header naming from specs/kernel/constants.json.

- Replace x-peac-* references with PEAC-Receipt
- Add explicit notes that legacy X-PEAC-* headers were removed in v0.9.15
- Clarify HTTP/2 case-insensitivity per RFC 7230