### PR TITLE
refactor: normalize rail semantics with facilitator field

### DIFF
--- a/packages/adapters/x402/daydreams/src/adapter.ts
+++ b/packages/adapters/x402/daydreams/src/adapter.ts
@@ -15,7 +15,8 @@ import type {
   AdapterErrorCode,
 } from './types.js';
 
-const RAIL_ID = 'x402.daydreams';
+const RAIL_ID = 'x402';
+const FACILITATOR = 'daydreams';
 
 /**
  * Create an error result
@@ -176,6 +177,7 @@ export function mapToPaymentEvidence(
     currency: event.currency.toUpperCase(),
     asset: event.currency.toUpperCase(),
     env: event.env ?? config?.defaultEnv ?? 'live',
+    facilitator: FACILITATOR,
     evidence,
   };
 }

--- a/packages/adapters/x402/daydreams/tests/adapter.test.ts
+++ b/packages/adapters/x402/daydreams/tests/adapter.test.ts
@@ -143,9 +143,10 @@ describe('x402-daydreams adapter', () => {
   });
 
   describe('mapToPaymentEvidence', () => {
-    it('should map to PaymentEvidence with correct rail', () => {
+    it('should map to PaymentEvidence with correct rail and facilitator', () => {
       const evidence = mapToPaymentEvidence(validEvent);
-      expect(evidence.rail).toBe('x402.daydreams');
+      expect(evidence.rail).toBe('x402');
+      expect(evidence.facilitator).toBe('daydreams');
     });
 
     it('should map reference to eventId', () => {
@@ -183,7 +184,8 @@ describe('x402-daydreams adapter', () => {
       const result = fromInferenceEvent(validEvent);
       expect(result.ok).toBe(true);
       if (result.ok) {
-        expect(result.value.rail).toBe('x402.daydreams');
+        expect(result.value.rail).toBe('x402');
+        expect(result.value.facilitator).toBe('daydreams');
         expect(result.value.amount).toBe(500);
         expect(result.value.currency).toBe('USD');
       }

--- a/packages/adapters/x402/fluora/src/adapter.ts
+++ b/packages/adapters/x402/fluora/src/adapter.ts
@@ -14,7 +14,8 @@ import type {
   AdapterErrorCode,
 } from './types.js';
 
-const RAIL_ID = 'x402.fluora';
+const RAIL_ID = 'x402';
+const FACILITATOR = 'fluora';
 
 /**
  * Create an error result
@@ -180,6 +181,7 @@ export function mapToPaymentEvidence(
     currency: event.currency.toUpperCase(),
     asset: event.currency.toUpperCase(),
     env: event.env ?? config?.defaultEnv ?? 'live',
+    facilitator: FACILITATOR,
     evidence,
   };
 

--- a/packages/adapters/x402/fluora/tests/adapter.test.ts
+++ b/packages/adapters/x402/fluora/tests/adapter.test.ts
@@ -136,9 +136,10 @@ describe('x402-fluora adapter', () => {
   });
 
   describe('mapToPaymentEvidence', () => {
-    it('should map to PaymentEvidence with correct rail', () => {
+    it('should map to PaymentEvidence with correct rail and facilitator', () => {
       const evidence = mapToPaymentEvidence(validEvent);
-      expect(evidence.rail).toBe('x402.fluora');
+      expect(evidence.rail).toBe('x402');
+      expect(evidence.facilitator).toBe('fluora');
     });
 
     it('should map reference to callId', () => {
@@ -189,7 +190,8 @@ describe('x402-fluora adapter', () => {
       const result = fromMcpCallEvent(validEvent);
       expect(result.ok).toBe(true);
       if (result.ok) {
-        expect(result.value.rail).toBe('x402.fluora');
+        expect(result.value.rail).toBe('x402');
+        expect(result.value.facilitator).toBe('fluora');
         expect(result.value.amount).toBe(100);
       }
     });

--- a/packages/adapters/x402/pinata/src/adapter.ts
+++ b/packages/adapters/x402/pinata/src/adapter.ts
@@ -14,7 +14,8 @@ import type {
   AdapterErrorCode,
 } from './types.js';
 
-const RAIL_ID = 'x402.pinata';
+const RAIL_ID = 'x402';
+const FACILITATOR = 'pinata';
 
 /**
  * Create an error result
@@ -210,6 +211,7 @@ export function mapToPaymentEvidence(
     currency: event.currency.toUpperCase(),
     asset: event.currency.toUpperCase(),
     env: event.env ?? config?.defaultEnv ?? 'live',
+    facilitator: FACILITATOR,
     evidence,
   };
 }

--- a/packages/adapters/x402/pinata/tests/adapter.test.ts
+++ b/packages/adapters/x402/pinata/tests/adapter.test.ts
@@ -149,9 +149,10 @@ describe('x402-pinata adapter', () => {
   });
 
   describe('mapToPaymentEvidence', () => {
-    it('should map to PaymentEvidence with correct rail', () => {
+    it('should map to PaymentEvidence with correct rail and facilitator', () => {
       const evidence = mapToPaymentEvidence(validEvent);
-      expect(evidence.rail).toBe('x402.pinata');
+      expect(evidence.rail).toBe('x402');
+      expect(evidence.facilitator).toBe('pinata');
     });
 
     it('should map reference to accessId', () => {
@@ -209,7 +210,8 @@ describe('x402-pinata adapter', () => {
       const result = fromAccessEvent(validEvent);
       expect(result.ok).toBe(true);
       if (result.ok) {
-        expect(result.value.rail).toBe('x402.pinata');
+        expect(result.value.rail).toBe('x402');
+        expect(result.value.facilitator).toBe('pinata');
         expect(result.value.amount).toBe(250);
       }
     });

--- a/packages/schema/src/evidence.ts
+++ b/packages/schema/src/evidence.ts
@@ -157,6 +157,24 @@ export interface PaymentEvidence {
   network?: string;
 
   /**
+   * Facilitator/platform name (OPTIONAL)
+   *
+   * Identifies the platform or service facilitating payments on a given rail.
+   * Used when the rail is a protocol (like "x402") and multiple vendors
+   * operate on that protocol.
+   *
+   * Examples:
+   * - "daydreams" - Daydreams AI inference platform
+   * - "fluora" - Fluora MCP marketplace
+   * - "pinata" - Pinata IPFS gateway
+   * - "coinbase" - Coinbase Commerce
+   *
+   * Note: This is the platform/vendor name, not an account identifier.
+   * For account references, use `facilitator_ref`.
+   */
+  facilitator?: string;
+
+  /**
    * Facilitator reference (OPTIONAL)
    *
    * Stable identifier for the PSP/facilitator processing this payment.


### PR DESCRIPTION
## Summary

- Add `facilitator` field to `PaymentEvidence` for platform identification
- Normalize `rail` value to just `"x402"` (protocol) instead of `"x402.<vendor>"`
- Update all x402 adapters to use the new pattern:
  - `@peac/adapter-x402-daydreams`: `rail="x402"`, `facilitator="daydreams"`
  - `@peac/adapter-x402-fluora`: `rail="x402"`, `facilitator="fluora"`
  - `@peac/adapter-x402-pinata`: `rail="x402"`, `facilitator="pinata"`

## Rationale

This clarifies the taxonomy:
- **`rail`**: Identifies the payment protocol (e.g., `"x402"`, `"stripe"`, `"upi"`)
- **`facilitator`**: Identifies the vendor/platform operating on that protocol

This allows consumers to query by protocol (`rail="x402"`) while still knowing which specific platform processed the payment (`facilitator="daydreams"`).

## Schema Change

Added to `PaymentEvidence` interface:

```typescript
/**
 * Facilitator/platform name (OPTIONAL)
 * 
 * Identifies the platform or service facilitating payments on a given rail.
 * Used when the rail is a protocol (like "x402") and multiple vendors
 * operate on that protocol.
 * 
 * Examples:
 * - "daydreams" - Daydreams AI inference platform
 * - "fluora" - Fluora MCP marketplace
 * - "pinata" - Pinata IPFS gateway
 * - "coinbase" - Coinbase Commerce
 */
facilitator?: string;
```

## Test plan

- [x] guard.sh passes
- [x] format:check passes
- [x] lint passes
- [x] typecheck:core passes
- [x] test:core passes (38 tasks, 82 adapter tests updated)