### PR TITLE
feat(schema): add CAL semantic types

### DIFF
--- a/packages/control/__tests__/cal-semantics.test.ts
+++ b/packages/control/__tests__/cal-semantics.test.ts
@@ -1,0 +1,213 @@
+/**
+ * CAL Semantic Types Tests (v0.9.16+)
+ *
+ * Tests for ControlPurpose, ControlLicensingMode, and extended ControlStep fields.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  ControlPurposeSchema,
+  ControlLicensingModeSchema,
+  ControlDecisionSchema,
+  ControlStepSchema,
+  ChainControlBlockSchema,
+} from '../src/validators';
+
+describe('ControlPurposeSchema', () => {
+  it('should accept valid purposes', () => {
+    expect(ControlPurposeSchema.parse('crawl')).toBe('crawl');
+    expect(ControlPurposeSchema.parse('index')).toBe('index');
+    expect(ControlPurposeSchema.parse('train')).toBe('train');
+    expect(ControlPurposeSchema.parse('inference')).toBe('inference');
+  });
+
+  it('should reject invalid purposes', () => {
+    expect(() => ControlPurposeSchema.parse('invalid')).toThrow();
+    expect(() => ControlPurposeSchema.parse('')).toThrow();
+    expect(() => ControlPurposeSchema.parse(123)).toThrow();
+  });
+});
+
+describe('ControlLicensingModeSchema', () => {
+  it('should accept valid licensing modes', () => {
+    expect(ControlLicensingModeSchema.parse('subscription')).toBe('subscription');
+    expect(ControlLicensingModeSchema.parse('pay_per_crawl')).toBe('pay_per_crawl');
+    expect(ControlLicensingModeSchema.parse('pay_per_inference')).toBe('pay_per_inference');
+  });
+
+  it('should reject invalid licensing modes', () => {
+    expect(() => ControlLicensingModeSchema.parse('invalid')).toThrow();
+    expect(() => ControlLicensingModeSchema.parse('per_use')).toThrow();
+    expect(() => ControlLicensingModeSchema.parse('')).toThrow();
+  });
+});
+
+describe('ControlDecisionSchema', () => {
+  it('should accept valid decisions', () => {
+    expect(ControlDecisionSchema.parse('allow')).toBe('allow');
+    expect(ControlDecisionSchema.parse('deny')).toBe('deny');
+    expect(ControlDecisionSchema.parse('review')).toBe('review');
+  });
+
+  it('should reject invalid decisions', () => {
+    expect(() => ControlDecisionSchema.parse('approved')).toThrow();
+    expect(() => ControlDecisionSchema.parse('rejected')).toThrow();
+  });
+});
+
+describe('ControlStepSchema', () => {
+  it('should accept minimal valid step', () => {
+    const step = {
+      engine: 'test-engine',
+      result: 'allow',
+    };
+    const parsed = ControlStepSchema.parse(step);
+    expect(parsed.engine).toBe('test-engine');
+    expect(parsed.result).toBe('allow');
+  });
+
+  it('should accept step with all optional fields', () => {
+    const step = {
+      engine: 'visa-tap',
+      version: '1.0',
+      policy_id: 'pol_123',
+      result: 'allow',
+      reason: 'within-limits',
+      purpose: 'inference',
+      licensing_mode: 'pay_per_inference',
+      scope: 'https://api.example.com/*',
+      limits_snapshot: { daily_limit: 1000 },
+      evidence_ref: 'https://evidence.example.com/123',
+    };
+    const parsed = ControlStepSchema.parse(step);
+    expect(parsed.purpose).toBe('inference');
+    expect(parsed.licensing_mode).toBe('pay_per_inference');
+    expect(parsed.scope).toBe('https://api.example.com/*');
+  });
+
+  it('should accept step with scope as array', () => {
+    const step = {
+      engine: 'content-policy',
+      result: 'allow',
+      scope: ['https://example.com/api/*', 'https://example.com/docs/*'],
+    };
+    const parsed = ControlStepSchema.parse(step);
+    expect(Array.isArray(parsed.scope)).toBe(true);
+    expect(parsed.scope).toHaveLength(2);
+  });
+
+  it('should reject step with invalid purpose', () => {
+    const step = {
+      engine: 'test-engine',
+      result: 'allow',
+      purpose: 'invalid-purpose',
+    };
+    expect(() => ControlStepSchema.parse(step)).toThrow();
+  });
+
+  it('should reject step with invalid licensing_mode', () => {
+    const step = {
+      engine: 'test-engine',
+      result: 'allow',
+      licensing_mode: 'free-tier',
+    };
+    expect(() => ControlStepSchema.parse(step)).toThrow();
+  });
+
+  it('should reject step without required engine field', () => {
+    const step = {
+      result: 'allow',
+    };
+    expect(() => ControlStepSchema.parse(step)).toThrow();
+  });
+});
+
+describe('ChainControlBlockSchema', () => {
+  it('should accept valid control block with single step', () => {
+    const block = {
+      chain: [{ engine: 'test-engine', result: 'allow' }],
+      decision: 'allow',
+    };
+    const parsed = ChainControlBlockSchema.parse(block);
+    expect(parsed.decision).toBe('allow');
+    expect(parsed.chain).toHaveLength(1);
+  });
+
+  it('should accept control block with multiple steps', () => {
+    const block = {
+      chain: [
+        { engine: 'spend-control', result: 'allow', purpose: 'inference' },
+        { engine: 'risk-engine', result: 'allow' },
+        { engine: 'merchant-policy', result: 'allow', licensing_mode: 'subscription' },
+      ],
+      decision: 'allow',
+    };
+    const parsed = ChainControlBlockSchema.parse(block);
+    expect(parsed.chain).toHaveLength(3);
+    expect(parsed.chain[0].purpose).toBe('inference');
+    expect(parsed.chain[2].licensing_mode).toBe('subscription');
+  });
+
+  it('should accept control block with combinator', () => {
+    const block = {
+      chain: [{ engine: 'test-engine', result: 'allow' }],
+      decision: 'allow',
+      combinator: 'any_can_veto',
+    };
+    const parsed = ChainControlBlockSchema.parse(block);
+    expect(parsed.combinator).toBe('any_can_veto');
+  });
+
+  it('should reject control block with empty chain', () => {
+    const block = {
+      chain: [],
+      decision: 'allow',
+    };
+    expect(() => ChainControlBlockSchema.parse(block)).toThrow();
+  });
+
+  it('should enforce decision consistency - deny if any step denies', () => {
+    const block = {
+      chain: [
+        { engine: 'engine-1', result: 'allow' },
+        { engine: 'engine-2', result: 'deny' },
+      ],
+      decision: 'allow', // Inconsistent - should be deny
+    };
+    expect(() => ChainControlBlockSchema.parse(block)).toThrow();
+  });
+
+  it('should enforce decision consistency - allow only if all allow', () => {
+    const block = {
+      chain: [
+        { engine: 'engine-1', result: 'allow' },
+        { engine: 'engine-2', result: 'allow' },
+      ],
+      decision: 'deny', // Inconsistent - should be allow
+    };
+    expect(() => ChainControlBlockSchema.parse(block)).toThrow();
+  });
+
+  it('should allow review decision when chain has review but no deny', () => {
+    const block = {
+      chain: [
+        { engine: 'engine-1', result: 'allow' },
+        { engine: 'engine-2', result: 'review' },
+      ],
+      decision: 'review',
+    };
+    const parsed = ChainControlBlockSchema.parse(block);
+    expect(parsed.decision).toBe('review');
+  });
+
+  it('should require deny decision when any step denies, even with review', () => {
+    const block = {
+      chain: [
+        { engine: 'engine-1', result: 'review' },
+        { engine: 'engine-2', result: 'deny' },
+      ],
+      decision: 'review', // Should be deny
+    };
+    expect(() => ChainControlBlockSchema.parse(block)).toThrow();
+  });
+});

--- a/packages/control/src/index.ts
+++ b/packages/control/src/index.ts
@@ -11,7 +11,15 @@ export type { ControlEngineAdapter, ControlEvaluationContext } from './adapter';
 export { ControlEngineRegistry } from './adapter';
 
 // Core control types (re-exported from schema)
-export type { ControlBlock, ControlStep, ControlDecision, ControlValidationResult } from './types';
+export type {
+  ControlBlock,
+  ControlStep,
+  ControlDecision,
+  ControlValidationResult,
+  // CAL semantic types (v0.9.16+)
+  ControlPurpose,
+  ControlLicensingMode,
+} from './types';
 
 // Generic constraint types (informational helpers)
 export type {
@@ -45,6 +53,12 @@ export {
   ConstraintSchema,
   ControlBlockSchema,
   ControlStateSchema,
+  // CAL semantic validators (v0.9.16+)
+  ControlPurposeSchema,
+  ControlLicensingModeSchema,
+  ControlDecisionSchema,
+  ControlStepSchema,
+  ChainControlBlockSchema,
 } from './validators';
 
 // Deprecated validator aliases (will be removed in v0.9.17)

--- a/packages/control/src/types.ts
+++ b/packages/control/src/types.ts
@@ -8,6 +8,9 @@ export type {
   ControlStep,
   ControlDecision,
   ControlValidationResult,
+  // CAL semantic types (v0.9.16+)
+  ControlPurpose,
+  ControlLicensingMode,
 } from '@peac/schema';
 
 // Import and re-export constraint types

--- a/packages/control/src/validators.ts
+++ b/packages/control/src/validators.ts
@@ -169,3 +169,20 @@ export const ControlStateSchema = z.object({
   last_use: z.number().int().positive().optional(),
   metadata: z.record(z.unknown()).optional(),
 });
+
+// -----------------------------------------------------------------------------
+// CAL Semantic Validators (v0.9.16+)
+// Re-exported from @peac/schema for convenience
+// -----------------------------------------------------------------------------
+
+export {
+  ControlPurposeSchema,
+  ControlLicensingModeSchema,
+  ControlDecisionSchema,
+  ControlStepSchema,
+  // Note: ControlBlockSchema from @peac/schema validates chain-based governance blocks
+  // (chain/decision/combinator), while the ControlBlockSchema above validates
+  // constraint-based blocks (mandate/scope/metadata). We export the chain-based
+  // one with a distinct name to avoid confusion.
+  ControlBlockSchema as ChainControlBlockSchema,
+} from '@peac/schema';

--- a/packages/schema/src/control.ts
+++ b/packages/schema/src/control.ts
@@ -11,6 +11,32 @@
 export type ControlDecision = 'allow' | 'deny' | 'review';
 
 /**
+ * Control purpose - what the access is for
+ *
+ * Used to map RSL, Content Signals, and other policy dialects
+ * to a normalized purpose for receipts.
+ *
+ * Well-known purposes:
+ * - "crawl": Web crawling/scraping
+ * - "index": Search engine indexing
+ * - "train": AI/ML model training
+ * - "inference": AI/ML inference/generation
+ */
+export type ControlPurpose = 'crawl' | 'index' | 'train' | 'inference';
+
+/**
+ * Control licensing mode - how access is licensed
+ *
+ * Used to capture the commercial arrangement for access.
+ *
+ * Well-known modes:
+ * - "subscription": Access via active subscription
+ * - "pay_per_crawl": Per-crawl payment
+ * - "pay_per_inference": Per-inference payment
+ */
+export type ControlLicensingMode = 'subscription' | 'pay_per_crawl' | 'pay_per_inference';
+
+/**
  * Composable control block - multi-party governance
  *
  * Structure:
@@ -72,6 +98,33 @@ export interface ControlStep {
 
   /** Human-readable reason for decision */
   reason?: string;
+
+  /**
+   * Purpose of this access (v0.9.16+)
+   *
+   * Normalized from RSL, Content Signals, ai.txt, etc.
+   * Used to capture what the access is for.
+   */
+  purpose?: ControlPurpose;
+
+  /**
+   * Licensing mode for this access (v0.9.16+)
+   *
+   * Captures the commercial arrangement.
+   */
+  licensing_mode?: ControlLicensingMode;
+
+  /**
+   * Scope of this control step (v0.9.16+)
+   *
+   * URI pattern(s) or resource identifier(s) this step applies to.
+   * Can be a single scope or multiple scopes.
+   *
+   * Examples:
+   * - "https://example.com/api/*"
+   * - ["https://example.com/docs/*", "https://example.com/blog/*"]
+   */
+  scope?: string | string[];
 
   /**
    * Limits snapshot at time of decision

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -22,6 +22,12 @@ export {
   Subject as SubjectSchema,
   AIPREFSnapshot as AIPREFSnapshotSchema,
   VerifyRequest as VerifyRequestSchema,
+  // CAL validators (v0.9.16+)
+  ControlPurposeSchema,
+  ControlLicensingModeSchema,
+  ControlDecisionSchema,
+  ControlStepSchema,
+  ControlBlockSchema,
 } from './validators';
 
 // Envelope types (v0.9.15+ normative structure)


### PR DESCRIPTION
Add ControlPurpose and ControlLicensingMode to support normalized policy mapping from RSL, Content Signals, and ai.txt.

- Add ControlPurpose: crawl | index | train | inference
- Add ControlLicensingMode: subscription | pay_per_crawl | pay_per_inference
- Extend ControlStep with purpose, licensing_mode, and scope fields
- Add Zod validators with control chain decision consistency
- Add 20 tests for new CAL semantic types and validators