### PR TITLE
docs: add scope ledger link and publishing section

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,8 @@
 # PEAC Protocol Roadmap
 
 > **Policy:** No feature is removed; only shipped, deferred, or cancelled with explicit rationale.
+>
+> See [Scope Ledger](roadmap/DEFERRED.md) for detailed tracking and acceptance criteria.
 
 ## Current Release: v0.9.18 (Dec 19, 2025)
 
@@ -74,3 +76,9 @@ This preserves x402 interop without lifecycle complexity in PEAC core.
 | v0.9.17 | Dec 14, 2025 | x402 v2, RSL 1.0, Policy Kit, subject binding             |
 | v0.9.16 | Dec 7, 2025  | CAL semantics, PaymentEvidence extensions, SubjectProfile |
 | v0.9.15 | Nov 2025     | Kernel-first architecture, package layering               |
+
+## Publishing
+
+- **npm dist-tag:** `next` for v0.9.x releases, `latest` reserved for v1.0+
+- **Tag requirement:** Real publishes require version tag (v0.9.18.1, etc.)
+- **Provenance:** npm provenance enabled via OIDC

--- a/docs/roadmap/DEFERRED.md
+++ b/docs/roadmap/DEFERRED.md
@@ -68,3 +68,14 @@ When items move from DEFER to SHIP, they must meet these criteria:
 | v0.9.21 | Risk Evidence Hook, Edge adapters, TAL extensions       | -                        |
 | v0.9.22 | Go SDK, Publisher Playbooks                             | -                        |
 | v0.9.23 | Dispute and Audit                                       | -                        |
+
+## Scope Audit
+
+Verify all deferred items remain tracked in this file:
+
+```bash
+# Run from repo root - all keywords must appear in this file
+rg -l "Analytics|Daydreams|Fluora|Faremeter|Pinata|Card-Rails|Risk.Evidence" docs/roadmap/DEFERRED.md
+```
+
+Keywords that must be tracked: Analytics, Daydreams, Fluora, Faremeter, Pinata, Card-Rails Bridge, Risk Evidence Hook, Go SDK, Publisher Playbooks, Dispute and Audit


### PR DESCRIPTION
## Summary
- Link ROADMAP.md to DEFERRED.md scope ledger
- Add publishing section with dist-tag policy and provenance notes
- Add scope audit section with grep command to DEFERRED.md

## Context
Part of post-v0.9.18 hygiene and v0.9.19 scope integrity work.