### PR TITLE
chore: v0.9.19 release hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Policy • Economics • Attribution • Compliance**
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-0.9.16-blue.svg)](https://github.com/peacprotocol/peac)
+[![Version](https://img.shields.io/badge/version-0.9.19-blue.svg)](https://github.com/peacprotocol/peac)
 
 PEAC is an open protocol for verifiable receipts and policy aware access across digital interactions between agents, APIs, crawlers, and web applications.
 
@@ -24,19 +24,20 @@ PEAC is stewarded by contributors from [Originary](https://www.originary.xyz) an
 
 PEAC does not replace existing protocols. It is the receipts and verification layer that works alongside them for plain APIs, human driven applications, and agentic workflows.
 
-**Payment rails (v0.9.16 status):**
+**Payment rails (v0.9.19 status):**
 
 - [x402](https://github.com/coinbase/x402) HTTP 402 payment flows for agentic interactions. Adapter implemented in `@peac/rails-x402`.
 - Card payments via Stripe API. Adapter implemented in `@peac/rails-stripe`.
+- [Razorpay](https://razorpay.com) India-focused payment gateway (UPI, cards, netbanking). Adapter in `@peac/rails-razorpay` (internal).
 - Additional rails such as regional gateways and Lightning style networks. Planned.
 
 The protocol is designed to work with generic HTTP 402 services, paywalls, routers, and data stores. Receipts do not depend on any single provider.
 
-**Agent protocols (v0.9.16 status):**
+**Agent protocols (v0.9.19 status):**
 
-- [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol) Tool context for language models. Mapping implemented.
-- [Agentic Commerce Protocol (ACP)](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol) Agent driven commerce. Mapping implemented.
-- [A2A Project](https://github.com/a2aproject/A2A) Agent to agent coordination. Planned for v0.9.16.
+- [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol) Tool context for language models. Mapping implemented with budget utilities.
+- [Agentic Commerce Protocol (ACP)](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol) Agent driven commerce. Mapping implemented with budget utilities.
+- [A2A Project](https://github.com/a2aproject/A2A) Agent to agent coordination. Planned.
 
 **Web policy surfaces:**
 
@@ -85,10 +86,10 @@ See [examples/x402-node-server](examples/x402-node-server) for a working impleme
 - Errors via `application/problem+json` (RFC 9457)
 - DPoP proof-of-possession binding (RFC 9449)
 
-**Rails and mappings (v0.9.16):**
+**Rails and mappings (v0.9.19):**
 
-- Payment rails: x402, Stripe (via `@peac/rails-*`)
-- Agent protocols: MCP, ACP (via `@peac/mappings-*`)
+- Payment rails: x402, Stripe, Razorpay (via `@peac/rails-*`)
+- Agent protocols: MCP, ACP with budget utilities (via `@peac/mappings-*`)
 - Transport bindings: HTTP, gRPC, WebSocket (via `@peac/transport-*`) - _scaffolding_
 
 **Policy surfaces:**
@@ -176,7 +177,7 @@ peac decode receipt.jws
 # Validate discovery manifest
 peac validate-discovery https://api.example.com
 
-# Policy commands (v0.9.17+)
+# Policy commands
 peac policy init                           # Create new peac-policy.yaml
 peac policy validate peac-policy.yaml      # Validate policy syntax
 peac policy explain peac-policy.yaml       # Debug rule matching
@@ -239,7 +240,7 @@ peac.txt is an optional, web-facing policy surface. The core of the protocol is 
 
 ```yaml
 # /.well-known/peac.txt
-version: 0.9.16
+version: 0.9.19
 usage: open
 
 purposes: [indexing, research, documentation]
@@ -256,7 +257,7 @@ repository: https://github.com/peacprotocol/peac
 **Example: Conditional API access**
 
 ```yaml
-version: 0.9.16
+version: 0.9.19
 usage: conditional
 
 purposes: [research, commercial]
@@ -295,7 +296,7 @@ PEAC is designed to sit alongside existing policy mechanisms rather than replace
 
 Libraries in this repo are structured so that you do not need to hand parse every policy file type separately. You can give agents and gateways one consistent picture of what is allowed, what must be paid, and what evidence is expected on every call.
 
-### Policy Kit (v0.9.17+)
+### Policy Kit
 
 > **Start here:** [docs/policy-kit/quickstart.md](docs/policy-kit/quickstart.md)
 
@@ -424,12 +425,13 @@ peac/
 │  ├─ cli/                 # Command-line tools
 │  ├─ rails/
 │  │  ├─ x402/             # HTTP 402 / x402 payment rail
-│  │  └─ stripe/           # Stripe payment rail
+│  │  ├─ stripe/           # Stripe payment rail
+│  │  └─ razorpay/         # Razorpay payment rail (internal)
 │  ├─ mappings/
 │  │  ├─ mcp/              # Model Context Protocol mapping
 │  │  ├─ acp/              # Agentic Commerce Protocol mapping
-│  │  └─ rsl/              # RSL usage token mapping (v0.9.17)
-│  ├─ policy-kit/            # Policy authoring and artifact generation (v0.9.17)
+│  │  └─ rsl/              # RSL usage token mapping
+│  ├─ policy-kit/            # Policy authoring and artifact generation
 │  ├─ transport/
 │  │  ├─ http/             # HTTP transport binding (scaffolding)
 │  │  ├─ grpc/             # gRPC transport binding (scaffolding)
@@ -487,29 +489,30 @@ peac/
 
 ## Packages
 
-**Core (stable, v0.9.16):**
+**Core (stable, v0.9.19):**
 
 - `@peac/kernel` - Zero-dependency constants and registries
 - `@peac/schema` - TypeScript types, Zod validators, JSON Schema
 - `@peac/crypto` - Ed25519 JWS signing and verification
 - `@peac/protocol` - High-level issue() and verify() functions
 
-**Runtime (stable, v0.9.16):**
+**Runtime (stable, v0.9.19):**
 
 - `@peac/server` - HTTP verification server with 402 support
 - `@peac/cli` - Command-line tools for receipts and policy
 
-**Rails (stable, v0.9.16):**
+**Rails (stable, v0.9.19):**
 
-- `@peac/rails-x402` - x402 payment rail adapter
+- `@peac/rails-x402` - x402 payment rail adapter with payment header detection
 - `@peac/rails-stripe` - Stripe payment rail adapter
+- `@peac/rails-razorpay` - Razorpay payment rail adapter (internal, not published)
 
-**Mappings (stable, v0.9.16):**
+**Mappings (stable, v0.9.19):**
 
-- `@peac/mappings-mcp` - Model Context Protocol integration
-- `@peac/mappings-acp` - Agentic Commerce Protocol integration
+- `@peac/mappings-mcp` - Model Context Protocol integration with budget utilities
+- `@peac/mappings-acp` - Agentic Commerce Protocol integration with budget utilities
 
-**Policy (stable, v0.9.17):**
+**Policy (stable, v0.9.19):**
 
 - `@peac/policy-kit` - Policy authoring, evaluation, and artifact generation
 - `@peac/mappings-rsl` - RSL (Robots Standard Language) mapping to CAL purposes
@@ -541,7 +544,7 @@ PEAC addresses seven protocol capabilities for AI and API infrastructure:
 | **Privacy**     | `@peac/privacy`     | Privacy budgeting and retention policy hooks      |
 | **Provenance**  | `@peac/provenance`  | Content provenance and C2PA integration           |
 
-These are optional higher-layer helpers built on top of the core receipt/kernel stack. The stable, production-ready surface for v0.9.16 is the kernel / schema / crypto / protocol / rails / server / cli stack. PEAC remains vendor-neutral; pillar packages provide building blocks, not a hosted service.
+These are optional higher-layer helpers built on top of the core receipt/kernel stack. The stable, production-ready surface for v0.9.19 is the kernel / schema / crypto / protocol / rails / server / cli stack. PEAC remains vendor-neutral; pillar packages provide building blocks, not a hosted service.
 
 ---
 
@@ -567,8 +570,8 @@ These are optional higher-layer helpers built on top of the core receipt/kernel 
 
 **Defense in depth:**
 
-- SSRF protection and strict URL validation (v0.9.16)
-- DPoP proof-of-possession for tokens (v0.9.16)
+- SSRF protection and strict URL validation
+- DPoP proof-of-possession for tokens
 - JWKS rotation and emergency revocation plans
 - Rate limiting and circuit breakers
 
@@ -584,7 +587,7 @@ These are optional higher-layer helpers built on top of the core receipt/kernel 
 **Library surface:**
 
 - TypeScript APIs are pre-1.0 and may have breaking changes between minor releases
-- Core packages (kernel, schema, crypto, protocol) are stable for v0.9.16
+- Core packages (kernel, schema, crypto, protocol) are stable for v0.9.19
 - Pillar packages (access, consent, etc.) are early scaffolding; APIs may change
 
 For forward-looking details, see the docs in `docs/` and the CHANGELOG.
@@ -633,7 +636,7 @@ pnpm -r test
 ## Security
 
 - Always verify JWS signatures and validate receipt structure
-- Use DPoP binding to tie receipts to specific requests (v0.9.16)
+- Use DPoP binding to tie receipts to specific requests
 - Treat external policy files as untrusted input
 - Enforce timeouts and SSRF guards when fetching JWKS or discovery manifests
 - Map all errors to RFC 9457 Problem Details

--- a/examples/x402-node-server/package.json
+++ b/examples/x402-node-server/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "demo": "tsx demo.ts",
-    "check": "tsc --noEmit"
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@peac/crypto": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,25 +194,6 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
 
-  examples/razorpay-upi:
-    dependencies:
-      '@peac/crypto':
-        specifier: workspace:*
-        version: link:../../packages/crypto
-      '@peac/protocol':
-        specifier: workspace:*
-        version: link:../../packages/protocol
-      '@peac/schema':
-        specifier: workspace:*
-        version: link:../../packages/schema
-    devDependencies:
-      tsx:
-        specifier: ^4.7.0
-        version: 4.20.6
-      typescript:
-        specifier: ^5.3.3
-        version: 5.9.3
-
   examples/rsl-collective:
     dependencies:
       '@peac/crypto':

--- a/scripts/find-invisible-unicode.mjs
+++ b/scripts/find-invisible-unicode.mjs
@@ -3,98 +3,106 @@
  * find-invisible-unicode.mjs
  *
  * Scans files for invisible/dangerous Unicode characters that GitHub warns about.
+ * Optionally fixes them with --fix mode.
  *
  * Usage:
  *   node scripts/find-invisible-unicode.mjs <file1> <file2> ...
- *   git diff --name-only origin/main...HEAD | node scripts/find-invisible-unicode.mjs --stdin
+ *   node scripts/find-invisible-unicode.mjs --fix <file1> <file2> ...
+ *   git ls-files -- '*.ts' '*.md' | node scripts/find-invisible-unicode.mjs --stdin
+ *   git ls-files -- '*.ts' '*.md' | node scripts/find-invisible-unicode.mjs --stdin --fix
  */
 
-import { readFileSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import { createInterface } from 'readline';
 
-// Characters to detect (matching GitHub's detector)
+// Characters to detect and fix
 const DANGEROUS_CODEPOINTS = {
-  // Bidirectional controls (Trojan Source)
-  0x202A: 'LEFT-TO-RIGHT EMBEDDING',
-  0x202B: 'RIGHT-TO-LEFT EMBEDDING',
-  0x202C: 'POP DIRECTIONAL FORMATTING',
-  0x202D: 'LEFT-TO-RIGHT OVERRIDE',
-  0x202E: 'RIGHT-TO-LEFT OVERRIDE',
+  // Bidirectional controls (Trojan Source) - REMOVE
+  0x202a: 'LEFT-TO-RIGHT EMBEDDING',
+  0x202b: 'RIGHT-TO-LEFT EMBEDDING',
+  0x202c: 'POP DIRECTIONAL FORMATTING',
+  0x202d: 'LEFT-TO-RIGHT OVERRIDE',
+  0x202e: 'RIGHT-TO-LEFT OVERRIDE',
   0x2066: 'LEFT-TO-RIGHT ISOLATE',
   0x2067: 'RIGHT-TO-LEFT ISOLATE',
   0x2068: 'FIRST STRONG ISOLATE',
   0x2069: 'POP DIRECTIONAL ISOLATE',
 
-  // Direction marks
-  0x200E: 'LEFT-TO-RIGHT MARK',
-  0x200F: 'RIGHT-TO-LEFT MARK',
-  0x061C: 'ARABIC LETTER MARK',
+  // Direction marks - REMOVE
+  0x200e: 'LEFT-TO-RIGHT MARK',
+  0x200f: 'RIGHT-TO-LEFT MARK',
+  0x061c: 'ARABIC LETTER MARK',
 
-  // Zero-width characters
-  0x200B: 'ZERO WIDTH SPACE',
-  0x200C: 'ZERO WIDTH NON-JOINER',
-  0x200D: 'ZERO WIDTH JOINER',
-
-  // BOM
-  0xFEFF: 'BYTE ORDER MARK',
-
-  // Other format characters that can be problematic
-  0x00AD: 'SOFT HYPHEN',
-  0x034F: 'COMBINING GRAPHEME JOINER',
-  0x115F: 'HANGUL CHOSEONG FILLER',
-  0x1160: 'HANGUL JUNGSEONG FILLER',
-  0x17B4: 'KHMER VOWEL INHERENT AQ',
-  0x17B5: 'KHMER VOWEL INHERENT AA',
-  0x180B: 'MONGOLIAN FREE VARIATION SELECTOR ONE',
-  0x180C: 'MONGOLIAN FREE VARIATION SELECTOR TWO',
-  0x180D: 'MONGOLIAN FREE VARIATION SELECTOR THREE',
-  0x180E: 'MONGOLIAN VOWEL SEPARATOR',
+  // Zero-width characters - REMOVE
+  0x200b: 'ZERO WIDTH SPACE',
+  0x200c: 'ZERO WIDTH NON-JOINER',
+  0x200d: 'ZERO WIDTH JOINER',
   0x2060: 'WORD JOINER',
+  0xfeff: 'BYTE ORDER MARK',
+
+  // NBSP variants - REPLACE WITH SPACE
+  0x00a0: 'NO-BREAK SPACE',
+  0x202f: 'NARROW NO-BREAK SPACE',
+
+  // Soft hyphen - REMOVE
+  0x00ad: 'SOFT HYPHEN',
+
+  // Other invisible format characters - REMOVE
+  0x034f: 'COMBINING GRAPHEME JOINER',
+  0x061c: 'ARABIC LETTER MARK',
+  0x115f: 'HANGUL CHOSEONG FILLER',
+  0x1160: 'HANGUL JUNGSEONG FILLER',
+  0x17b4: 'KHMER VOWEL INHERENT AQ',
+  0x17b5: 'KHMER VOWEL INHERENT AA',
+  0x180b: 'MONGOLIAN FREE VARIATION SELECTOR ONE',
+  0x180c: 'MONGOLIAN FREE VARIATION SELECTOR TWO',
+  0x180d: 'MONGOLIAN FREE VARIATION SELECTOR THREE',
+  0x180e: 'MONGOLIAN VOWEL SEPARATOR',
   0x2061: 'FUNCTION APPLICATION',
   0x2062: 'INVISIBLE TIMES',
   0x2063: 'INVISIBLE SEPARATOR',
   0x2064: 'INVISIBLE PLUS',
-  0xFE00: 'VARIATION SELECTOR-1',
-  0xFE01: 'VARIATION SELECTOR-2',
-  0xFE02: 'VARIATION SELECTOR-3',
-  0xFE03: 'VARIATION SELECTOR-4',
-  0xFE04: 'VARIATION SELECTOR-5',
-  0xFE05: 'VARIATION SELECTOR-6',
-  0xFE06: 'VARIATION SELECTOR-7',
-  0xFE07: 'VARIATION SELECTOR-8',
-  0xFE08: 'VARIATION SELECTOR-9',
-  0xFE09: 'VARIATION SELECTOR-10',
-  0xFE0A: 'VARIATION SELECTOR-11',
-  0xFE0B: 'VARIATION SELECTOR-12',
-  0xFE0C: 'VARIATION SELECTOR-13',
-  0xFE0D: 'VARIATION SELECTOR-14',
-  0xFE0E: 'VARIATION SELECTOR-15',
-  0xFE0F: 'VARIATION SELECTOR-16',
-  0xFFF9: 'INTERLINEAR ANNOTATION ANCHOR',
-  0xFFFA: 'INTERLINEAR ANNOTATION SEPARATOR',
-  0xFFFB: 'INTERLINEAR ANNOTATION TERMINATOR',
+  0xfe00: 'VARIATION SELECTOR-1',
+  0xfe01: 'VARIATION SELECTOR-2',
+  0xfe02: 'VARIATION SELECTOR-3',
+  0xfe03: 'VARIATION SELECTOR-4',
+  0xfe04: 'VARIATION SELECTOR-5',
+  0xfe05: 'VARIATION SELECTOR-6',
+  0xfe06: 'VARIATION SELECTOR-7',
+  0xfe07: 'VARIATION SELECTOR-8',
+  0xfe08: 'VARIATION SELECTOR-9',
+  0xfe09: 'VARIATION SELECTOR-10',
+  0xfe0a: 'VARIATION SELECTOR-11',
+  0xfe0b: 'VARIATION SELECTOR-12',
+  0xfe0c: 'VARIATION SELECTOR-13',
+  0xfe0d: 'VARIATION SELECTOR-14',
+  0xfe0e: 'VARIATION SELECTOR-15',
+  0xfe0f: 'VARIATION SELECTOR-16',
+  0xfff9: 'INTERLINEAR ANNOTATION ANCHOR',
+  0xfffa: 'INTERLINEAR ANNOTATION SEPARATOR',
+  0xfffb: 'INTERLINEAR ANNOTATION TERMINATOR',
 };
+
+// Characters that should be replaced with a regular space
+const NBSP_CODEPOINTS = new Set([0x00a0, 0x202f]);
 
 // Build regex from codepoints
 const codepointPattern = Object.keys(DANGEROUS_CODEPOINTS)
-  .map(cp => `\\u{${Number(cp).toString(16).padStart(4, '0')}}`)
+  .map((cp) => `\\u{${Number(cp).toString(16).padStart(4, '0')}}`)
   .join('|');
 const dangerousRegex = new RegExp(`(${codepointPattern})`, 'gu');
 
 function escapeForDisplay(str) {
-  return str
-    .replace(/\n/g, '\\n')
-    .replace(/\r/g, '\\r')
-    .replace(/\t/g, '\\t');
+  return str.replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t');
 }
 
 function scanFile(filePath) {
   let content;
   try {
     content = readFileSync(filePath, 'utf-8');
-  } catch (err) {
+  } catch {
     // Skip files that can't be read (binary, missing, etc.)
-    return [];
+    return { findings: [], content: null };
   }
 
   const findings = [];
@@ -124,18 +132,46 @@ function scanFile(filePath) {
         codepoint: `U+${codepoint.toString(16).toUpperCase().padStart(4, '0')}`,
         name: DANGEROUS_CODEPOINTS[codepoint] || 'UNKNOWN',
         context: escapeForDisplay(context),
+        isNbsp: NBSP_CODEPOINTS.has(codepoint),
       });
     }
   }
 
-  return findings;
+  return { findings, content };
+}
+
+function fixContent(content) {
+  let fixed = content;
+
+  // Strip BOM at start of file
+  if (fixed.charCodeAt(0) === 0xfeff) {
+    fixed = fixed.slice(1);
+  }
+
+  // Replace NBSP variants with regular space
+  fixed = fixed.replace(/[\u00A0\u202F]/g, ' ');
+
+  // Remove all other dangerous characters
+  fixed = fixed.replace(dangerousRegex, (match) => {
+    const cp = match.codePointAt(0);
+    // NBSP already handled above, skip here
+    if (NBSP_CODEPOINTS.has(cp)) {
+      return ' ';
+    }
+    return '';
+  });
+
+  return fixed;
 }
 
 async function main() {
   const args = process.argv.slice(2);
+  const fixMode = args.includes('--fix');
+  const stdinMode = args.includes('--stdin');
+
   let files = [];
 
-  if (args.includes('--stdin')) {
+  if (stdinMode) {
     // Read file list from stdin
     const rl = createInterface({ input: process.stdin });
     for await (const line of rl) {
@@ -144,42 +180,84 @@ async function main() {
         files.push(trimmed);
       }
     }
-  } else if (args.length > 0) {
-    files = args.filter(f => !f.startsWith('-'));
   } else {
+    files = args.filter((f) => !f.startsWith('-'));
+  }
+
+  if (files.length === 0 && !stdinMode) {
     console.error('Usage:');
     console.error('  node scripts/find-invisible-unicode.mjs <file1> <file2> ...');
-    console.error('  git diff --name-only origin/main...HEAD | node scripts/find-invisible-unicode.mjs --stdin');
+    console.error('  node scripts/find-invisible-unicode.mjs --fix <file1> <file2> ...');
+    console.error(
+      "  git ls-files -- '*.ts' '*.md' | node scripts/find-invisible-unicode.mjs --stdin"
+    );
+    console.error(
+      "  git ls-files -- '*.ts' '*.md' | node scripts/find-invisible-unicode.mjs --stdin --fix"
+    );
     process.exit(1);
   }
 
   // Filter to text files only (skip binaries, images, etc.)
-  const textExtensions = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.json', '.md', '.yaml', '.yml', '.txt', '.sh', '.html', '.css'];
-  const textFiles = files.filter(f => {
+  const textExtensions = [
+    '.ts',
+    '.tsx',
+    '.js',
+    '.jsx',
+    '.mjs',
+    '.cjs',
+    '.json',
+    '.md',
+    '.yaml',
+    '.yml',
+    '.txt',
+    '.sh',
+    '.html',
+    '.css',
+  ];
+  const textFiles = files.filter((f) => {
     const ext = f.slice(f.lastIndexOf('.'));
     return textExtensions.includes(ext) || !f.includes('.');
   });
 
   let totalFindings = 0;
+  let filesFixed = 0;
 
   for (const file of textFiles) {
-    const findings = scanFile(file);
-    for (const f of findings) {
-      console.log(`${f.file}:${f.line}:${f.col} ${f.codepoint} ${f.name} ...${f.context}...`);
-      totalFindings++;
+    const { findings, content } = scanFile(file);
+
+    if (findings.length > 0) {
+      for (const f of findings) {
+        console.log(`${f.file}:${f.line}:${f.col} ${f.codepoint} ${f.name} ...${f.context}...`);
+        totalFindings++;
+      }
+
+      if (fixMode && content !== null) {
+        const fixed = fixContent(content);
+        if (fixed !== content) {
+          writeFileSync(file, fixed, 'utf-8');
+          console.log(`  -> Fixed: ${file}`);
+          filesFixed++;
+        }
+      }
     }
   }
 
   if (totalFindings > 0) {
-    console.error(`\nFound ${totalFindings} dangerous Unicode character(s)`);
-    process.exit(1);
+    if (fixMode) {
+      console.error(`\nFound ${totalFindings} dangerous Unicode character(s) in ${filesFixed} file(s) - FIXED`);
+      process.exit(0);
+    } else {
+      console.error(`\nFound ${totalFindings} dangerous Unicode character(s)`);
+      console.error('Run with --fix to automatically clean them');
+      process.exit(1);
+    }
   } else {
     console.log('No dangerous Unicode characters found');
     process.exit(0);
   }
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.error(err);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary

Pre-release hygiene for v0.9.19 tagging:

- Enhanced `scripts/find-invisible-unicode.mjs` with `--fix` mode and NBSP detection (U+00A0, U+202F)
- Updated README.md version references from 0.9.16 to 0.9.19
- Added Razorpay under payment rails in README (marked as internal)
- Fixed x402-node-server example to have proper build/typecheck scripts

## Test plan

- [x] Unicode scanner runs clean on entire repo
- [x] All 5 flagship examples have build/typecheck scripts
- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [x] `pnpm typecheck:core` passes
- [x] `pnpm test:core` passes
- [x] `./scripts/guard.sh` passes (including unicode check)
- [x] `pnpm format:check` passes
- [x] `./scripts/check-publish-list.sh` passes (22 public packages)