### PR TITLE
feat(schema): add SubjectProfile and SubjectProfileSnapshot

### DIFF
--- a/packages/schema/__tests__/subject-profile.test.ts
+++ b/packages/schema/__tests__/subject-profile.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Tests for SubjectProfile and SubjectProfileSnapshot schemas
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  SubjectTypeSchema,
+  SubjectProfileSchema,
+  SubjectProfileSnapshotSchema,
+} from '../src/validators';
+
+describe('SubjectTypeSchema', () => {
+  it('accepts "human"', () => {
+    expect(SubjectTypeSchema.safeParse('human').success).toBe(true);
+  });
+
+  it('accepts "org"', () => {
+    expect(SubjectTypeSchema.safeParse('org').success).toBe(true);
+  });
+
+  it('accepts "agent"', () => {
+    expect(SubjectTypeSchema.safeParse('agent').success).toBe(true);
+  });
+
+  it('rejects invalid type', () => {
+    expect(SubjectTypeSchema.safeParse('bot').success).toBe(false);
+    expect(SubjectTypeSchema.safeParse('').success).toBe(false);
+    expect(SubjectTypeSchema.safeParse('HUMAN').success).toBe(false);
+  });
+});
+
+describe('SubjectProfileSchema', () => {
+  describe('valid cases', () => {
+    it('accepts minimal human profile', () => {
+      const result = SubjectProfileSchema.safeParse({
+        id: 'user:alice@example.com',
+        type: 'human',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts minimal org profile', () => {
+      const result = SubjectProfileSchema.safeParse({
+        id: 'org:acme-corp',
+        type: 'org',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts minimal agent profile', () => {
+      const result = SubjectProfileSchema.safeParse({
+        id: 'agent:gpt-4-crawler',
+        type: 'agent',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts profile with labels', () => {
+      const result = SubjectProfileSchema.safeParse({
+        id: 'user:bob',
+        type: 'human',
+        labels: ['premium', 'verified'],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts profile with metadata', () => {
+      const result = SubjectProfileSchema.safeParse({
+        id: 'org:startup',
+        type: 'org',
+        metadata: { plan: 'enterprise', seats: 50 },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts profile with all fields', () => {
+      const result = SubjectProfileSchema.safeParse({
+        id: 'agent:indexer-v2',
+        type: 'agent',
+        labels: ['crawler', 'indexer', 'trusted'],
+        metadata: { version: '2.0', operator: 'search-co' },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts empty labels array', () => {
+      const result = SubjectProfileSchema.safeParse({
+        id: 'user:empty-labels',
+        type: 'human',
+        labels: [],
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('invalid cases', () => {
+    it('rejects missing id', () => {
+      const result = SubjectProfileSchema.safeParse({
+        type: 'human',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects empty id', () => {
+      const result = SubjectProfileSchema.safeParse({
+        id: '',
+        type: 'human',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects missing type', () => {
+      const result = SubjectProfileSchema.safeParse({
+        id: 'user:alice',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects invalid type', () => {
+      const result = SubjectProfileSchema.safeParse({
+        id: 'user:alice',
+        type: 'robot',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects empty string in labels array', () => {
+      const result = SubjectProfileSchema.safeParse({
+        id: 'user:alice',
+        type: 'human',
+        labels: ['valid', ''],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects unknown fields (strict mode)', () => {
+      const result = SubjectProfileSchema.safeParse({
+        id: 'user:alice',
+        type: 'human',
+        unknownField: 'should fail',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+describe('SubjectProfileSnapshotSchema', () => {
+  const validSubject = {
+    id: 'user:alice',
+    type: 'human' as const,
+  };
+
+  describe('valid cases', () => {
+    it('accepts minimal snapshot', () => {
+      const result = SubjectProfileSnapshotSchema.safeParse({
+        subject: validSubject,
+        captured_at: '2025-01-15T10:30:00Z',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts snapshot with source', () => {
+      const result = SubjectProfileSnapshotSchema.safeParse({
+        subject: validSubject,
+        captured_at: '2025-01-15T10:30:00Z',
+        source: 'idp:auth0',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts snapshot with version', () => {
+      const result = SubjectProfileSnapshotSchema.safeParse({
+        subject: validSubject,
+        captured_at: '2025-01-15T10:30:00Z',
+        version: '1.0',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts snapshot with all fields', () => {
+      const result = SubjectProfileSnapshotSchema.safeParse({
+        subject: {
+          id: 'agent:crawler',
+          type: 'agent',
+          labels: ['trusted'],
+          metadata: { tier: 'premium' },
+        },
+        captured_at: '2025-01-15T10:30:00.123Z',
+        source: 'directory:ldap',
+        version: '2.1',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts snapshot with milliseconds in timestamp', () => {
+      const result = SubjectProfileSnapshotSchema.safeParse({
+        subject: validSubject,
+        captured_at: '2025-12-07T15:45:30.999Z',
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('invalid cases', () => {
+    it('rejects missing subject', () => {
+      const result = SubjectProfileSnapshotSchema.safeParse({
+        captured_at: '2025-01-15T10:30:00Z',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects invalid subject', () => {
+      const result = SubjectProfileSnapshotSchema.safeParse({
+        subject: { id: 'user:alice' }, // missing type
+        captured_at: '2025-01-15T10:30:00Z',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects missing captured_at', () => {
+      const result = SubjectProfileSnapshotSchema.safeParse({
+        subject: validSubject,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects empty captured_at', () => {
+      const result = SubjectProfileSnapshotSchema.safeParse({
+        subject: validSubject,
+        captured_at: '',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects empty source', () => {
+      const result = SubjectProfileSnapshotSchema.safeParse({
+        subject: validSubject,
+        captured_at: '2025-01-15T10:30:00Z',
+        source: '',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects empty version', () => {
+      const result = SubjectProfileSnapshotSchema.safeParse({
+        subject: validSubject,
+        captured_at: '2025-01-15T10:30:00Z',
+        version: '',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects unknown fields (strict mode)', () => {
+      const result = SubjectProfileSnapshotSchema.safeParse({
+        subject: validSubject,
+        captured_at: '2025-01-15T10:30:00Z',
+        extra: 'should fail',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -7,6 +7,7 @@
 export * from './envelope';
 export * from './control';
 export * from './evidence';
+export * from './subject';
 export * from './errors';
 
 // Legacy types (for backward compatibility in tests)
@@ -31,6 +32,10 @@ export {
   // Payment evidence validators (v0.9.16+)
   PaymentSplitSchema,
   PaymentEvidenceSchema,
+  // Subject profile validators (v0.9.16+)
+  SubjectTypeSchema,
+  SubjectProfileSchema,
+  SubjectProfileSnapshotSchema,
 } from './validators';
 
 // Envelope types (v0.9.15+ normative structure)

--- a/packages/schema/src/subject.ts
+++ b/packages/schema/src/subject.ts
@@ -1,0 +1,120 @@
+/**
+ * PEAC Subject Profile Types
+ *
+ * Subject profiles for identity and authorization context.
+ * Used in conjunction with receipts and control decisions.
+ */
+
+/**
+ * Subject identifier (opaque string)
+ *
+ * Examples:
+ * - "user:alice@example.com"
+ * - "org:acme-corp"
+ * - "agent:gpt-4-crawler"
+ */
+export type SubjectId = string;
+
+/**
+ * Subject type classification
+ *
+ * - "human": Individual person
+ * - "org": Organization or legal entity
+ * - "agent": Autonomous software agent (AI, bot, crawler)
+ */
+export type SubjectType = 'human' | 'org' | 'agent';
+
+/**
+ * Subject profile - identity and classification
+ *
+ * Minimal profile structure for subjects in the PEAC ecosystem.
+ * Profiles are intentionally lightweight; detailed identity
+ * attributes belong in external identity systems.
+ *
+ * Invariants:
+ * - `id` is REQUIRED (non-empty string)
+ * - `type` is REQUIRED (one of: human, org, agent)
+ * - `labels` if present must be non-empty strings
+ */
+export interface SubjectProfile {
+  /**
+   * Subject identifier (REQUIRED)
+   *
+   * Stable, unique identifier for this subject.
+   * Format is application-specific.
+   */
+  id: SubjectId;
+
+  /**
+   * Subject type (REQUIRED)
+   *
+   * Classification of the subject for policy purposes.
+   */
+  type: SubjectType;
+
+  /**
+   * Labels for categorization (OPTIONAL)
+   *
+   * Freeform tags for grouping or filtering subjects.
+   * Examples: ["premium", "verified"], ["crawler", "indexer"]
+   */
+  labels?: string[];
+
+  /**
+   * Additional metadata (OPTIONAL)
+   *
+   * Application-specific attributes.
+   */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Subject profile snapshot - point-in-time capture
+ *
+ * Captures the state of a subject profile at a specific moment.
+ * Used for audit trails, policy evaluation records, and receipts.
+ *
+ * Invariants:
+ * - `subject` is REQUIRED (valid SubjectProfile)
+ * - `captured_at` is REQUIRED (ISO 8601 timestamp)
+ */
+export interface SubjectProfileSnapshot {
+  /**
+   * Subject profile (REQUIRED)
+   *
+   * The captured profile state.
+   */
+  subject: SubjectProfile;
+
+  /**
+   * Capture timestamp (REQUIRED)
+   *
+   * MUST be an RFC 3339 / ISO 8601 UTC timestamp string.
+   * Examples:
+   * - "2025-01-15T10:30:00Z"
+   * - "2025-01-15T10:30:00.123Z"
+   *
+   * Note: Schema validates non-empty string only; format
+   * enforcement is left to application layer for v0.9.16.
+   */
+  captured_at: string;
+
+  /**
+   * Source of the snapshot (OPTIONAL)
+   *
+   * Identifies where this profile data came from.
+   * Examples:
+   * - "idp:auth0"
+   * - "directory:ldap"
+   * - "manual"
+   */
+  source?: string;
+
+  /**
+   * Profile version (OPTIONAL)
+   *
+   * Version tag for the profile schema or data.
+   * Useful for tracking profile format changes over time.
+   */
+  version?: string;
+}

--- a/packages/schema/src/validators.ts
+++ b/packages/schema/src/validators.ts
@@ -193,3 +193,46 @@ export const PaymentEvidenceSchema = z
     splits: z.array(PaymentSplitSchema).optional(),
   })
   .strict();
+
+// -----------------------------------------------------------------------------
+// Subject Profile Validators (v0.9.16+)
+// -----------------------------------------------------------------------------
+
+/**
+ * Subject type schema
+ */
+export const SubjectTypeSchema = z.enum(['human', 'org', 'agent']);
+
+/**
+ * Subject profile schema
+ *
+ * Invariants:
+ * - id is required (non-empty string)
+ * - type is required (human, org, or agent)
+ * - labels if present must be non-empty strings
+ */
+export const SubjectProfileSchema = z
+  .object({
+    id: z.string().min(1),
+    type: SubjectTypeSchema,
+    labels: z.array(z.string().min(1)).optional(),
+    metadata: z.record(z.unknown()).optional(),
+  })
+  .strict();
+
+/**
+ * Subject profile snapshot schema
+ *
+ * Invariants:
+ * - subject is required (valid SubjectProfile)
+ * - captured_at is required (non-empty string)
+ *   MUST be RFC 3339 / ISO 8601 UTC; format not enforced in schema for v0.9.16
+ */
+export const SubjectProfileSnapshotSchema = z
+  .object({
+    subject: SubjectProfileSchema,
+    captured_at: z.string().min(1),
+    source: z.string().min(1).optional(),
+    version: z.string().min(1).optional(),
+  })
+  .strict();


### PR DESCRIPTION
## Summary

Add Subject Profile Catalogue v0.1 types and validators for v0.9.16:

- New `SubjectId` and `SubjectType` (`human`, `org`, `agent`)
- `SubjectProfile` interface:
  - `id: SubjectId`
  - `type: SubjectType`
  - `labels?: string[]`
  - `metadata?: Record<string, unknown>`
- `SubjectProfileSnapshot` interface:
  - `subject: SubjectProfile`
  - `captured_at: string` (ISO 8601 expected)
  - `source?: string`
  - `version?: string`

- Zod validators:
  - `SubjectTypeSchema`
  - `SubjectProfileSchema` (strict)
  - `SubjectProfileSnapshotSchema` (strict)

## Invariants

- `SubjectProfileSchema`:
  - `id` required, non-empty string
  - `type` required, one of `human | org | agent`
  - `labels` if present must be non-empty strings
  - `metadata` optional record
  - `.strict()` rejects unknown fields

- `SubjectProfileSnapshotSchema`:
  - `subject` required, valid `SubjectProfile`
  - `captured_at` required, non-empty string (ISO 8601 expected, not parsed here)
  - `source` optional, non-empty string
  - `version` optional, non-empty string
  - `.strict()` rejects unknown fields