### PR TITLE
chore: release v0.9.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to PEAC Protocol will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.17] - Unreleased
+## [0.9.17] - 2025-12-14
 
 ### Added
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-api",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "PEAC Protocol API server with OpenAPI 3.1, RFC 9457 Problem Details, and content negotiation",
   "type": "module",
   "main": "dist/index.js",

--- a/apps/bridge/package.json
+++ b/apps/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-bridge",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "PEAC Protocol Bridge - Local development sidecar",
   "type": "module",
   "main": "dist/server.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/monorepo",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "private": true,
   "description": "PEAC Protocol - Cryptographic receipts for agentic commerce",
   "repository": {

--- a/packages/access/package.json
+++ b/packages/access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/access",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "PEAC access pillar (placeholder for v0.9.18+)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/aipref/package.json
+++ b/packages/aipref/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/pref",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "AIPREF resolver with robots.txt bridge",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/attribution/package.json
+++ b/packages/attribution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/attribution",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "PEAC attribution pillar (placeholder for v0.9.18+)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/cli",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "PEAC protocol command-line tools",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/compliance/package.json
+++ b/packages/compliance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/compliance",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "PEAC compliance pillar (placeholder for v0.9.18+)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/consent/package.json
+++ b/packages/consent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/consent",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "PEAC consent pillar (placeholder for v0.9.18+)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/control/package.json
+++ b/packages/control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/control",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "PEAC Protocol Control - control engine interfaces and validation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/core",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "DEPRECATED - Use @peac/kernel, @peac/schema, @peac/crypto, @peac/protocol instead",
   "type": "module",
   "homepage": "https://peacprotocol.org",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/crypto",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "Ed25519 JWS signing and verification for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/disc",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "PEAC discovery with ≤20 lines enforcement",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/intelligence/package.json
+++ b/packages/intelligence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/intelligence",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "PEAC intelligence pillar (placeholder for v0.9.18+)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/kernel",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "PEAC protocol kernel - normative constants, errors, and registries",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/mappings/acp/package.json
+++ b/packages/mappings/acp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-acp",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "Agentic Commerce Protocol (ACP) integration for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/mcp/package.json
+++ b/packages/mappings/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-mcp",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "Model Context Protocol (MCP) integration for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/pay402/package.json
+++ b/packages/pay402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/pay402",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "Generic HTTP 402 adapter with multi-rail payment negotiation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/privacy/package.json
+++ b/packages/privacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/privacy",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "Privacy pillar for PEAC protocol - privacy budgeting, data protection, and privacy-preserving receipts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/protocol",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "PEAC protocol implementation - receipt issuance and verification",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/provenance/package.json
+++ b/packages/provenance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/provenance",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "Provenance pillar for PEAC protocol - content provenance, C2PA integration, and chain-of-custody",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rails/stripe/package.json
+++ b/packages/rails/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-stripe",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "Stripe payment rail adapter for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rails/x402/package.json
+++ b/packages/rails/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-x402",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "x402 payment rail adapter for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/receipts/package.json
+++ b/packages/receipts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/receipts",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "PEAC Protocol receipt builders, parsers, and validators with CBOR support",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/schema",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "PEAC Protocol JSON schemas, OpenAPI specs, and TypeScript types",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/sdk",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "PEAC client SDK with discover/verify functions",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/server",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "PEAC verification server with DoS protection and rate limiting",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Bump all package versions from 0.9.16 to 0.9.17
- Finalize CHANGELOG.md with release date (2025-12-14)

## What's in v0.9.17

- **x402 v2 Adapter**: Full x402 v2 compatibility with v1 fallback (`X402Dialect = 'v1' | 'v2' | 'auto'`)
- **RSL 1.0 Alignment**: Extended `ControlPurpose` with RSL tokens (`ai_input`, `ai_search`, `search`), new `@peac/mappings-rsl` package
- **Subject Binding**: Optional `subject_snapshot` on `AuthContext` for identity context at issuance
- **issueJws()**: Convenience wrapper returning just the JWS string for header-centric flows
- **Policy Kit v0.1**: New `@peac/policy-kit` package for deterministic CAL policy evaluation
  - YAML/JSON policy format with first-match-wins rule semantics
  - Compile to deployment artifacts: `peac.txt`, `robots-ai-snippet.txt`, `aipref-headers.json`, `ai-policy.md`
  - Configurable receipts (`required` | `optional` | `omit`) with sensible defaults
- **CLI Policy Commands**: `peac policy init`, `peac policy validate`, `peac policy explain`, `peac policy generate`
  - `--dry-run` for safe preview without writing files
  - `--well-known` to output peac.txt to `.well-known/` subdirectory

## Breaking Changes

- `issue()` now returns `IssueResult { jws, subject_snapshot? }` instead of `string`
- Migration path documented in CHANGELOG.md

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm build` passes  
- [x] `pnpm typecheck:core` passes
- [x] `pnpm test:core` passes (122 tests)
- [x] `pnpm format:check` passes