### PR TITLE
feat(surfaces): add Next.js Edge middleware for TAP verification

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -645,6 +645,28 @@ importers:
         specifier: ^5.6.2
         version: 5.9.3
 
+  surfaces/nextjs/middleware:
+    dependencies:
+      '@peac/http-signatures':
+        specifier: workspace:*
+        version: link:../../../packages/http-signatures
+      '@peac/jwks-cache':
+        specifier: workspace:*
+        version: link:../../../packages/jwks-cache
+      '@peac/mappings-tap':
+        specifier: workspace:*
+        version: link:../../../packages/mappings/tap
+    devDependencies:
+      next:
+        specifier: ^15.0.0
+        version: 15.5.9(react-dom@19.2.3)(react@19.2.3)
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@20.19.25)
+
   surfaces/workers/cloudflare:
     dependencies:
       '@peac/http-signatures':
@@ -2039,6 +2061,13 @@ packages:
     deprecated: Use @eslint/object-schema instead
     dev: true
 
+  /@img/colour@1.0.0:
+    resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
+    engines: {node: '>=18'}
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@img/sharp-darwin-arm64@0.33.5:
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -2047,6 +2076,17 @@ packages:
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.0.4
+    dev: true
+    optional: true
+
+  /@img/sharp-darwin-arm64@0.34.5:
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
     dev: true
     optional: true
 
@@ -2061,8 +2101,27 @@ packages:
     dev: true
     optional: true
 
+  /@img/sharp-darwin-x64@0.34.5:
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    dev: true
+    optional: true
+
   /@img/sharp-libvips-darwin-arm64@1.0.4:
     resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@img/sharp-libvips-darwin-arm64@1.2.4:
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
@@ -2077,8 +2136,24 @@ packages:
     dev: true
     optional: true
 
+  /@img/sharp-libvips-darwin-x64@1.2.4:
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@img/sharp-libvips-linux-arm64@1.0.4:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@img/sharp-libvips-linux-arm64@1.2.4:
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
@@ -2093,8 +2168,40 @@ packages:
     dev: true
     optional: true
 
+  /@img/sharp-libvips-linux-arm@1.2.4:
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@img/sharp-libvips-linux-ppc64@1.2.4:
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@img/sharp-libvips-linux-riscv64@1.2.4:
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@img/sharp-libvips-linux-s390x@1.0.4:
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@img/sharp-libvips-linux-s390x@1.2.4:
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
@@ -2109,6 +2216,14 @@ packages:
     dev: true
     optional: true
 
+  /@img/sharp-libvips-linux-x64@1.2.4:
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@img/sharp-libvips-linuxmusl-arm64@1.0.4:
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
@@ -2117,8 +2232,24 @@ packages:
     dev: true
     optional: true
 
+  /@img/sharp-libvips-linuxmusl-arm64@1.2.4:
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@img/sharp-libvips-linuxmusl-x64@1.0.4:
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@img/sharp-libvips-linuxmusl-x64@1.2.4:
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
@@ -2136,6 +2267,17 @@ packages:
     dev: true
     optional: true
 
+  /@img/sharp-linux-arm64@0.34.5:
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    dev: true
+    optional: true
+
   /@img/sharp-linux-arm@0.33.5:
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -2144,6 +2286,39 @@ packages:
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linux-arm': 1.0.5
+    dev: true
+    optional: true
+
+  /@img/sharp-linux-arm@0.34.5:
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    dev: true
+    optional: true
+
+  /@img/sharp-linux-ppc64@0.34.5:
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    dev: true
+    optional: true
+
+  /@img/sharp-linux-riscv64@0.34.5:
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
     dev: true
     optional: true
 
@@ -2158,6 +2333,17 @@ packages:
     dev: true
     optional: true
 
+  /@img/sharp-linux-s390x@0.34.5:
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    dev: true
+    optional: true
+
   /@img/sharp-linux-x64@0.33.5:
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -2166,6 +2352,17 @@ packages:
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.0.4
+    dev: true
+    optional: true
+
+  /@img/sharp-linux-x64@0.34.5:
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
     dev: true
     optional: true
 
@@ -2180,6 +2377,17 @@ packages:
     dev: true
     optional: true
 
+  /@img/sharp-linuxmusl-arm64@0.34.5:
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    dev: true
+    optional: true
+
   /@img/sharp-linuxmusl-x64@0.33.5:
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -2188,6 +2396,17 @@ packages:
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+    dev: true
+    optional: true
+
+  /@img/sharp-linuxmusl-x64@0.34.5:
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
     dev: true
     optional: true
 
@@ -2201,6 +2420,25 @@ packages:
     dev: true
     optional: true
 
+  /@img/sharp-wasm32@0.34.5:
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+    requiresBuild: true
+    dependencies:
+      '@emnapi/runtime': 1.7.1
+    dev: true
+    optional: true
+
+  /@img/sharp-win32-arm64@0.34.5:
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@img/sharp-win32-ia32@0.33.5:
     resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -2210,8 +2448,26 @@ packages:
     dev: true
     optional: true
 
+  /@img/sharp-win32-ia32@0.34.5:
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@img/sharp-win32-x64@0.33.5:
     resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@img/sharp-win32-x64@0.34.5:
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
@@ -2498,6 +2754,82 @@ packages:
       '@jridgewell/sourcemap-codec': 1.5.5
     dev: true
 
+  /@next/env@15.5.9:
+    resolution: {integrity: sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg==}
+    dev: true
+
+  /@next/swc-darwin-arm64@15.5.7:
+    resolution: {integrity: sha512-IZwtxCEpI91HVU/rAUOOobWSZv4P2DeTtNaCdHqLcTJU4wdNXgAySvKa/qJCgR5m6KI8UsKDXtO2B31jcaw1Yw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@next/swc-darwin-x64@15.5.7:
+    resolution: {integrity: sha512-UP6CaDBcqaCBuiq/gfCEJw7sPEoX1aIjZHnBWN9v9qYHQdMKvCKcAVs4OX1vIjeE+tC5EIuwDTVIoXpUes29lg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@next/swc-linux-arm64-gnu@15.5.7:
+    resolution: {integrity: sha512-NCslw3GrNIw7OgmRBxHtdWFQYhexoUCq+0oS2ccjyYLtcn1SzGzeM54jpTFonIMUjNbHmpKpziXnpxhSWLcmBA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@next/swc-linux-arm64-musl@15.5.7:
+    resolution: {integrity: sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@next/swc-linux-x64-gnu@15.5.7:
+    resolution: {integrity: sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@next/swc-linux-x64-musl@15.5.7:
+    resolution: {integrity: sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@next/swc-win32-arm64-msvc@15.5.7:
+    resolution: {integrity: sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@next/swc-win32-x64-msvc@15.5.7:
+    resolution: {integrity: sha512-gMzgBX164I6DN+9/PGA+9dQiwmTkE4TloBNx8Kv9UiGARsr9Nba7IpcBRA1iTV9vwlYnrE3Uy6I7Aj6qLjQuqw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@noble/ed25519@2.3.0:
     resolution: {integrity: sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==}
     dev: false
@@ -2720,6 +3052,12 @@ packages:
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
     dependencies:
       '@sinonjs/commons': 3.0.1
+    dev: true
+
+  /@swc/helpers@0.5.15:
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+    dependencies:
+      tslib: 2.8.1
     dev: true
 
   /@types/babel__core@7.20.5:
@@ -3423,6 +3761,10 @@ packages:
 
   /cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+    dev: true
+
+  /client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
     dev: true
 
   /cliui@8.0.1:
@@ -5118,6 +5460,49 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: true
 
+  /next@15.5.9(react-dom@19.2.3)(react@19.2.3):
+    resolution: {integrity: sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==}
+    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+    dependencies:
+      '@next/env': 15.5.9
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001756
+      postcss: 8.4.31
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      styled-jsx: 5.1.6(react@19.2.3)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.5.7
+      '@next/swc-darwin-x64': 15.5.7
+      '@next/swc-linux-arm64-gnu': 15.5.7
+      '@next/swc-linux-arm64-musl': 15.5.7
+      '@next/swc-linux-x64-gnu': 15.5.7
+      '@next/swc-linux-x64-musl': 15.5.7
+      '@next/swc-win32-arm64-msvc': 15.5.7
+      '@next/swc-win32-x64-msvc': 15.5.7
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+    dev: true
+
   /node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
     dev: true
@@ -5366,6 +5751,15 @@ packages:
       tsx: 4.20.6
     dev: true
 
+  /postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+    dev: true
+
   /postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -5420,8 +5814,22 @@ packages:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
 
+  /react-dom@19.2.3(react@19.2.3):
+    resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
+    peerDependencies:
+      react: ^19.2.3
+    dependencies:
+      react: 19.2.3
+      scheduler: 0.27.0
+    dev: true
+
   /react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+    dev: true
+
+  /react@19.2.3:
+    resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /readdirp@4.1.2:
@@ -5547,6 +5955,10 @@ packages:
       queue-microtask: 1.2.3
     dev: true
 
+  /scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+    dev: true
+
   /semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -5586,6 +5998,42 @@ packages:
       '@img/sharp-wasm32': 0.33.5
       '@img/sharp-win32-ia32': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
+    dev: true
+    optional: true
+
+  /sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    requiresBuild: true
+    dependencies:
+      '@img/colour': 1.0.0
+      detect-libc: 2.1.2
+      semver: 7.7.3
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
     dev: true
     optional: true
 
@@ -5753,6 +6201,23 @@ packages:
     resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
     dependencies:
       js-tokens: 9.0.1
+    dev: true
+
+  /styled-jsx@5.1.6(react@19.2.3):
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.3
     dev: true
 
   /sucrase@3.35.0:
@@ -5929,7 +6394,6 @@ packages:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
     requiresBuild: true
     dev: true
-    optional: true
 
   /tsup@8.5.1(tsx@4.20.6)(typescript@5.9.3):
     resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,4 @@ packages:
   - 'packages/transport/*'
   - 'apps/*'
   - 'surfaces/workers/*'
+  - 'surfaces/nextjs/*'

--- a/surfaces/nextjs/middleware/README.md
+++ b/surfaces/nextjs/middleware/README.md
@@ -1,0 +1,147 @@
+# @peac/middleware-nextjs
+
+> PEAC TAP verifier and 402 access gate for Next.js Edge Runtime
+
+## Features
+
+- **TAP Verification**: Verify Visa Trusted Agent Protocol signatures at the edge
+- **402 Access Gate**: Return payment challenges for unauthenticated requests
+- **Replay Protection**: Pluggable nonce deduplication with LRU fallback
+- **RFC 9457 Errors**: Structured problem+json error responses
+- **Issuer Allowlist**: Restrict which TAP issuers are accepted
+- **Path Bypass**: Skip verification for specific paths
+
+## Quick Start
+
+```typescript
+// middleware.ts
+import { createPeacMiddleware, LRUReplayStore } from '@peac/middleware-nextjs';
+
+export const middleware = createPeacMiddleware({
+  issuerAllowlist: ['https://trusted-agent.example.com'],
+  bypassPaths: ['/api/health', '/public/**'],
+  replayStore: new LRUReplayStore(), // Best-effort, per-isolate
+});
+
+export const config = {
+  matcher: '/api/:path*',
+};
+```
+
+## Configuration
+
+| Option                   | Type                               | Default            | Description                    |
+| ------------------------ | ---------------------------------- | ------------------ | ------------------------------ |
+| `mode`                   | `"receipt_or_tap"` \| `"tap_only"` | `"receipt_or_tap"` | Verification mode              |
+| `issuerAllowlist`        | `string[]`                         | **REQUIRED**       | Allowed issuer origins         |
+| `bypassPaths`            | `string[]`                         | `[]`               | Paths to skip verification     |
+| `replayStore`            | `ReplayStore`                      | `undefined`        | Nonce replay protection        |
+| `unsafeAllowAnyIssuer`   | `boolean`                          | `false`            | UNSAFE: Skip issuer check      |
+| `unsafeAllowUnknownTags` | `boolean`                          | `false`            | UNSAFE: Allow unknown TAP tags |
+| `unsafeAllowNoReplay`    | `boolean`                          | `false`            | UNSAFE: Skip replay protection |
+
+## Verification Modes
+
+### `receipt_or_tap` (default)
+
+- TAP headers present + valid: Forward to origin (200)
+- TAP headers present + invalid: Error response (4xx)
+- **No TAP headers: 402 Payment Required**
+
+### `tap_only`
+
+- TAP headers present + valid: Forward to origin (200)
+- TAP headers present + invalid: Error response (4xx)
+- **No TAP headers: 401 Signature Missing**
+
+## Security Defaults (Fail-Closed)
+
+| Invariant                  | Default                   | Override                      |
+| -------------------------- | ------------------------- | ----------------------------- |
+| Issuer allowlist required  | 500 error if empty        | `unsafeAllowAnyIssuer=true`   |
+| Unknown TAP tags rejected  | 400 error                 | `unsafeAllowUnknownTags=true` |
+| Replay protection required | 401 if nonce but no store | `unsafeAllowNoReplay=true`    |
+| Max window                 | 400 if > 480s (8 min)     | None (per Visa spec)          |
+
+## Error Codes
+
+| Code                                 | Status | Meaning                              |
+| ------------------------------------ | ------ | ------------------------------------ |
+| `E_RECEIPT_MISSING`                  | 402    | No TAP headers (receipt_or_tap mode) |
+| `E_TAP_SIGNATURE_MISSING`            | 401    | No TAP headers (tap_only mode)       |
+| `E_TAP_SIGNATURE_INVALID`            | 401    | Signature verification failed        |
+| `E_TAP_TIME_INVALID`                 | 401    | Timestamp validation failed          |
+| `E_TAP_WINDOW_TOO_LARGE`             | 400    | Window > 8 minutes                   |
+| `E_TAP_TAG_UNKNOWN`                  | 400    | Unknown TAP tag                      |
+| `E_TAP_ALGORITHM_INVALID`            | 400    | Wrong algorithm (must be ed25519)    |
+| `E_TAP_KEY_NOT_FOUND`                | 401    | Key not found at JWKS endpoint       |
+| `E_TAP_NONCE_REPLAY`                 | 409    | Nonce replay detected                |
+| `E_TAP_REPLAY_PROTECTION_REQUIRED`   | 401    | Nonce present but no replay store    |
+| `E_ISSUER_NOT_ALLOWED`               | 403    | Issuer not in allowlist              |
+| `E_CONFIG_ISSUER_ALLOWLIST_REQUIRED` | 500    | Empty allowlist (misconfiguration)   |
+
+## Replay Protection
+
+### Option 1: LRU Store (Best-Effort)
+
+```typescript
+import { createPeacMiddleware, LRUReplayStore } from '@peac/middleware-nextjs';
+
+export const middleware = createPeacMiddleware({
+  issuerAllowlist: ['https://issuer.example.com'],
+  replayStore: new LRUReplayStore({ maxEntries: 1000 }),
+});
+```
+
+**WARNING**: LRU store is per-isolate only. Different edge instances have separate caches.
+This provides best-effort protection but is NOT globally consistent.
+A warning header `X-PEAC-Warning: replay-best-effort` is added to responses.
+
+### Option 2: External Store (Recommended for Production)
+
+Implement the `ReplayStore` interface with Redis, database, or other distributed store:
+
+```typescript
+interface ReplayStore {
+  seen(ctx: ReplayContext): Promise<boolean>;
+}
+```
+
+### Option 3: No Replay Protection (UNSAFE)
+
+```typescript
+export const middleware = createPeacMiddleware({
+  issuerAllowlist: ['https://issuer.example.com'],
+  unsafeAllowNoReplay: true, // NOT recommended for production
+});
+```
+
+## Parity with Cloudflare Worker
+
+This middleware maintains exact behavioral parity with `@peac/worker-cloudflare`:
+
+- Same error codes and status mappings
+- Same fail-closed security defaults
+- Same replay protection semantics
+- Same TAP validation rules (8-min window, ed25519 only, tag allowlist)
+
+## Response Headers
+
+On successful verification:
+
+```
+X-PEAC-Verified: true
+X-PEAC-Engine: tap
+X-PEAC-TAP-Tag: agent-browser-auth
+```
+
+Warnings (if applicable):
+
+```
+X-PEAC-Warning: replay-best-effort     # LRU store in use
+X-PEAC-Warning: replay-protection-disabled  # unsafeAllowNoReplay=true
+```
+
+## License
+
+Apache-2.0

--- a/surfaces/nextjs/middleware/package.json
+++ b/surfaces/nextjs/middleware/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@peac/middleware-nextjs",
+  "version": "0.9.18",
+  "private": true,
+  "description": "PEAC TAP verifier and 402 access gate for Next.js Edge Runtime",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "nextjs",
+    "middleware",
+    "edge",
+    "peac",
+    "tap",
+    "verification"
+  ],
+  "author": "PEAC Protocol Contributors",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/peacprotocol/peac/issues"
+  },
+  "homepage": "https://peacprotocol.org",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/peacprotocol/peac.git",
+    "directory": "surfaces/nextjs/middleware"
+  },
+  "dependencies": {
+    "@peac/http-signatures": "workspace:*",
+    "@peac/jwks-cache": "workspace:*",
+    "@peac/mappings-tap": "workspace:*"
+  },
+  "devDependencies": {
+    "next": "^15.0.0",
+    "typescript": "^5.3.0",
+    "vitest": "^2.0.0"
+  },
+  "peerDependencies": {
+    "next": ">=13.0.0"
+  }
+}

--- a/surfaces/nextjs/middleware/src/errors.ts
+++ b/surfaces/nextjs/middleware/src/errors.ts
@@ -1,0 +1,224 @@
+/**
+ * @peac/middleware-nextjs - RFC 9457 Problem Details errors
+ *
+ * Structured error responses for PEAC verification failures.
+ * Parity with Cloudflare Worker error semantics.
+ *
+ * SECURITY: Error details MUST NOT contain sensitive data such as:
+ * - Raw Signature or Signature-Input header values
+ * - Private key material
+ * - Internal paths or configuration
+ */
+
+import type { ProblemDetails, HandlerResponse } from './types.js';
+
+/**
+ * Stable error codes for middleware verification failures.
+ *
+ * These codes are included in the `code` extension field for programmatic handling.
+ * Format: E_<CATEGORY>_<ERROR>
+ *
+ * PARITY: Must match Cloudflare Worker error codes exactly.
+ */
+export const ErrorCodes = {
+  // Receipt errors (402 - Payment Required)
+  RECEIPT_MISSING: 'E_RECEIPT_MISSING',
+  RECEIPT_INVALID: 'E_RECEIPT_INVALID',
+  RECEIPT_EXPIRED: 'E_RECEIPT_EXPIRED',
+
+  // TAP errors (401 - Authentication)
+  TAP_SIGNATURE_MISSING: 'E_TAP_SIGNATURE_MISSING',
+  TAP_SIGNATURE_INVALID: 'E_TAP_SIGNATURE_INVALID',
+  TAP_TIME_INVALID: 'E_TAP_TIME_INVALID',
+  TAP_WINDOW_TOO_LARGE: 'E_TAP_WINDOW_TOO_LARGE',
+  TAP_TAG_UNKNOWN: 'E_TAP_TAG_UNKNOWN',
+  TAP_ALGORITHM_INVALID: 'E_TAP_ALGORITHM_INVALID',
+  TAP_KEY_NOT_FOUND: 'E_TAP_KEY_NOT_FOUND',
+
+  // Replay error (409 - Conflict)
+  TAP_NONCE_REPLAY: 'E_TAP_NONCE_REPLAY',
+
+  // Replay protection required (401 - requires config change)
+  TAP_REPLAY_PROTECTION_REQUIRED: 'E_TAP_REPLAY_PROTECTION_REQUIRED',
+
+  // Issuer errors (403 - Forbidden)
+  ISSUER_NOT_ALLOWED: 'E_ISSUER_NOT_ALLOWED',
+
+  // Configuration errors (500 - Server misconfiguration)
+  CONFIG_ISSUER_ALLOWLIST_REQUIRED: 'E_CONFIG_ISSUER_ALLOWLIST_REQUIRED',
+
+  // Internal errors (500)
+  INTERNAL_ERROR: 'E_INTERNAL_ERROR',
+} as const;
+
+export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];
+
+/**
+ * HTTP status codes for error types.
+ *
+ * Status code semantics:
+ * - 400: Client error (malformed request, invalid parameters)
+ * - 401: Authentication required (missing/invalid credentials)
+ * - 402: Payment Required (reserved for PEAC receipt payment flows)
+ * - 403: Forbidden (authenticated but not authorized)
+ * - 409: Conflict (replay detection - request conflicts with previous state)
+ * - 500: Server error (configuration, internal failure)
+ *
+ * PARITY: Must match Cloudflare Worker status mappings exactly.
+ */
+const ErrorHttpStatus: Record<ErrorCode, number> = {
+  // 402 - Payment Required (reserved for payment flows)
+  [ErrorCodes.RECEIPT_MISSING]: 402,
+  [ErrorCodes.RECEIPT_INVALID]: 402,
+  [ErrorCodes.RECEIPT_EXPIRED]: 402,
+
+  // 401 - Authentication errors
+  [ErrorCodes.TAP_SIGNATURE_MISSING]: 401,
+  [ErrorCodes.TAP_SIGNATURE_INVALID]: 401,
+  [ErrorCodes.TAP_TIME_INVALID]: 401,
+  [ErrorCodes.TAP_KEY_NOT_FOUND]: 401,
+  [ErrorCodes.TAP_REPLAY_PROTECTION_REQUIRED]: 401,
+
+  // 400 - Client errors (malformed)
+  [ErrorCodes.TAP_WINDOW_TOO_LARGE]: 400,
+  [ErrorCodes.TAP_TAG_UNKNOWN]: 400,
+  [ErrorCodes.TAP_ALGORITHM_INVALID]: 400,
+
+  // 403 - Forbidden (issuer not in allowlist)
+  [ErrorCodes.ISSUER_NOT_ALLOWED]: 403,
+
+  // 409 - Conflict (replay detected)
+  [ErrorCodes.TAP_NONCE_REPLAY]: 409,
+
+  // 500 - Server errors
+  [ErrorCodes.CONFIG_ISSUER_ALLOWLIST_REQUIRED]: 500,
+  [ErrorCodes.INTERNAL_ERROR]: 500,
+};
+
+/**
+ * Error titles for problem details.
+ */
+const ErrorTitles: Record<ErrorCode, string> = {
+  [ErrorCodes.RECEIPT_MISSING]: 'Payment Required',
+  [ErrorCodes.RECEIPT_INVALID]: 'Invalid Receipt',
+  [ErrorCodes.RECEIPT_EXPIRED]: 'Receipt Expired',
+
+  [ErrorCodes.TAP_SIGNATURE_MISSING]: 'Signature Missing',
+  [ErrorCodes.TAP_SIGNATURE_INVALID]: 'Invalid Signature',
+  [ErrorCodes.TAP_TIME_INVALID]: 'Invalid Signature Time',
+  [ErrorCodes.TAP_WINDOW_TOO_LARGE]: 'Signature Window Too Large',
+  [ErrorCodes.TAP_TAG_UNKNOWN]: 'Unknown TAP Tag',
+  [ErrorCodes.TAP_ALGORITHM_INVALID]: 'Invalid Algorithm',
+  [ErrorCodes.TAP_KEY_NOT_FOUND]: 'Key Not Found',
+  [ErrorCodes.TAP_NONCE_REPLAY]: 'Nonce Replay Detected',
+  [ErrorCodes.TAP_REPLAY_PROTECTION_REQUIRED]: 'Replay Protection Required',
+
+  [ErrorCodes.ISSUER_NOT_ALLOWED]: 'Issuer Not Allowed',
+
+  [ErrorCodes.CONFIG_ISSUER_ALLOWLIST_REQUIRED]: 'Configuration Error',
+  [ErrorCodes.INTERNAL_ERROR]: 'Internal Server Error',
+};
+
+/**
+ * Base URI for problem types.
+ */
+const PROBLEM_TYPE_BASE = 'https://peacprotocol.org/problems';
+
+/**
+ * Sanitize error detail to prevent leaking sensitive information.
+ *
+ * Removes or redacts:
+ * - Signature header values
+ * - Key material
+ * - Internal paths
+ */
+function sanitizeDetail(detail: string | undefined): string | undefined {
+  if (!detail) return undefined;
+
+  // Redact anything that looks like a signature or key
+  return detail
+    .replace(/sig1=:[A-Za-z0-9+/=]+:/g, 'sig1:[REDACTED]:')
+    .replace(/signature[:\s]*[A-Za-z0-9+/=]{20,}/gi, 'signature:[REDACTED]')
+    .replace(/-----BEGIN[^-]+-----[\s\S]*?-----END[^-]+-----/g, '[REDACTED KEY]');
+}
+
+/**
+ * Create RFC 9457 Problem Details object.
+ *
+ * Includes stable `code` extension for programmatic error handling.
+ */
+export function createProblemDetails(
+  code: ErrorCode,
+  detail?: string,
+  instance?: string
+): ProblemDetails {
+  // Map code to URL-safe slug for type URI
+  const typeSlug = code.toLowerCase().replace(/^e_/, '');
+
+  return {
+    type: `${PROBLEM_TYPE_BASE}/${typeSlug}`,
+    title: ErrorTitles[code],
+    status: ErrorHttpStatus[code],
+    detail: sanitizeDetail(detail),
+    instance,
+    code, // Stable error code extension
+  };
+}
+
+/**
+ * Get HTTP status for error code.
+ */
+export function getErrorStatus(code: ErrorCode): number {
+  return ErrorHttpStatus[code];
+}
+
+/**
+ * Create RFC 9457 Problem Details handler response.
+ *
+ * Runtime-neutral (no Response object dependency).
+ */
+export function createErrorHandlerResponse(
+  code: ErrorCode,
+  detail?: string,
+  instance?: string,
+  extraHeaders?: Record<string, string>
+): HandlerResponse {
+  const problem = createProblemDetails(code, detail, instance);
+
+  return {
+    status: problem.status,
+    headers: {
+      'Content-Type': 'application/problem+json',
+      'Cache-Control': 'no-store',
+      ...extraHeaders,
+    },
+    body: JSON.stringify(problem),
+  };
+}
+
+/**
+ * Create 402 Payment Required handler response.
+ *
+ * Includes WWW-Authenticate header for PEAC challenge.
+ */
+export function createChallengeHandlerResponse(
+  requestUrl: string,
+  extraHeaders?: Record<string, string>
+): HandlerResponse {
+  const problem = createProblemDetails(
+    ErrorCodes.RECEIPT_MISSING,
+    'A valid PEAC receipt is required to access this resource.',
+    requestUrl
+  );
+
+  return {
+    status: 402,
+    headers: {
+      'Content-Type': 'application/problem+json',
+      'WWW-Authenticate': 'PEAC realm="peac-verifier"',
+      'Cache-Control': 'no-store',
+      ...extraHeaders,
+    },
+    body: JSON.stringify(problem),
+  };
+}

--- a/surfaces/nextjs/middleware/src/handler.ts
+++ b/surfaces/nextjs/middleware/src/handler.ts
@@ -1,0 +1,334 @@
+/**
+ * @peac/middleware-nextjs - Core handler
+ *
+ * Pure handler function for TAP verification.
+ * Runtime-neutral for testability.
+ */
+
+import { createResolver, type JwksKeyResolver } from '@peac/jwks-cache';
+import { verifyTapProof, TAP_CONSTANTS, type TapRequest } from '@peac/mappings-tap';
+import type {
+  MiddlewareConfig,
+  VerificationMode,
+  VerificationResult,
+  ReplayStore,
+  ReplayContext,
+  HandlerRequest,
+  HandlerResponse,
+} from './types.js';
+import {
+  ErrorCodes,
+  type ErrorCode,
+  createErrorHandlerResponse,
+  createChallengeHandlerResponse,
+  getErrorStatus,
+} from './errors.js';
+
+/**
+ * Check if request has TAP signature headers.
+ */
+function hasTapHeaders(headers: Record<string, string>): boolean {
+  const signatureInput =
+    headers['signature-input'] ?? headers['Signature-Input'] ?? headers['SIGNATURE-INPUT'];
+  const signature = headers['signature'] ?? headers['Signature'] ?? headers['SIGNATURE'];
+  return Boolean(signatureInput && signature);
+}
+
+/**
+ * Extract issuer origin from keyid.
+ *
+ * TAP keyid is typically a JWKS URI like "https://issuer.example.com/.well-known/jwks.json#key-1"
+ */
+function extractIssuerFromKeyid(keyid: string): string {
+  try {
+    const url = new URL(keyid);
+    return url.origin;
+  } catch {
+    // If keyid is not a URL, use it as-is
+    return keyid;
+  }
+}
+
+/**
+ * Check if issuer is in allowlist.
+ */
+function isIssuerAllowed(keyid: string, allowlist: string[]): boolean {
+  const issuerOrigin = extractIssuerFromKeyid(keyid);
+
+  return allowlist.some((allowed) => {
+    try {
+      const allowedOrigin = new URL(allowed).origin;
+      return allowedOrigin === issuerOrigin;
+    } catch {
+      // If allowed entry is not a valid URL, compare as-is
+      return allowed === issuerOrigin;
+    }
+  });
+}
+
+/**
+ * Check if path matches any bypass pattern.
+ * Supports simple glob patterns (* and **).
+ */
+function matchesBypassPath(pathname: string, patterns: string[]): boolean {
+  for (const pattern of patterns) {
+    // Convert glob pattern to regex
+    const regexPattern = pattern
+      .replace(/[.+^${}()|[\]\\]/g, '\\$&') // Escape regex special chars except * and ?
+      .replace(/\*\*/g, '.*') // ** matches anything including /
+      .replace(/\*/g, '[^/]*'); // * matches anything except /
+
+    const regex = new RegExp(`^${regexPattern}$`);
+    if (regex.test(pathname)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Map TAP error code to handler error code.
+ */
+function mapTapErrorCode(tapErrorCode: string | undefined): string {
+  if (!tapErrorCode) {
+    return ErrorCodes.TAP_SIGNATURE_INVALID;
+  }
+
+  // Map common TAP error codes
+  const mapping: Record<string, string> = {
+    E_TAP_WINDOW_TOO_LARGE: ErrorCodes.TAP_WINDOW_TOO_LARGE,
+    E_TAP_TIME_INVALID: ErrorCodes.TAP_TIME_INVALID,
+    E_TAP_ALGORITHM_INVALID: ErrorCodes.TAP_ALGORITHM_INVALID,
+    E_TAP_TAG_UNKNOWN: ErrorCodes.TAP_TAG_UNKNOWN,
+    E_SIGNATURE_INVALID: ErrorCodes.TAP_SIGNATURE_INVALID,
+    E_KEY_NOT_FOUND: ErrorCodes.TAP_KEY_NOT_FOUND,
+  };
+
+  return mapping[tapErrorCode] ?? ErrorCodes.TAP_SIGNATURE_INVALID;
+}
+
+/**
+ * Options for TAP verification.
+ */
+interface VerifyTapOptions {
+  keyResolver: JwksKeyResolver;
+  replayStore: ReplayStore | null;
+  unsafeAllowUnknownTags: boolean;
+  unsafeAllowNoReplay: boolean;
+}
+
+/**
+ * Verify TAP proof from request headers.
+ */
+async function verifyTap(
+  request: HandlerRequest,
+  options: VerifyTapOptions
+): Promise<VerificationResult & { warnReplayDisabled?: boolean; warnBestEffortReplay?: boolean }> {
+  const { keyResolver, replayStore, unsafeAllowUnknownTags, unsafeAllowNoReplay } = options;
+
+  // Check for TAP headers
+  if (!hasTapHeaders(request.headers)) {
+    return {
+      valid: false,
+      isTap: false,
+      errorCode: ErrorCodes.TAP_SIGNATURE_MISSING,
+      errorMessage: 'No TAP signature headers present',
+    };
+  }
+
+  // Build TAP request
+  const tapRequest: TapRequest = {
+    method: request.method,
+    url: request.url,
+    headers: request.headers,
+  };
+
+  // Verify TAP proof
+  const result = await verifyTapProof(tapRequest, {
+    keyResolver,
+    allowUnknownTags: unsafeAllowUnknownTags,
+  });
+
+  if (!result.valid) {
+    return {
+      valid: false,
+      isTap: true,
+      errorCode: result.errorCode,
+      errorMessage: result.errorMessage,
+    };
+  }
+
+  // Check nonce replay protection
+  const evidence = result.controlEntry?.evidence;
+  let warnReplayDisabled = false;
+  let warnBestEffortReplay = false;
+
+  if (evidence?.nonce && evidence?.keyid) {
+    if (replayStore) {
+      const replayCtx: ReplayContext = {
+        issuer: extractIssuerFromKeyid(evidence.keyid),
+        keyid: evidence.keyid,
+        nonce: evidence.nonce,
+        ttlSeconds: TAP_CONSTANTS.MAX_WINDOW_SECONDS,
+      };
+
+      const isReplay = await replayStore.seen(replayCtx);
+
+      if (isReplay) {
+        return {
+          valid: false,
+          isTap: true,
+          errorCode: ErrorCodes.TAP_NONCE_REPLAY,
+          errorMessage: 'Nonce replay detected',
+        };
+      }
+
+      // Check if using best-effort store
+      if (replayStore.type === 'best-effort') {
+        warnBestEffortReplay = true;
+      }
+    } else if (!unsafeAllowNoReplay) {
+      // Fail-closed: reject requests with nonces but no replay store
+      return {
+        valid: false,
+        isTap: true,
+        errorCode: ErrorCodes.TAP_REPLAY_PROTECTION_REQUIRED,
+        errorMessage:
+          'Replay protection required but not configured. ' +
+          'Provide a replayStore or set unsafeAllowNoReplay=true (NOT recommended for production).',
+      };
+    } else {
+      // Warn that replay protection is not configured (unsafe mode)
+      warnReplayDisabled = true;
+    }
+  }
+
+  return {
+    valid: true,
+    isTap: true,
+    controlEntry: result.controlEntry,
+    warnReplayDisabled,
+    warnBestEffortReplay,
+  };
+}
+
+/**
+ * Handle request verification.
+ *
+ * Returns null if request should be forwarded to origin (success or bypass).
+ * Returns HandlerResponse if request should be rejected.
+ */
+export async function handleRequest(
+  request: HandlerRequest,
+  config: MiddlewareConfig
+): Promise<HandlerResponse | null> {
+  const mode: VerificationMode = config.mode ?? 'receipt_or_tap';
+  const bypassPaths = config.bypassPaths ?? [];
+
+  // Parse URL
+  let pathname: string;
+  try {
+    pathname = new URL(request.url).pathname;
+  } catch {
+    // If URL parsing fails, use the raw URL as pathname
+    pathname = request.url;
+  }
+
+  // Check bypass paths first
+  if (matchesBypassPath(pathname, bypassPaths)) {
+    return null; // Forward to origin
+  }
+
+  // SECURITY: Fail-closed on issuer allowlist
+  if (config.issuerAllowlist.length === 0 && !config.unsafeAllowAnyIssuer) {
+    return createErrorHandlerResponse(
+      ErrorCodes.CONFIG_ISSUER_ALLOWLIST_REQUIRED,
+      'Middleware misconfigured: issuerAllowlist is required. ' +
+        'Set unsafeAllowAnyIssuer=true to bypass (NOT recommended for production).'
+    );
+  }
+
+  // Create JWKS resolver with issuer allowlist
+  const keyResolver = createResolver({
+    isAllowedHost: (host) => {
+      if (config.unsafeAllowAnyIssuer) {
+        return true; // UNSAFE: Open access
+      }
+      return config.issuerAllowlist.some((allowed) => {
+        try {
+          return new URL(allowed).host === host;
+        } catch {
+          return false;
+        }
+      });
+    },
+  });
+
+  // Verify TAP
+  const result = await verifyTap(request, {
+    keyResolver,
+    replayStore: config.replayStore ?? null,
+    unsafeAllowUnknownTags: config.unsafeAllowUnknownTags ?? false,
+    unsafeAllowNoReplay: config.unsafeAllowNoReplay ?? false,
+  });
+
+  // Non-TAP requests: mode determines behavior
+  if (!result.isTap) {
+    if (mode === 'receipt_or_tap') {
+      // Return 402 challenge (PEAC receipt required)
+      return createChallengeHandlerResponse(request.url);
+    } else {
+      // tap_only mode: return 401 (signature missing)
+      return createErrorHandlerResponse(
+        ErrorCodes.TAP_SIGNATURE_MISSING,
+        'TAP signature required',
+        request.url
+      );
+    }
+  }
+
+  // TAP verification failed
+  if (!result.valid) {
+    // Check if error code is already in our format (from verifyTap internal errors)
+    const errorCodeValues = Object.values(ErrorCodes) as string[];
+    const isInternalError = result.errorCode && errorCodeValues.includes(result.errorCode);
+    const mappedCode = isInternalError ? result.errorCode : mapTapErrorCode(result.errorCode);
+    return createErrorHandlerResponse(mappedCode as ErrorCode, result.errorMessage, request.url);
+  }
+
+  // TAP verification succeeded - check issuer allowlist
+  if (result.controlEntry?.evidence.keyid && !config.unsafeAllowAnyIssuer) {
+    const keyid = result.controlEntry.evidence.keyid;
+    if (!isIssuerAllowed(keyid, config.issuerAllowlist)) {
+      return createErrorHandlerResponse(ErrorCodes.ISSUER_NOT_ALLOWED, 'Issuer not in allowlist');
+    }
+  }
+
+  // Success - return null to indicate forward to origin
+  // Caller should add appropriate headers to the forwarded response
+  return null;
+}
+
+/**
+ * Get verification headers to add to successful response.
+ */
+export function getVerificationHeaders(
+  result: VerificationResult & { warnReplayDisabled?: boolean; warnBestEffortReplay?: boolean }
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    'X-PEAC-Verified': 'true',
+    'X-PEAC-Engine': 'tap',
+  };
+
+  if (result.controlEntry?.evidence.tag) {
+    headers['X-PEAC-TAP-Tag'] = result.controlEntry.evidence.tag;
+  }
+
+  if (result.warnReplayDisabled) {
+    headers['X-PEAC-Warning'] = 'replay-protection-disabled';
+  } else if (result.warnBestEffortReplay) {
+    headers['X-PEAC-Warning'] = 'replay-best-effort';
+  }
+
+  return headers;
+}

--- a/surfaces/nextjs/middleware/src/index.ts
+++ b/surfaces/nextjs/middleware/src/index.ts
@@ -1,0 +1,192 @@
+/**
+ * @peac/middleware-nextjs
+ *
+ * PEAC TAP verifier and 402 access gate for Next.js Edge Runtime.
+ *
+ * Features:
+ * - TAP (Trusted Agent Protocol) verification
+ * - 402 Payment Required challenge for unauthenticated requests
+ * - Pluggable replay protection
+ * - RFC 9457 problem+json error responses
+ * - Configurable issuer allowlist
+ * - Path-based bypass
+ *
+ * Parity with Cloudflare Worker:
+ * - Same error codes and status mappings
+ * - Same fail-closed security defaults
+ * - Same replay protection semantics
+ *
+ * @see https://peacprotocol.org
+ */
+
+import { handleRequest } from './handler.js';
+import type { MiddlewareConfig, HandlerRequest } from './types.js';
+
+// Re-export types and utilities
+export type {
+  MiddlewareConfig,
+  VerificationMode,
+  ReplayStore,
+  ReplayContext,
+  VerificationResult,
+  ProblemDetails,
+  HandlerRequest,
+  HandlerResponse,
+} from './types.js';
+export { handleRequest, getVerificationHeaders } from './handler.js';
+export { LRUReplayStore, type LRUReplayStoreOptions } from './replay-store.js';
+export { ErrorCodes, createProblemDetails, getErrorStatus } from './errors.js';
+
+/**
+ * Minimal Next.js types for middleware compatibility.
+ * These match Next.js 13/14/15 Edge Runtime signatures.
+ */
+interface NextRequestLike {
+  method: string;
+  url: string;
+  headers: Headers;
+}
+
+interface NextResponseLike {
+  headers: Headers;
+}
+
+type NextMiddlewareLike = (
+  request: NextRequestLike
+) => Promise<Response | NextResponseLike | undefined>;
+
+/**
+ * Convert Headers to Record.
+ */
+function headersToRecord(headers: Headers): Record<string, string> {
+  const record: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    record[key] = value;
+  });
+  return record;
+}
+
+/**
+ * Create PEAC middleware for Next.js.
+ *
+ * Security defaults (fail-closed):
+ * - issuerAllowlist is REQUIRED (500 error if empty unless unsafeAllowAnyIssuer=true)
+ * - Unknown TAP tags are REJECTED (unless unsafeAllowUnknownTags=true)
+ * - Replay protection is REQUIRED when nonce present (unless unsafeAllowNoReplay=true)
+ *
+ * @example
+ * ```typescript
+ * // middleware.ts
+ * import { createPeacMiddleware, LRUReplayStore } from '@peac/middleware-nextjs';
+ *
+ * export const middleware = createPeacMiddleware({
+ *   issuerAllowlist: ['https://trusted-agent.example.com'],
+ *   bypassPaths: ['/api/health', '/public/**'],
+ *   replayStore: new LRUReplayStore(), // Best-effort, per-isolate
+ * });
+ *
+ * export const config = {
+ *   matcher: '/api/:path*',
+ * };
+ * ```
+ */
+export function createPeacMiddleware(config: MiddlewareConfig): NextMiddlewareLike {
+  return async function peacMiddleware(request: NextRequestLike): Promise<Response> {
+    // Convert to handler request format
+    const handlerRequest: HandlerRequest = {
+      method: request.method,
+      url: request.url,
+      headers: headersToRecord(request.headers),
+    };
+
+    try {
+      // Handle verification
+      const result = await handleRequest(handlerRequest, config);
+
+      if (result !== null) {
+        // Return error response
+        return new Response(result.body, {
+          status: result.status,
+          headers: result.headers,
+        });
+      }
+
+      // Success - use Response.next() pattern
+      // In Next.js middleware, returning undefined or a response with
+      // x-middleware-next header indicates request should continue
+      return new Response(null, {
+        headers: {
+          'x-middleware-next': '1',
+          'X-PEAC-Verified': 'true',
+          'X-PEAC-Engine': 'tap',
+        },
+      });
+    } catch (error) {
+      // Internal error
+      console.error('[PEAC] Middleware error:', error);
+
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+      return new Response(
+        JSON.stringify({
+          type: 'https://peacprotocol.org/problems/internal_error',
+          title: 'Internal Server Error',
+          status: 500,
+          detail: errorMessage,
+          code: 'E_INTERNAL_ERROR',
+        }),
+        {
+          status: 500,
+          headers: {
+            'Content-Type': 'application/problem+json',
+            'Cache-Control': 'no-store',
+          },
+        }
+      );
+    }
+  };
+}
+
+/**
+ * Convenience wrapper for use with NextResponse.
+ *
+ * @example
+ * ```typescript
+ * import { NextResponse } from 'next/server';
+ * import { withPeacVerification, LRUReplayStore } from '@peac/middleware-nextjs';
+ *
+ * const peacConfig = {
+ *   issuerAllowlist: ['https://trusted-agent.example.com'],
+ *   replayStore: new LRUReplayStore(),
+ * };
+ *
+ * export async function middleware(request: NextRequest) {
+ *   const errorResponse = await withPeacVerification(request, peacConfig);
+ *   if (errorResponse) {
+ *     return errorResponse;
+ *   }
+ *   return NextResponse.next();
+ * }
+ * ```
+ */
+export async function withPeacVerification(
+  request: NextRequestLike,
+  config: MiddlewareConfig
+): Promise<Response | null> {
+  const handlerRequest: HandlerRequest = {
+    method: request.method,
+    url: request.url,
+    headers: headersToRecord(request.headers),
+  };
+
+  const result = await handleRequest(handlerRequest, config);
+
+  if (result !== null) {
+    return new Response(result.body, {
+      status: result.status,
+      headers: result.headers,
+    });
+  }
+
+  return null;
+}

--- a/surfaces/nextjs/middleware/src/replay-store.ts
+++ b/surfaces/nextjs/middleware/src/replay-store.ts
@@ -1,0 +1,128 @@
+/**
+ * @peac/middleware-nextjs - LRU Replay Store
+ *
+ * Best-effort replay protection using in-memory LRU cache.
+ *
+ * WARNING: Per-isolate only - NOT globally consistent across edge instances.
+ * Use this only when strong replay protection is not available.
+ *
+ * For production, consider:
+ * - Redis with atomic SETNX
+ * - Database with unique constraints
+ * - External service with strong consistency
+ */
+
+import type { ReplayStore, ReplayContext } from './types.js';
+
+/**
+ * Entry in the LRU cache.
+ */
+interface CacheEntry {
+  /** SHA-256 hash of issuer|keyid|nonce */
+  key: string;
+  /** Expiration timestamp (Unix ms) */
+  expiresAt: number;
+}
+
+/**
+ * LRU Replay Store configuration.
+ */
+export interface LRUReplayStoreOptions {
+  /** Maximum entries in cache (default: 1000) */
+  maxEntries?: number;
+}
+
+/**
+ * Best-effort replay store using LRU cache.
+ *
+ * Properties:
+ * - Per-isolate: Different edge instances have separate caches
+ * - Eviction: Oldest entries evicted when maxEntries reached
+ * - TTL: Entries automatically expire after ttlSeconds
+ * - Hashing: Keys stored as SHA-256(issuer|keyid|nonce)
+ *
+ * Limitations:
+ * - NOT atomic: Race conditions possible under high concurrency
+ * - NOT distributed: Each isolate has its own cache
+ * - NOT persistent: Lost on isolate restart
+ */
+export class LRUReplayStore implements ReplayStore {
+  readonly type = 'best-effort' as const;
+  private readonly maxEntries: number;
+  private readonly cache: Map<string, CacheEntry> = new Map();
+
+  constructor(options: LRUReplayStoreOptions = {}) {
+    this.maxEntries = options.maxEntries ?? 1000;
+  }
+
+  /**
+   * Check if nonce has been seen. If not, mark it as seen.
+   *
+   * @returns true if replay detected, false if new
+   */
+  async seen(ctx: ReplayContext): Promise<boolean> {
+    // Hash the key to prevent correlation
+    const key = await this.hashKey(ctx.issuer, ctx.keyid, ctx.nonce);
+    const now = Date.now();
+    const expiresAt = now + ctx.ttlSeconds * 1000;
+
+    // Clean expired entries first
+    this.cleanExpired(now);
+
+    // Check if key exists and not expired
+    const existing = this.cache.get(key);
+    if (existing && existing.expiresAt > now) {
+      // Replay detected
+      return true;
+    }
+
+    // Evict oldest if at capacity
+    if (this.cache.size >= this.maxEntries) {
+      const oldestKey = this.cache.keys().next().value;
+      if (oldestKey) {
+        this.cache.delete(oldestKey);
+      }
+    }
+
+    // Add new entry (moves to end of Map iteration order)
+    this.cache.set(key, { key, expiresAt });
+
+    return false;
+  }
+
+  /**
+   * Hash the replay key to prevent correlation.
+   */
+  private async hashKey(issuer: string, keyid: string, nonce: string): Promise<string> {
+    const data = `${issuer}|${keyid}|${nonce}`;
+    const encoder = new TextEncoder();
+    const hashBuffer = await crypto.subtle.digest('SHA-256', encoder.encode(data));
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+  }
+
+  /**
+   * Remove expired entries.
+   */
+  private cleanExpired(now: number): void {
+    for (const [key, entry] of this.cache) {
+      if (entry.expiresAt <= now) {
+        this.cache.delete(key);
+      }
+    }
+  }
+
+  /**
+   * Get current cache size (for testing).
+   */
+  get size(): number {
+    return this.cache.size;
+  }
+
+  /**
+   * Clear all entries (for testing).
+   */
+  clear(): void {
+    this.cache.clear();
+  }
+}

--- a/surfaces/nextjs/middleware/src/types.ts
+++ b/surfaces/nextjs/middleware/src/types.ts
@@ -1,0 +1,152 @@
+/**
+ * @peac/middleware-nextjs - Type definitions
+ *
+ * Next.js Edge middleware for TAP verification and 402 access gate.
+ * Maintains parity with Cloudflare Worker semantics.
+ */
+
+import type { TapControlEntry } from '@peac/mappings-tap';
+
+/**
+ * Verification mode for the middleware.
+ *
+ * - "receipt_or_tap": Missing TAP headers return 402 (receipt challenge)
+ * - "tap_only": Missing TAP headers return 401 (signature missing)
+ */
+export type VerificationMode = 'receipt_or_tap' | 'tap_only';
+
+/**
+ * Middleware configuration.
+ *
+ * Security defaults (fail-closed):
+ * - ISSUER_ALLOWLIST is REQUIRED (500 if empty unless unsafeAllowAnyIssuer=true)
+ * - Unknown TAP tags are REJECTED (unless unsafeAllowUnknownTags=true)
+ * - Replay protection is REQUIRED when nonce present (unless unsafeAllowNoReplay=true)
+ */
+export interface MiddlewareConfig {
+  /** Verification mode (default: "receipt_or_tap") */
+  mode?: VerificationMode;
+
+  /** Allowed issuer origins (REQUIRED for production) */
+  issuerAllowlist: string[];
+
+  /** Bypass path patterns (glob-style) */
+  bypassPaths?: string[];
+
+  /** Optional replay store for nonce deduplication */
+  replayStore?: ReplayStore;
+
+  /** UNSAFE: Allow any issuer when allowlist is empty (default: false) */
+  unsafeAllowAnyIssuer?: boolean;
+
+  /** UNSAFE: Allow unknown TAP tags (default: false - fail-closed) */
+  unsafeAllowUnknownTags?: boolean;
+
+  /** UNSAFE: Allow requests without replay protection (default: false) */
+  unsafeAllowNoReplay?: boolean;
+}
+
+/**
+ * Context for replay detection.
+ *
+ * Used to create a hashed key that prevents correlation
+ * while still detecting replays per issuer/key/nonce tuple.
+ */
+export interface ReplayContext {
+  /** Issuer origin (e.g., "https://issuer.example.com") */
+  issuer: string;
+
+  /** Key ID from the signature */
+  keyid: string;
+
+  /** Nonce value from the signature */
+  nonce: string;
+
+  /** TTL in seconds (480 for TAP 8-min window) */
+  ttlSeconds: number;
+}
+
+/**
+ * Replay store interface for nonce deduplication.
+ *
+ * Keys are stored as SHA-256 hashes of `issuer|keyid|nonce` to prevent
+ * correlation of raw identifiers in storage.
+ */
+export interface ReplayStore {
+  /**
+   * Check if nonce has been seen. If not, mark it as seen.
+   *
+   * @param ctx - Replay context with issuer, keyid, nonce, and TTL
+   * @returns true if replay detected (nonce already seen), false if new
+   */
+  seen(ctx: ReplayContext): Promise<boolean>;
+
+  /**
+   * Optional: Identify this store type for warning headers.
+   * Returns "best-effort" for LRU-based stores.
+   */
+  readonly type?: 'strong' | 'best-effort';
+}
+
+/**
+ * Verification result from the middleware.
+ */
+export interface VerificationResult {
+  /** Whether verification succeeded */
+  valid: boolean;
+
+  /** Whether this was a TAP request */
+  isTap: boolean;
+
+  /** Control entry if TAP verification succeeded */
+  controlEntry?: TapControlEntry;
+
+  /** Error code if verification failed */
+  errorCode?: string;
+
+  /** Error message if verification failed */
+  errorMessage?: string;
+}
+
+/**
+ * RFC 9457 Problem Details response.
+ *
+ * Includes PEAC-specific `code` extension for stable error identification.
+ */
+export interface ProblemDetails {
+  /** Problem type URI */
+  type: string;
+
+  /** Short human-readable summary */
+  title: string;
+
+  /** HTTP status code */
+  status: number;
+
+  /** Human-readable explanation (MUST NOT contain sensitive data) */
+  detail?: string;
+
+  /** URI reference for the specific occurrence */
+  instance?: string;
+
+  /** PEAC extension: stable error code (e.g., "E_TAP_SIGNATURE_INVALID") */
+  code?: string;
+}
+
+/**
+ * Handler request interface (runtime-neutral).
+ */
+export interface HandlerRequest {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+}
+
+/**
+ * Handler response interface.
+ */
+export interface HandlerResponse {
+  status: number;
+  headers: Record<string, string>;
+  body?: string;
+}

--- a/surfaces/nextjs/middleware/tests/handler.test.ts
+++ b/surfaces/nextjs/middleware/tests/handler.test.ts
@@ -1,0 +1,334 @@
+/**
+ * @peac/middleware-nextjs - Handler tests
+ *
+ * Tests for the core request handler.
+ * Validates parity with Cloudflare Worker behavior.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleRequest } from '../src/handler.js';
+import { ErrorCodes } from '../src/errors.js';
+import type { MiddlewareConfig, HandlerRequest, ReplayStore } from '../src/types.js';
+
+// Hoist mock functions so they're available at module load time
+const { mockVerifyTapProof } = vi.hoisted(() => ({
+  mockVerifyTapProof: vi.fn(),
+}));
+
+// Mock JWKS resolver to avoid network calls
+vi.mock('@peac/jwks-cache', () => ({
+  createResolver: () => async () => null, // Key not found by default
+}));
+
+// Mock TAP verification
+vi.mock('@peac/mappings-tap', () => ({
+  verifyTapProof: mockVerifyTapProof,
+  TAP_CONSTANTS: { MAX_WINDOW_SECONDS: 480 },
+}));
+
+describe('handleRequest', () => {
+  const baseConfig: MiddlewareConfig = {
+    issuerAllowlist: ['https://issuer.example.com'],
+  };
+
+  const baseRequest: HandlerRequest = {
+    method: 'GET',
+    url: 'https://api.example.com/resource',
+    headers: {},
+  };
+
+  beforeEach(() => {
+    mockVerifyTapProof.mockReset();
+  });
+
+  describe('bypass paths', () => {
+    it('returns null for bypass paths', async () => {
+      const config: MiddlewareConfig = {
+        ...baseConfig,
+        bypassPaths: ['/health', '/public/**'],
+      };
+
+      const result = await handleRequest(
+        { ...baseRequest, url: 'https://api.example.com/health' },
+        config
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for wildcard bypass paths', async () => {
+      const config: MiddlewareConfig = {
+        ...baseConfig,
+        bypassPaths: ['/public/**'],
+      };
+
+      const result = await handleRequest(
+        { ...baseRequest, url: 'https://api.example.com/public/file.js' },
+        config
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('issuer allowlist', () => {
+    it('returns 500 when issuerAllowlist is empty', async () => {
+      const config: MiddlewareConfig = {
+        issuerAllowlist: [],
+      };
+
+      const result = await handleRequest(baseRequest, config);
+
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(500);
+      expect(JSON.parse(result!.body!).code).toBe(ErrorCodes.CONFIG_ISSUER_ALLOWLIST_REQUIRED);
+    });
+
+    it('allows empty allowlist with unsafeAllowAnyIssuer', async () => {
+      const config: MiddlewareConfig = {
+        issuerAllowlist: [],
+        unsafeAllowAnyIssuer: true,
+      };
+
+      // No TAP headers -> 402 in receipt_or_tap mode
+      const result = await handleRequest(baseRequest, config);
+
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(402);
+    });
+  });
+
+  describe('mode: receipt_or_tap (default)', () => {
+    it('returns 402 when no TAP headers present', async () => {
+      const result = await handleRequest(baseRequest, baseConfig);
+
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(402);
+      expect(JSON.parse(result!.body!).code).toBe(ErrorCodes.RECEIPT_MISSING);
+      expect(result!.headers['WWW-Authenticate']).toBe('PEAC realm="peac-verifier"');
+    });
+  });
+
+  describe('mode: tap_only', () => {
+    it('returns 401 when no TAP headers present', async () => {
+      const config: MiddlewareConfig = {
+        ...baseConfig,
+        mode: 'tap_only',
+      };
+
+      const result = await handleRequest(baseRequest, config);
+
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(401);
+      expect(JSON.parse(result!.body!).code).toBe(ErrorCodes.TAP_SIGNATURE_MISSING);
+    });
+  });
+
+  describe('TAP verification', () => {
+    const tapRequest: HandlerRequest = {
+      ...baseRequest,
+      headers: {
+        'signature-input':
+          'sig1=("@method" "@target-uri");created=1234567890;expires=1234568370;keyid="https://issuer.example.com/.well-known/jwks#key-1";alg="ed25519"',
+        signature: 'sig1=:base64signature:',
+      },
+    };
+
+    it('returns 401 when signature is invalid', async () => {
+      mockVerifyTapProof.mockResolvedValue({
+        valid: false,
+        errorCode: 'E_SIGNATURE_INVALID',
+        errorMessage: 'Signature verification failed',
+      });
+
+      const result = await handleRequest(tapRequest, baseConfig);
+
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(401);
+      expect(JSON.parse(result!.body!).code).toBe(ErrorCodes.TAP_SIGNATURE_INVALID);
+    });
+
+    it('returns 400 when window is too large', async () => {
+      mockVerifyTapProof.mockResolvedValue({
+        valid: false,
+        errorCode: 'E_TAP_WINDOW_TOO_LARGE',
+        errorMessage: 'Window too large',
+      });
+
+      const result = await handleRequest(tapRequest, baseConfig);
+
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(400);
+      expect(JSON.parse(result!.body!).code).toBe(ErrorCodes.TAP_WINDOW_TOO_LARGE);
+    });
+
+    it('returns 400 when tag is unknown', async () => {
+      mockVerifyTapProof.mockResolvedValue({
+        valid: false,
+        errorCode: 'E_TAP_TAG_UNKNOWN',
+        errorMessage: 'Unknown tag',
+      });
+
+      const result = await handleRequest(tapRequest, baseConfig);
+
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(400);
+      expect(JSON.parse(result!.body!).code).toBe(ErrorCodes.TAP_TAG_UNKNOWN);
+    });
+
+    it('returns 403 when issuer not in allowlist', async () => {
+      mockVerifyTapProof.mockResolvedValue({
+        valid: true,
+        controlEntry: {
+          engine: 'tap',
+          result: 'allow',
+          evidence: {
+            protocol: 'visa-tap',
+            tag: 'agent-browser-auth',
+            keyid: 'https://untrusted.example.com/.well-known/jwks#key-1',
+            created: 1234567890,
+            expires: 1234568370,
+            coveredComponents: ['@method', '@target-uri'],
+            signatureBase64: 'base64',
+            verified: true,
+            jwksSource: '/.well-known/jwks',
+          },
+        },
+      });
+
+      const result = await handleRequest(tapRequest, baseConfig);
+
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(403);
+      expect(JSON.parse(result!.body!).code).toBe(ErrorCodes.ISSUER_NOT_ALLOWED);
+    });
+
+    it('returns null (forward) when TAP is valid and issuer allowed', async () => {
+      mockVerifyTapProof.mockResolvedValue({
+        valid: true,
+        controlEntry: {
+          engine: 'tap',
+          result: 'allow',
+          evidence: {
+            protocol: 'visa-tap',
+            tag: 'agent-browser-auth',
+            keyid: 'https://issuer.example.com/.well-known/jwks#key-1',
+            created: 1234567890,
+            expires: 1234568370,
+            coveredComponents: ['@method', '@target-uri'],
+            signatureBase64: 'base64',
+            verified: true,
+            jwksSource: '/.well-known/jwks',
+          },
+        },
+      });
+
+      const result = await handleRequest(tapRequest, baseConfig);
+
+      expect(result).toBeNull(); // Forward to origin
+    });
+  });
+
+  describe('replay protection', () => {
+    const tapRequestWithNonce: HandlerRequest = {
+      ...baseRequest,
+      headers: {
+        'signature-input':
+          'sig1=("@method");created=1234567890;expires=1234568370;keyid="https://issuer.example.com/.well-known/jwks#key-1";nonce="abc123";alg="ed25519"',
+        signature: 'sig1=:base64signature:',
+      },
+    };
+
+    it('returns 401 when nonce present but no replay store', async () => {
+      mockVerifyTapProof.mockResolvedValue({
+        valid: true,
+        controlEntry: {
+          engine: 'tap',
+          result: 'allow',
+          evidence: {
+            protocol: 'visa-tap',
+            tag: 'agent-browser-auth',
+            keyid: 'https://issuer.example.com/.well-known/jwks#key-1',
+            created: 1234567890,
+            expires: 1234568370,
+            nonce: 'abc123',
+            coveredComponents: ['@method'],
+            signatureBase64: 'base64',
+            verified: true,
+            jwksSource: '/.well-known/jwks',
+          },
+        },
+      });
+
+      const result = await handleRequest(tapRequestWithNonce, baseConfig);
+
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(401);
+      expect(JSON.parse(result!.body!).code).toBe(ErrorCodes.TAP_REPLAY_PROTECTION_REQUIRED);
+    });
+
+    it('returns 409 when replay detected', async () => {
+      const replayStore: ReplayStore = {
+        seen: vi.fn().mockResolvedValue(true), // Replay detected
+      };
+
+      mockVerifyTapProof.mockResolvedValue({
+        valid: true,
+        controlEntry: {
+          engine: 'tap',
+          result: 'allow',
+          evidence: {
+            protocol: 'visa-tap',
+            tag: 'agent-browser-auth',
+            keyid: 'https://issuer.example.com/.well-known/jwks#key-1',
+            created: 1234567890,
+            expires: 1234568370,
+            nonce: 'abc123',
+            coveredComponents: ['@method'],
+            signatureBase64: 'base64',
+            verified: true,
+            jwksSource: '/.well-known/jwks',
+          },
+        },
+      });
+
+      const result = await handleRequest(tapRequestWithNonce, {
+        ...baseConfig,
+        replayStore,
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(409);
+      expect(JSON.parse(result!.body!).code).toBe(ErrorCodes.TAP_NONCE_REPLAY);
+    });
+
+    it('allows bypass with unsafeAllowNoReplay', async () => {
+      mockVerifyTapProof.mockResolvedValue({
+        valid: true,
+        controlEntry: {
+          engine: 'tap',
+          result: 'allow',
+          evidence: {
+            protocol: 'visa-tap',
+            tag: 'agent-browser-auth',
+            keyid: 'https://issuer.example.com/.well-known/jwks#key-1',
+            created: 1234567890,
+            expires: 1234568370,
+            nonce: 'abc123',
+            coveredComponents: ['@method'],
+            signatureBase64: 'base64',
+            verified: true,
+            jwksSource: '/.well-known/jwks',
+          },
+        },
+      });
+
+      const result = await handleRequest(tapRequestWithNonce, {
+        ...baseConfig,
+        unsafeAllowNoReplay: true,
+      });
+
+      expect(result).toBeNull(); // Forward to origin
+    });
+  });
+});

--- a/surfaces/nextjs/middleware/tests/replay-store.test.ts
+++ b/surfaces/nextjs/middleware/tests/replay-store.test.ts
@@ -1,0 +1,148 @@
+/**
+ * @peac/middleware-nextjs - LRU Replay Store tests
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { LRUReplayStore } from '../src/replay-store.js';
+
+describe('LRUReplayStore', () => {
+  let store: LRUReplayStore;
+
+  beforeEach(() => {
+    store = new LRUReplayStore({ maxEntries: 3 });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns false for new nonce', async () => {
+    const result = await store.seen({
+      issuer: 'https://issuer.example.com',
+      keyid: 'key-1',
+      nonce: 'nonce-1',
+      ttlSeconds: 480,
+    });
+
+    expect(result).toBe(false);
+    expect(store.size).toBe(1);
+  });
+
+  it('returns true for seen nonce', async () => {
+    const ctx = {
+      issuer: 'https://issuer.example.com',
+      keyid: 'key-1',
+      nonce: 'nonce-1',
+      ttlSeconds: 480,
+    };
+
+    await store.seen(ctx);
+    const result = await store.seen(ctx);
+
+    expect(result).toBe(true);
+  });
+
+  it('evicts oldest entry when maxEntries reached', async () => {
+    // Add 3 entries (max)
+    await store.seen({
+      issuer: 'https://issuer.example.com',
+      keyid: 'key-1',
+      nonce: 'nonce-1',
+      ttlSeconds: 480,
+    });
+    await store.seen({
+      issuer: 'https://issuer.example.com',
+      keyid: 'key-1',
+      nonce: 'nonce-2',
+      ttlSeconds: 480,
+    });
+    await store.seen({
+      issuer: 'https://issuer.example.com',
+      keyid: 'key-1',
+      nonce: 'nonce-3',
+      ttlSeconds: 480,
+    });
+
+    expect(store.size).toBe(3);
+
+    // Add 4th entry - should evict oldest
+    await store.seen({
+      issuer: 'https://issuer.example.com',
+      keyid: 'key-1',
+      nonce: 'nonce-4',
+      ttlSeconds: 480,
+    });
+
+    expect(store.size).toBe(3);
+
+    // First nonce should be evicted, so it's "new" again
+    const result = await store.seen({
+      issuer: 'https://issuer.example.com',
+      keyid: 'key-1',
+      nonce: 'nonce-1',
+      ttlSeconds: 480,
+    });
+
+    expect(result).toBe(false); // Was evicted, so it's new
+  });
+
+  it('expires entries after TTL', async () => {
+    const ctx = {
+      issuer: 'https://issuer.example.com',
+      keyid: 'key-1',
+      nonce: 'nonce-1',
+      ttlSeconds: 480, // 8 minutes
+    };
+
+    await store.seen(ctx);
+
+    // Advance time past TTL
+    vi.advanceTimersByTime(481 * 1000);
+
+    // Should be "new" again after expiration
+    const result = await store.seen(ctx);
+
+    expect(result).toBe(false);
+  });
+
+  it('has type "best-effort"', () => {
+    expect(store.type).toBe('best-effort');
+  });
+
+  it('can be cleared', async () => {
+    await store.seen({
+      issuer: 'https://issuer.example.com',
+      keyid: 'key-1',
+      nonce: 'nonce-1',
+      ttlSeconds: 480,
+    });
+
+    expect(store.size).toBe(1);
+
+    store.clear();
+
+    expect(store.size).toBe(0);
+  });
+
+  it('isolates by issuer+keyid+nonce combination', async () => {
+    // Same nonce but different issuer should be separate
+    const result1 = await store.seen({
+      issuer: 'https://issuer1.example.com',
+      keyid: 'key-1',
+      nonce: 'same-nonce',
+      ttlSeconds: 480,
+    });
+
+    const result2 = await store.seen({
+      issuer: 'https://issuer2.example.com',
+      keyid: 'key-1',
+      nonce: 'same-nonce',
+      ttlSeconds: 480,
+    });
+
+    expect(result1).toBe(false); // New
+    expect(result2).toBe(false); // Also new (different issuer)
+    expect(store.size).toBe(2);
+  });
+});

--- a/surfaces/nextjs/middleware/tsconfig.json
+++ b/surfaces/nextjs/middleware/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "module": "NodeNext",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "moduleResolution": "NodeNext"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "tests"]
+}


### PR DESCRIPTION
## Summary

Adds `@peac/middleware-nextjs` - Next.js Edge middleware for TAP verification with 402 access gate, maintaining behavioral parity with the Cloudflare Worker (PR #169).

## File Tree

```
surfaces/nextjs/middleware/
  src/
    types.ts       - Type definitions (MiddlewareConfig, ReplayStore, etc.)
    errors.ts      - Error codes, status mappings, RFC 9457 responses
    handler.ts     - Core verification logic (pure function)
    replay-store.ts - LRUReplayStore for best-effort replay protection
    index.ts       - Middleware factory and exports
  tests/
    handler.test.ts      - 14 handler tests
    replay-store.test.ts - 7 LRU store tests
  README.md
  package.json
  tsconfig.json
```

## API

```typescript
// Middleware factory
export function createPeacMiddleware(config: MiddlewareConfig): NextMiddlewareLike

// Direct handler (for custom integration)
export async function withPeacVerification(request, config): Promise<Response | null>

// Best-effort replay store (exported utility)
export class LRUReplayStore implements ReplayStore
```

## Configuration Truth Table

| Config | Default | Effect |
|--------|---------|--------|
| `issuerAllowlist` | **REQUIRED** | 500 E_CONFIG_ISSUER_ALLOWLIST_REQUIRED if empty |
| `mode` | `receipt_or_tap` | `receipt_or_tap`: 402 on missing; `tap_only`: 401 on missing |
| `bypassPaths` | `[]` | Glob patterns to skip verification |
| `replayStore` | `undefined` | If nonce present + no store: 401 E_TAP_REPLAY_PROTECTION_REQUIRED |
| `unsafeAllowAnyIssuer` | `false` | Bypass issuer allowlist (UNSAFE) |
| `unsafeAllowUnknownTags` | `false` | Accept unknown TAP tags (UNSAFE) |
| `unsafeAllowNoReplay` | `false` | Skip replay protection (UNSAFE) |

## Error Code / Status Mapping

| Error Code | HTTP Status | Scenario |
|------------|-------------|----------|
| `E_RECEIPT_MISSING` | 402 | No TAP headers in receipt_or_tap mode |
| `E_TAP_SIGNATURE_MISSING` | 401 | No TAP headers in tap_only mode |
| `E_TAP_SIGNATURE_INVALID` | 401 | Signature verification failed |
| `E_TAP_WINDOW_TOO_LARGE` | 400 | expires - created > 480s |
| `E_TAP_TAG_UNKNOWN` | 400 | Unknown TAP tag (fail-closed) |
| `E_ISSUER_NOT_ALLOWED` | 403 | Issuer not in allowlist |
| `E_TAP_NONCE_REPLAY` | 409 | Nonce replay detected |
| `E_TAP_REPLAY_PROTECTION_REQUIRED` | 401 | Nonce present but no replay store |
| `E_CONFIG_ISSUER_ALLOWLIST_REQUIRED` | 500 | Empty allowlist without unsafe flag |

## Bundle Size

```
dist/ total: 100K (uncompressed)
JS files:
  errors.js      6.7 KB
  handler.js     9.5 KB
  index.js       4.7 KB
  replay-store.js 3.1 KB
  types.js       0.2 KB
  ---------------
  Total:        24.2 KB
```

## Gate Outputs

All gates pass:

```
lint: OK
build: 35 packages successful
typecheck:core: OK
test:core: 112 tests (5 packages)
guard.sh: 15 checks OK
format:check: OK
```

Middleware-specific tests: **21 tests passed**
- handler.test.ts: 14 tests
- replay-store.test.ts: 7 tests

## Parity with Cloudflare Worker

- Same error codes and HTTP status mappings
- Same fail-closed security defaults
- Same RFC 9457 Problem Details format
- Same verification modes (receipt_or_tap, tap_only)
- Same UNSAFE_* escape hatches
- Warning header when best-effort replay store used: `X-PEAC-Warning: replay-best-effort`

## Test Plan

- [x] All gates pass locally
- [x] Handler tests cover bypass paths, issuer allowlist, modes, TAP verification, replay protection
- [x] LRUReplayStore tests cover LRU eviction, TTL expiration, key isolation
- [ ] CI passes