### PR TITLE
fix(ci): use packageManager from package.json for pnpm version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,8 +39,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
+        # Uses packageManager field from package.json
 
       - name: Install deps
         run: pnpm -w install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Remove explicit pnpm version from publish.yml
- Let pnpm/action-setup@v4 read from package.json's packageManager field
- Fixes version mismatch error: pnpm@9 vs pnpm@8.15.0

## Context
The publish workflow failed with:
```
Multiple versions of pnpm specified:
- version 9 in the GitHub Action config
- version pnpm@8.15.0 in package.json
```

This fix allows the workflow to use the same pnpm version as local development.