### PR TITLE
fix: remove private flag from razorpay package

### DIFF
--- a/packages/rails/razorpay/package.json
+++ b/packages/rails/razorpay/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@peac/rails-razorpay",
   "version": "0.9.19",
-  "private": true,
   "description": "Razorpay payment rail adapter for PEAC protocol (UPI, cards, netbanking)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Remove contradictory `"private": true` from `@peac/rails-razorpay` package.json.

## Issue

The package had contradictory settings:
- `"private": true` - prevents npm from publishing this package
- `"publishConfig.access": "public"` - configures the package for public npm access

This was likely a copy-paste error when creating the package.

## Fix

Removed `"private": true` to match other rails packages (`@peac/rails-stripe`, `@peac/rails-x402`).

## Test plan

- [x] guard.sh passes
- [x] format:check passes
- [x] typecheck:core passes