### PR TITLE
feat(protocol,schema): add SubjectProfile

### DIFF
--- a/packages/mappings/acp/tests/acp.test.ts
+++ b/packages/mappings/acp/tests/acp.test.ts
@@ -127,7 +127,7 @@ describe('ACP integration', () => {
       const { privateKey } = await generateKeypair();
 
       // Issue PEAC receipt
-      const receiptJWS = await issue({
+      const result = await issue({
         iss: 'https://merchant.example.com',
         aud: 'https://api.example.com',
         amt: receiptInput.amt,
@@ -143,12 +143,12 @@ describe('ACP integration', () => {
       });
 
       // Verify it's a valid JWS
-      expect(receiptJWS.split('.')).toHaveLength(3);
+      expect(result.jws.split('.')).toHaveLength(3);
 
       // Log golden vector
-      console.log('\n=== GOLDEN VECTOR A (ACP → PEAC, Stripe) ===');
+      console.log('\n=== GOLDEN VECTOR A (ACP -> PEAC, Stripe) ===');
       console.log('ACP Event:', JSON.stringify(acpEvent, null, 2));
-      console.log('PEAC Receipt JWS:', receiptJWS);
+      console.log('PEAC Receipt JWS:', result.jws);
       console.log('===========================================\n');
     });
 
@@ -174,7 +174,7 @@ describe('ACP integration', () => {
       const { privateKey } = await generateKeypair();
 
       // Issue PEAC receipt
-      const receiptJWS = await issue({
+      const result = await issue({
         iss: 'https://merchant.example.com',
         aud: 'https://api.example.com',
         amt: receiptInput.amt,
@@ -190,12 +190,12 @@ describe('ACP integration', () => {
       });
 
       // Verify it's a valid JWS
-      expect(receiptJWS.split('.')).toHaveLength(3);
+      expect(result.jws.split('.')).toHaveLength(3);
 
       // Log golden vector
-      console.log('\n=== GOLDEN VECTOR B (ACP → PEAC, x402) ===');
+      console.log('\n=== GOLDEN VECTOR B (ACP -> PEAC, x402) ===');
       console.log('ACP Event:', JSON.stringify(acpEvent, null, 2));
-      console.log('PEAC Receipt JWS:', receiptJWS);
+      console.log('PEAC Receipt JWS:', result.jws);
       console.log('=========================================\n');
     });
   });

--- a/packages/protocol/tests/protocol.test.ts
+++ b/packages/protocol/tests/protocol.test.ts
@@ -13,7 +13,7 @@ describe('PEAC Protocol', () => {
     it('should issue a valid receipt with UUIDv7 rid', async () => {
       const { privateKey } = await generateKeypair();
 
-      const jws = await issue({
+      const result = await issue({
         iss: 'https://api.example.com',
         aud: 'https://app.example.com',
         amt: 9999,
@@ -26,6 +26,10 @@ describe('PEAC Protocol', () => {
         privateKey,
         kid: '2025-01-15T10:30:00Z',
       });
+
+      // Result should have jws property
+      expect(result.jws).toBeDefined();
+      const jws = result.jws;
 
       // JWS should have three parts
       expect(jws.split('.')).toHaveLength(3);
@@ -57,7 +61,7 @@ describe('PEAC Protocol', () => {
     it('should include subject if provided', async () => {
       const { privateKey } = await generateKeypair();
 
-      const jws = await issue({
+      const result = await issue({
         iss: 'https://api.example.com',
         aud: 'https://app.example.com',
         amt: 9999,
@@ -72,7 +76,7 @@ describe('PEAC Protocol', () => {
         kid: '2025-01-15T10:30:00Z',
       });
 
-      const decoded = decode<PEACReceiptClaims>(jws);
+      const decoded = decode<PEACReceiptClaims>(result.jws);
 
       expect(decoded.payload.subject).toEqual({
         uri: 'https://app.example.com/api/resource/123',
@@ -83,7 +87,7 @@ describe('PEAC Protocol', () => {
       const { privateKey } = await generateKeypair();
       const exp = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
 
-      const jws = await issue({
+      const result = await issue({
         iss: 'https://api.example.com',
         aud: 'https://app.example.com',
         amt: 9999,
@@ -98,7 +102,7 @@ describe('PEAC Protocol', () => {
         kid: '2025-01-15T10:30:00Z',
       });
 
-      const decoded = decode<PEACReceiptClaims>(jws);
+      const decoded = decode<PEACReceiptClaims>(result.jws);
 
       expect(decoded.payload.exp).toBe(exp);
     });
@@ -206,7 +210,7 @@ describe('PEAC Protocol', () => {
     it('should generate unique UUIDv7 for each receipt', async () => {
       const { privateKey } = await generateKeypair();
 
-      const jws1 = await issue({
+      const result1 = await issue({
         iss: 'https://api.example.com',
         aud: 'https://app.example.com',
         amt: 9999,
@@ -220,7 +224,7 @@ describe('PEAC Protocol', () => {
         kid: '2025-01-15T10:30:00Z',
       });
 
-      const jws2 = await issue({
+      const result2 = await issue({
         iss: 'https://api.example.com',
         aud: 'https://app.example.com',
         amt: 9999,
@@ -234,8 +238,8 @@ describe('PEAC Protocol', () => {
         kid: '2025-01-15T10:30:00Z',
       });
 
-      const decoded1 = decode<PEACReceiptClaims>(jws1);
-      const decoded2 = decode<PEACReceiptClaims>(jws2);
+      const decoded1 = decode<PEACReceiptClaims>(result1.jws);
+      const decoded2 = decode<PEACReceiptClaims>(result2.jws);
 
       // RIDs should be different
       expect(decoded1.payload.rid).not.toBe(decoded2.payload.rid);

--- a/packages/protocol/tests/subject-snapshot.test.ts
+++ b/packages/protocol/tests/subject-snapshot.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Subject Snapshot Tests (v0.9.17+)
+ *
+ * Golden tests for SubjectProfileSnapshot in receipts.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { generateKeypair } from '@peac/crypto';
+import { issue } from '../src/issue';
+import { SubjectProfileSnapshot } from '@peac/schema';
+
+describe('Subject Snapshot', () => {
+  // Store original console.warn
+  const originalWarn = console.warn;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    console.warn = originalWarn;
+  });
+
+  describe('issue() with subject_snapshot', () => {
+    it('should issue receipt without subject_snapshot (existing behavior)', async () => {
+      const { privateKey } = await generateKeypair();
+
+      const result = await issue({
+        iss: 'https://api.example.com',
+        aud: 'https://app.example.com',
+        amt: 9999,
+        cur: 'USD',
+        rail: 'stripe',
+        reference: 'cs_123456',
+        asset: 'USD',
+        env: 'test',
+        evidence: { session_id: 'cs_123456' },
+        privateKey,
+        kid: '2025-01-15T10:30:00Z',
+      });
+
+      // JWS should be present
+      expect(result.jws.split('.')).toHaveLength(3);
+
+      // No subject_snapshot should be returned
+      expect(result.subject_snapshot).toBeUndefined();
+    });
+
+    it('should issue receipt with human subject_snapshot', async () => {
+      const { privateKey } = await generateKeypair();
+
+      const snapshot: SubjectProfileSnapshot = {
+        subject: {
+          id: 'user:abc123',
+          type: 'human',
+          labels: ['premium', 'verified'],
+        },
+        captured_at: '2025-01-15T10:30:00Z',
+        source: 'idp:auth0',
+      };
+
+      const result = await issue({
+        iss: 'https://api.example.com',
+        aud: 'https://app.example.com',
+        amt: 9999,
+        cur: 'USD',
+        rail: 'stripe',
+        reference: 'cs_123456',
+        asset: 'USD',
+        env: 'test',
+        evidence: { session_id: 'cs_123456' },
+        subject_snapshot: snapshot,
+        privateKey,
+        kid: '2025-01-15T10:30:00Z',
+      });
+
+      // JWS should be present
+      expect(result.jws.split('.')).toHaveLength(3);
+
+      // Validated subject_snapshot should be returned
+      expect(result.subject_snapshot).toEqual(snapshot);
+    });
+
+    it('should issue receipt with org subject_snapshot', async () => {
+      const { privateKey } = await generateKeypair();
+
+      const snapshot: SubjectProfileSnapshot = {
+        subject: {
+          id: 'org:acme-corp',
+          type: 'org',
+          labels: ['enterprise'],
+        },
+        captured_at: '2025-01-15T10:30:00Z',
+      };
+
+      const result = await issue({
+        iss: 'https://api.example.com',
+        aud: 'https://app.example.com',
+        amt: 9999,
+        cur: 'USD',
+        rail: 'stripe',
+        reference: 'cs_123456',
+        asset: 'USD',
+        env: 'test',
+        evidence: { session_id: 'cs_123456' },
+        subject_snapshot: snapshot,
+        privateKey,
+        kid: '2025-01-15T10:30:00Z',
+      });
+
+      expect(result.subject_snapshot).toEqual(snapshot);
+    });
+
+    it('should issue receipt with agent subject_snapshot', async () => {
+      const { privateKey } = await generateKeypair();
+
+      const snapshot: SubjectProfileSnapshot = {
+        subject: {
+          id: 'agent:gpt-crawler-v2',
+          type: 'agent',
+          labels: ['crawler', 'indexer'],
+        },
+        captured_at: '2025-01-15T10:30:00Z',
+        source: 'manual',
+        version: '1.0',
+      };
+
+      const result = await issue({
+        iss: 'https://api.example.com',
+        aud: 'https://app.example.com',
+        amt: 9999,
+        cur: 'USD',
+        rail: 'stripe',
+        reference: 'cs_123456',
+        asset: 'USD',
+        env: 'test',
+        evidence: { session_id: 'cs_123456' },
+        subject_snapshot: snapshot,
+        privateKey,
+        kid: '2025-01-15T10:30:00Z',
+      });
+
+      expect(result.subject_snapshot).toEqual(snapshot);
+    });
+
+    it('should reject invalid subject_snapshot (missing id)', async () => {
+      const { privateKey } = await generateKeypair();
+
+      const invalidSnapshot = {
+        subject: {
+          // id is missing
+          type: 'human',
+        },
+        captured_at: '2025-01-15T10:30:00Z',
+      };
+
+      await expect(
+        issue({
+          iss: 'https://api.example.com',
+          aud: 'https://app.example.com',
+          amt: 9999,
+          cur: 'USD',
+          rail: 'stripe',
+          reference: 'cs_123456',
+          asset: 'USD',
+          env: 'test',
+          evidence: { session_id: 'cs_123456' },
+          subject_snapshot: invalidSnapshot as SubjectProfileSnapshot,
+          privateKey,
+          kid: '2025-01-15T10:30:00Z',
+        })
+      ).rejects.toThrow();
+    });
+
+    it('should reject invalid subject_snapshot (missing type)', async () => {
+      const { privateKey } = await generateKeypair();
+
+      const invalidSnapshot = {
+        subject: {
+          id: 'user:abc123',
+          // type is missing
+        },
+        captured_at: '2025-01-15T10:30:00Z',
+      };
+
+      await expect(
+        issue({
+          iss: 'https://api.example.com',
+          aud: 'https://app.example.com',
+          amt: 9999,
+          cur: 'USD',
+          rail: 'stripe',
+          reference: 'cs_123456',
+          asset: 'USD',
+          env: 'test',
+          evidence: { session_id: 'cs_123456' },
+          subject_snapshot: invalidSnapshot as SubjectProfileSnapshot,
+          privateKey,
+          kid: '2025-01-15T10:30:00Z',
+        })
+      ).rejects.toThrow();
+    });
+
+    it('should log advisory PII warning for email-like subject id', async () => {
+      const { privateKey } = await generateKeypair();
+
+      const snapshot: SubjectProfileSnapshot = {
+        subject: {
+          id: 'john@example.com', // Looks like PII
+          type: 'human',
+        },
+        captured_at: '2025-01-15T10:30:00Z',
+      };
+
+      const result = await issue({
+        iss: 'https://api.example.com',
+        aud: 'https://app.example.com',
+        amt: 9999,
+        cur: 'USD',
+        rail: 'stripe',
+        reference: 'cs_123456',
+        asset: 'USD',
+        env: 'test',
+        evidence: { session_id: 'cs_123456' },
+        subject_snapshot: snapshot,
+        privateKey,
+        kid: '2025-01-15T10:30:00Z',
+      });
+
+      // Should still succeed
+      expect(result.subject_snapshot).toEqual(snapshot);
+
+      // Should have logged a warning
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('looks like PII'));
+    });
+
+    it('should not log duplicate PII warnings for same subject id', async () => {
+      const { privateKey } = await generateKeypair();
+
+      const snapshot: SubjectProfileSnapshot = {
+        subject: {
+          id: 'duplicate@example.com', // Looks like PII
+          type: 'human',
+        },
+        captured_at: '2025-01-15T10:30:00Z',
+      };
+
+      // Issue twice with the same PII-like id
+      await issue({
+        iss: 'https://api.example.com',
+        aud: 'https://app.example.com',
+        amt: 9999,
+        cur: 'USD',
+        rail: 'stripe',
+        reference: 'cs_123456',
+        asset: 'USD',
+        env: 'test',
+        evidence: { session_id: 'cs_123456' },
+        subject_snapshot: snapshot,
+        privateKey,
+        kid: '2025-01-15T10:30:00Z',
+      });
+
+      await issue({
+        iss: 'https://api.example.com',
+        aud: 'https://app.example.com',
+        amt: 9999,
+        cur: 'USD',
+        rail: 'stripe',
+        reference: 'cs_123456',
+        asset: 'USD',
+        env: 'test',
+        evidence: { session_id: 'cs_123456' },
+        subject_snapshot: snapshot,
+        privateKey,
+        kid: '2025-01-15T10:30:00Z',
+      });
+
+      // Warning should only be logged once (deduplicated)
+      const piiWarnings = warnSpy.mock.calls.filter((call) =>
+        call[0].includes('duplicate@example.com')
+      );
+      expect(piiWarnings).toHaveLength(1);
+    });
+  });
+});

--- a/packages/schema/src/envelope.ts
+++ b/packages/schema/src/envelope.ts
@@ -7,6 +7,7 @@
 
 import type { ControlBlock } from './control';
 import type { PaymentEvidence, AttestationEvidence } from './evidence';
+import type { SubjectProfileSnapshot } from './subject';
 
 /**
  * Authentication and Authorization Context
@@ -24,6 +25,8 @@ export interface AuthContext {
   enforcement?: EnforcementContext;
   binding?: TransportBinding;
   ctx?: ContextMetadata;
+  /** Subject profile snapshot for policy evaluation (v0.9.17+) */
+  subject_snapshot?: SubjectProfileSnapshot;
 }
 
 export interface EnforcementContext {

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -37,6 +37,8 @@ export {
   SubjectTypeSchema,
   SubjectProfileSchema,
   SubjectProfileSnapshotSchema,
+  // Subject snapshot validation helper (v0.9.17+)
+  validateSubjectSnapshot,
 } from './validators';
 
 // Envelope types (v0.9.15+ normative structure)

--- a/tests/conformance/parity.spec.ts
+++ b/tests/conformance/parity.spec.ts
@@ -34,7 +34,7 @@ describe('Rail Parity Conformance', () => {
       currency: 'usd', // Stripe uses lowercase
     });
 
-    const stripeReceiptJWS = await issue({
+    const stripeResult = await issue({
       iss: ISS,
       aud: AUD,
       amt: AMOUNT,
@@ -56,7 +56,7 @@ describe('Rail Parity Conformance', () => {
       currency: CURRENCY, // x402 uses uppercase
     });
 
-    const x402ReceiptJWS = await issue({
+    const x402Result = await issue({
       iss: ISS,
       aud: AUD,
       amt: AMOUNT,
@@ -72,8 +72,8 @@ describe('Rail Parity Conformance', () => {
     });
 
     // Decode both receipts
-    const stripeDecoded = decode<PEACReceiptClaims>(stripeReceiptJWS);
-    const x402Decoded = decode<PEACReceiptClaims>(x402ReceiptJWS);
+    const stripeDecoded = decode<PEACReceiptClaims>(stripeResult.jws);
+    const x402Decoded = decode<PEACReceiptClaims>(x402Result.jws);
 
     // --- PARITY ASSERTIONS ---
 
@@ -158,7 +158,7 @@ describe('Rail Parity Conformance', () => {
       currency: 'usd',
     });
 
-    const stripeJWS = await issue({
+    const stripeResult = await issue({
       iss: 'https://api.example.com',
       aud: 'https://app.example.com',
       amt: 9999,
@@ -179,7 +179,7 @@ describe('Rail Parity Conformance', () => {
       currency: 'USD',
     });
 
-    const x402JWS = await issue({
+    const x402Result = await issue({
       iss: 'https://api.example.com',
       aud: 'https://app.example.com',
       amt: 8888, // Different!
@@ -193,8 +193,8 @@ describe('Rail Parity Conformance', () => {
       kid,
     });
 
-    const stripeDecoded = decode<PEACReceiptClaims>(stripeJWS);
-    const x402Decoded = decode<PEACReceiptClaims>(x402JWS);
+    const stripeDecoded = decode<PEACReceiptClaims>(stripeResult.jws);
+    const x402Decoded = decode<PEACReceiptClaims>(x402Result.jws);
 
     // Amounts should NOT match
     expect(stripeDecoded.payload.amt).not.toBe(x402Decoded.payload.amt);
@@ -224,7 +224,7 @@ describe('Rail Parity Conformance', () => {
     expect(x402Payment.currency).toBe('EUR');
 
     // Issue receipts
-    const stripeJWS = await issue({
+    const stripeResult = await issue({
       iss: 'https://api.example.com',
       aud: 'https://app.example.com',
       amt: 1000,
@@ -238,7 +238,7 @@ describe('Rail Parity Conformance', () => {
       kid,
     });
 
-    const x402JWS = await issue({
+    const x402Result = await issue({
       iss: 'https://api.example.com',
       aud: 'https://app.example.com',
       amt: 1000,
@@ -252,8 +252,8 @@ describe('Rail Parity Conformance', () => {
       kid,
     });
 
-    const stripeDecoded = decode<PEACReceiptClaims>(stripeJWS);
-    const x402Decoded = decode<PEACReceiptClaims>(x402JWS);
+    const stripeDecoded = decode<PEACReceiptClaims>(stripeResult.jws);
+    const x402Decoded = decode<PEACReceiptClaims>(x402Result.jws);
 
     // Currencies MUST be identical (both uppercase)
     expect(stripeDecoded.payload.cur).toBe('EUR');

--- a/tests/performance/verify.bench.ts
+++ b/tests/performance/verify.bench.ts
@@ -59,7 +59,7 @@ describe('Performance Benchmarks', () => {
     const kid = '2025-01-26T12:00:00Z';
 
     // Generate test receipt
-    const testJWS = await issue({
+    const testResult = await issue({
       iss: 'https://api.example.com',
       aud: 'https://app.example.com',
       amt: 9999,
@@ -70,15 +70,16 @@ describe('Performance Benchmarks', () => {
       privateKey,
       kid,
     });
+    const testJWS = testResult.jws;
 
     // Warmup (10 iterations)
-    console.log('⏱️  Warmup: 10 iterations...');
+    console.log('Warmup: 10 iterations...');
     for (let i = 0; i < 10; i++) {
       await jwsVerify(testJWS, publicKey);
     }
 
     // Benchmark (1000 iterations)
-    console.log('📊 Benchmark: 1000 iterations...\n');
+    console.log('Benchmark: 1000 iterations...\n');
     const timings: number[] = [];
 
     for (let i = 0; i < 1000; i++) {
@@ -94,12 +95,12 @@ describe('Performance Benchmarks', () => {
     const metrics = calculateMetrics(timings);
 
     // Display results
-    console.log('📈 Performance Metrics:');
+    console.log('Performance Metrics:');
     console.log(`   Min:  ${metrics.min_ms.toFixed(2)}ms`);
     console.log(`   Max:  ${metrics.max_ms.toFixed(2)}ms`);
     console.log(`   Mean: ${metrics.mean_ms.toFixed(2)}ms`);
     console.log(`   p50:  ${metrics.p50_ms.toFixed(2)}ms`);
-    console.log(`   p95:  ${metrics.p95_ms.toFixed(2)}ms (GATE: ≤10ms)`);
+    console.log(`   p95:  ${metrics.p95_ms.toFixed(2)}ms (GATE: <=10ms)`);
     console.log(`   p99:  ${metrics.p99_ms.toFixed(2)}ms`);
     console.log(`   Iterations: ${metrics.iterations}\n`);
 
@@ -108,12 +109,12 @@ describe('Performance Benchmarks', () => {
     fs.writeFileSync(metricsPath, JSON.stringify(metrics, null, 2));
     console.log(`Metrics saved to: ${metricsPath}\n`);
 
-    // CRITICAL CI GATE: p95 MUST be ≤ 10ms
+    // CRITICAL CI GATE: p95 MUST be <= 10ms
     if (metrics.p95_ms > 10) {
       console.error(`[FAIL] PERFORMANCE GATE FAILED: p95 (${metrics.p95_ms.toFixed(2)}ms) > 10ms`);
       expect(metrics.p95_ms).toBeLessThanOrEqual(10);
     } else {
-      console.log(`[OK] PERFORMANCE GATE PASSED: p95 (${metrics.p95_ms.toFixed(2)}ms) ≤ 10ms`);
+      console.log(`[OK] PERFORMANCE GATE PASSED: p95 (${metrics.p95_ms.toFixed(2)}ms) <= 10ms`);
     }
 
     // Aspirational targets (warnings, not failures)
@@ -126,14 +127,14 @@ describe('Performance Benchmarks', () => {
     }
   });
 
-  it('issue p95 SHOULD be ≤ 50ms', async () => {
+  it('issue p95 SHOULD be <= 50ms', async () => {
     console.log('\nStarting issuance performance benchmark...\n');
 
     const { privateKey } = await generateKeypair();
     const kid = '2025-01-26T12:00:00Z';
 
     // Warmup
-    console.log('⏱️  Warmup: 10 iterations...');
+    console.log('Warmup: 10 iterations...');
     for (let i = 0; i < 10; i++) {
       await issue({
         iss: 'https://api.example.com',
@@ -148,7 +149,7 @@ describe('Performance Benchmarks', () => {
     }
 
     // Benchmark
-    console.log('📊 Benchmark: 1000 iterations...\n');
+    console.log('Benchmark: 1000 iterations...\n');
     const timings: number[] = [];
 
     for (let i = 0; i < 1000; i++) {
@@ -169,22 +170,22 @@ describe('Performance Benchmarks', () => {
 
     const metrics = calculateMetrics(timings);
 
-    console.log('📈 Issuance Performance:');
+    console.log('Issuance Performance:');
     console.log(`   Min:  ${metrics.min_ms.toFixed(2)}ms`);
     console.log(`   Mean: ${metrics.mean_ms.toFixed(2)}ms`);
     console.log(`   p50:  ${metrics.p50_ms.toFixed(2)}ms`);
-    console.log(`   p95:  ${metrics.p95_ms.toFixed(2)}ms (target: ≤50ms)`);
+    console.log(`   p95:  ${metrics.p95_ms.toFixed(2)}ms (target: <=50ms)`);
     console.log(`   p99:  ${metrics.p99_ms.toFixed(2)}ms\n`);
 
     // Soft target (warning, not failure)
     if (metrics.p95_ms > 50) {
       console.warn(`[WARN]  Issue p95 (${metrics.p95_ms.toFixed(2)}ms) > 50ms (target)`);
     } else {
-      console.log(`[OK] Issue p95 (${metrics.p95_ms.toFixed(2)}ms) ≤ 50ms`);
+      console.log(`[OK] Issue p95 (${metrics.p95_ms.toFixed(2)}ms) <= 50ms`);
     }
   });
 
-  it('JCS canonicalization p95 SHOULD be ≤ 1ms', async () => {
+  it('JCS canonicalization p95 SHOULD be <= 1ms', async () => {
     console.log('\nStarting JCS canonicalization benchmark...\n');
 
     const { canonicalize } = await import('../../packages/crypto/src/jcs');
@@ -220,17 +221,17 @@ describe('Performance Benchmarks', () => {
 
     const metrics = calculateMetrics(timings);
 
-    console.log('📈 JCS Canonicalization Performance:');
+    console.log('JCS Canonicalization Performance:');
     console.log(`   Min:  ${metrics.min_ms.toFixed(3)}ms`);
     console.log(`   Mean: ${metrics.mean_ms.toFixed(3)}ms`);
     console.log(`   p50:  ${metrics.p50_ms.toFixed(3)}ms`);
-    console.log(`   p95:  ${metrics.p95_ms.toFixed(3)}ms (target: ≤1ms)`);
+    console.log(`   p95:  ${metrics.p95_ms.toFixed(3)}ms (target: <=1ms)`);
     console.log(`   p99:  ${metrics.p99_ms.toFixed(3)}ms\n`);
 
     if (metrics.p95_ms > 1) {
       console.warn(`[WARN]  JCS p95 (${metrics.p95_ms.toFixed(3)}ms) > 1ms (target)`);
     } else {
-      console.log(`[OK] JCS p95 (${metrics.p95_ms.toFixed(3)}ms) ≤ 1ms`);
+      console.log(`[OK] JCS p95 (${metrics.p95_ms.toFixed(3)}ms) <= 1ms`);
     }
   });
 });

--- a/tests/vectors/negative.spec.ts
+++ b/tests/vectors/negative.spec.ts
@@ -17,7 +17,7 @@ describe('Negative Test Vectors', () => {
       const { privateKey } = await generateKeypair();
 
       // Issue valid receipt
-      const validJWS = await issue({
+      const result = await issue({
         iss: 'https://api.example.com',
         aud: 'https://app.example.com',
         amt: 9999,
@@ -27,6 +27,7 @@ describe('Negative Test Vectors', () => {
         privateKey,
         kid: '2025-01-26T12:00:00Z',
       });
+      const validJWS = result.jws;
 
       // Tamper with signature (flip one bit)
       const parts = validJWS.split('.');
@@ -46,7 +47,7 @@ describe('Negative Test Vectors', () => {
     it('MUST reject receipt with completely invalid signature', async () => {
       const { privateKey, publicKey } = await generateKeypair();
 
-      const validJWS = await issue({
+      const result = await issue({
         iss: 'https://api.example.com',
         aud: 'https://app.example.com',
         amt: 9999,
@@ -56,6 +57,7 @@ describe('Negative Test Vectors', () => {
         privateKey,
         kid: '2025-01-26T12:00:00Z',
       });
+      const validJWS = result.jws;
 
       // Replace signature with garbage
       const parts = validJWS.split('.');
@@ -73,7 +75,7 @@ describe('Negative Test Vectors', () => {
       const { privateKey, publicKey } = await generateKeypair();
 
       // Issue receipt for 9999
-      const validJWS = await issue({
+      const result = await issue({
         iss: 'https://api.example.com',
         aud: 'https://app.example.com',
         amt: 9999,
@@ -83,6 +85,7 @@ describe('Negative Test Vectors', () => {
         privateKey,
         kid: '2025-01-26T12:00:00Z',
       });
+      const validJWS = result.jws;
 
       // Decode and modify amount
       const { payload } = decode<PEACReceiptClaims>(validJWS);
@@ -103,7 +106,7 @@ describe('Negative Test Vectors', () => {
     it('MUST reject receipt with modified recipient (aud)', async () => {
       const { privateKey, publicKey } = await generateKeypair();
 
-      const validJWS = await issue({
+      const result = await issue({
         iss: 'https://api.example.com',
         aud: 'https://legitimate.example.com',
         amt: 9999,
@@ -113,6 +116,7 @@ describe('Negative Test Vectors', () => {
         privateKey,
         kid: '2025-01-26T12:00:00Z',
       });
+      const validJWS = result.jws;
 
       // Tamper with audience
       const { payload } = decode<PEACReceiptClaims>(validJWS);
@@ -131,7 +135,7 @@ describe('Negative Test Vectors', () => {
     it('MUST reject receipt with modified payment scheme', async () => {
       const { privateKey, publicKey } = await generateKeypair();
 
-      const validJWS = await issue({
+      const result = await issue({
         iss: 'https://api.example.com',
         aud: 'https://app.example.com',
         amt: 9999,
@@ -141,8 +145,9 @@ describe('Negative Test Vectors', () => {
         privateKey,
         kid: '2025-01-26T12:00:00Z',
       });
+      const validJWS = result.jws;
 
-      // Tamper with payment scheme (Stripe → x402)
+      // Tamper with payment scheme (Stripe -> x402)
       const { payload } = decode<PEACReceiptClaims>(validJWS);
       const tamperedPayload = {
         ...payload,
@@ -261,7 +266,7 @@ describe('Negative Test Vectors', () => {
       const { privateKey } = await generateKeypair();
 
       // Issue receipt that expired 1 hour ago
-      const expiredJWS = await issue({
+      const result = await issue({
         iss: 'https://api.example.com',
         aud: 'https://app.example.com',
         amt: 9999,
@@ -272,6 +277,7 @@ describe('Negative Test Vectors', () => {
         privateKey,
         kid: '2025-01-26T12:00:00Z',
       });
+      const expiredJWS = result.jws;
 
       // Note: verifyReceipt would check expiry, but it requires JWKS fetch
       // For now, we just verify the JWS was created with exp in the past
@@ -346,7 +352,7 @@ describe('Negative Test Vectors', () => {
       const { privateKey: privKey1 } = await generateKeypair();
       const { publicKey: pubKey2 } = await generateKeypair(); // Different keypair!
 
-      const jws = await issue({
+      const issueResult = await issue({
         iss: 'https://api.example.com',
         aud: 'https://app.example.com',
         amt: 9999,
@@ -358,7 +364,7 @@ describe('Negative Test Vectors', () => {
       });
 
       // Verify with wrong public key
-      const result = await jwsVerify(jws, pubKey2);
+      const result = await jwsVerify(issueResult.jws, pubKey2);
 
       expect(result.valid).toBe(false);
 


### PR DESCRIPTION
## Summary
- Add optional `subject_snapshot?: SubjectProfileSnapshot` to `AuthContext` (envelope-level, not JWS claims)
- Add `validateSubjectSnapshot()` helper with PII warning (deduplicated)
- Update `issue()` to accept subject_snapshot, return `IssueResult { jws, subject_snapshot? }`
- Update `verify()` to accept and return subject_snapshot in response

## Key Design Decisions
- **Placement**: `auth.subject_snapshot` (not root-level) for envelope structure consistency
- **Not signed**: Envelope metadata outside JWS claims to keep cryptographic surface small
- **Wire format unchanged**: `peac.receipt/0.9` remains frozen

## Test plan
- [x] 8 golden tests for subject snapshots (human, org, agent, absent, invalid)
- [x] PII warning deduplication test
- [x] All existing tests updated for new `IssueResult` return type
- [x] Conformance, performance, and negative tests pass
- [x] All gates pass (lint, build, typecheck:core, test:core)

## References
- P0.2 in v0.9.17 scope
- PROTOCOL-BEHAVIOR.md Section 8.5