### PR TITLE
docs: update release guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Planned (v0.9.20)
+
+- Analytics surface
+- x402 service adapters
+- Card payment rails
+- Additional edge workers
+- gRPC transport
+
 ## [0.9.19] - 2025-12-24
 
 ### Added

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,27 +20,43 @@ git push
 
 ### 2. Publish Packages
 
+**CRITICAL: Always use pnpm for publishing, never the npm CLI directly.**
+
+pnpm resolves `workspace:*` dependencies to actual version numbers. The npm CLI does not understand the workspace protocol and publishes broken packages.
+
 ```bash
-# Set NPM auth (locally or in CI)
+# Set NPM auth
 export NPM_TOKEN=***your_token***
 
-# Publish core packages only (filters out legacy adapters)
-pnpm -r \
-  --filter @peac/core \
-  --filter @peac/receipts \
-  --filter @peac/pref \
-  --filter @peac/disc \
-  --filter @peac/pay402 \
-  --filter @peac/sdk \
-  publish --access public --no-git-checks
+# 0) DRY-RUN first (no registry writes) - always do this!
+pnpm -r --filter "./packages/**" publish --access public --tag next --dry-run --report-summary
+
+# 1a) Stable release (tag: latest)
+pnpm -r --filter "./packages/**" publish --access public --report-summary
+
+# 1b) Prerelease channel (tag: next)
+pnpm -r --filter "./packages/**" publish --access public --tag next --report-summary
 ```
+
+**Notes:**
+
+- `pnpm -r` = explicit recursive publish across workspace
+- `--filter "./packages/**"` = scope to packages directory only
+- `--dry-run` = preview what would publish without touching registry
+- `--report-summary` = machine-readable summary of published packages
 
 ### 3. Verify Publication
 
 ```bash
 # Check versions on registry
-pnpm view @peac/core version
-pnpm view @peac/sdk version
+for pkg in kernel schema crypto protocol control cli server core receipts pref disc pay402 sdk http-signatures jwks-cache policy-kit rails-stripe rails-x402 mappings-acp mappings-mcp mappings-rsl mappings-tap; do
+  echo -n "@peac/$pkg: "
+  npm view @peac/$pkg@next version 2>/dev/null || echo "NOT FOUND"
+done
+
+# Verify workspace:* was resolved correctly
+npm view @peac/protocol@next dependencies
+# Should show "@peac/schema": "0.9.X", NOT "workspace:*"
 ```
 
 ### 4. Smoke Test
@@ -49,7 +65,7 @@ pnpm view @peac/sdk version
 # Test in fresh environment
 TMPDIR=$(mktemp -d); cd "$TMPDIR"
 pnpm init -y
-pnpm add @peac/core@latest @peac/sdk@latest
+pnpm add @peac/core@next @peac/sdk@next
 node -e "import('@peac/core').then(m=>console.log('verifyReceipt OK:', typeof m.verifyReceipt==='function'))"
 ```
 
@@ -66,11 +82,36 @@ ALLOW_TAG_PUSH=1 git push --tags
 - `.npmrc` is configured for `${NPM_TOKEN}` env var
 - `publish-branch` allows `main|master|release/.*`
 - Pre-push hook blocks accidental tag pushes (set `ALLOW_TAG_PUSH=1` to override)
-- `--no-git-checks` bypasses branch restrictions for release branches
+- Publishing is done locally via pnpm (not via CI workflow)
 
-## Package Filters
+## Published Packages (22 total)
 
-We publish only these packages:
+**Layer 0-3 (Core):**
+
+- `@peac/kernel` - Types, constants, errors
+- `@peac/schema` - Zod schemas, validation
+- `@peac/crypto` - Signing, verification
+- `@peac/protocol` - High-level protocol APIs
+- `@peac/control` - Control flow APIs
+
+**Layer 4 (Adapters):**
+
+- `@peac/http-signatures` - RFC 9421 HTTP Message Signatures
+- `@peac/jwks-cache` - Edge-safe JWKS fetch
+- `@peac/mappings-acp` - Agent Communication Protocol mapping
+- `@peac/mappings-mcp` - Model Context Protocol mapping
+- `@peac/mappings-rsl` - RSL usage token mapping
+- `@peac/mappings-tap` - Visa TAP mapping
+- `@peac/policy-kit` - Policy evaluation engine
+- `@peac/rails-stripe` - Stripe payment rail
+- `@peac/rails-x402` - x402 payment rail
+
+**Layer 5 (Applications):**
+
+- `@peac/cli` - Command-line interface
+- `@peac/server` - Server utilities
+
+**Layer 6 (Consumer SDK):**
 
 - `@peac/core` - Core receipt verification
 - `@peac/receipts` - Receipt utilities
@@ -79,4 +120,9 @@ We publish only these packages:
 - `@peac/pay402` - Payment handling
 - `@peac/sdk` - Client SDK
 
-Legacy adapters (`@peac/adapter-*`) are intentionally excluded.
+**Private packages** (NOT published):
+
+- `@peac/access`, `@peac/attribution`, `@peac/compliance`, `@peac/consent`
+- `@peac/intelligence`, `@peac/privacy`, `@peac/provenance`
+- `@peac/rails-razorpay` (India-specific, requires separate npm org)
+- `@peac/transport-*` (scaffolds)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,20 +1,19 @@
 # PEAC Protocol Roadmap
 
-## Current Release: v0.9.18 (Dec 19, 2025)
+## Current Release: v0.9.19 (Dec 24, 2025)
 
 Shipped:
 
-- TAP foundation packages (@peac/http-signatures, @peac/jwks-cache, @peac/mappings-tap)
-- Cloudflare Worker TAP verifier
-- Next.js Edge middleware
-- Schema normalization (toCoreClaims)
-- Canonical flow examples
-- Governance docs
+- Razorpay payment adapter (UPI, cards, netbanking)
+- MCP/ACP budget utilities with bigint minor units
+- x402 payment headers detection
+- 5 flagship examples + CI harness
 
 ## Version History
 
 | Version | Date         | Highlights                                                |
 | ------- | ------------ | --------------------------------------------------------- |
+| v0.9.19 | Dec 24, 2025 | Razorpay adapter, MCP/ACP budget, x402 headers, examples  |
 | v0.9.18 | Dec 19, 2025 | TAP foundation, surfaces, schema normalization            |
 | v0.9.17 | Dec 14, 2025 | x402 v2, RSL 1.0, Policy Kit, subject binding             |
 | v0.9.16 | Dec 7, 2025  | CAL semantics, PaymentEvidence extensions, SubjectProfile |


### PR DESCRIPTION
## Summary

- Updated RELEASING.md with proper pnpm publish commands (`-r`, `--dry-run`, `--report-summary`)
- Updated 22-package list with layer organization, removed `--no-git-checks`
- Updated docs/ROADMAP.md to show v0.9.19 as current release
- Added Unreleased/v0.9.20 planned section to CHANGELOG.md

## Changes

**RELEASING.md:**
- `pnpm -r --filter "./packages/**" publish` with explicit recursion
- Added `--dry-run` step before actual publish
- Added `--report-summary` for machine-readable output
- Removed `--no-git-checks` flag
- Full 22-package list with layer organization
- Private packages section

**docs/ROADMAP.md:**
- Current release: v0.9.19 (Dec 24, 2025)
- Version history table updated

**CHANGELOG.md:**
- Added Planned (v0.9.20) section under Unreleased

## Test plan

- [x] `./scripts/guard.sh` passes
- [x] `pnpm format:check` passes
- [x] `pnpm build` passes