### PR TITLE
chore(release): bump to v0.9.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to PEAC Protocol will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.16] - 2025-12-07
+
+### Added
+
+- **Control Abstraction Layer (CAL) semantics**: `ControlPurpose` (`crawl`, `index`, `train`, `inference`), `ControlLicensingMode` (`subscription`, `pay_per_crawl`, `pay_per_inference`), and `any_can_veto` decision combinator with chain validation
+- **PaymentEvidence extensions**: `aggregator` field for marketplace or platform identifiers, `splits[]` array for multi-party allocation with invariants (party required, amount or share required)
+- **Subject Profile Catalogue**: `SubjectProfile` and `SubjectProfileSnapshot` types and validators for `human`, `org`, and `agent` subjects
+- **Subject profile privacy guidance**: PROTOCOL-BEHAVIOR Section 8.4 specifying SubjectProfile as OPTIONAL, with opaque identifiers, data minimization, and retention documentation requirements
+
+### Changed
+
+- `@peac/schema` now exports CAL, PaymentEvidence, and SubjectProfile validators
+- PROTOCOL-BEHAVIOR version set to 0.9.16 and extended with Section 8.4 privacy guidance
+
 ## [0.9.15] - 2025-11-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Policy • Economics • Attribution • Compliance**
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-0.9.15-blue.svg)](https://github.com/peacprotocol/peac)
+[![Version](https://img.shields.io/badge/version-0.9.16-blue.svg)](https://github.com/peacprotocol/peac)
 
 PEAC is an open protocol for verifiable receipts and policy aware access across digital interactions between agents, APIs, crawlers, and web applications.
 
@@ -24,7 +24,7 @@ PEAC is stewarded by contributors from [Originary](https://www.originary.xyz) an
 
 PEAC does not replace existing protocols. It is the receipts and verification layer that works alongside them for plain APIs, human driven applications, and agentic workflows.
 
-**Payment rails (v0.9.15 status):**
+**Payment rails (v0.9.16 status):**
 
 - [x402](https://github.com/coinbase/x402) HTTP 402 payment flows for agentic interactions. Adapter implemented in `@peac/rails-x402`.
 - Card payments via Stripe API. Adapter implemented in `@peac/rails-stripe`.
@@ -32,7 +32,7 @@ PEAC does not replace existing protocols. It is the receipts and verification la
 
 The protocol is designed to work with generic HTTP 402 services, paywalls, routers, and data stores. Receipts do not depend on any single provider.
 
-**Agent protocols (v0.9.15 status):**
+**Agent protocols (v0.9.16 status):**
 
 - [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol) Tool context for language models. Mapping implemented.
 - [Agentic Commerce Protocol (ACP)](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol) Agent driven commerce. Mapping implemented.
@@ -65,7 +65,7 @@ _Names above are illustrative examples for interoperability. PEAC is vendor neut
 - Errors via `application/problem+json` (RFC 9457)
 - DPoP proof-of-possession binding (RFC 9449)
 
-**Rails and mappings (v0.9.15):**
+**Rails and mappings (v0.9.16):**
 
 - Payment rails: x402, Stripe (via `@peac/rails-*`)
 - Agent protocols: MCP, ACP (via `@peac/mappings-*`)
@@ -213,7 +213,7 @@ peac.txt is an optional, web-facing policy surface. The core of the protocol is 
 
 ```yaml
 # /.well-known/peac.txt
-version: 0.9.15
+version: 0.9.16
 usage: open
 
 purposes: [indexing, research, documentation]
@@ -230,7 +230,7 @@ repository: https://github.com/peacprotocol/peac
 **Example: Conditional API access**
 
 ```yaml
-version: 0.9.15
+version: 0.9.16
 usage: conditional
 
 purposes: [research, commercial]
@@ -357,24 +357,24 @@ peac/
 
 ## Packages
 
-**Core (stable, v0.9.15):**
+**Core (stable, v0.9.16):**
 
 - `@peac/kernel` - Zero-dependency constants and registries
 - `@peac/schema` - TypeScript types, Zod validators, JSON Schema
 - `@peac/crypto` - Ed25519 JWS signing and verification
 - `@peac/protocol` - High-level issue() and verify() functions
 
-**Runtime (stable, v0.9.15):**
+**Runtime (stable, v0.9.16):**
 
 - `@peac/server` - HTTP verification server with 402 support
 - `@peac/cli` - Command-line tools for receipts and policy
 
-**Rails (stable, v0.9.15):**
+**Rails (stable, v0.9.16):**
 
 - `@peac/rails-x402` - x402 payment rail adapter
 - `@peac/rails-stripe` - Stripe payment rail adapter
 
-**Mappings (stable, v0.9.15):**
+**Mappings (stable, v0.9.16):**
 
 - `@peac/mappings-mcp` - Model Context Protocol integration
 - `@peac/mappings-acp` - Agentic Commerce Protocol integration
@@ -407,7 +407,7 @@ PEAC addresses seven protocol capabilities for AI and API infrastructure:
 | **Privacy**     | `@peac/privacy`     | Privacy budgeting and retention policy hooks      |
 | **Provenance**  | `@peac/provenance`  | Content provenance and C2PA integration           |
 
-These are optional higher-layer helpers built on top of the core receipt/kernel stack. The stable, production-ready surface for v0.9.15 is the kernel / schema / crypto / protocol / rails / server / cli stack. PEAC remains vendor-neutral; pillar packages provide building blocks, not a hosted service.
+These are optional higher-layer helpers built on top of the core receipt/kernel stack. The stable, production-ready surface for v0.9.16 is the kernel / schema / crypto / protocol / rails / server / cli stack. PEAC remains vendor-neutral; pillar packages provide building blocks, not a hosted service.
 
 ---
 
@@ -450,7 +450,7 @@ These are optional higher-layer helpers built on top of the core receipt/kernel 
 **Library surface:**
 
 - TypeScript APIs are pre-1.0 and may have breaking changes between minor releases
-- Core packages (kernel, schema, crypto, protocol) are stable for v0.9.15
+- Core packages (kernel, schema, crypto, protocol) are stable for v0.9.16
 - Pillar packages (access, consent, etc.) are early scaffolding; APIs may change
 
 For forward-looking details, see the docs in `docs/` and the CHANGELOG.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-api",
-  "version": "0.9.14",
+  "version": "0.9.16",
   "description": "PEAC Protocol API server with OpenAPI 3.1, RFC 9457 Problem Details, and content negotiation",
   "type": "module",
   "main": "dist/index.js",

--- a/apps/bridge/package.json
+++ b/apps/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-bridge",
-  "version": "0.9.13.2",
+  "version": "0.9.16",
   "description": "PEAC Protocol Bridge - Local development sidecar",
   "type": "module",
   "main": "dist/server.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/monorepo",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "private": true,
   "description": "PEAC Protocol - Cryptographic receipts for agentic commerce",
   "repository": {

--- a/packages/access/package.json
+++ b/packages/access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/access",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "PEAC access pillar (placeholder for v0.9.18+)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/aipref/package.json
+++ b/packages/aipref/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/pref",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "AIPREF resolver with robots.txt bridge",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/attribution/package.json
+++ b/packages/attribution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/attribution",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "PEAC attribution pillar (placeholder for v0.9.18+)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/cli",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "PEAC protocol command-line tools",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/compliance/package.json
+++ b/packages/compliance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/compliance",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "PEAC compliance pillar (placeholder for v0.9.18+)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/consent/package.json
+++ b/packages/consent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/consent",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "PEAC consent pillar (placeholder for v0.9.18+)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/control/package.json
+++ b/packages/control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/control",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "PEAC Protocol Control - control engine interfaces and validation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/core",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "DEPRECATED - Use @peac/kernel, @peac/schema, @peac/crypto, @peac/protocol instead",
   "type": "module",
   "homepage": "https://peacprotocol.org",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/crypto",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "Ed25519 JWS signing and verification for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/disc",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "PEAC discovery with ≤20 lines enforcement",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/intelligence/package.json
+++ b/packages/intelligence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/intelligence",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "PEAC intelligence pillar (placeholder for v0.9.18+)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/kernel",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "PEAC protocol kernel - normative constants, errors, and registries",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/mappings/acp/package.json
+++ b/packages/mappings/acp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-acp",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "Agentic Commerce Protocol (ACP) integration for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/mcp/package.json
+++ b/packages/mappings/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-mcp",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "Model Context Protocol (MCP) integration for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/pay402/package.json
+++ b/packages/pay402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/pay402",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "Generic HTTP 402 adapter with multi-rail payment negotiation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/privacy/package.json
+++ b/packages/privacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/privacy",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "Privacy pillar for PEAC protocol - privacy budgeting, data protection, and privacy-preserving receipts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/protocol",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "PEAC protocol implementation - receipt issuance and verification",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/provenance/package.json
+++ b/packages/provenance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/provenance",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "Provenance pillar for PEAC protocol - content provenance, C2PA integration, and chain-of-custody",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rails/stripe/package.json
+++ b/packages/rails/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-stripe",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "Stripe payment rail adapter for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rails/x402/package.json
+++ b/packages/rails/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-x402",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "x402 payment rail adapter for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/receipts/package.json
+++ b/packages/receipts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/receipts",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "PEAC Protocol receipt builders, parsers, and validators with CBOR support",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/schema",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "PEAC Protocol JSON schemas, OpenAPI specs, and TypeScript types",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/sdk",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "PEAC client SDK with discover/verify functions",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/server",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "PEAC verification server with DoS protection and rate limiting",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/transport/grpc/package.json
+++ b/packages/transport/grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-grpc",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "PEAC gRPC transport layer (placeholder for v0.9.17+)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/transport/http/package.json
+++ b/packages/transport/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-http",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "PEAC HTTP transport layer - headers, middleware, DPoP L3/L4",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/transport/ws/package.json
+++ b/packages/transport/ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-ws",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "PEAC WebSocket transport layer (placeholder for v0.9.17+)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Release v0.9.16 with version bumps and documentation updates. No behavioral changes - this is a pure release cut.

### What's in v0.9.16

- **Control Abstraction Layer (CAL) semantics**: `ControlPurpose` (crawl, index, train, inference), `ControlLicensingMode` (subscription, pay_per_crawl, pay_per_inference), and `any_can_veto` decision combinator
- **PaymentEvidence extensions**: `aggregator` field for marketplace/platform identifiers, `splits[]` array for multi-party allocation
- **Subject Profile Catalogue**: `SubjectProfile` and `SubjectProfileSnapshot` types and validators
- **Privacy guidance**: PROTOCOL-BEHAVIOR Section 8.4 with opaque identifiers, data minimization, retention policies

## Release Checklist

- [x] Bump root `package.json` to 0.9.16
- [x] Bump all `packages/*/package.json` to 0.9.16
- [x] Bump `apps/*/package.json` to 0.9.16
- [x] Update README.md version badge and status sections
- [x] Add CHANGELOG.md entry for 0.9.16
- [x] Run `pnpm lint` - passed
- [x] Run `pnpm build` - passed
- [x] Run `pnpm typecheck:core` - passed
- [x] Run `pnpm test:core` - passed (83 tests)
- [x] Run `pnpm --filter @peac/schema test` - passed (57 tests)
- [x] Run `pnpm --filter @peac/control test` - passed (32 tests)
- [x] Run `./scripts/check-planning-leak.sh` - passed

## Files Changed (32)

- `package.json` - version bump
- `packages/*/package.json` - version bumps (27 packages)
- `apps/*/package.json` - version bumps (2 apps)
- `README.md` - version badge and status sections
- `CHANGELOG.md` - v0.9.16 entry