### PR TITLE
fix(docs): correct TAP terminology (Trusted Agent Protocol)

### DIFF
--- a/docs/specs/PEAC-HTTP402-PROFILE.md
+++ b/docs/specs/PEAC-HTTP402-PROFILE.md
@@ -234,7 +234,7 @@ PEAC is NOT limited to HTTP 402. Other enforcement methods:
 }
 ```
 
-### 7.2 TAP (Token Authentication Protocol)
+### 7.2 TAP (Trusted Agent Protocol)
 
 ```json
 {

--- a/docs/specs/registries.json
+++ b/docs/specs/registries.json
@@ -102,7 +102,7 @@
     {
       "id": "tap",
       "category": "card-protocol",
-      "description": "Token Authentication Protocol (Visa TAP)",
+      "description": "Trusted Agent Protocol (Visa TAP)",
       "reference": "https://developer.visa.com/",
       "status": "informational"
     }

--- a/packages/kernel/src/registries.ts
+++ b/packages/kernel/src/registries.ts
@@ -133,7 +133,7 @@ export const AGENT_PROTOCOLS: readonly AgentProtocolEntry[] = [
   {
     id: 'tap',
     category: 'card-protocol',
-    description: 'Token Authentication Protocol (Visa TAP)',
+    description: 'Trusted Agent Protocol (Visa TAP)',
     reference: 'https://developer.visa.com/',
     status: 'informational',
   },

--- a/packages/schema/src/control.ts
+++ b/packages/schema/src/control.ts
@@ -88,7 +88,7 @@ export interface ControlStep {
    *
    * Well-known engines:
    * - "spend-control-service" - Spend control mandate engine
-   * - "visa-tap" - Visa Token Authentication Protocol
+   * - "visa-tap" - Visa Trusted Agent Protocol
    * - "google-ap2" - Google Agent Protocol v2
    * - "risk-engine" - Risk scoring
    * - "merchant-policy" - Merchant-specific policy

--- a/specs/kernel/registries.json
+++ b/specs/kernel/registries.json
@@ -103,7 +103,7 @@
     {
       "id": "tap",
       "category": "card-protocol",
-      "description": "Token Authentication Protocol (Visa TAP)",
+      "description": "Trusted Agent Protocol (Visa TAP)",
       "reference": "https://developer.visa.com/",
       "status": "informational"
     }


### PR DESCRIPTION
## Summary

- Correct TAP terminology: "Trusted Agent Protocol"

## Files Changed

- `docs/specs/PEAC-HTTP402-PROFILE.md`
- `docs/specs/registries.json`
- `specs/kernel/registries.json`
- `packages/kernel/src/registries.ts`
- `packages/schema/src/control.ts`

## Test plan

- [x] `pnpm format:check` - passed
- [x] `pnpm lint` - passed
- [x] `pnpm typecheck:core` - passed
- [x] `pnpm test:core` - passed
- [x] `./scripts/guard.sh` - passed
- [x] `./scripts/check-planning-leak.sh` - passed
- [x] `rg "Token Authentication"` returns no matches