### PR TITLE
chore: release v0.9.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.19] - 2025-12-24
+
+### Added
+
+- **@peac/rails-razorpay** (private, not published to npm): India-focused payment adapter for Razorpay (UPI, cards, netbanking)
+  - Webhook signature verification using raw bytes + constant-time compare (`timingSafeEqual`)
+  - Payment normalization to PEAC PaymentEvidence with safe integer enforcement
+  - VPA privacy: HMAC-SHA256 hashing by default (prevents dictionary attacks)
+  - Structured error handling with RFC 9457 problem+json support
+- **MCP/ACP Budget Utilities**: Budget enforcement for agent commerce
+  - `checkBudget()`: Pure function with bigint minor units for precise currency math
+  - Per-call, daily, and monthly budget limits with currency match enforcement
+  - Explicit "unbounded" semantics when no limits configured
+  - Identical implementation in `@peac/mappings-mcp` and `@peac/mappings-acp`
+- **x402 Payment Headers**: Headers-only detection in `@peac/rails-x402`
+  - `detectPaymentRequired()`, `extractPaymentReference()`, `extractPaymentResponse()`
+  - Case-insensitive header lookup (works with any `HeadersLike` interface)
+  - No DOM types leaked into core packages
+- **MCP Tool Call Example**: `examples/mcp-tool-call/` demonstrating paid MCP tools with budget enforcement
+- **CI Examples Harness**: `pnpm examples:check` for TypeScript validation of all examples
+- **Unicode Scanner**: `scripts/find-invisible-unicode.mjs` for Trojan Source attack prevention
+  - Detects bidirectional controls, direction marks, zero-width chars, BOM
+  - Integrated into `scripts/guard.sh` as CI gate
+
+### Security
+
+- **Razorpay webhook**: Raw bytes verification prevents JSON canonicalization attacks
+- **VPA hashing**: HMAC-SHA256 prevents rainbow table attacks on common VPAs
+- **Amount validation**: Safe integer enforcement prevents precision loss
+- **Trojan Source prevention**: Unicode scanner blocks hidden bidirectional characters
+
+### Notes
+
+- PaymentEvidence.amount remains `number` for v0.9.19 (enforced as integer minor units)
+- x402 payment headers are headers-only (no body parsing, no Response dependency)
+- VPA hashing uses HMAC-SHA256; changing hash key changes all hashes (audit trail impact)
+
 ## [0.9.18] - 2025-12-19
 
 ### Added

--- a/docs/specs/REGISTRIES.md
+++ b/docs/specs/REGISTRIES.md
@@ -64,12 +64,13 @@ Located at: `docs/specs/registries.json`
 
 ### 3.1 Current Entries
 
-| ID             | Category           | Description                         | Reference                                                     |
-| -------------- | ------------------ | ----------------------------------- | ------------------------------------------------------------- |
-| `x402`         | agentic-payment    | HTTP 402-based paid call receipts   | https://www.x402.org/                                         |
-| `l402`         | agentic-payment    | Lightning HTTP 402 Protocol (LSAT)  | https://docs.lightning.engineering/the-lightning-network/l402 |
-| `card-network` | card               | Generic card network (Visa/MC/etc.) | -                                                             |
-| `upi`          | account-to-account | Unified Payments Interface (India)  | https://www.npci.org.in/                                      |
+| ID             | Category           | Description                               | Reference                                                     |
+| -------------- | ------------------ | ----------------------------------------- | ------------------------------------------------------------- |
+| `x402`         | agentic-payment    | HTTP 402-based paid call receipts         | https://www.x402.org/                                         |
+| `l402`         | agentic-payment    | Lightning HTTP 402 Protocol (LSAT)        | https://docs.lightning.engineering/the-lightning-network/l402 |
+| `card-network` | card               | Generic card network (Visa/MC/etc.)       | -                                                             |
+| `upi`          | account-to-account | Unified Payments Interface (India)        | https://www.npci.org.in/                                      |
+| `razorpay`     | payment-gateway    | Razorpay gateway (UPI, cards, netbanking) | https://razorpay.com/docs/                                    |
 
 ### 3.2 Adding New Rails
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/monorepo",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "private": true,
   "description": "PEAC Protocol - Cryptographic receipts for agentic commerce",
   "repository": {

--- a/packages/access/package.json
+++ b/packages/access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/access",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "private": true,
   "description": "PEAC access pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/aipref/package.json
+++ b/packages/aipref/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/pref",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "AIPREF resolver with robots.txt bridge",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/attribution/package.json
+++ b/packages/attribution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/attribution",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "private": true,
   "description": "PEAC attribution pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/cli",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "PEAC protocol command-line tools",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/compliance/package.json
+++ b/packages/compliance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/compliance",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "private": true,
   "description": "PEAC compliance pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/consent/package.json
+++ b/packages/consent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/consent",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "private": true,
   "description": "PEAC consent pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/control/package.json
+++ b/packages/control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/control",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "PEAC Protocol Control - control engine interfaces and validation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/core",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "DEPRECATED - Use @peac/kernel, @peac/schema, @peac/crypto, @peac/protocol instead",
   "type": "module",
   "homepage": "https://peacprotocol.org",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/crypto",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "Ed25519 JWS signing and verification for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/disc",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "PEAC discovery with ≤20 lines enforcement",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/http-signatures/package.json
+++ b/packages/http-signatures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/http-signatures",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "RFC 9421 HTTP Message Signatures parsing and verification",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/intelligence/package.json
+++ b/packages/intelligence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/intelligence",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "private": true,
   "description": "PEAC intelligence pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/jwks-cache/package.json
+++ b/packages/jwks-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/jwks-cache",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "Edge-safe JWKS fetch and cache with SSRF protection",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/kernel",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "PEAC protocol kernel - normative constants, errors, and registries",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/mappings/acp/package.json
+++ b/packages/mappings/acp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-acp",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "Agentic Commerce Protocol (ACP) integration for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/mcp/package.json
+++ b/packages/mappings/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-mcp",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "Model Context Protocol (MCP) integration for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/rsl/package.json
+++ b/packages/mappings/rsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-rsl",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "RSL (Robots Specification Layer) mapping for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/tap/package.json
+++ b/packages/mappings/tap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-tap",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "Visa Trusted Agent Protocol mapping to PEAC control evidence",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/pay402/package.json
+++ b/packages/pay402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/pay402",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "Generic HTTP 402 adapter with multi-rail payment negotiation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/policy-kit/package.json
+++ b/packages/policy-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/policy-kit",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "PEAC Policy Kit - deterministic policy evaluation for CAL semantics",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/privacy/package.json
+++ b/packages/privacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/privacy",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "private": true,
   "description": "Privacy pillar for PEAC protocol - privacy budgeting, data protection, and privacy-preserving receipts",
   "main": "dist/index.js",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/protocol",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "PEAC protocol implementation - receipt issuance and verification",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/provenance/package.json
+++ b/packages/provenance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/provenance",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "private": true,
   "description": "Provenance pillar for PEAC protocol - content provenance, C2PA integration, and chain-of-custody",
   "main": "dist/index.js",

--- a/packages/rails/razorpay/package.json
+++ b/packages/rails/razorpay/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@peac/rails-razorpay",
-  "version": "0.9.18",
+  "version": "0.9.19",
+  "private": true,
   "description": "Razorpay payment rail adapter for PEAC protocol (UPI, cards, netbanking)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rails/stripe/package.json
+++ b/packages/rails/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-stripe",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "Stripe payment rail adapter for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rails/x402/package.json
+++ b/packages/rails/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-x402",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "x402 payment rail adapter for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/receipts/package.json
+++ b/packages/receipts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/receipts",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "PEAC Protocol receipt builders, parsers, and validators with CBOR support",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/schema",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "PEAC Protocol JSON schemas, OpenAPI specs, and TypeScript types",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/sdk",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "PEAC client SDK with discover/verify functions",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/server",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "PEAC verification server with DoS protection and rate limiting",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/transport/grpc/package.json
+++ b/packages/transport/grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-grpc",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "private": true,
   "description": "PEAC gRPC transport layer (placeholder for v0.9.17+)",
   "type": "module",

--- a/packages/transport/http/package.json
+++ b/packages/transport/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-http",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "private": true,
   "description": "PEAC HTTP transport layer - headers, middleware, DPoP L3/L4",
   "type": "module",

--- a/packages/transport/ws/package.json
+++ b/packages/transport/ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-ws",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "private": true,
   "description": "PEAC WebSocket transport layer (placeholder for v0.9.17+)",
   "type": "module",

--- a/specs/kernel/registries.json
+++ b/specs/kernel/registries.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "PEAC protocol registries - payment rails, control engines, transport methods, agent protocols",
   "payment_rails": [
     {
@@ -29,6 +29,13 @@
       "category": "account-to-account",
       "description": "Unified Payments Interface",
       "reference": "https://www.npci.org.in/",
+      "status": "informational"
+    },
+    {
+      "id": "razorpay",
+      "category": "payment-gateway",
+      "description": "Razorpay payment gateway (UPI, cards, netbanking, wallets)",
+      "reference": "https://razorpay.com/docs/",
       "status": "informational"
     }
   ],


### PR DESCRIPTION
## Summary

Release v0.9.19 with version bumps and CHANGELOG.

### Changes in this PR

- **Version bumps**: All 33 packages bumped from 0.9.18 to 0.9.19
- **CHANGELOG**: Added v0.9.19 entry
- **Registry**: Added `razorpay` payment rail to registries
- **Scripts**: Updated check-publish-list.sh (22 -> 23 packages)

### What's in v0.9.19

**New Packages:**
- `@peac/rails-razorpay`: India-focused payment adapter (UPI, cards, netbanking)

**New Features:**
- MCP/ACP budget utilities with bigint math
- x402 payment headers (headers-only detection)
- MCP tool call example
- CI examples harness
- Unicode scanner for Trojan Source prevention

### Pre-merge Checklist

- [x] All 33 packages at version 0.9.19
- [x] CHANGELOG updated
- [x] Registry updated with razorpay rail
- [x] check-publish-list.sh updated (23 packages, 12 tested)
- [x] All gates pass locally

### Post-merge

After merge:
1. Tag: `git tag v0.9.19 && git push origin v0.9.19`
2. Create GitHub release
3. Publish to npm: `npm publish` for each package