### PR TITLE
chore(npm): normalize package metadata

### DIFF
--- a/packages/access/package.json
+++ b/packages/access/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@peac/access",
   "version": "0.9.17",
+  "private": true,
   "description": "PEAC access pillar (placeholder for v0.9.18+)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/aipref/package.json
+++ b/packages/aipref/package.json
@@ -33,7 +33,18 @@
     "robots",
     "preferences"
   ],
-  "license": "MIT",
-  "repository": "https://github.com/peac-protocol/peac",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/peacprotocol/peac.git",
+    "directory": "packages/aipref"
+  },
+  "bugs": {
+    "url": "https://github.com/peacprotocol/peac/issues"
+  },
+  "homepage": "https://github.com/peacprotocol/peac#readme",
+  "publishConfig": {
+    "access": "public"
+  },
   "sideEffects": false
 }

--- a/packages/attribution/package.json
+++ b/packages/attribution/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@peac/attribution",
   "version": "0.9.17",
+  "private": true,
   "description": "PEAC attribution pillar (placeholder for v0.9.18+)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,6 +14,17 @@
   },
   "author": "jithinraj <7850727+jithinraj@users.noreply.github.com>",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/peacprotocol/peac/issues"
+  },
+  "homepage": "https://github.com/peacprotocol/peac#readme",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "test": "vitest run",

--- a/packages/compliance/package.json
+++ b/packages/compliance/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@peac/compliance",
   "version": "0.9.17",
+  "private": true,
   "description": "PEAC compliance pillar (placeholder for v0.9.18+)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/consent/package.json
+++ b/packages/consent/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@peac/consent",
   "version": "0.9.17",
+  "private": true,
   "description": "PEAC consent pillar (placeholder for v0.9.18+)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/control/package.json
+++ b/packages/control/package.json
@@ -10,7 +10,14 @@
     "directory": "packages/control"
   },
   "author": "jithinraj <7850727+jithinraj@users.noreply.github.com>",
-  "license": "MIT",
+  "license": "Apache-2.0",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "test": "vitest run",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,11 @@
   "bugs": {
     "url": "https://github.com/peacprotocol/peac/issues"
   },
-  "repository": "https://github.com/peacprotocol/peac",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/peacprotocol/peac.git",
+    "directory": "packages/core"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -11,6 +11,17 @@
   },
   "author": "jithinraj <7850727+jithinraj@users.noreply.github.com>",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/peacprotocol/peac/issues"
+  },
+  "homepage": "https://github.com/peacprotocol/peac#readme",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "test": "vitest run",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -36,7 +36,18 @@
     "well-known",
     "abnf"
   ],
-  "license": "MIT",
-  "repository": "https://github.com/peac-protocol/peac",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/peacprotocol/peac.git",
+    "directory": "packages/discovery"
+  },
+  "bugs": {
+    "url": "https://github.com/peacprotocol/peac/issues"
+  },
+  "homepage": "https://github.com/peacprotocol/peac#readme",
+  "publishConfig": {
+    "access": "public"
+  },
   "sideEffects": false
 }

--- a/packages/intelligence/package.json
+++ b/packages/intelligence/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@peac/intelligence",
   "version": "0.9.17",
+  "private": true,
   "description": "PEAC intelligence pillar (placeholder for v0.9.18+)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -51,6 +51,22 @@
   ],
   "author": "PEAC Protocol Contributors",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/peacprotocol/peac.git",
+    "directory": "packages/kernel"
+  },
+  "bugs": {
+    "url": "https://github.com/peacprotocol/peac/issues"
+  },
+  "homepage": "https://github.com/peacprotocol/peac#readme",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "typescript": "^5.6.2"
   }

--- a/packages/mappings/acp/package.json
+++ b/packages/mappings/acp/package.json
@@ -11,6 +11,17 @@
   },
   "author": "jithinraj <7850727+jithinraj@users.noreply.github.com>",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/peacprotocol/peac/issues"
+  },
+  "homepage": "https://github.com/peacprotocol/peac#readme",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "test": "vitest run",

--- a/packages/mappings/mcp/package.json
+++ b/packages/mappings/mcp/package.json
@@ -11,6 +11,17 @@
   },
   "author": "jithinraj <7850727+jithinraj@users.noreply.github.com>",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/peacprotocol/peac/issues"
+  },
+  "homepage": "https://github.com/peacprotocol/peac#readme",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "test": "vitest run",

--- a/packages/mappings/rsl/package.json
+++ b/packages/mappings/rsl/package.json
@@ -11,6 +11,17 @@
   },
   "author": "jithinraj <7850727+jithinraj@users.noreply.github.com>",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/peacprotocol/peac/issues"
+  },
+  "homepage": "https://github.com/peacprotocol/peac#readme",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "test": "vitest run",

--- a/packages/pay402/package.json
+++ b/packages/pay402/package.json
@@ -55,6 +55,15 @@
   ],
   "author": "PEAC Protocol",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/peacprotocol/peac.git",
+    "directory": "packages/pay402"
+  },
+  "bugs": {
+    "url": "https://github.com/peacprotocol/peac/issues"
+  },
+  "homepage": "https://github.com/peacprotocol/peac#readme",
   "engines": {
     "node": ">=20.0.0"
   }

--- a/packages/policy-kit/package.json
+++ b/packages/policy-kit/package.json
@@ -11,6 +11,17 @@
   },
   "author": "jithinraj <7850727+jithinraj@users.noreply.github.com>",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/peacprotocol/peac/issues"
+  },
+  "homepage": "https://github.com/peacprotocol/peac#readme",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "test": "vitest run",

--- a/packages/privacy/package.json
+++ b/packages/privacy/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@peac/privacy",
   "version": "0.9.17",
+  "private": true,
   "description": "Privacy pillar for PEAC protocol - privacy budgeting, data protection, and privacy-preserving receipts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -11,6 +11,17 @@
   },
   "author": "jithinraj <7850727+jithinraj@users.noreply.github.com>",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/peacprotocol/peac/issues"
+  },
+  "homepage": "https://github.com/peacprotocol/peac#readme",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "test": "vitest run",

--- a/packages/provenance/package.json
+++ b/packages/provenance/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@peac/provenance",
   "version": "0.9.17",
+  "private": true,
   "description": "Provenance pillar for PEAC protocol - content provenance, C2PA integration, and chain-of-custody",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rails/stripe/package.json
+++ b/packages/rails/stripe/package.json
@@ -11,6 +11,17 @@
   },
   "author": "jithinraj <7850727+jithinraj@users.noreply.github.com>",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/peacprotocol/peac/issues"
+  },
+  "homepage": "https://github.com/peacprotocol/peac#readme",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "test": "vitest run",

--- a/packages/rails/x402/package.json
+++ b/packages/rails/x402/package.json
@@ -11,6 +11,17 @@
   },
   "author": "jithinraj <7850727+jithinraj@users.noreply.github.com>",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/peacprotocol/peac/issues"
+  },
+  "homepage": "https://github.com/peacprotocol/peac#readme",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "test": "vitest run",

--- a/packages/receipts/package.json
+++ b/packages/receipts/package.json
@@ -61,6 +61,15 @@
   ],
   "author": "PEAC Protocol",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/peacprotocol/peac.git",
+    "directory": "packages/receipts"
+  },
+  "bugs": {
+    "url": "https://github.com/peacprotocol/peac/issues"
+  },
+  "homepage": "https://github.com/peacprotocol/peac#readme",
   "engines": {
     "node": ">=20.0.0"
   }

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -10,7 +10,18 @@
     "directory": "packages/schema"
   },
   "author": "jithinraj <7850727+jithinraj@users.noreply.github.com>",
-  "license": "MIT",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/peacprotocol/peac/issues"
+  },
+  "homepage": "https://github.com/peacprotocol/peac#readme",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "test": "vitest run",

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -38,7 +38,18 @@
     "verify",
     "discover"
   ],
-  "license": "MIT",
-  "repository": "https://github.com/peac-protocol/peac",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/peacprotocol/peac.git",
+    "directory": "packages/sdk-js"
+  },
+  "bugs": {
+    "url": "https://github.com/peacprotocol/peac/issues"
+  },
+  "homepage": "https://github.com/peacprotocol/peac#readme",
+  "publishConfig": {
+    "access": "public"
+  },
   "sideEffects": false
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,6 +14,17 @@
   },
   "author": "jithinraj <7850727+jithinraj@users.noreply.github.com>",
   "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/peacprotocol/peac/issues"
+  },
+  "homepage": "https://github.com/peacprotocol/peac#readme",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "start": "node dist/cli.js",

--- a/packages/transport/grpc/package.json
+++ b/packages/transport/grpc/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@peac/transport-grpc",
   "version": "0.9.16",
+  "private": true,
   "description": "PEAC gRPC transport layer (placeholder for v0.9.17+)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/transport/http/package.json
+++ b/packages/transport/http/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@peac/transport-http",
   "version": "0.9.16",
+  "private": true,
   "description": "PEAC HTTP transport layer - headers, middleware, DPoP L3/L4",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/transport/ws/package.json
+++ b/packages/transport/ws/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@peac/transport-ws",
   "version": "0.9.16",
+  "private": true,
   "description": "PEAC WebSocket transport layer (placeholder for v0.9.17+)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
- Fix repository/bugs/homepage URLs to proper object format
- Set publishConfig.access=public for scoped public packages
- Mark pillar scaffolding packages as private
- Mark transport placeholder packages as private
