### PR TITLE
feat(schema): iterative JSON validator and cycle detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Domain guard
         run: bash -euxo pipefail scripts/guard.sh
 
+      - name: Package hygiene (drift, duplicates, private+publishConfig)
+        run: bash scripts/check-publish-list.sh
+
       - name: TypeScript check (core packages)
         run: pnpm typecheck:core
 

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -12,7 +12,16 @@ export * from './errors';
 export * from './normalize';
 
 // JSON-safe validation schemas (v0.9.21+)
-export { JsonPrimitiveSchema, JsonValueSchema, JsonObjectSchema, JsonArraySchema } from './json';
+export {
+  JsonPrimitiveSchema,
+  JsonValueSchema,
+  JsonObjectSchema,
+  JsonArraySchema,
+  // Iterative validator for DoS protection (v0.9.21+)
+  JSON_EVIDENCE_LIMITS,
+  assertJsonSafeIterative,
+} from './json';
+export type { JsonEvidenceLimits, JsonSafetyResult } from './json';
 
 // Legacy types (for backward compatibility in tests)
 export * from './constants';
@@ -43,7 +52,10 @@ export {
   SubjectProfileSnapshotSchema,
   // Subject snapshot validation helper (v0.9.17+)
   validateSubjectSnapshot,
+  // Evidence validation with DoS protection (v0.9.21+)
+  validateEvidence,
 } from './validators';
+export type { EvidenceValidationResult } from './validators';
 
 // Envelope types (v0.9.15+ normative structure)
 export type {

--- a/packages/schema/src/json.ts
+++ b/packages/schema/src/json.ts
@@ -87,3 +87,194 @@ export const JsonObjectSchema: z.ZodType<JsonObject> = PlainObjectSchema.transfo
  * JSON array schema - array of JSON values
  */
 export const JsonArraySchema: z.ZodType<JsonArray> = z.array(JsonValueSchema);
+
+/**
+ * Default limits for JSON evidence validation
+ *
+ * These are conservative defaults to prevent DoS attacks via deeply nested
+ * or excessively large JSON structures.
+ */
+export const JSON_EVIDENCE_LIMITS = {
+  /** Maximum nesting depth (default: 32) */
+  maxDepth: 32,
+  /** Maximum array length (default: 10,000) */
+  maxArrayLength: 10_000,
+  /** Maximum object keys (default: 1,000) */
+  maxObjectKeys: 1_000,
+  /** Maximum string length in bytes (default: 65,536 = 64KB) */
+  maxStringLength: 65_536,
+} as const;
+
+/**
+ * Limits for JSON evidence validation
+ */
+export interface JsonEvidenceLimits {
+  maxDepth?: number;
+  maxArrayLength?: number;
+  maxObjectKeys?: number;
+  maxStringLength?: number;
+}
+
+/**
+ * Result of JSON safety validation
+ */
+export type JsonSafetyResult =
+  | { ok: true }
+  | { ok: false; error: string; path: (string | number)[] };
+
+/**
+ * Iterative JSON safety validator
+ *
+ * Validates that a value is JSON-safe without using recursion, preventing
+ * stack overflow on deeply nested structures. Uses an explicit stack for
+ * traversal and WeakSet for cycle detection.
+ *
+ * Rejects:
+ * - Cycles (object references itself directly or indirectly)
+ * - Non-plain objects (Date, Map, Set, class instances)
+ * - Non-finite numbers (NaN, Infinity, -Infinity)
+ * - undefined, BigInt, functions, symbols
+ * - Structures exceeding depth/size limits
+ *
+ * @param value - Value to validate
+ * @param limits - Optional limits (defaults to JSON_EVIDENCE_LIMITS)
+ * @returns Result indicating success or failure with error details
+ */
+export function assertJsonSafeIterative(
+  value: unknown,
+  limits: JsonEvidenceLimits = {}
+): JsonSafetyResult {
+  const maxDepth = limits.maxDepth ?? JSON_EVIDENCE_LIMITS.maxDepth;
+  const maxArrayLength = limits.maxArrayLength ?? JSON_EVIDENCE_LIMITS.maxArrayLength;
+  const maxObjectKeys = limits.maxObjectKeys ?? JSON_EVIDENCE_LIMITS.maxObjectKeys;
+  const maxStringLength = limits.maxStringLength ?? JSON_EVIDENCE_LIMITS.maxStringLength;
+
+  // Track visited objects for cycle detection
+  const visited = new WeakSet<object>();
+
+  // Stack of items to process: [value, path, depth]
+  const stack: Array<[unknown, (string | number)[], number]> = [[value, [], 0]];
+
+  while (stack.length > 0) {
+    const [current, path, depth] = stack.pop()!;
+
+    // Check depth limit
+    if (depth > maxDepth) {
+      return {
+        ok: false,
+        error: `Maximum depth exceeded (limit: ${maxDepth})`,
+        path,
+      };
+    }
+
+    // Handle null (valid JSON)
+    if (current === null) {
+      continue;
+    }
+
+    // Handle primitives
+    const type = typeof current;
+
+    if (type === 'string') {
+      if ((current as string).length > maxStringLength) {
+        return {
+          ok: false,
+          error: `String exceeds maximum length (limit: ${maxStringLength})`,
+          path,
+        };
+      }
+      continue;
+    }
+
+    if (type === 'number') {
+      if (!Number.isFinite(current as number)) {
+        return {
+          ok: false,
+          error: `Non-finite number: ${current}`,
+          path,
+        };
+      }
+      continue;
+    }
+
+    if (type === 'boolean') {
+      continue;
+    }
+
+    // Reject non-JSON types
+    if (type === 'undefined') {
+      return { ok: false, error: 'undefined is not valid JSON', path };
+    }
+
+    if (type === 'bigint') {
+      return { ok: false, error: 'BigInt is not valid JSON', path };
+    }
+
+    if (type === 'function') {
+      return { ok: false, error: 'Function is not valid JSON', path };
+    }
+
+    if (type === 'symbol') {
+      return { ok: false, error: 'Symbol is not valid JSON', path };
+    }
+
+    // Handle objects (arrays and plain objects)
+    if (type === 'object') {
+      const obj = current as object;
+
+      // Cycle detection
+      if (visited.has(obj)) {
+        return { ok: false, error: 'Cycle detected in object graph', path };
+      }
+      visited.add(obj);
+
+      // Handle arrays
+      if (Array.isArray(obj)) {
+        if (obj.length > maxArrayLength) {
+          return {
+            ok: false,
+            error: `Array exceeds maximum length (limit: ${maxArrayLength})`,
+            path,
+          };
+        }
+        // Push array elements to stack in reverse order for correct traversal
+        for (let i = obj.length - 1; i >= 0; i--) {
+          stack.push([obj[i], [...path, i], depth + 1]);
+        }
+        continue;
+      }
+
+      // Check for non-plain objects (Date, Map, Set, class instances, etc.)
+      const proto = Object.getPrototypeOf(obj);
+      if (proto !== Object.prototype && proto !== null) {
+        const constructorName = obj.constructor?.name ?? 'unknown';
+        return {
+          ok: false,
+          error: `Non-plain object (${constructorName}) is not valid JSON`,
+          path,
+        };
+      }
+
+      // Handle plain objects
+      const keys = Object.keys(obj);
+      if (keys.length > maxObjectKeys) {
+        return {
+          ok: false,
+          error: `Object exceeds maximum key count (limit: ${maxObjectKeys})`,
+          path,
+        };
+      }
+      // Push object values to stack
+      for (let i = keys.length - 1; i >= 0; i--) {
+        const key = keys[i];
+        stack.push([(obj as Record<string, unknown>)[key], [...path, key], depth + 1]);
+      }
+      continue;
+    }
+
+    // Shouldn't reach here, but reject unknown types
+    return { ok: false, error: `Unknown type: ${type}`, path };
+  }
+
+  return { ok: true };
+}

--- a/specs/kernel/errors.json
+++ b/specs/kernel/errors.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "version": "0.9.15",
+  "version": "0.9.21",
   "description": "PEAC error codes - normative source of truth",
   "errors": [
     {
@@ -130,6 +130,14 @@
       "description": "Control engine requires manual review",
       "retriable": true,
       "category": "control"
+    },
+    {
+      "code": "E_EVIDENCE_NOT_JSON",
+      "http_status": 400,
+      "title": "Evidence Not JSON-Safe",
+      "description": "Evidence contains non-JSON-safe values (NaN, Infinity, undefined, BigInt, Date, Map, Set, functions, symbols, class instances, or cycles)",
+      "retriable": false,
+      "category": "validation"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add `assertJsonSafeIterative()` with explicit stack-based traversal (no recursion) to prevent stack overflow on deeply nested payloads
- Enforce DoS caps: maxDepth=32, maxArrayLength=10k, maxObjectKeys=1k, maxStringLength=64KB
- Detect cycles via WeakSet (rejects self-reference and indirect cycles)
- Add `validateEvidence()` returning `Result<value, PEACError>` pattern
- Add E_EVIDENCE_NOT_JSON to kernel SoT (`specs/kernel/errors.json` v0.9.21)
- Add CI guardrails: duplicate package detection, private+publishConfig check
- 61 new tests covering all validation scenarios

## Technical Details

### Iterative Validator (No Recursion)
The previous Zod-based JSON schema used recursive validation which could stack overflow on deeply nested input. The new `assertJsonSafeIterative()` uses an explicit stack:

```typescript
const stack: Array<[unknown, (string | number)[], number]> = [[value, [], 0]];
while (stack.length > 0) {
  const [current, path, depth] = stack.pop()!;
  // validate and push children to stack
}
```

### Cycle Detection
Uses WeakSet to track visited objects and detect cycles:
- Direct self-reference: `obj.self = obj`
- Indirect cycles: `a.b = b; b.a = a`
- Array cycles: `arr.push(arr)`

### DoS Caps
Conservative defaults (configurable via internal limits parameter):
- maxDepth: 32 levels
- maxArrayLength: 10,000 elements
- maxObjectKeys: 1,000 keys
- maxStringLength: 65,536 bytes (64KB)

### CI Guardrails
`scripts/check-publish-list.sh` now checks:
1. Package list drift (27 public packages)
2. Duplicate package names in workspace
3. Private packages with publishConfig (confusing pattern)

## Test plan
- [x] All 61 new JSON validation tests pass
- [x] `pnpm test:core` passes (181 tests in schema package)
- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [x] `pnpm typecheck:core` passes
- [x] `scripts/check-publish-list.sh` passes
- [x] `scripts/guard.sh` passes