### PR TITLE
fix(mappings-rsl): align with RSL 1.0 token vocabulary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to PEAC Protocol will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **RSL 1.0 Token Vocabulary**: Corrected RSL token mapping to match RSL 1.0 specification
+  - RSL uses `ai-index`, not `ai-search` (was a mistaken assumption in v0.9.17)
+  - Added `ai_index` ControlPurpose (RSL 1.0 canonical)
+  - Added `all` RSL token support (expands to all purposes)
+  - **BREAKING**: Removed `ai_search` ControlPurpose (use `ai_index` or `ai_input` instead)
+
+### Migration (ai_search removal)
+
+If you used `ai_search`:
+
+- For **AI search summaries / RAG grounding**: use `ai_input` (RSL: `ai-input`)
+- For **AI indexing / embedding index creation**: use `ai_index` (RSL: `ai-index`)
+
 ## [0.9.17] - 2025-12-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ const peacTxt = compilePeacTxt(policy, {
 **Key features:**
 
 - First-match-wins rule semantics (like firewall rules)
-- CAL purposes: `crawl`, `index`, `train`, `inference`, `ai_input`, `ai_search`, `search`
+- CAL purposes: `crawl`, `index`, `train`, `inference`, `ai_input`, `ai_index`, `search`
 - Deterministic, auditable, side-effect free evaluation
 - No scripting or dynamic code
 

--- a/docs/policy-kit/quickstart.md
+++ b/docs/policy-kit/quickstart.md
@@ -178,11 +178,11 @@ peac policy explain peac-policy.yaml --subject-type human --purpose inference
 
 ### Common Validation Errors
 
-| Error                 | Cause                          | Fix                                                                            |
-| --------------------- | ------------------------------ | ------------------------------------------------------------------------------ |
-| `Invalid version`     | Missing or wrong version field | Use `version: "peac-policy/0.1"`                                               |
-| `Unknown purpose`     | Typo in purpose name           | Use: `crawl`, `index`, `train`, `inference`, `ai_input`, `ai_search`, `search` |
-| `Duplicate rule name` | Two rules with same name       | Use unique names for each rule                                                 |
+| Error                 | Cause                          | Fix                                                                           |
+| --------------------- | ------------------------------ | ----------------------------------------------------------------------------- |
+| `Invalid version`     | Missing or wrong version field | Use `version: "peac-policy/0.1"`                                              |
+| `Unknown purpose`     | Typo in purpose name           | Use: `crawl`, `index`, `train`, `inference`, `ai_input`, `ai_index`, `search` |
+| `Duplicate rule name` | Two rules with same name       | Use unique names for each rule                                                |
 
 ### What `--dry-run` Shows
 

--- a/packages/cli/src/commands/policy.ts
+++ b/packages/cli/src/commands/policy.ts
@@ -305,7 +305,7 @@ policy
   .option('-i, --id <id>', 'Subject ID')
   .option(
     '-p, --purpose <purpose>',
-    'Access purpose (crawl, index, train, inference, ai_input, ai_search, search)'
+    'Access purpose (crawl, index, train, inference, ai_input, ai_index, search)'
   )
   .option(
     '-m, --licensing-mode <mode>',

--- a/packages/control/__tests__/cal-semantics.test.ts
+++ b/packages/control/__tests__/cal-semantics.test.ts
@@ -21,9 +21,9 @@ describe('ControlPurposeSchema', () => {
     expect(ControlPurposeSchema.parse('inference')).toBe('inference');
   });
 
-  it('should accept RSL-aligned purposes (v0.9.17+)', () => {
+  it('should accept RSL-aligned purposes (v0.9.17+, v0.9.18+)', () => {
     expect(ControlPurposeSchema.parse('ai_input')).toBe('ai_input');
-    expect(ControlPurposeSchema.parse('ai_search')).toBe('ai_search');
+    expect(ControlPurposeSchema.parse('ai_index')).toBe('ai_index');
     expect(ControlPurposeSchema.parse('search')).toBe('search');
   });
 

--- a/packages/mappings/rsl/README.md
+++ b/packages/mappings/rsl/README.md
@@ -1,12 +1,16 @@
 # @peac/mappings-rsl
 
-Minimal RSL (Robots Specification Layer) to PEAC CAL mapping.
+Minimal RSL (Robots Specification Layer) 1.0 to PEAC CAL mapping.
 
 ## Scope
 
-Maps RSL usage tokens (`ai-train`, `ai-input`, `ai-search`, `search`, `ai-all`) to PEAC `ControlPurpose` values. Provides lenient handling: unknown tokens log a warning but do not throw.
+Maps RSL 1.0 usage tokens (`all`, `ai-all`, `ai-train`, `ai-input`, `ai-index`, `search`) to PEAC `ControlPurpose` values. Provides lenient handling: unknown tokens log a warning but do not throw.
 
-## Non-goals (v0.9.17)
+**RSL 1.0 Specification**: [rslstandard.org/rsl](https://rslstandard.org/rsl)
+
+**Media Type**: `application/rsl+xml` (for RSL files)
+
+## Non-goals (v0.9.18)
 
 - No OLP/CAP/EMS support
 - No RSL-specific envelope fields
@@ -20,4 +24,7 @@ import { rslUsageTokensToControlPurposes } from '@peac/mappings-rsl';
 
 const result = rslUsageTokensToControlPurposes(['ai-train', 'ai-input']);
 // result.purposes = ['train', 'ai_input']
+
+const allAi = rslUsageTokensToControlPurposes(['ai-all']);
+// result.purposes = ['train', 'ai_input', 'ai_index']
 ```

--- a/packages/mappings/rsl/src/index.ts
+++ b/packages/mappings/rsl/src/index.ts
@@ -14,27 +14,39 @@ import type { RslUsageToken, RslMappingResult, RslRule } from './types';
 export type { RslUsageToken, RslMappingResult, RslRule } from './types';
 
 /**
- * Mapping from RSL usage tokens to PEAC ControlPurpose values
+ * Mapping from RSL 1.0 usage tokens to PEAC ControlPurpose values
  *
- * Rules:
+ * RSL 1.0 tokens (canonical):
+ * - all       -> ['train', 'ai_input', 'ai_index', 'search'] (all purposes)
+ * - ai-all    -> ['train', 'ai_input', 'ai_index'] (all AI purposes)
  * - ai-train  -> ['train']
  * - ai-input  -> ['ai_input']
- * - ai-search -> ['ai_search']
+ * - ai-index  -> ['ai_index']
  * - search    -> ['search']
- * - ai-all    -> ['train', 'ai_input', 'ai_search']
+ *
+ * @see https://rslstandard.org/rsl for RSL 1.0 specification
  */
 const RSL_TO_CAL_MAP: Record<RslUsageToken, ControlPurpose[]> = {
+  all: ['train', 'ai_input', 'ai_index', 'search'],
+  'ai-all': ['train', 'ai_input', 'ai_index'],
   'ai-train': ['train'],
   'ai-input': ['ai_input'],
-  'ai-search': ['ai_search'],
+  'ai-index': ['ai_index'],
   search: ['search'],
-  'ai-all': ['train', 'ai_input', 'ai_search'],
 };
 
 /**
- * Known RSL usage tokens
+ * Known RSL 1.0 usage tokens
+ * @see https://rslstandard.org/rsl for canonical token list
  */
-const KNOWN_RSL_TOKENS = new Set<string>(['ai-train', 'ai-input', 'ai-search', 'search', 'ai-all']);
+const KNOWN_RSL_TOKENS = new Set<string>([
+  'all',
+  'ai-all',
+  'ai-train',
+  'ai-input',
+  'ai-index',
+  'search',
+]);
 
 /**
  * Set of unknown tokens we've already warned about (dedupe in-process)
@@ -80,9 +92,9 @@ export function isValidRslToken(token: string): token is RslUsageToken {
  *
  * @example
  * ```ts
- * // ai-all expands to multiple purposes
+ * // ai-all expands to multiple AI purposes
  * const result = rslUsageTokensToControlPurposes(['ai-all']);
- * // result.purposes = ['train', 'ai_input', 'ai_search']
+ * // result.purposes = ['train', 'ai_input', 'ai_index']
  * ```
  *
  * @example
@@ -163,8 +175,8 @@ export function controlPurposeToRslToken(purpose: ControlPurpose): RslUsageToken
       return 'ai-train';
     case 'ai_input':
       return 'ai-input';
-    case 'ai_search':
-      return 'ai-search';
+    case 'ai_index':
+      return 'ai-index';
     case 'search':
       return 'search';
     // No RSL equivalent for these
@@ -178,12 +190,13 @@ export function controlPurposeToRslToken(purpose: ControlPurpose): RslUsageToken
 }
 
 /**
- * Get all known RSL usage tokens
+ * Get all known RSL 1.0 usage tokens
  *
- * @returns Array of all known RSL usage tokens
+ * @returns Array of all known RSL 1.0 usage tokens
+ * @see https://rslstandard.org/rsl for canonical token list
  */
 export function getKnownRslTokens(): RslUsageToken[] {
-  return ['ai-train', 'ai-input', 'ai-search', 'search', 'ai-all'];
+  return ['all', 'ai-all', 'ai-train', 'ai-input', 'ai-index', 'search'];
 }
 
 /**

--- a/packages/mappings/rsl/src/types.ts
+++ b/packages/mappings/rsl/src/types.ts
@@ -11,16 +11,18 @@
 /**
  * RSL usage token type
  *
- * Standard RSL usage tokens that control how content may be used.
+ * Standard RSL 1.0 usage tokens that control how content may be used.
+ * @see https://rslstandard.org/rsl for the canonical RSL 1.0 specification
  *
- * Well-known tokens:
+ * RSL 1.0 tokens:
+ * - "all": All usage types (shorthand for everything)
+ * - "ai-all": All AI usage types (ai-train + ai-input + ai-index)
  * - "ai-train": AI/ML model training
  * - "ai-input": RAG/grounding (using content as input to AI)
- * - "ai-search": AI-powered search
+ * - "ai-index": AI-powered search/indexing
  * - "search": Traditional search engine indexing
- * - "ai-all": Shorthand for ai-train + ai-input + ai-search
  */
-export type RslUsageToken = 'ai-train' | 'ai-input' | 'ai-search' | 'search' | 'ai-all';
+export type RslUsageToken = 'all' | 'ai-all' | 'ai-train' | 'ai-input' | 'ai-index' | 'search';
 
 /**
  * RSL rule structure (simplified)

--- a/packages/policy-kit/tests/compiler.test.ts
+++ b/packages/policy-kit/tests/compiler.test.ts
@@ -71,8 +71,8 @@ const rslPurposePolicy: PolicyDocument = {
   defaults: { decision: 'deny' },
   rules: [
     {
-      name: 'allow-ai-search',
-      purpose: 'ai_search',
+      name: 'allow-ai-index',
+      purpose: 'ai_index',
       decision: 'allow',
     },
     {
@@ -184,11 +184,11 @@ describe('compilePeacTxt', () => {
     expect(output).not.toContain('receipts: optional');
   });
 
-  it('should correctly extract RSL purposes (ai_input, ai_search, search)', () => {
+  it('should correctly extract RSL purposes (ai_input, ai_index, search)', () => {
     const output = compilePeacTxt(rslPurposePolicy, { includeComments: false });
 
     // RSL purposes should be extracted and sorted alphabetically
-    expect(output).toContain('purposes: [ai_input, ai_search, search, train]');
+    expect(output).toContain('purposes: [ai_index, ai_input, search, train]');
   });
 
   it('golden: minimal deny policy peac.txt (no comments)', () => {

--- a/packages/policy-kit/tests/loader.test.ts
+++ b/packages/policy-kit/tests/loader.test.ts
@@ -302,7 +302,7 @@ describe('complex policy validation', () => {
   });
 
   it('should validate all valid purposes', () => {
-    const purposes = ['crawl', 'index', 'train', 'inference', 'ai_input', 'ai_search', 'search'];
+    const purposes = ['crawl', 'index', 'train', 'inference', 'ai_input', 'ai_index', 'search'];
 
     for (const purpose of purposes) {
       const policy = {

--- a/packages/schema/src/control.ts
+++ b/packages/schema/src/control.ts
@@ -22,8 +22,13 @@ export type ControlDecision = 'allow' | 'deny' | 'review';
  * - "train": AI/ML model training
  * - "inference": AI/ML inference/generation
  * - "ai_input": RAG/grounding (using content as input to AI) [v0.9.17+, RSL alignment]
- * - "ai_search": AI-powered search [v0.9.17+, RSL alignment]
+ * - "ai_index": AI-powered search/indexing [v0.9.18+, RSL 1.0 alignment]
  * - "search": Traditional search indexing [v0.9.17+, RSL alignment]
+ *
+ * Note: RSL 1.0 uses "ai-index" (not "ai-search"). PEAC maps RSL "ai-index" to
+ * "ai_index". Previous versions used "ai_search" which has been removed.
+ *
+ * @see https://rslstandard.org/rsl for RSL 1.0 specification
  */
 export type ControlPurpose =
   | 'crawl'
@@ -31,7 +36,7 @@ export type ControlPurpose =
   | 'train'
   | 'inference'
   | 'ai_input'
-  | 'ai_search'
+  | 'ai_index'
   | 'search';
 
 /**

--- a/packages/schema/src/validators.ts
+++ b/packages/schema/src/validators.ts
@@ -80,7 +80,10 @@ export const VerifyRequest = z
 /**
  * Control purpose - what the access is for
  *
- * v0.9.17+: Added ai_input, ai_search, search for RSL alignment
+ * v0.9.17+: Added ai_input, search for RSL alignment
+ * v0.9.18+: Added ai_index (RSL 1.0 canonical token). Removed ai_search.
+ *
+ * @see https://rslstandard.org/rsl for RSL 1.0 specification
  */
 export const ControlPurposeSchema = z.enum([
   'crawl',
@@ -88,7 +91,7 @@ export const ControlPurposeSchema = z.enum([
   'train',
   'inference',
   'ai_input',
-  'ai_search',
+  'ai_index',
   'search',
 ]);
 


### PR DESCRIPTION
## Summary

Corrects RSL token vocabulary to match [RSL 1.0 specification](https://rslstandard.org/rsl).

**Why**: v0.9.17 mistakenly implemented `ai-search` / `ai_search`, but the RSL 1.0 canonical token is `ai-index`. This was a misunderstanding of the RSL spec during initial implementation.

**BREAKING CHANGE**: Removed `ai_search` ControlPurpose.

## Changes

- Replace RSL token `ai-search` with `ai-index` (RSL 1.0 canonical)
- Add RSL token `all` (expands to all purposes)
- Remove `ai_search` ControlPurpose
- Add `ai_index` ControlPurpose
- Add RSL 1.0 token vocabulary parity test (Golden Vector D)
- Update all docs, tests, and references

**RSL 1.0 canonical tokens**: `all`, `ai-all`, `ai-train`, `ai-input`, `ai-index`, `search`

## Migration

If you used `ai_search`:

- For **AI search summaries / RAG grounding**: use `ai_input` (RSL: `ai-input`)
- For **AI indexing / embedding index creation**: use `ai_index` (RSL: `ai-index`)

## Test plan

- [x] All existing RSL mapping tests updated and passing (47 tests)
- [x] Golden Vector D: RSL 1.0 Token Vocabulary Parity test added
- [x] `pnpm typecheck:core` passes
- [x] `pnpm test:core` passes
- [x] `pnpm lint` passes
- [x] `pnpm build` passes