### PR TITLE
docs: evidence lane rules + telemetry ADR

### DIFF
--- a/docs/architecture/ADR-001-telemetry-package-taxonomy.md
+++ b/docs/architecture/ADR-001-telemetry-package-taxonomy.md
@@ -25,11 +25,11 @@ When adding OpenTelemetry support, we considered several package naming options:
 
 ### Package Type Taxonomy
 
-| Package Type   | Purpose                  | Examples                        |
-| -------------- | ------------------------ | ------------------------------- |
-| `rails/*`      | **Payment normalization**| stripe, x402, razorpay, card    |
-| `mappings/*`   | **Protocol mappings**    | mcp, acp, rsl, tap              |
-| `transport/*`  | **Transport bindings**   | grpc, http, ws                  |
+| Package Type  | Purpose                   | Examples                     |
+| ------------- | ------------------------- | ---------------------------- |
+| `rails/*`     | **Payment normalization** | stripe, x402, razorpay, card |
+| `mappings/*`  | **Protocol mappings**     | mcp, acp, rsl, tap           |
+| `transport/*` | **Transport bindings**    | grpc, http, ws               |
 
 OpenTelemetry is **none of these**. It is:
 

--- a/specs/wire/README.md
+++ b/specs/wire/README.md
@@ -136,11 +136,11 @@ Attestation fields:
 
 Evidence in PEAC receipts is organized into distinct "lanes" with specific scopes and semantics. This separation is critical for correct interpretation and prevents scope confusion.
 
-| Lane             | Location                   | Scope                      | Examples                                             |
-| ---------------- | -------------------------- | -------------------------- | ---------------------------------------------------- |
-| Payment Evidence | `payment.evidence.*`       | **Rail-scoped**            | Fraud signals, charge lifecycle, processor refs      |
-| Attestations     | `evidence.attestations[]`  | **Interaction-scoped**     | Content safety, bot classification, policy decisions |
-| Extensions       | `*.extensions`             | **Non-normative metadata** | Trace correlation, vendor extras, audit hints        |
+| Lane             | Location                  | Scope                      | Examples                                             |
+| ---------------- | ------------------------- | -------------------------- | ---------------------------------------------------- |
+| Payment Evidence | `payment.evidence.*`      | **Rail-scoped**            | Fraud signals, charge lifecycle, processor refs      |
+| Attestations     | `evidence.attestations[]` | **Interaction-scoped**     | Content safety, bot classification, policy decisions |
+| Extensions       | `*.extensions`            | **Non-normative metadata** | Trace correlation, vendor extras, audit hints        |
 
 ### Lane Semantics
 


### PR DESCRIPTION
## Summary

- Add **Evidence Lane Rules** section to `specs/wire/README.md` (normative)
- Add **ADR-001** for telemetry package taxonomy decision

## Changes

### Evidence Lane Rules

Documents the normative separation of evidence "lanes" in PEAC receipts:

| Lane | Scope | Purpose |
|------|-------|---------|
| `payment.evidence.*` | Rail-scoped | Payment processor proof |
| `evidence.attestations[]` | Interaction-scoped | Third-party claims |
| `*.extensions` | Non-normative | Correlation hints, vendor extras |

**Critical invariant:** Extensions MUST NOT be required for verification correctness.

Includes trace context extension example using `w3c/traceparent` (vendor-neutral).

### ADR-001: Telemetry Package Taxonomy

Documents the decision to use:
- `@peac/telemetry` (interfaces + no-op)
- `@peac/telemetry-otel` (OTel adapter)

Rather than `@peac/rails-otel` or `@peac/mappings-otel`.

Rationale: OpenTelemetry is infrastructure, not a payment rail or protocol mapping.

## Test plan

- [x] Guard script passes
- [x] No breaking changes (docs only)

Part of v0.9.22 telemetry preparation (PR 1/5).