### PR TITLE
chore: post-release hygiene for v0.9.17

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,15 @@ peac/
 3. **Development**: Follow coding standards and test coverage requirements
 4. **Testing**: Ensure all tests pass and coverage is maintained
 5. **Pull Request**: Submit PR with clear description
+6. **Merge**: Maintainers merge PRs manually on GitHub (see below)
+
+### Git Safety Rules
+
+- **Never merge PRs from terminal** - Do not use `gh pr merge`, `git merge`, or any CLI merge command
+- PRs are **always merged manually on GitHub** web interface by maintainers
+- Contributors: create branch, commit, push, open PR via `gh pr create`
+- Tags are created **only after** PR is merged and confirmed on GitHub
+- Never force push to any branch, especially `main`
 
 ## Development Standards
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ Libraries in this repo are structured so that you do not need to hand parse ever
 
 ### Policy Kit (v0.9.17+)
 
+> **Start here:** [docs/policy-kit/quickstart.md](docs/policy-kit/quickstart.md)
+
 The `@peac/policy-kit` package provides a file-based policy format for authoring policies once and compiling them to multiple deployment surfaces.
 
 **Install:**

--- a/docs/CANONICAL_DOCS_INDEX.md
+++ b/docs/CANONICAL_DOCS_INDEX.md
@@ -1,6 +1,6 @@
 # PEAC Protocol - Canonical Documentation Index
 
-**Version:** 0.9.15
+**Version:** 0.9.17
 **Status:** Authoritative
 
 This document defines which documentation files are the canonical, up-to-date references for the PEAC Protocol.
@@ -38,6 +38,14 @@ This document defines which documentation files are the canonical, up-to-date re
 | ---------------------------------- | ----------------- | -------------------------- |
 | [ARCHITECTURE.md](ARCHITECTURE.md) | **Authoritative** | Kernel-first DAG, layering |
 | [CI_BEHAVIOR.md](CI_BEHAVIOR.md)   | **Authoritative** | CI pipeline behavior       |
+| [QA.md](QA.md)                     | **Reference**     | Manual QA checklist        |
+| [deps-policy.md](deps-policy.md)   | **Reference**     | Dependency update policy   |
+
+### Policy Kit
+
+| Document                                             | Status            | Purpose                    |
+| ---------------------------------------------------- | ----------------- | -------------------------- |
+| [policy-kit/quickstart.md](policy-kit/quickstart.md) | **Authoritative** | Policy Kit getting started |
 
 ---
 

--- a/docs/QA.md
+++ b/docs/QA.md
@@ -1,0 +1,116 @@
+# Manual QA Checklist
+
+This document provides a manual QA checklist for validating PEAC Protocol releases.
+
+## Pre-Release Checklist
+
+Run these checks before tagging a new release:
+
+### 1. Build and Test
+
+```bash
+# Clean install
+rm -rf node_modules pnpm-lock.yaml
+pnpm install
+
+# Build all packages
+pnpm build
+
+# Run core tests (must pass)
+pnpm test:core
+
+# Run full test suite
+pnpm test
+
+# TypeScript checks
+pnpm typecheck:core    # Blocking - must pass
+pnpm typecheck:legacy  # Advisory
+```
+
+### 2. Lint and Format
+
+```bash
+# ESLint
+pnpm lint
+
+# Prettier format check
+pnpm format:check
+```
+
+### 3. Policy Kit CLI
+
+```bash
+# Initialize a policy file
+peac policy init
+
+# Validate the generated policy
+peac policy validate peac-policy.yaml
+
+# Explain a rule
+peac policy explain peac-policy.yaml --subject-type agent --purpose train
+
+# Generate artifacts (dry run)
+peac policy generate peac-policy.yaml --well-known --dry-run
+
+# Generate artifacts (write files)
+peac policy generate peac-policy.yaml --well-known --out dist/peac
+```
+
+### 4. Version Consistency
+
+```bash
+# Check all packages have the same version
+grep -r '"version":' package.json packages/*/package.json | grep -v node_modules
+
+# Search for stale version references (update version numbers as needed)
+rg "0\.9\.16|v0\.9\.16" --glob '!CHANGELOG.md' --glob '!archive/**' --glob '!pnpm-lock.yaml'
+```
+
+### 5. Guard Scripts
+
+```bash
+# Domain guard (no peac.dev references)
+./scripts/guard.sh
+
+# Planning leak check
+./scripts/check-planning-leak.sh
+```
+
+## Post-Release Verification
+
+After tagging and pushing a release:
+
+### 1. Verify Tag
+
+```bash
+git tag -l 'v0.9.*' | tail -5
+git log --oneline -3 origin/main
+```
+
+### 2. Smoke Test Install (optional)
+
+```bash
+# In a fresh directory
+mkdir /tmp/peac-test && cd /tmp/peac-test
+pnpm init
+pnpm add @peac/protocol @peac/schema @peac/crypto
+# Verify packages install correctly
+```
+
+## CI Validation
+
+The following CI checks run automatically on every PR:
+
+| Check               | Command                 | Status   |
+| ------------------- | ----------------------- | -------- |
+| Format              | `pnpm format:check`     | Blocking |
+| Lint                | `pnpm lint`             | Blocking |
+| Domain Guard        | `scripts/guard.sh`      | Blocking |
+| TypeScript (core)   | `pnpm typecheck:core`   | Blocking |
+| TypeScript (legacy) | `pnpm typecheck:legacy` | Advisory |
+| Build               | `pnpm build`            | Blocking |
+| Core Tests          | `pnpm test:core`        | Blocking |
+| Conformance         | `tests/conformance/`    | Blocking |
+| Performance         | P95 verify <=5ms        | Advisory |
+
+See [CI_BEHAVIOR.md](./CI_BEHAVIOR.md) for detailed CI documentation.

--- a/docs/deps-policy.md
+++ b/docs/deps-policy.md
@@ -1,0 +1,79 @@
+# Dependency Management Policy
+
+This document describes how we manage dependency updates in the PEAC Protocol monorepo.
+
+## Risk Classification
+
+### Group 1: Low Risk (Patch/Minor)
+
+- Patch updates to any dependency
+- Minor updates to dev-only dependencies (prettier, eslint plugins, vitest)
+- Minor updates to well-tested utilities (lodash, date-fns)
+
+**Process:** Merge individually after CI passes. One PR at a time.
+
+### Group 2: High Risk (Requires Review)
+
+- Minor updates to core runtime deps:
+  - `zod` (schema validation)
+  - `@noble/ed25519` (cryptography)
+  - Any package in `@peac/crypto`, `@peac/schema`, `@peac/protocol`
+- Any update that changes test snapshots or golden files
+- Updates to TypeScript compiler
+
+**Process:** Review changes carefully. Run full test suite locally. Document any behavior changes.
+
+### Group 3: Major Updates (Project-Level)
+
+- Major version bumps to any dependency
+- Updates that require code changes to compile
+- Updates with known breaking changes
+
+**Process:** Close the dependabot PR. Create a dedicated issue/RFC. Implement in a feature branch with migration notes.
+
+## Decision Rules
+
+1. **Never bundle multiple major upgrades** in a single PR
+2. **If golden tests change**, explicitly review and document why
+3. **Core runtime deps** (crypto, schema, protocol) are high risk even for minor updates
+4. **Tooling-only updates** (prettier, lint config) can be grouped if tests pass
+5. **Security updates** take priority but still follow the review process
+
+## Merge Process
+
+For each dependabot PR:
+
+1. Wait for CI to complete and pass
+2. Classify the update by risk group
+3. For Group 1 (low risk):
+   - Verify CI green
+   - Optionally run `pnpm build && pnpm test:core` locally
+   - Merge with message: `chore(deps): bump <pkg> from x to y`
+4. For Group 2 (high risk):
+   - Run full test suite locally
+   - Review changelog of the dependency
+   - Document any behavior changes in PR description
+   - Merge with detailed message
+5. For Group 3 (major):
+   - Close the PR
+   - Open an issue: "Upgrade <pkg> to vX"
+   - Plan the upgrade as a mini-project
+
+## Automation (Future)
+
+Consider these improvements if dependabot PR volume becomes high:
+
+- Group low-risk PRs into weekly batches
+- Separate runtime deps from dev deps in dependabot config
+- Auto-merge patch updates to dev dependencies
+- Disable auto-PRs for major versions
+
+## Security Updates
+
+Security updates are prioritized but still follow review:
+
+1. **Critical/High severity**: Review and merge within 24 hours
+2. **Medium severity**: Review and merge within 1 week
+3. **Low severity**: Batch with regular updates
+
+Always verify the security advisory is legitimate before merging.

--- a/docs/policy-kit/quickstart.md
+++ b/docs/policy-kit/quickstart.md
@@ -1,0 +1,214 @@
+# Policy Kit Quickstart
+
+PEAC Policy Kit lets you define access policies for AI agents in a simple YAML file, then compile them into deployable artifacts that crawlers and agents can discover.
+
+**Flow:** `peac-policy.yaml` -> validate -> generate -> deploy artifacts
+
+## Install
+
+```bash
+# From the PEAC monorepo
+pnpm add @peac/cli
+
+# Or use directly from the repo
+pnpm --filter @peac/cli build
+```
+
+## Quick Start
+
+### 1. Initialize a Policy File
+
+```bash
+peac policy init
+```
+
+This creates `peac-policy.yaml` with a minimal open policy.
+
+### 2. Edit Your Policy
+
+```yaml
+# peac-policy.yaml
+version: 'peac-policy/0.1'
+
+defaults:
+  decision: allow # or "deny" for restrictive default
+
+rules:
+  - name: block-training
+    purpose: train
+    decision: deny
+
+  - name: allow-search-bots
+    subject:
+      type: agent
+      labels: [search-bot]
+    purpose: [crawl, index]
+    decision: allow
+```
+
+### 3. Validate the Policy
+
+```bash
+peac policy validate peac-policy.yaml
+
+# Verbose output
+peac policy validate peac-policy.yaml --verbose
+```
+
+### 4. Preview Generated Artifacts
+
+```bash
+peac policy generate peac-policy.yaml --well-known --dry-run
+```
+
+This shows what would be generated without writing files.
+
+### 5. Generate Artifacts
+
+```bash
+peac policy generate peac-policy.yaml --well-known --out dist/peac
+```
+
+### 6. Deploy
+
+Copy the generated files to your web server:
+
+```bash
+cp dist/peac/.well-known/peac.txt /.well-known/peac.txt
+```
+
+## Generated Artifacts
+
+| File                    | Purpose                     | Deploy To               |
+| ----------------------- | --------------------------- | ----------------------- |
+| `.well-known/peac.txt`  | Authoritative policy signal | `/.well-known/peac.txt` |
+| `robots-ai-snippet.txt` | Robots.txt additions        | Append to `/robots.txt` |
+| `aipref-headers.json`   | AIPREF-compatible headers   | HTTP middleware         |
+| `ai-policy.md`          | Human-readable summary      | Documentation           |
+
+**Note:** `peac.txt` is the source of truth. Other artifacts are for compatibility.
+
+## Common Recipes
+
+### Open Policy (Allow Everything)
+
+```yaml
+version: 'peac-policy/0.1'
+defaults:
+  decision: allow
+rules: []
+```
+
+Generated `peac.txt`:
+
+```
+version: 0.9
+usage: open
+receipts: optional
+```
+
+### Conditional Policy (Deny by Default)
+
+```yaml
+version: 'peac-policy/0.1'
+defaults:
+  decision: deny
+
+rules:
+  - name: allow-search
+    purpose: [crawl, index, search]
+    decision: allow
+
+  - name: allow-inference-with-receipt
+    purpose: inference
+    decision: allow
+```
+
+Generated `peac.txt`:
+
+```
+version: 0.9
+usage: conditional
+purposes: [crawl, index, inference, search]
+receipts: required
+```
+
+### Require Receipts
+
+```bash
+peac policy generate peac-policy.yaml --receipts required
+```
+
+Or override in the command:
+
+```bash
+peac policy generate peac-policy.yaml --receipts optional
+peac policy generate peac-policy.yaml --receipts omit
+```
+
+### Add Rate Limiting
+
+```bash
+peac policy generate peac-policy.yaml --rate-limit "100/hour"
+```
+
+### Add Negotiation URL
+
+```bash
+peac policy generate peac-policy.yaml --negotiate "https://example.com/negotiate"
+```
+
+### Add Contact Info
+
+```bash
+peac policy generate peac-policy.yaml --contact "licensing@example.com"
+```
+
+## Debugging
+
+### Explain a Specific Rule Match
+
+```bash
+# What decision applies for an agent doing training?
+peac policy explain peac-policy.yaml --subject-type agent --purpose train
+
+# What about a human doing inference?
+peac policy explain peac-policy.yaml --subject-type human --purpose inference
+```
+
+### Common Validation Errors
+
+| Error                 | Cause                          | Fix                                                                            |
+| --------------------- | ------------------------------ | ------------------------------------------------------------------------------ |
+| `Invalid version`     | Missing or wrong version field | Use `version: "peac-policy/0.1"`                                               |
+| `Unknown purpose`     | Typo in purpose name           | Use: `crawl`, `index`, `train`, `inference`, `ai_input`, `ai_search`, `search` |
+| `Duplicate rule name` | Two rules with same name       | Use unique names for each rule                                                 |
+
+### What `--dry-run` Shows
+
+```
+=== DRY RUN ===
+Would write: dist/peac/.well-known/peac.txt
+---
+version: 0.9
+usage: conditional
+purposes: [crawl, index, train]
+receipts: required
+---
+
+Would write: dist/peac/robots-ai-snippet.txt
+...
+```
+
+## Safety Notes
+
+1. **Rule order matters** - First matching rule wins (like firewall rules)
+2. **Robots snippet is conservative** - Review before appending to `robots.txt`
+3. **AIPREF output is for compatibility** - `peac.txt` is the authoritative source
+4. **Test with `--dry-run` first** - Always preview before writing files
+
+## Next Steps
+
+- [Policy Kit API Reference](../api-reference.md)
+- [PROTOCOL-BEHAVIOR.md](../specs/PROTOCOL-BEHAVIOR.md) - Protocol specification
+- [README](../../README.md) - Full documentation


### PR DESCRIPTION
## Summary

Post-release housekeeping for v0.9.17:

- Add Git Safety Rules to CONTRIBUTING.md
- Add `docs/QA.md` with manual QA checklist for releases
- Add `docs/deps-policy.md` with dependency update policy
- Add `docs/policy-kit/quickstart.md` with Policy Kit getting started guide
- Update `docs/CANONICAL_DOCS_INDEX.md` to v0.9.17 with new docs
- Add quickstart link to README Policy Kit section

## New Documentation

| File | Purpose |
|------|---------|
| `docs/QA.md` | Manual QA checklist for pre/post release validation |
| `docs/deps-policy.md` | Policy for triaging dependabot PRs by risk level |
| `docs/policy-kit/quickstart.md` | Copy-paste getting started guide for Policy Kit |

## Test plan

- [x] `pnpm format:check` passes
- [x] `pnpm lint` passes
- [ ] Docs render correctly on GitHub