### PR TITLE
feat(schema): add purpose type hierarchy for v0.9.24

### DIFF
--- a/packages/schema/__tests__/purpose.test.ts
+++ b/packages/schema/__tests__/purpose.test.ts
@@ -1,0 +1,441 @@
+/**
+ * Purpose type and validation tests (v0.9.24+)
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  // Types
+  type PurposeToken,
+  type CanonicalPurpose,
+  type PurposeReason,
+  type LegacyPurpose,
+  // Constants
+  PURPOSE_TOKEN_REGEX,
+  MAX_PURPOSE_TOKEN_LENGTH,
+  MAX_PURPOSE_TOKENS_PER_REQUEST,
+  CANONICAL_PURPOSES,
+  PURPOSE_REASONS,
+  INTERNAL_PURPOSE_UNDECLARED,
+  // Validation functions
+  isValidPurposeToken,
+  isCanonicalPurpose,
+  isLegacyPurpose,
+  isValidPurposeReason,
+  isUndeclaredPurpose,
+  // Normalization functions
+  normalizePurposeToken,
+  parsePurposeHeader,
+  validatePurposeTokens,
+  deriveKnownPurposes,
+  // Legacy mapping
+  mapLegacyToCanonical,
+  normalizeToCanonicalOrPreserve,
+} from '../src/purpose';
+
+// Also test Zod validators
+import { PurposeTokenSchema, CanonicalPurposeSchema, PurposeReasonSchema } from '../src/validators';
+
+describe('Purpose Types (v0.9.24+)', () => {
+  describe('Constants', () => {
+    it('should have correct canonical purposes', () => {
+      expect(CANONICAL_PURPOSES).toEqual(['train', 'search', 'user_action', 'inference', 'index']);
+    });
+
+    it('should have correct purpose reasons', () => {
+      expect(PURPOSE_REASONS).toEqual([
+        'allowed',
+        'constrained',
+        'denied',
+        'downgraded',
+        'undeclared_default',
+        'unknown_preserved',
+      ]);
+    });
+
+    it('should have internal undeclared value', () => {
+      expect(INTERNAL_PURPOSE_UNDECLARED).toBe('undeclared');
+    });
+
+    it('should have reasonable limits', () => {
+      expect(MAX_PURPOSE_TOKEN_LENGTH).toBe(64);
+      expect(MAX_PURPOSE_TOKENS_PER_REQUEST).toBe(10);
+    });
+  });
+
+  describe('PurposeToken Validation', () => {
+    describe('valid tokens', () => {
+      const validTokens = [
+        'train',
+        'search',
+        'user_action',
+        'inference',
+        'index',
+        'crawl',
+        'ai_input',
+        'ai_index',
+        'custom_purpose',
+        'a',
+        'ab',
+        'a1',
+        'a_1',
+        'train123',
+        'my_custom_purpose_with_underscores',
+      ];
+
+      validTokens.forEach((token) => {
+        it(`should accept valid token: "${token}"`, () => {
+          expect(isValidPurposeToken(token)).toBe(true);
+          expect(PURPOSE_TOKEN_REGEX.test(token)).toBe(true);
+        });
+      });
+    });
+
+    describe('valid vendor-prefixed tokens', () => {
+      const validVendorTokens = [
+        'cf:ai_crawler',
+        'vendor:custom_purpose',
+        'peac:experimental',
+        'akamai:bot_check',
+        'fastly:edge_compute',
+        'x:y',
+      ];
+
+      validVendorTokens.forEach((token) => {
+        it(`should accept vendor-prefixed token: "${token}"`, () => {
+          expect(isValidPurposeToken(token)).toBe(true);
+          expect(PURPOSE_TOKEN_REGEX.test(token)).toBe(true);
+        });
+      });
+    });
+
+    describe('invalid tokens', () => {
+      const invalidTokens = [
+        '', // empty
+        '   ', // whitespace only
+        'Train', // uppercase
+        'USER_ACTION', // all caps
+        'user-action', // hyphen (not allowed)
+        '123abc', // starts with number
+        '_train', // starts with underscore
+        'train!', // special character
+        'train@search', // @ symbol
+        'a'.repeat(65), // too long
+        ':prefix', // starts with colon
+        'prefix:', // ends with colon
+        'pre:fix:extra', // multiple colons
+        'Pre:fix', // uppercase in prefix
+        'pre:Fix', // uppercase in suffix
+      ];
+
+      invalidTokens.forEach((token) => {
+        it(`should reject invalid token: "${token.slice(0, 20)}${token.length > 20 ? '...' : ''}"`, () => {
+          expect(isValidPurposeToken(token)).toBe(false);
+        });
+      });
+
+      it('should reject non-string values', () => {
+        expect(isValidPurposeToken(123 as unknown as string)).toBe(false);
+        expect(isValidPurposeToken(null as unknown as string)).toBe(false);
+        expect(isValidPurposeToken(undefined as unknown as string)).toBe(false);
+        expect(isValidPurposeToken({} as unknown as string)).toBe(false);
+      });
+    });
+
+    describe('length limits', () => {
+      it('should accept token at max length', () => {
+        const maxToken = 'a'.repeat(64);
+        expect(isValidPurposeToken(maxToken)).toBe(true);
+      });
+
+      it('should reject token over max length', () => {
+        const overToken = 'a'.repeat(65);
+        expect(isValidPurposeToken(overToken)).toBe(false);
+      });
+    });
+  });
+
+  describe('CanonicalPurpose Validation', () => {
+    it('should accept all canonical purposes', () => {
+      const canonical: CanonicalPurpose[] = [
+        'train',
+        'search',
+        'user_action',
+        'inference',
+        'index',
+      ];
+      canonical.forEach((purpose) => {
+        expect(isCanonicalPurpose(purpose)).toBe(true);
+      });
+    });
+
+    it('should reject non-canonical purposes', () => {
+      expect(isCanonicalPurpose('crawl')).toBe(false);
+      expect(isCanonicalPurpose('ai_input')).toBe(false);
+      expect(isCanonicalPurpose('ai_index')).toBe(false);
+      expect(isCanonicalPurpose('unknown')).toBe(false);
+      expect(isCanonicalPurpose('cf:ai_crawler')).toBe(false);
+    });
+  });
+
+  describe('LegacyPurpose Validation', () => {
+    it('should accept legacy purposes', () => {
+      expect(isLegacyPurpose('crawl')).toBe(true);
+      expect(isLegacyPurpose('ai_input')).toBe(true);
+      expect(isLegacyPurpose('ai_index')).toBe(true);
+    });
+
+    it('should reject non-legacy purposes', () => {
+      expect(isLegacyPurpose('train')).toBe(false);
+      expect(isLegacyPurpose('search')).toBe(false);
+      expect(isLegacyPurpose('unknown')).toBe(false);
+    });
+  });
+
+  describe('PurposeReason Validation', () => {
+    it('should accept all valid reasons', () => {
+      const reasons: PurposeReason[] = [
+        'allowed',
+        'constrained',
+        'denied',
+        'downgraded',
+        'undeclared_default',
+        'unknown_preserved',
+      ];
+      reasons.forEach((reason) => {
+        expect(isValidPurposeReason(reason)).toBe(true);
+      });
+    });
+
+    it('should reject invalid reasons', () => {
+      expect(isValidPurposeReason('invalid')).toBe(false);
+      expect(isValidPurposeReason('allow')).toBe(false);
+      expect(isValidPurposeReason('')).toBe(false);
+    });
+  });
+
+  describe('Undeclared Purpose Check', () => {
+    it('should detect undeclared purpose', () => {
+      expect(isUndeclaredPurpose('undeclared')).toBe(true);
+    });
+
+    it('should not match other tokens', () => {
+      expect(isUndeclaredPurpose('train')).toBe(false);
+      expect(isUndeclaredPurpose('Undeclared')).toBe(false);
+      expect(isUndeclaredPurpose('')).toBe(false);
+    });
+  });
+});
+
+describe('Purpose Normalization', () => {
+  describe('normalizePurposeToken', () => {
+    it('should lowercase tokens', () => {
+      expect(normalizePurposeToken('TRAIN')).toBe('train');
+      expect(normalizePurposeToken('Train')).toBe('train');
+      expect(normalizePurposeToken('USER_ACTION')).toBe('user_action');
+    });
+
+    it('should trim whitespace', () => {
+      expect(normalizePurposeToken('  train  ')).toBe('train');
+      expect(normalizePurposeToken('\ttrain\n')).toBe('train');
+    });
+
+    it('should handle vendor prefixes', () => {
+      expect(normalizePurposeToken('CF:AI_CRAWLER')).toBe('cf:ai_crawler');
+    });
+  });
+
+  describe('parsePurposeHeader', () => {
+    it('should parse single purpose', () => {
+      expect(parsePurposeHeader('train')).toEqual(['train']);
+    });
+
+    it('should parse multiple purposes', () => {
+      expect(parsePurposeHeader('train, search')).toEqual(['train', 'search']);
+      expect(parsePurposeHeader('train,search,inference')).toEqual([
+        'train',
+        'search',
+        'inference',
+      ]);
+    });
+
+    it('should handle whitespace', () => {
+      expect(parsePurposeHeader('  train  ,  search  ')).toEqual(['train', 'search']);
+      expect(parsePurposeHeader('train , search')).toEqual(['train', 'search']);
+    });
+
+    it('should lowercase all tokens', () => {
+      expect(parsePurposeHeader('TRAIN, SEARCH')).toEqual(['train', 'search']);
+    });
+
+    it('should deduplicate tokens', () => {
+      expect(parsePurposeHeader('train, train, search')).toEqual(['train', 'search']);
+    });
+
+    it('should preserve order', () => {
+      expect(parsePurposeHeader('search, train, inference')).toEqual([
+        'search',
+        'train',
+        'inference',
+      ]);
+    });
+
+    it('should drop empty tokens', () => {
+      expect(parsePurposeHeader('train,,search')).toEqual(['train', 'search']);
+      expect(parsePurposeHeader(',train,')).toEqual(['train']);
+    });
+
+    it('should return empty array for empty/null input', () => {
+      expect(parsePurposeHeader('')).toEqual([]);
+      expect(parsePurposeHeader(null as unknown as string)).toEqual([]);
+      expect(parsePurposeHeader(undefined as unknown as string)).toEqual([]);
+    });
+
+    it('should handle vendor prefixes', () => {
+      expect(parsePurposeHeader('train, cf:ai_crawler')).toEqual(['train', 'cf:ai_crawler']);
+    });
+  });
+
+  describe('validatePurposeTokens', () => {
+    it('should validate all valid tokens', () => {
+      const result = validatePurposeTokens(['train', 'search', 'user_action']);
+      expect(result.valid).toBe(true);
+      expect(result.tokens).toEqual(['train', 'search', 'user_action']);
+      expect(result.invalidTokens).toEqual([]);
+      expect(result.undeclaredPresent).toBe(false);
+    });
+
+    it('should detect invalid tokens', () => {
+      const result = validatePurposeTokens(['train', 'INVALID!', 'search']);
+      expect(result.valid).toBe(false);
+      expect(result.invalidTokens).toContain('INVALID!');
+    });
+
+    it('should detect explicit undeclared', () => {
+      const result = validatePurposeTokens(['train', 'undeclared']);
+      expect(result.valid).toBe(false);
+      expect(result.undeclaredPresent).toBe(true);
+    });
+
+    it('should preserve unknown but valid tokens', () => {
+      const result = validatePurposeTokens(['train', 'unknown_vendor_purpose']);
+      expect(result.valid).toBe(true);
+      expect(result.tokens).toContain('unknown_vendor_purpose');
+    });
+
+    it('should validate empty array', () => {
+      const result = validatePurposeTokens([]);
+      expect(result.valid).toBe(true);
+      expect(result.tokens).toEqual([]);
+    });
+  });
+
+  describe('deriveKnownPurposes', () => {
+    it('should filter canonical purposes', () => {
+      const declared = ['train', 'cf:ai_crawler', 'search', 'unknown'];
+      const known = deriveKnownPurposes(declared);
+      expect(known).toEqual(['train', 'search']);
+    });
+
+    it('should return empty for no canonical purposes', () => {
+      const declared = ['cf:ai_crawler', 'unknown', 'crawl'];
+      const known = deriveKnownPurposes(declared);
+      expect(known).toEqual([]);
+    });
+
+    it('should return all for all canonical', () => {
+      const declared = ['train', 'search', 'user_action', 'inference', 'index'];
+      const known = deriveKnownPurposes(declared);
+      expect(known).toEqual(['train', 'search', 'user_action', 'inference', 'index']);
+    });
+  });
+});
+
+describe('Legacy Purpose Mapping', () => {
+  describe('mapLegacyToCanonical', () => {
+    it('should map crawl to index', () => {
+      const result = mapLegacyToCanonical('crawl');
+      expect(result.canonical).toBe('index');
+      expect(result.mapping_note).toContain('crawl');
+      expect(result.mapping_note).toContain('index');
+    });
+
+    it('should map ai_input to inference', () => {
+      const result = mapLegacyToCanonical('ai_input');
+      expect(result.canonical).toBe('inference');
+    });
+
+    it('should map ai_index to index', () => {
+      const result = mapLegacyToCanonical('ai_index');
+      expect(result.canonical).toBe('index');
+    });
+  });
+
+  describe('normalizeToCanonicalOrPreserve', () => {
+    it('should return canonical purpose unchanged', () => {
+      const result = normalizeToCanonicalOrPreserve('train');
+      expect(result.purpose).toBe('train');
+      expect(result.mapped).toBe(false);
+    });
+
+    it('should map legacy purpose', () => {
+      const result = normalizeToCanonicalOrPreserve('crawl');
+      expect(result.purpose).toBe('index');
+      expect(result.mapped).toBe(true);
+      if (result.mapped) {
+        expect(result.from).toBe('crawl');
+      }
+    });
+
+    it('should preserve unknown purpose', () => {
+      const result = normalizeToCanonicalOrPreserve('cf:ai_crawler');
+      expect(result.purpose).toBe('cf:ai_crawler');
+      expect(result.mapped).toBe(false);
+      if (!result.mapped && 'unknown' in result) {
+        expect(result.unknown).toBe(true);
+      }
+    });
+  });
+});
+
+describe('Zod Validators', () => {
+  describe('PurposeTokenSchema', () => {
+    it('should accept valid tokens', () => {
+      expect(() => PurposeTokenSchema.parse('train')).not.toThrow();
+      expect(() => PurposeTokenSchema.parse('user_action')).not.toThrow();
+      expect(() => PurposeTokenSchema.parse('cf:ai_crawler')).not.toThrow();
+    });
+
+    it('should reject invalid tokens', () => {
+      expect(() => PurposeTokenSchema.parse('')).toThrow();
+      expect(() => PurposeTokenSchema.parse('TRAIN')).toThrow();
+      expect(() => PurposeTokenSchema.parse('train!')).toThrow();
+    });
+  });
+
+  describe('CanonicalPurposeSchema', () => {
+    it('should accept canonical purposes', () => {
+      expect(() => CanonicalPurposeSchema.parse('train')).not.toThrow();
+      expect(() => CanonicalPurposeSchema.parse('search')).not.toThrow();
+      expect(() => CanonicalPurposeSchema.parse('user_action')).not.toThrow();
+      expect(() => CanonicalPurposeSchema.parse('inference')).not.toThrow();
+      expect(() => CanonicalPurposeSchema.parse('index')).not.toThrow();
+    });
+
+    it('should reject non-canonical purposes', () => {
+      expect(() => CanonicalPurposeSchema.parse('crawl')).toThrow();
+      expect(() => CanonicalPurposeSchema.parse('unknown')).toThrow();
+    });
+  });
+
+  describe('PurposeReasonSchema', () => {
+    it('should accept valid reasons', () => {
+      expect(() => PurposeReasonSchema.parse('allowed')).not.toThrow();
+      expect(() => PurposeReasonSchema.parse('denied')).not.toThrow();
+      expect(() => PurposeReasonSchema.parse('undeclared_default')).not.toThrow();
+    });
+
+    it('should reject invalid reasons', () => {
+      expect(() => PurposeReasonSchema.parse('invalid')).toThrow();
+      expect(() => PurposeReasonSchema.parse('')).toThrow();
+    });
+  });
+});

--- a/packages/schema/src/control.ts
+++ b/packages/schema/src/control.ts
@@ -21,6 +21,7 @@ export type ControlDecision = 'allow' | 'deny' | 'review';
  * - "index": Search engine indexing
  * - "train": AI/ML model training
  * - "inference": AI/ML inference/generation
+ * - "user_action": Agent acting on user behalf [v0.9.24+]
  * - "ai_input": RAG/grounding (using content as input to AI) [v0.9.17+, RSL alignment]
  * - "ai_index": AI-powered search/indexing [v0.9.18+, RSL 1.0 alignment]
  * - "search": Traditional search indexing [v0.9.17+, RSL alignment]
@@ -35,6 +36,7 @@ export type ControlPurpose =
   | 'index'
   | 'train'
   | 'inference'
+  | 'user_action'
   | 'ai_input'
   | 'ai_index'
   | 'search';

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -10,6 +10,7 @@ export * from './evidence';
 export * from './subject';
 export * from './errors';
 export * from './normalize';
+export * from './purpose';
 
 // JSON-safe validation schemas (v0.9.21+)
 export {
@@ -57,6 +58,10 @@ export {
   // Attestation validators (v0.9.21+)
   AttestationSchema,
   ExtensionsSchema,
+  // Purpose validators (v0.9.24+)
+  PurposeTokenSchema,
+  CanonicalPurposeSchema,
+  PurposeReasonSchema,
   // Subject snapshot validation helper (v0.9.17+)
   validateSubjectSnapshot,
   // Evidence validation with DoS protection (v0.9.21+)

--- a/packages/schema/src/purpose.ts
+++ b/packages/schema/src/purpose.ts
@@ -1,0 +1,332 @@
+/**
+ * PEAC Purpose Types (v0.9.24+)
+ *
+ * Purpose type hierarchy for forward-compatible purpose handling:
+ * - PurposeToken: Wire format (string) - preserves unknown tokens
+ * - CanonicalPurpose: PEAC's normative vocabulary - enforcement semantics
+ * - PurposeReason: Audit spine for enforcement decisions
+ *
+ * @see specs/kernel/constants.json for canonical values
+ */
+
+/**
+ * PurposeToken - Wire format string with validation grammar
+ *
+ * Allows unknown tokens for forward compatibility. Any valid token
+ * that matches the grammar is accepted and preserved.
+ *
+ * Grammar: lowercase, max 64 chars, [a-z0-9_] + optional vendor prefix (vendor:token)
+ * Examples: "train", "search", "user_action", "cf:ai_crawler", "vendor:custom_purpose"
+ */
+export type PurposeToken = string;
+
+/**
+ * CanonicalPurpose - PEAC's normative vocabulary
+ *
+ * These are the only tokens PEAC enforces semantics for.
+ * Matches specs/kernel/constants.json purpose.canonical_tokens.
+ *
+ * - train: Model training data collection
+ * - search: Traditional search indexing
+ * - user_action: Agent acting on user behalf (v0.9.24+)
+ * - inference: Runtime inference / RAG
+ * - index: Content indexing (store)
+ */
+export type CanonicalPurpose = 'train' | 'search' | 'user_action' | 'inference' | 'index';
+
+/**
+ * Internal-only purpose value (never valid on wire)
+ *
+ * Applied when PEAC-Purpose header is missing or empty.
+ * Explicit "undeclared" in request -> 400 Bad Request.
+ */
+export type InternalPurpose = 'undeclared';
+
+/**
+ * PurposeReason - Audit spine for enforcement decisions
+ *
+ * Captures WHY a purpose was enforced differently than declared.
+ * Matches specs/kernel/constants.json purpose.reason_values.
+ */
+export type PurposeReason =
+  | 'allowed' // Purpose permitted as declared (happy path)
+  | 'constrained' // Allowed with rate limits applied
+  | 'denied' // Purpose rejected by policy
+  | 'downgraded' // More restrictive purpose applied
+  | 'undeclared_default' // No purpose declared, default applied
+  | 'unknown_preserved'; // Unknown purpose token, preserved but flagged
+
+/**
+ * Legacy purpose tokens from pre-v0.9.24
+ *
+ * These are mapped to CanonicalPurpose via mapLegacyToCanonical().
+ * Retained for backward compatibility with existing ControlPurpose usage.
+ */
+export type LegacyPurpose = 'crawl' | 'ai_input' | 'ai_index';
+
+// ============================================================================
+// Validation Constants
+// ============================================================================
+
+/**
+ * Grammar validation for PurposeToken
+ *
+ * Pattern: lowercase letter followed by lowercase letters, digits, or underscores,
+ * with optional vendor prefix separated by colon.
+ *
+ * Valid: "train", "user_action", "cf:ai_crawler"
+ * Invalid: "Train", "USER_ACTION", "123abc", ""
+ */
+export const PURPOSE_TOKEN_REGEX = /^[a-z][a-z0-9_]*(?::[a-z][a-z0-9_]*)?$/;
+
+/** Maximum length for a purpose token */
+export const MAX_PURPOSE_TOKEN_LENGTH = 64;
+
+/** Maximum number of purpose tokens per request (RECOMMENDED, not MUST) */
+export const MAX_PURPOSE_TOKENS_PER_REQUEST = 10;
+
+/** Canonical purpose tokens (from constants.json) */
+export const CANONICAL_PURPOSES: readonly CanonicalPurpose[] = [
+  'train',
+  'search',
+  'user_action',
+  'inference',
+  'index',
+] as const;
+
+/** Purpose reason values (from constants.json) */
+export const PURPOSE_REASONS: readonly PurposeReason[] = [
+  'allowed',
+  'constrained',
+  'denied',
+  'downgraded',
+  'undeclared_default',
+  'unknown_preserved',
+] as const;
+
+/** Internal-only purpose value */
+export const INTERNAL_PURPOSE_UNDECLARED: InternalPurpose = 'undeclared';
+
+// ============================================================================
+// Validation Functions
+// ============================================================================
+
+/**
+ * Check if a string is a valid PurposeToken
+ *
+ * Validates against the purpose token grammar:
+ * - Lowercase letters, digits, underscores
+ * - Optional vendor prefix with colon
+ * - Max 64 characters
+ *
+ * @param token - String to validate
+ * @returns true if valid PurposeToken
+ */
+export function isValidPurposeToken(token: string): token is PurposeToken {
+  if (typeof token !== 'string') return false;
+  if (token.length === 0 || token.length > MAX_PURPOSE_TOKEN_LENGTH) return false;
+  return PURPOSE_TOKEN_REGEX.test(token);
+}
+
+/**
+ * Check if a PurposeToken is a CanonicalPurpose
+ *
+ * @param token - Token to check
+ * @returns true if token is in canonical vocabulary
+ */
+export function isCanonicalPurpose(token: string): token is CanonicalPurpose {
+  return (CANONICAL_PURPOSES as readonly string[]).includes(token);
+}
+
+/**
+ * Check if a PurposeToken is a LegacyPurpose
+ *
+ * @param token - Token to check
+ * @returns true if token is a legacy purpose
+ */
+export function isLegacyPurpose(token: string): token is LegacyPurpose {
+  return token === 'crawl' || token === 'ai_input' || token === 'ai_index';
+}
+
+/**
+ * Check if a string is a valid PurposeReason
+ *
+ * @param reason - String to check
+ * @returns true if valid PurposeReason
+ */
+export function isValidPurposeReason(reason: string): reason is PurposeReason {
+  return (PURPOSE_REASONS as readonly string[]).includes(reason);
+}
+
+/**
+ * Check if a purpose token is the internal-only "undeclared" value
+ *
+ * Used to reject explicit "undeclared" on wire (400 Bad Request).
+ *
+ * @param token - Token to check
+ * @returns true if token is "undeclared"
+ */
+export function isUndeclaredPurpose(token: string): boolean {
+  return token === INTERNAL_PURPOSE_UNDECLARED;
+}
+
+// ============================================================================
+// Normalization Functions
+// ============================================================================
+
+/**
+ * Normalize a purpose token
+ *
+ * Applies normalization rules:
+ * - Trim whitespace
+ * - Lowercase
+ *
+ * @param token - Raw token from header
+ * @returns Normalized token
+ */
+export function normalizePurposeToken(token: string): string {
+  return token.trim().toLowerCase();
+}
+
+/**
+ * Parse PEAC-Purpose header value into array of tokens
+ *
+ * Applies parsing rules:
+ * - Split on commas
+ * - Trim optional whitespace (OWS) around tokens
+ * - Lowercase all tokens
+ * - Drop empty tokens
+ * - Deduplicate
+ * - Preserve input order
+ *
+ * @param headerValue - Raw PEAC-Purpose header value
+ * @returns Array of normalized PurposeToken values
+ */
+export function parsePurposeHeader(headerValue: string): PurposeToken[] {
+  if (!headerValue || typeof headerValue !== 'string') {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const tokens: PurposeToken[] = [];
+
+  for (const part of headerValue.split(',')) {
+    const normalized = normalizePurposeToken(part);
+    if (normalized.length > 0 && !seen.has(normalized)) {
+      seen.add(normalized);
+      tokens.push(normalized);
+    }
+  }
+
+  return tokens;
+}
+
+/**
+ * Validate parsed purpose tokens
+ *
+ * Returns validation result with:
+ * - valid: All tokens pass grammar validation
+ * - tokens: All normalized tokens (including invalid ones)
+ * - invalidTokens: Tokens that failed grammar validation
+ * - undeclaredPresent: true if explicit "undeclared" was found (should reject)
+ *
+ * @param tokens - Array of parsed tokens
+ * @returns Validation result
+ */
+export interface PurposeValidationResult {
+  valid: boolean;
+  tokens: PurposeToken[];
+  invalidTokens: string[];
+  undeclaredPresent: boolean;
+}
+
+export function validatePurposeTokens(tokens: PurposeToken[]): PurposeValidationResult {
+  const invalidTokens: string[] = [];
+  let undeclaredPresent = false;
+
+  for (const token of tokens) {
+    if (isUndeclaredPurpose(token)) {
+      undeclaredPresent = true;
+    }
+    if (!isValidPurposeToken(token)) {
+      invalidTokens.push(token);
+    }
+  }
+
+  return {
+    valid: invalidTokens.length === 0 && !undeclaredPresent,
+    tokens,
+    invalidTokens,
+    undeclaredPresent,
+  };
+}
+
+/**
+ * Derive known canonical purposes from declared tokens
+ *
+ * Filters purpose_declared to get only canonical purposes.
+ * This is a helper derivation, NOT stored on wire.
+ *
+ * @param declared - Array of declared PurposeTokens
+ * @returns Array of CanonicalPurpose tokens
+ */
+export function deriveKnownPurposes(declared: PurposeToken[]): CanonicalPurpose[] {
+  return declared.filter(isCanonicalPurpose);
+}
+
+// ============================================================================
+// Legacy Mapping
+// ============================================================================
+
+/**
+ * Legacy purpose to canonical mapping
+ */
+const LEGACY_TO_CANONICAL: Record<LegacyPurpose, CanonicalPurpose> = {
+  crawl: 'index', // Crawl implies indexing
+  ai_input: 'inference', // RAG/grounding -> inference context
+  ai_index: 'index', // AI-powered indexing -> index
+};
+
+/**
+ * Map legacy purpose to canonical purpose
+ *
+ * Used for backward compatibility with pre-v0.9.24 ControlPurpose values.
+ *
+ * @param legacy - Legacy purpose token
+ * @returns Mapping result with canonical purpose and audit note
+ */
+export interface LegacyMappingResult {
+  canonical: CanonicalPurpose;
+  mapping_note: string;
+}
+
+export function mapLegacyToCanonical(legacy: LegacyPurpose): LegacyMappingResult {
+  const canonical = LEGACY_TO_CANONICAL[legacy];
+  return {
+    canonical,
+    mapping_note: `Mapped legacy '${legacy}' to canonical '${canonical}'`,
+  };
+}
+
+/**
+ * Normalize any purpose token (canonical, legacy, or unknown)
+ *
+ * Returns the canonical form if known, otherwise preserves the token.
+ *
+ * @param token - Any valid PurposeToken
+ * @returns Canonical purpose if mapped, otherwise original token
+ */
+export function normalizeToCanonicalOrPreserve(
+  token: PurposeToken
+):
+  | { purpose: CanonicalPurpose; mapped: false }
+  | { purpose: PurposeToken; mapped: true; from: LegacyPurpose }
+  | { purpose: PurposeToken; mapped: false; unknown: true } {
+  if (isCanonicalPurpose(token)) {
+    return { purpose: token, mapped: false };
+  }
+  if (isLegacyPurpose(token)) {
+    return { purpose: LEGACY_TO_CANONICAL[token], mapped: true, from: token };
+  }
+  return { purpose: token, mapped: false, unknown: true };
+}

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -5,6 +5,7 @@
 import { PEAC_WIRE_TYP, PEAC_ALG } from './constants';
 import type { ControlBlock } from './control';
 import type { PaymentEvidence, PaymentRailId } from './evidence';
+import type { PurposeToken, CanonicalPurpose, PurposeReason } from './purpose';
 
 /**
  * Subject of the receipt (what was paid for)
@@ -86,6 +87,30 @@ export interface PEACReceiptClaims {
 
   /** Extensions (additive-only) */
   ext?: ReceiptExtensions;
+
+  /**
+   * Purposes declared by requester (v0.9.24+)
+   *
+   * ALWAYS array, even for single purpose: ["train"]
+   * Empty array if header missing/empty (internal 'undeclared' state)
+   * Uses PurposeToken (string) to preserve unknown tokens (forward-compat)
+   */
+  purpose_declared?: PurposeToken[];
+
+  /**
+   * Single purpose enforced by policy (v0.9.24+)
+   *
+   * MUST be one of declared purposes OR a downgrade
+   * Uses CanonicalPurpose (enforcement requires semantics)
+   */
+  purpose_enforced?: CanonicalPurpose;
+
+  /**
+   * Reason for enforcement decision (v0.9.24+)
+   *
+   * The audit spine - explains WHY purpose was enforced as it was
+   */
+  purpose_reason?: PurposeReason;
 }
 
 /**


### PR DESCRIPTION
## Summary

Add forward-compatible purpose types for PEAC-Purpose header support in v0.9.24.

**New Types:**
- `PurposeToken`: Wire format string type that preserves unknown tokens for forward compatibility
- `CanonicalPurpose`: PEAC's normative vocabulary (`train`, `search`, `user_action`, `inference`, `index`)
- `PurposeReason`: Audit spine for enforcement decisions (`allowed`, `constrained`, `denied`, `downgraded`, `undeclared_default`, `unknown_preserved`)
- `LegacyPurpose`: Pre-v0.9.24 tokens with mapping to canonical

**Schema Changes:**
- Add `purpose.ts` with type definitions, validation functions, and legacy mapping
- Add `user_action` to `ControlPurpose` for agent-on-behalf scenarios
- Add `purpose_declared`, `purpose_enforced`, `purpose_reason` to `PEACReceiptClaims`
- Add Zod validators: `PurposeTokenSchema`, `CanonicalPurposeSchema`, `PurposeReasonSchema`
- Export all new types and validators from index

**Key Design Decisions:**
- `PurposeToken` is string (not enum) to preserve unknown tokens for forward compatibility
- Unknown tokens are preserved and forwarded, not rejected
- Legacy purposes (`crawl`, `ai_input`, `ai_index`) map to canonical with audit notes
- Explicit `undeclared` on wire is invalid (internal-only, 400 Bad Request)
- Grammar: `/^[a-z][a-z0-9_]*(?::[a-z][a-z0-9_]*)?$/` allows vendor prefixes

## Test Plan

- [x] 83 new tests for purpose validation
- [x] All 292 schema tests pass
- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [x] `pnpm typecheck:core` passes

## Part of v0.9.24 Purpose Implementation

This is PR1 of 5 for the v0.9.24 release:
1. **Schema + validators** (this PR)
2. Protocol issue()/verify() wiring for purpose
3. Policy Kit profiles (strict/balanced/open)
4. Robots bridge + AIPREF mapping package
5. Release chores (version bumps, CHANGELOG)