### PR TITLE
feat(mappings-rsl,schema): add RSL 1.0

### DIFF
--- a/packages/control/__tests__/cal-semantics.test.ts
+++ b/packages/control/__tests__/cal-semantics.test.ts
@@ -21,6 +21,12 @@ describe('ControlPurposeSchema', () => {
     expect(ControlPurposeSchema.parse('inference')).toBe('inference');
   });
 
+  it('should accept RSL-aligned purposes (v0.9.17+)', () => {
+    expect(ControlPurposeSchema.parse('ai_input')).toBe('ai_input');
+    expect(ControlPurposeSchema.parse('ai_search')).toBe('ai_search');
+    expect(ControlPurposeSchema.parse('search')).toBe('search');
+  });
+
   it('should reject invalid purposes', () => {
     expect(() => ControlPurposeSchema.parse('invalid')).toThrow();
     expect(() => ControlPurposeSchema.parse('')).toThrow();

--- a/packages/mappings/rsl/README.md
+++ b/packages/mappings/rsl/README.md
@@ -1,0 +1,23 @@
+# @peac/mappings-rsl
+
+Minimal RSL (Robots Specification Layer) to PEAC CAL mapping.
+
+## Scope
+
+Maps RSL usage tokens (`ai-train`, `ai-input`, `ai-search`, `search`, `ai-all`) to PEAC `ControlPurpose` values. Provides lenient handling: unknown tokens log a warning but do not throw.
+
+## Non-goals (v0.9.17)
+
+- No OLP/CAP/EMS support
+- No RSL-specific envelope fields
+- No live robots.txt discovery or XML parsing
+- No hardcoded license server endpoints
+
+## Usage
+
+```ts
+import { rslUsageTokensToControlPurposes } from '@peac/mappings-rsl';
+
+const result = rslUsageTokensToControlPurposes(['ai-train', 'ai-input']);
+// result.purposes = ['train', 'ai_input']
+```

--- a/packages/mappings/rsl/package.json
+++ b/packages/mappings/rsl/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@peac/mappings-rsl",
+  "version": "0.9.17",
+  "description": "RSL (Robots Specification Layer) mapping for PEAC",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/peacprotocol/peac.git",
+    "directory": "packages/mappings/rsl"
+  },
+  "author": "jithinraj <7850727+jithinraj@users.noreply.github.com>",
+  "license": "Apache-2.0",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@peac/schema": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.3",
+    "vitest": "^1.1.0"
+  }
+}

--- a/packages/mappings/rsl/src/index.ts
+++ b/packages/mappings/rsl/src/index.ts
@@ -1,0 +1,215 @@
+/**
+ * RSL (Robots Specification Layer) mapping for PEAC
+ *
+ * Maps RSL usage tokens to PEAC ControlPurpose values.
+ * Provides a standards-aligned way to express content licensing
+ * intentions in PEAC receipts.
+ *
+ * @packageDocumentation
+ */
+
+import type { ControlPurpose } from '@peac/schema';
+import type { RslUsageToken, RslMappingResult, RslRule } from './types';
+
+export type { RslUsageToken, RslMappingResult, RslRule } from './types';
+
+/**
+ * Mapping from RSL usage tokens to PEAC ControlPurpose values
+ *
+ * Rules:
+ * - ai-train  -> ['train']
+ * - ai-input  -> ['ai_input']
+ * - ai-search -> ['ai_search']
+ * - search    -> ['search']
+ * - ai-all    -> ['train', 'ai_input', 'ai_search']
+ */
+const RSL_TO_CAL_MAP: Record<RslUsageToken, ControlPurpose[]> = {
+  'ai-train': ['train'],
+  'ai-input': ['ai_input'],
+  'ai-search': ['ai_search'],
+  search: ['search'],
+  'ai-all': ['train', 'ai_input', 'ai_search'],
+};
+
+/**
+ * Known RSL usage tokens
+ */
+const KNOWN_RSL_TOKENS = new Set<string>(['ai-train', 'ai-input', 'ai-search', 'search', 'ai-all']);
+
+/**
+ * Set of unknown tokens we've already warned about (dedupe in-process)
+ */
+const warnedTokens = new Set<string>();
+
+/**
+ * Warn about unknown RSL token (deduped to avoid log spam)
+ */
+function warnUnknownToken(token: string): void {
+  if (!warnedTokens.has(token)) {
+    warnedTokens.add(token);
+    console.warn(`[peac:rsl] Unknown RSL usage token: "${token}"`);
+  }
+}
+
+/**
+ * Check if a string is a valid RSL usage token
+ *
+ * @param token - String to check
+ * @returns True if token is a known RSL usage token
+ */
+export function isValidRslToken(token: string): token is RslUsageToken {
+  return KNOWN_RSL_TOKENS.has(token);
+}
+
+/**
+ * Map RSL usage tokens to PEAC ControlPurpose values
+ *
+ * Converts one or more RSL usage tokens to their corresponding
+ * PEAC ControlPurpose values. Unknown tokens are logged as warnings
+ * but do not cause errors (lenient handling).
+ *
+ * @param tokens - Array of RSL usage tokens (or strings)
+ * @returns Mapping result with purposes and any unknown tokens
+ *
+ * @example
+ * ```ts
+ * const result = rslUsageTokensToControlPurposes(['ai-train', 'ai-input']);
+ * // result.purposes = ['train', 'ai_input']
+ * // result.unknownTokens = []
+ * ```
+ *
+ * @example
+ * ```ts
+ * // ai-all expands to multiple purposes
+ * const result = rslUsageTokensToControlPurposes(['ai-all']);
+ * // result.purposes = ['train', 'ai_input', 'ai_search']
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Unknown tokens are collected but don't throw
+ * const result = rslUsageTokensToControlPurposes(['ai-train', 'unknown-token']);
+ * // result.purposes = ['train']
+ * // result.unknownTokens = ['unknown-token']
+ * // (warning logged to console)
+ * ```
+ */
+export function rslUsageTokensToControlPurposes(
+  tokens: (RslUsageToken | string)[]
+): RslMappingResult {
+  const purposes = new Set<ControlPurpose>();
+  const unknownTokens: string[] = [];
+
+  for (const token of tokens) {
+    if (isValidRslToken(token)) {
+      const mapped = RSL_TO_CAL_MAP[token];
+      for (const purpose of mapped) {
+        purposes.add(purpose);
+      }
+    } else {
+      unknownTokens.push(token);
+      // Lenient handling: log warning but don't throw (deduped)
+      warnUnknownToken(token);
+    }
+  }
+
+  return {
+    purposes: Array.from(purposes),
+    unknownTokens,
+  };
+}
+
+/**
+ * Map a single RSL usage token to PEAC ControlPurpose values
+ *
+ * Convenience function for mapping a single token.
+ *
+ * @param token - RSL usage token
+ * @returns Array of ControlPurpose values, or empty array if unknown
+ *
+ * @example
+ * ```ts
+ * const purposes = rslTokenToControlPurposes('ai-train');
+ * // purposes = ['train']
+ * ```
+ */
+export function rslTokenToControlPurposes(token: RslUsageToken | string): ControlPurpose[] {
+  if (isValidRslToken(token)) {
+    return [...RSL_TO_CAL_MAP[token]];
+  }
+  warnUnknownToken(token);
+  return [];
+}
+
+/**
+ * Map PEAC ControlPurpose back to RSL usage token
+ *
+ * Reverse mapping for generating RSL-compatible output.
+ * Note: This is a best-effort mapping; some purposes may not
+ * have a direct RSL equivalent.
+ *
+ * @param purpose - PEAC ControlPurpose value
+ * @returns RSL usage token or null if no direct mapping
+ *
+ * @example
+ * ```ts
+ * const token = controlPurposeToRslToken('train');
+ * // token = 'ai-train'
+ * ```
+ */
+export function controlPurposeToRslToken(purpose: ControlPurpose): RslUsageToken | null {
+  switch (purpose) {
+    case 'train':
+      return 'ai-train';
+    case 'ai_input':
+      return 'ai-input';
+    case 'ai_search':
+      return 'ai-search';
+    case 'search':
+      return 'search';
+    // No RSL equivalent for these
+    case 'crawl':
+    case 'index':
+    case 'inference':
+      return null;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Get all known RSL usage tokens
+ *
+ * @returns Array of all known RSL usage tokens
+ */
+export function getKnownRslTokens(): RslUsageToken[] {
+  return ['ai-train', 'ai-input', 'ai-search', 'search', 'ai-all'];
+}
+
+/**
+ * Parse RSL rule from a simple string representation
+ *
+ * Parses a comma-separated list of RSL usage tokens.
+ * This is a minimal parser for v0.9.17; full robots.txt
+ * License: directive parsing is out of scope.
+ *
+ * @param input - Comma-separated usage tokens
+ * @returns RslRule with parsed tokens
+ *
+ * @example
+ * ```ts
+ * const rule = parseRslTokenString('ai-train, ai-input');
+ * // rule.tokens = ['ai-train', 'ai-input']
+ * ```
+ */
+export function parseRslTokenString(input: string): RslRule {
+  const tokens = input
+    .split(',')
+    .map((t) => t.trim().toLowerCase())
+    .filter((t) => t.length > 0) as RslUsageToken[];
+
+  return {
+    tokens,
+    allow: true,
+  };
+}

--- a/packages/mappings/rsl/src/types.ts
+++ b/packages/mappings/rsl/src/types.ts
@@ -1,0 +1,56 @@
+/**
+ * RSL (Robots Specification Layer) type definitions
+ *
+ * RSL is a machine-readable licensing specification for web content.
+ * This module defines types for RSL usage tokens that can be mapped
+ * to PEAC ControlPurpose values.
+ *
+ * @see https://www.robots.dev/rsl (RSL specification)
+ */
+
+/**
+ * RSL usage token type
+ *
+ * Standard RSL usage tokens that control how content may be used.
+ *
+ * Well-known tokens:
+ * - "ai-train": AI/ML model training
+ * - "ai-input": RAG/grounding (using content as input to AI)
+ * - "ai-search": AI-powered search
+ * - "search": Traditional search engine indexing
+ * - "ai-all": Shorthand for ai-train + ai-input + ai-search
+ */
+export type RslUsageToken = 'ai-train' | 'ai-input' | 'ai-search' | 'search' | 'ai-all';
+
+/**
+ * RSL rule structure (simplified)
+ *
+ * Represents a single RSL rule from a robots.txt License: directive
+ * or llms.txt configuration.
+ *
+ * Note: This is a minimal subset for v0.9.17 alignment. Full RSL
+ * support (OLP, CAP, EMS) is out of scope for this version.
+ */
+export interface RslRule {
+  /** Usage tokens that apply to this rule */
+  tokens: RslUsageToken[];
+
+  /** Whether this rule allows or disallows the usage (default: allow) */
+  allow?: boolean;
+
+  /** Optional scope pattern (URL path pattern) */
+  scope?: string;
+}
+
+/**
+ * RSL mapping result
+ *
+ * Result of mapping RSL usage tokens to PEAC ControlPurpose values.
+ */
+export interface RslMappingResult {
+  /** Mapped PEAC ControlPurpose values */
+  purposes: import('@peac/schema').ControlPurpose[];
+
+  /** Any unknown tokens that were encountered (logged as warnings) */
+  unknownTokens: string[];
+}

--- a/packages/mappings/rsl/tests/rsl-mapping.test.ts
+++ b/packages/mappings/rsl/tests/rsl-mapping.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Tests for RSL (Robots Specification Layer) mapping
+ *
+ * Golden vectors for RSL usage token to PEAC ControlPurpose mapping.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  rslUsageTokensToControlPurposes,
+  rslTokenToControlPurposes,
+  controlPurposeToRslToken,
+  isValidRslToken,
+  getKnownRslTokens,
+  parseRslTokenString,
+} from '../src/index';
+
+describe('RSL mapping', () => {
+  describe('isValidRslToken', () => {
+    it('should return true for known RSL tokens', () => {
+      expect(isValidRslToken('ai-train')).toBe(true);
+      expect(isValidRslToken('ai-input')).toBe(true);
+      expect(isValidRslToken('ai-search')).toBe(true);
+      expect(isValidRslToken('search')).toBe(true);
+      expect(isValidRslToken('ai-all')).toBe(true);
+    });
+
+    it('should return false for unknown tokens', () => {
+      expect(isValidRslToken('unknown')).toBe(false);
+      expect(isValidRslToken('ai-train-v2')).toBe(false);
+      expect(isValidRslToken('')).toBe(false);
+      expect(isValidRslToken('AI-TRAIN')).toBe(false); // case-sensitive
+    });
+  });
+
+  describe('getKnownRslTokens', () => {
+    it('should return all known RSL tokens', () => {
+      const tokens = getKnownRslTokens();
+      expect(tokens).toContain('ai-train');
+      expect(tokens).toContain('ai-input');
+      expect(tokens).toContain('ai-search');
+      expect(tokens).toContain('search');
+      expect(tokens).toContain('ai-all');
+      expect(tokens).toHaveLength(5);
+    });
+  });
+
+  describe('rslTokenToControlPurposes', () => {
+    it('should map ai-train to train', () => {
+      const purposes = rslTokenToControlPurposes('ai-train');
+      expect(purposes).toEqual(['train']);
+    });
+
+    it('should map ai-input to ai_input', () => {
+      const purposes = rslTokenToControlPurposes('ai-input');
+      expect(purposes).toEqual(['ai_input']);
+    });
+
+    it('should map ai-search to ai_search', () => {
+      const purposes = rslTokenToControlPurposes('ai-search');
+      expect(purposes).toEqual(['ai_search']);
+    });
+
+    it('should map search to search', () => {
+      const purposes = rslTokenToControlPurposes('search');
+      expect(purposes).toEqual(['search']);
+    });
+
+    it('should expand ai-all to train, ai_input, ai_search', () => {
+      const purposes = rslTokenToControlPurposes('ai-all');
+      expect(purposes).toEqual(['train', 'ai_input', 'ai_search']);
+    });
+
+    it('should return empty array for unknown token', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const purposes = rslTokenToControlPurposes('unknown-token');
+      expect(purposes).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledWith('[peac:rsl] Unknown RSL usage token: "unknown-token"');
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('rslUsageTokensToControlPurposes', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should map single token', () => {
+      const result = rslUsageTokensToControlPurposes(['ai-train']);
+      expect(result.purposes).toEqual(['train']);
+      expect(result.unknownTokens).toEqual([]);
+    });
+
+    it('should map multiple tokens', () => {
+      const result = rslUsageTokensToControlPurposes(['ai-train', 'ai-input']);
+      expect(result.purposes).toContain('train');
+      expect(result.purposes).toContain('ai_input');
+      expect(result.purposes).toHaveLength(2);
+      expect(result.unknownTokens).toEqual([]);
+    });
+
+    it('should deduplicate purposes', () => {
+      const result = rslUsageTokensToControlPurposes(['ai-train', 'ai-train']);
+      expect(result.purposes).toEqual(['train']);
+    });
+
+    it('should expand ai-all and deduplicate with individual tokens', () => {
+      const result = rslUsageTokensToControlPurposes(['ai-all', 'ai-train']);
+      expect(result.purposes).toContain('train');
+      expect(result.purposes).toContain('ai_input');
+      expect(result.purposes).toContain('ai_search');
+      expect(result.purposes).toHaveLength(3);
+    });
+
+    it('should collect unknown tokens without throwing', () => {
+      const result = rslUsageTokensToControlPurposes(['ai-train', 'unknown', 'also-unknown']);
+      expect(result.purposes).toEqual(['train']);
+      expect(result.unknownTokens).toEqual(['unknown', 'also-unknown']);
+    });
+
+    it('should handle empty array', () => {
+      const result = rslUsageTokensToControlPurposes([]);
+      expect(result.purposes).toEqual([]);
+      expect(result.unknownTokens).toEqual([]);
+    });
+  });
+
+  describe('controlPurposeToRslToken', () => {
+    it('should map train back to ai-train', () => {
+      expect(controlPurposeToRslToken('train')).toBe('ai-train');
+    });
+
+    it('should map ai_input back to ai-input', () => {
+      expect(controlPurposeToRslToken('ai_input')).toBe('ai-input');
+    });
+
+    it('should map ai_search back to ai-search', () => {
+      expect(controlPurposeToRslToken('ai_search')).toBe('ai-search');
+    });
+
+    it('should map search back to search', () => {
+      expect(controlPurposeToRslToken('search')).toBe('search');
+    });
+
+    it('should return null for purposes without RSL equivalent', () => {
+      expect(controlPurposeToRslToken('crawl')).toBeNull();
+      expect(controlPurposeToRslToken('index')).toBeNull();
+      expect(controlPurposeToRslToken('inference')).toBeNull();
+    });
+  });
+
+  describe('parseRslTokenString', () => {
+    it('should parse comma-separated tokens', () => {
+      const rule = parseRslTokenString('ai-train, ai-input');
+      expect(rule.tokens).toEqual(['ai-train', 'ai-input']);
+      expect(rule.allow).toBe(true);
+    });
+
+    it('should handle single token', () => {
+      const rule = parseRslTokenString('ai-train');
+      expect(rule.tokens).toEqual(['ai-train']);
+    });
+
+    it('should trim whitespace', () => {
+      const rule = parseRslTokenString('  ai-train  ,  ai-input  ');
+      expect(rule.tokens).toEqual(['ai-train', 'ai-input']);
+    });
+
+    it('should lowercase tokens', () => {
+      const rule = parseRslTokenString('AI-TRAIN, AI-INPUT');
+      expect(rule.tokens).toEqual(['ai-train', 'ai-input']);
+    });
+
+    it('should handle empty string', () => {
+      const rule = parseRslTokenString('');
+      expect(rule.tokens).toEqual([]);
+    });
+  });
+
+  describe('Golden Vectors', () => {
+    /**
+     * GOLDEN VECTOR A: Basic RSL to CAL mapping
+     *
+     * Verifies that standard RSL usage tokens map correctly
+     * to PEAC ControlPurpose values.
+     */
+    describe('Golden Vector A: Basic RSL to CAL mapping', () => {
+      const vectors: Array<{
+        name: string;
+        input: string[];
+        expectedPurposes: string[];
+      }> = [
+        {
+          name: 'ai-train only',
+          input: ['ai-train'],
+          expectedPurposes: ['train'],
+        },
+        {
+          name: 'ai-input only (RAG/grounding)',
+          input: ['ai-input'],
+          expectedPurposes: ['ai_input'],
+        },
+        {
+          name: 'ai-search only',
+          input: ['ai-search'],
+          expectedPurposes: ['ai_search'],
+        },
+        {
+          name: 'search only (traditional)',
+          input: ['search'],
+          expectedPurposes: ['search'],
+        },
+        {
+          name: 'ai-all expands to multiple',
+          input: ['ai-all'],
+          expectedPurposes: ['train', 'ai_input', 'ai_search'],
+        },
+        {
+          name: 'combination: ai-train + ai-input',
+          input: ['ai-train', 'ai-input'],
+          expectedPurposes: ['train', 'ai_input'],
+        },
+        {
+          name: 'combination: search + ai-search',
+          input: ['search', 'ai-search'],
+          expectedPurposes: ['search', 'ai_search'],
+        },
+        {
+          name: 'all tokens',
+          input: ['ai-train', 'ai-input', 'ai-search', 'search'],
+          expectedPurposes: ['train', 'ai_input', 'ai_search', 'search'],
+        },
+      ];
+
+      for (const vector of vectors) {
+        it(`should map: ${vector.name}`, () => {
+          const result = rslUsageTokensToControlPurposes(vector.input);
+          expect(result.purposes.sort()).toEqual(vector.expectedPurposes.sort());
+          expect(result.unknownTokens).toEqual([]);
+
+          // Log golden vector
+          console.log(
+            `\n=== GOLDEN VECTOR: ${vector.name} ===\n` +
+              `RSL Input: ${JSON.stringify(vector.input)}\n` +
+              `CAL Output: ${JSON.stringify(result.purposes)}\n` +
+              `===================================\n`
+          );
+        });
+      }
+    });
+
+    /**
+     * GOLDEN VECTOR B: Lenient handling of unknown tokens
+     *
+     * Verifies that unknown tokens are collected but don't
+     * cause errors (lenient handling per P0.5 spec).
+     */
+    describe('Golden Vector B: Lenient unknown token handling', () => {
+      beforeEach(() => {
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+      });
+
+      afterEach(() => {
+        vi.restoreAllMocks();
+      });
+
+      it('should collect unknown tokens without throwing', () => {
+        const result = rslUsageTokensToControlPurposes([
+          'ai-train',
+          'future-token',
+          'another-unknown',
+        ]);
+
+        expect(result.purposes).toEqual(['train']);
+        expect(result.unknownTokens).toEqual(['future-token', 'another-unknown']);
+
+        // Log golden vector
+        console.log(
+          '\n=== GOLDEN VECTOR: Unknown Token Handling ===\n' +
+            `RSL Input: ${JSON.stringify(['ai-train', 'future-token', 'another-unknown'])}\n` +
+            `CAL Output: ${JSON.stringify(result.purposes)}\n` +
+            `Unknown: ${JSON.stringify(result.unknownTokens)}\n` +
+            '=============================================\n'
+        );
+      });
+
+      it('should handle all unknown tokens gracefully', () => {
+        const result = rslUsageTokensToControlPurposes(['unknown1', 'unknown2']);
+
+        expect(result.purposes).toEqual([]);
+        expect(result.unknownTokens).toEqual(['unknown1', 'unknown2']);
+      });
+    });
+
+    /**
+     * GOLDEN VECTOR C: Round-trip mapping
+     *
+     * Verifies that CAL purposes with RSL equivalents can
+     * be mapped back to RSL tokens.
+     */
+    describe('Golden Vector C: Round-trip mapping', () => {
+      const roundTripVectors = [
+        { purpose: 'train', rslToken: 'ai-train' },
+        { purpose: 'ai_input', rslToken: 'ai-input' },
+        { purpose: 'ai_search', rslToken: 'ai-search' },
+        { purpose: 'search', rslToken: 'search' },
+      ] as const;
+
+      for (const vector of roundTripVectors) {
+        it(`should round-trip: ${vector.purpose} <-> ${vector.rslToken}`, () => {
+          // RSL -> CAL
+          const purposes = rslTokenToControlPurposes(vector.rslToken);
+          expect(purposes).toContain(vector.purpose);
+
+          // CAL -> RSL
+          const token = controlPurposeToRslToken(vector.purpose);
+          expect(token).toBe(vector.rslToken);
+
+          // Log golden vector
+          console.log(
+            `\n=== GOLDEN VECTOR: Round-trip ${vector.purpose} ===\n` +
+              `RSL "${vector.rslToken}" -> CAL ${JSON.stringify(purposes)}\n` +
+              `CAL "${vector.purpose}" -> RSL "${token}"\n` +
+              '===============================================\n'
+          );
+        });
+      }
+    });
+  });
+});

--- a/packages/mappings/rsl/tsconfig.json
+++ b/packages/mappings/rsl/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"],
+  "references": [{ "path": "../../schema" }]
+}

--- a/packages/schema/src/control.ts
+++ b/packages/schema/src/control.ts
@@ -21,8 +21,18 @@ export type ControlDecision = 'allow' | 'deny' | 'review';
  * - "index": Search engine indexing
  * - "train": AI/ML model training
  * - "inference": AI/ML inference/generation
+ * - "ai_input": RAG/grounding (using content as input to AI) [v0.9.17+, RSL alignment]
+ * - "ai_search": AI-powered search [v0.9.17+, RSL alignment]
+ * - "search": Traditional search indexing [v0.9.17+, RSL alignment]
  */
-export type ControlPurpose = 'crawl' | 'index' | 'train' | 'inference';
+export type ControlPurpose =
+  | 'crawl'
+  | 'index'
+  | 'train'
+  | 'inference'
+  | 'ai_input'
+  | 'ai_search'
+  | 'search';
 
 /**
  * Control licensing mode - how access is licensed

--- a/packages/schema/src/validators.ts
+++ b/packages/schema/src/validators.ts
@@ -79,8 +79,18 @@ export const VerifyRequest = z
 
 /**
  * Control purpose - what the access is for
+ *
+ * v0.9.17+: Added ai_input, ai_search, search for RSL alignment
  */
-export const ControlPurposeSchema = z.enum(['crawl', 'index', 'train', 'inference']);
+export const ControlPurposeSchema = z.enum([
+  'crawl',
+  'index',
+  'train',
+  'inference',
+  'ai_input',
+  'ai_search',
+  'search',
+]);
 
 /**
  * Control licensing mode - how access is licensed

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,6 +329,22 @@ importers:
         specifier: ^1.1.0
         version: 1.6.1(@types/node@20.19.25)
 
+  packages/mappings/rsl:
+    dependencies:
+      '@peac/schema':
+        specifier: workspace:*
+        version: link:../../schema
+    devDependencies:
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.25
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.1.0
+        version: 1.6.1(@types/node@20.19.25)
+
   packages/pay402:
     devDependencies:
       '@types/jest':


### PR DESCRIPTION
## Summary

Adds minimal RSL 1.0 alignment (P0.5 for v0.9.17):
- Extends `ControlPurpose` with RSL usage tokens
- Creates `@peac/mappings-rsl` package for RSL to CAL mapping
- Updates PROTOCOL-BEHAVIOR.md with mapping table

## RSL usageToken to ControlPurpose Mapping Table

| RSL Token | CAL ControlPurpose | Notes |
|-----------|-------------------|-------|
| `ai-train` | `['train']` | AI/ML model training |
| `ai-input` | `['ai_input']` | RAG/grounding |
| `ai-search` | `['ai_search']` | AI-powered search |
| `search` | `['search']` | Traditional search indexing |
| `ai-all` | `['train', 'ai_input', 'ai_search']` | Expands to multiple purposes |

## Forward-compatibility for Unknown Tokens

- Unknown RSL tokens log a warning via `[peac:rsl]` namespace but do NOT throw
- Warnings are deduplicated in-process to avoid log spam
- Unknown tokens are collected in `RslMappingResult.unknownTokens` for inspection

## Non-goals (v0.9.17)

- No OLP/CAP/EMS implementation
- No RSL-specific fields in PEAC envelope
- No hardcoded RSL endpoints or license servers
- No live robots.txt `License:` discovery or XML parsing

## Test plan

- [x] 39 tests covering single-token, multi-token, ai-all expansion, unknown token handling
- [x] Golden vectors for RSL to CAL mapping
- [x] Round-trip mapping tests (CAL to RSL back to CAL)
- [x] Zod schema tests for new ControlPurpose values
- [x] All gates pass: lint, build, typecheck:core, test:core