### PR TITLE
fix: correct version references from 0.9.22 to 0.9.21

### DIFF
--- a/packages/schema/src/envelope.ts
+++ b/packages/schema/src/envelope.ts
@@ -28,7 +28,7 @@ export interface AuthContext {
   ctx?: ContextMetadata;
   /** Subject profile snapshot for policy evaluation (v0.9.17+) */
   subject_snapshot?: SubjectProfileSnapshot;
-  /** Namespaced extensions (v0.9.22+) */
+  /** Namespaced extensions (v0.9.21+) */
   extensions?: Extensions;
 }
 
@@ -53,9 +53,9 @@ export interface EvidenceBlock {
   payment?: PaymentEvidence;
   attestation?: AttestationEvidence;
   payments?: PaymentEvidence[];
-  /** Generic attestations (v0.9.22+) */
+  /** Generic attestations (v0.9.21+) */
   attestations?: Attestation[];
-  /** Namespaced extensions (v0.9.22+) */
+  /** Namespaced extensions (v0.9.21+) */
   extensions?: Extensions;
 }
 

--- a/packages/schema/src/evidence.ts
+++ b/packages/schema/src/evidence.ts
@@ -330,7 +330,7 @@ export interface AttestationEvidence {
  * This is a generic slot for third-party claims. Specific attestation
  * types (like risk_assessment) define their evidence schema by convention.
  *
- * v0.9.22+: Added in schema_set_version 0.9.22.
+ * v0.9.21+: Added in schema_set_version 0.9.21.
  */
 export interface Attestation {
   /**
@@ -415,7 +415,7 @@ export interface Attestation {
  * This provides a forward-compatible extension mechanism for all blocks
  * that use `additionalProperties: false`.
  *
- * v0.9.22+: Added in schema_set_version 0.9.22.
+ * v0.9.21+: Added in schema_set_version 0.9.21.
  */
 export interface Extensions {
   [key: string]: JsonValue;

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -54,7 +54,7 @@ export {
   SubjectTypeSchema,
   SubjectProfileSchema,
   SubjectProfileSnapshotSchema,
-  // Attestation validators (v0.9.22+)
+  // Attestation validators (v0.9.21+)
   AttestationSchema,
   ExtensionsSchema,
   // Subject snapshot validation helper (v0.9.17+)

--- a/packages/schema/src/validators.ts
+++ b/packages/schema/src/validators.ts
@@ -277,7 +277,7 @@ export const SubjectProfileSnapshotSchema = z
   .strict();
 
 // -----------------------------------------------------------------------------
-// Attestation Validators (v0.9.22+)
+// Attestation Validators (v0.9.21+)
 // -----------------------------------------------------------------------------
 
 /**

--- a/scripts/guard.sh
+++ b/scripts/guard.sh
@@ -41,7 +41,7 @@ fi
 
 echo "== field regressions (typos) =="
 # Catch common misspellings of 'receipt' and legacy field names (intentionally spelled wrong below)
-# Note: issued_at is valid for Attestation type (v0.9.22+), exclude attestation-related files
+# Note: issued_at is valid for Attestation type (v0.9.21+), exclude attestation-related files
 LEGACY_FIELD_FILES='^(ex/|profiles/|scripts/guard\.sh|CHANGELOG\.md|docs/(migration/|MIGRATION_|PEAC_NORMATIVE_DECISIONS_LOG\.md|PEAC_v0\.9\.15_ACTUAL_SCOPE\.md|interop\.md)|specs/(wire/|conformance/)|packages/schema/src/(evidence|validators)\.ts)'
 if git grep -nE '\bissued_at\b|payment\.scheme|peacrece?i?e?pt(s)?\b' -- ':!node_modules' ':!archive/**' \
   | grep -vE "$LEGACY_FIELD_FILES" | grep .; then

--- a/specs/wire/VERSION.json
+++ b/specs/wire/VERSION.json
@@ -1,7 +1,7 @@
 {
   "$comment": "PEAC Wire Format Schema Version Metadata. schema_set_version tracks the JSON Schema definitions independently of npm package versions.",
   "wire_format": "peac.receipt/0.9",
-  "schema_set_version": "0.9.22",
+  "schema_set_version": "0.9.21",
   "json_schema_draft": "2020-12",
   "last_updated": "2025-12-31",
   "status": "stable",


### PR DESCRIPTION
## Summary

- Correct schema_set_version from 0.9.22 to 0.9.21 in VERSION.json
- Update TypeScript comments to reference v0.9.21+ (not v0.9.22+)
- Update guard script comment

The Attestation and Extensions feature (PR #216) belongs in v0.9.21, not v0.9.22.

## Test Plan

- [x] Build passes
- [x] TypeScript check passes
- [x] Lint passes