### PR TITLE
feat(schema): maxTotalNodes DoS cap + internal-only limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
       - name: Package hygiene (drift, duplicates, private+publishConfig)
         run: bash scripts/check-publish-list.sh
 
+      - name: Error code parity (advisory)
+        continue-on-error: true
+        run: bash scripts/check-error-codes.sh
+
       - name: TypeScript check (core packages)
         run: pnpm typecheck:core
 

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -21,7 +21,11 @@ export {
   JSON_EVIDENCE_LIMITS,
   assertJsonSafeIterative,
 } from './json';
-export type { JsonEvidenceLimits, JsonSafetyResult } from './json';
+export type { JsonSafetyResult } from './json';
+
+// Internal types - exported with UNSAFE_ prefix for testing only
+// Do NOT use in production code; use validateEvidence() with defaults instead
+export type { JsonEvidenceLimits as UNSAFE_JsonEvidenceLimits } from './json';
 
 // Legacy types (for backward compatibility in tests)
 export * from './constants';

--- a/scripts/check-error-codes.sh
+++ b/scripts/check-error-codes.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# scripts/check-error-codes.sh
+# Verify TS error codes are defined in kernel SoT
+
+set -e
+
+echo "=== Checking error code parity ==="
+
+# Get error codes from kernel SoT
+KERNEL_CODES=$(node -e "
+const errors = require('./specs/kernel/errors.json').errors;
+console.log(errors.map(e => e.code).sort().join('\n'));
+")
+
+# Get error codes from TS ERROR_CODES constant and error maps
+# Look for actual error code definitions, not just E_ prefixed variables
+TS_CODES=$(node -e "
+const fs = require('fs');
+const path = require('path');
+
+const codes = new Set();
+
+// Files known to define error codes
+const errorFiles = [
+  'packages/schema/src/errors.ts',
+  'packages/transport/grpc/src/index.ts',
+  'packages/http-signatures/src/errors.ts',
+  'packages/mappings/tap/src/errors.ts',
+  'packages/jwks-cache/src/errors.ts',
+  'surfaces/nextjs/middleware/src/errors.ts',
+  'surfaces/workers/cloudflare/src/errors.ts',
+];
+
+for (const file of errorFiles) {
+  try {
+    const content = fs.readFileSync(file, 'utf8');
+    // Match string literals that are error codes
+    const matches = content.matchAll(/['\"]E_[A-Z_]+['\"]/g);
+    for (const m of matches) {
+      const code = m[0].slice(1, -1); // Remove quotes
+      if (code.length > 2) codes.add(code);
+    }
+  } catch {}
+}
+
+console.log([...codes].sort().join('\n'));
+")
+
+# Compare and report
+echo ""
+echo "Kernel SoT codes ($(echo "$KERNEL_CODES" | wc -l | tr -d ' ')):"
+echo "$KERNEL_CODES" | sed 's/^/  /'
+echo ""
+echo "TS-defined codes ($(echo "$TS_CODES" | wc -l | tr -d ' ')):"
+echo "$TS_CODES" | sed 's/^/  /'
+
+# Check for codes in TS but not in kernel
+MISSING_IN_KERNEL=()
+while IFS= read -r code; do
+  if [ -n "$code" ] && ! echo "$KERNEL_CODES" | grep -q "^${code}$"; then
+    MISSING_IN_KERNEL+=("$code")
+  fi
+done <<< "$TS_CODES"
+
+# Check for codes in kernel but not used in TS
+UNUSED_KERNEL=()
+while IFS= read -r code; do
+  if [ -n "$code" ] && ! echo "$TS_CODES" | grep -q "^${code}$"; then
+    UNUSED_KERNEL+=("$code")
+  fi
+done <<< "$KERNEL_CODES"
+
+echo ""
+if [ ${#MISSING_IN_KERNEL[@]} -gt 0 ]; then
+  echo "DRIFT: Codes defined in TS but not in kernel SoT (${#MISSING_IN_KERNEL[@]}):"
+  for code in "${MISSING_IN_KERNEL[@]}"; do
+    echo "  $code"
+  done
+  echo ""
+  echo "Action: Add these to specs/kernel/errors.json"
+else
+  echo "OK: All TS error codes are in kernel SoT"
+fi
+
+echo ""
+if [ ${#UNUSED_KERNEL[@]} -gt 0 ]; then
+  echo "INFO: Codes in kernel SoT but not found in TS error files (${#UNUSED_KERNEL[@]}):"
+  for code in "${UNUSED_KERNEL[@]}"; do
+    echo "  $code"
+  done
+  echo "(These may be used elsewhere or reserved for future use)"
+fi
+
+echo ""
+echo "=== Error code check complete ==="
+
+# Don't fail CI - this is advisory until full alignment
+exit 0


### PR DESCRIPTION
## Summary

- Add `maxTotalNodes` cap (default 100k) to `assertJsonSafeIterative()`
  - Prevents wide DoS attacks that bypass per-container limits
  - Counts every node (objects, arrays, primitives) visited
- Mark `JsonEvidenceLimits` as internal via `UNSAFE_` prefix
  - Production code should use `validateEvidence()` with defaults
  - Limits are still configurable for testing via `UNSAFE_JsonEvidenceLimits`
- Add CI error code parity check (advisory)
  - New script: `scripts/check-error-codes.sh`
  - Detects drift between TS error codes and `specs/kernel/errors.json`
  - Advisory only (continue-on-error) until full alignment in v0.9.22
- Add 5 new tests for total nodes limit validation

## DoS Protection Details

The previous validator capped depth (32), per-array length (10k), per-object keys (1k), and string length (64KB). However, this still allowed adversarial "wide" structures:

```js
// 100 objects * 900 keys each = 90,000 total nodes
// Each container is under limits, but total is excessive
const attack = Array(100).fill(null).map(() => 
  Object.fromEntries(Array(900).fill(0).map((_, i) => [`k${i}`, i]))
);
```

With `maxTotalNodes: 100_000` (default), the validator now fails fast on wide structures.

## Error Code Parity

The audit revealed significant drift between error codes:
- `specs/kernel/errors.json`: 17 codes (normative SoT)
- TS packages: 45 codes (many not in SoT)

The new CI check identifies this drift for gradual alignment.

## Test plan
- [x] 5 new tests for maxTotalNodes (accept at limit, reject over, custom limit, counts primitives, prevents wide attack)
- [x] All 186 schema tests pass
- [x] All core tests pass (39 files)
- [x] `pnpm lint` passes
- [x] `pnpm build` passes  
- [x] `pnpm typecheck:core` passes
- [x] `scripts/check-publish-list.sh` passes
- [x] `scripts/check-error-codes.sh` runs (advisory)