### PR TITLE
docs: update roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Planned (v0.9.20)
+
+- Analytics surface
+- x402 service adapters
+- Card payment rails
+- Additional edge workers
+- gRPC transport
+
 ## [0.9.19] - 2025-12-24
 
 ### Added

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,20 +1,19 @@
 # PEAC Protocol Roadmap
 
-## Current Release: v0.9.18 (Dec 19, 2025)
+## Current Release: v0.9.19 (Dec 24, 2025)
 
 Shipped:
 
-- TAP foundation packages (@peac/http-signatures, @peac/jwks-cache, @peac/mappings-tap)
-- Cloudflare Worker TAP verifier
-- Next.js Edge middleware
-- Schema normalization (toCoreClaims)
-- Canonical flow examples
-- Governance docs
+- Razorpay payment adapter (UPI, cards, netbanking)
+- MCP/ACP budget utilities with bigint minor units
+- x402 payment headers detection
+- 5 flagship examples + CI harness
 
 ## Version History
 
 | Version | Date         | Highlights                                                |
 | ------- | ------------ | --------------------------------------------------------- |
+| v0.9.19 | Dec 24, 2025 | Razorpay adapter, MCP/ACP budget, x402 headers, examples  |
 | v0.9.18 | Dec 19, 2025 | TAP foundation, surfaces, schema normalization            |
 | v0.9.17 | Dec 14, 2025 | x402 v2, RSL 1.0, Policy Kit, subject binding             |
 | v0.9.16 | Dec 7, 2025  | CAL semantics, PaymentEvidence extensions, SubjectProfile |


### PR DESCRIPTION
## Summary

- docs/ROADMAP.md: Update current release to v0.9.19 (Dec 24, 2025)
- CHANGELOG.md: Add minimal Planned (v0.9.20) section

## Changes

Minimal doc updates only (no implementation details leaked).

## Test plan

- [x] `./scripts/guard.sh` passes
- [x] `pnpm format:check` passes