### PR TITLE
chore(ci): add dedicated unicode security scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,13 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Unicode security scan (Trojan Source)
+        run: |
+          # Scan active packages for invisible/bidirectional Unicode (CVE-2021-42574)
+          git ls-files -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs' '*.cjs' '*.json' '*.md' '*.yaml' '*.yml' \
+            | grep -vE '^(archive/|node_modules/)' \
+            | node scripts/find-invisible-unicode.mjs --stdin
+
       - name: Domain guard
         run: bash -euxo pipefail scripts/guard.sh
 


### PR DESCRIPTION
## Summary

Add explicit CI step for invisible/bidirectional Unicode detection (CVE-2021-42574 / Trojan Source).

## Rationale

While the unicode scanner is already part of `guard.sh`, having a dedicated CI step provides:
- Better visibility in CI logs
- Clear step name indicating security scanning
- Easier to identify failures related to unicode issues

## What it scans

The step scans all TypeScript, JavaScript, JSON, Markdown, and YAML files for dangerous invisible Unicode characters that could be used for supply chain attacks.

Excludes:
- `archive/` (legacy code)
- `node_modules/` (dependencies)

## Test plan

- [x] guard.sh passes locally
- [x] format:check passes
- CI will validate the new step on PR