### PR TITLE
feat(policy-kit): add enforcement profiles

### DIFF
--- a/packages/policy-kit/src/enforcement-profiles.ts
+++ b/packages/policy-kit/src/enforcement-profiles.ts
@@ -1,0 +1,347 @@
+/**
+ * Enforcement Profiles (v0.9.24+)
+ *
+ * Pre-defined profiles for handling undeclared and unknown purposes.
+ * These are distinct from use-case profiles (api-provider, news-media, etc.).
+ *
+ * Three canonical profiles:
+ * - `strict`: Deny undeclared purposes (regulated data, private APIs)
+ * - `balanced`: Review + constraints for undeclared (general web, DEFAULT)
+ * - `open`: Allow undeclared purposes with recording (public content, research)
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   getEnforcementProfile,
+ *   evaluateWithProfile,
+ *   ENFORCEMENT_PROFILES,
+ * } from '@peac/policy-kit';
+ *
+ * // Get the balanced profile (default)
+ * const profile = getEnforcementProfile('balanced');
+ *
+ * // Evaluate with enforcement profile
+ * const result = evaluateWithProfile(policy, context, 'balanced');
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+import type {
+  EnforcementProfile,
+  EnforcementProfileId,
+  PolicyConstraints,
+  ControlDecision,
+} from './types';
+
+// -----------------------------------------------------------------------------
+// Canonical Enforcement Profiles
+// -----------------------------------------------------------------------------
+
+/**
+ * Strict enforcement profile.
+ *
+ * Use for: Regulated data, private APIs, compliance-critical resources.
+ * - Undeclared purposes: DENY
+ * - Unknown purpose tokens: DENY
+ * - Receipts: Required
+ */
+export const STRICT_PROFILE: EnforcementProfile = {
+  id: 'strict',
+  name: 'Strict',
+  description:
+    'Deny undeclared purposes. Use for regulated data, private APIs, or compliance-critical resources.',
+  undeclared_decision: 'deny',
+  unknown_decision: 'deny',
+  purpose_reason: 'denied',
+  receipts: 'required',
+};
+
+/**
+ * Balanced enforcement profile (DEFAULT).
+ *
+ * Use for: General web, gradual compliance, typical publisher use case.
+ * - Undeclared purposes: REVIEW + constraints
+ * - Unknown purpose tokens: REVIEW + preserve
+ * - Receipts: Optional (encouraged)
+ */
+export const BALANCED_PROFILE: EnforcementProfile = {
+  id: 'balanced',
+  name: 'Balanced',
+  description: 'Review undeclared purposes with rate limits. Default for general web publishers.',
+  undeclared_decision: 'review',
+  unknown_decision: 'review',
+  purpose_reason: 'undeclared_default',
+  default_constraints: {
+    rate_limit: {
+      window_s: 3600, // 1 hour
+      max: 100,
+      retry_after_s: 60,
+    },
+  },
+  receipts: 'optional',
+};
+
+/**
+ * Open enforcement profile.
+ *
+ * Use for: Public content, research data, open access resources.
+ * - Undeclared purposes: ALLOW (recorded)
+ * - Unknown purpose tokens: ALLOW (preserved)
+ * - Receipts: Optional (for attribution)
+ */
+export const OPEN_PROFILE: EnforcementProfile = {
+  id: 'open',
+  name: 'Open',
+  description:
+    'Allow undeclared purposes with recording. Use for public content and research data.',
+  undeclared_decision: 'allow',
+  unknown_decision: 'allow',
+  purpose_reason: 'allowed',
+  receipts: 'optional',
+};
+
+/**
+ * All canonical enforcement profiles indexed by ID.
+ */
+export const ENFORCEMENT_PROFILES: Record<EnforcementProfileId, EnforcementProfile> = {
+  strict: STRICT_PROFILE,
+  balanced: BALANCED_PROFILE,
+  open: OPEN_PROFILE,
+};
+
+/**
+ * Default enforcement profile ID.
+ *
+ * `balanced` is the default to encourage adoption while maintaining some protection.
+ */
+export const DEFAULT_ENFORCEMENT_PROFILE: EnforcementProfileId = 'balanced';
+
+/**
+ * All enforcement profile IDs.
+ */
+export const ENFORCEMENT_PROFILE_IDS: readonly EnforcementProfileId[] = [
+  'strict',
+  'balanced',
+  'open',
+];
+
+// -----------------------------------------------------------------------------
+// Profile Lookup Functions
+// -----------------------------------------------------------------------------
+
+/**
+ * Get an enforcement profile by ID.
+ *
+ * @param id - Profile ID
+ * @returns Enforcement profile
+ * @throws Error if profile ID is invalid
+ *
+ * @example
+ * ```typescript
+ * const profile = getEnforcementProfile('balanced');
+ * console.log(profile.undeclared_decision); // 'review'
+ * ```
+ */
+export function getEnforcementProfile(id: EnforcementProfileId): EnforcementProfile {
+  const profile = ENFORCEMENT_PROFILES[id];
+  if (!profile) {
+    throw new Error(`Invalid enforcement profile ID: ${id}`);
+  }
+  return profile;
+}
+
+/**
+ * Check if a string is a valid enforcement profile ID.
+ *
+ * @param id - String to check
+ * @returns true if valid profile ID
+ */
+export function isEnforcementProfileId(id: string): id is EnforcementProfileId {
+  return ENFORCEMENT_PROFILE_IDS.includes(id as EnforcementProfileId);
+}
+
+/**
+ * Get the default enforcement profile.
+ *
+ * @returns The balanced profile (default)
+ */
+export function getDefaultEnforcementProfile(): EnforcementProfile {
+  return ENFORCEMENT_PROFILES[DEFAULT_ENFORCEMENT_PROFILE];
+}
+
+// -----------------------------------------------------------------------------
+// Purpose Evaluation with Enforcement Profile
+// -----------------------------------------------------------------------------
+
+/**
+ * Result of purpose evaluation with enforcement profile.
+ */
+export interface PurposeEvaluationResult {
+  /** Decision from enforcement profile */
+  decision: ControlDecision;
+
+  /** Purpose enforced (for receipts) */
+  purpose_enforced?: string;
+
+  /** Reason for the decision */
+  purpose_reason: string;
+
+  /** Constraints to apply (for 'review' decisions) */
+  constraints?: PolicyConstraints;
+
+  /** Whether the purpose was declared */
+  purpose_declared: boolean;
+
+  /** Whether unknown purpose tokens were present */
+  has_unknown_tokens: boolean;
+
+  /** Preserved unknown tokens (for forward compatibility) */
+  unknown_tokens: string[];
+
+  /** The profile that was applied */
+  profile_id: EnforcementProfileId;
+}
+
+/**
+ * Canonical purpose tokens that PEAC defines semantics for.
+ */
+const CANONICAL_PURPOSES = new Set(['train', 'search', 'user_action', 'inference', 'index']);
+
+/**
+ * Legacy purpose tokens that map to canonical purposes.
+ */
+const LEGACY_PURPOSE_MAP: Record<string, string> = {
+  crawl: 'index',
+  ai_input: 'inference',
+  ai_index: 'index',
+};
+
+/**
+ * Check if a purpose token is canonical.
+ */
+function isCanonicalPurpose(token: string): boolean {
+  return CANONICAL_PURPOSES.has(token);
+}
+
+/**
+ * Check if a purpose token is a known legacy token.
+ */
+function isLegacyPurpose(token: string): boolean {
+  return token in LEGACY_PURPOSE_MAP;
+}
+
+/**
+ * Evaluate declared purposes against an enforcement profile.
+ *
+ * This determines what decision to make based on the declared purposes
+ * and the enforcement profile's rules for undeclared/unknown purposes.
+ *
+ * @param declaredPurposes - Array of purpose tokens from PEAC-Purpose header
+ * @param profileId - Enforcement profile ID (default: 'balanced')
+ * @returns Purpose evaluation result
+ *
+ * @example
+ * ```typescript
+ * // No purposes declared - uses undeclared_decision from profile
+ * const result1 = evaluatePurpose([], 'strict');
+ * // { decision: 'deny', purpose_reason: 'denied', ... }
+ *
+ * // Known purpose declared
+ * const result2 = evaluatePurpose(['train'], 'balanced');
+ * // { decision: 'allow', purpose_enforced: 'train', ... }
+ *
+ * // Unknown purpose token
+ * const result3 = evaluatePurpose(['vendor:custom'], 'balanced');
+ * // { decision: 'review', has_unknown_tokens: true, unknown_tokens: ['vendor:custom'], ... }
+ * ```
+ */
+export function evaluatePurpose(
+  declaredPurposes: string[],
+  profileId: EnforcementProfileId = DEFAULT_ENFORCEMENT_PROFILE
+): PurposeEvaluationResult {
+  const profile = getEnforcementProfile(profileId);
+
+  // No purposes declared - apply undeclared handling
+  if (declaredPurposes.length === 0) {
+    return {
+      decision: profile.undeclared_decision,
+      purpose_reason: 'undeclared_default',
+      constraints:
+        profile.undeclared_decision === 'review' ? profile.default_constraints : undefined,
+      purpose_declared: false,
+      has_unknown_tokens: false,
+      unknown_tokens: [],
+      profile_id: profileId,
+    };
+  }
+
+  // Categorize declared purposes
+  const canonicalTokens: string[] = [];
+  const legacyTokens: string[] = [];
+  const unknownTokens: string[] = [];
+
+  for (const token of declaredPurposes) {
+    if (isCanonicalPurpose(token)) {
+      canonicalTokens.push(token);
+    } else if (isLegacyPurpose(token)) {
+      legacyTokens.push(token);
+    } else {
+      unknownTokens.push(token);
+    }
+  }
+
+  // If we have unknown tokens, apply unknown_decision
+  if (unknownTokens.length > 0 && canonicalTokens.length === 0 && legacyTokens.length === 0) {
+    // Only unknown tokens - apply unknown handling
+    return {
+      decision: profile.unknown_decision,
+      purpose_reason: 'unknown_preserved',
+      constraints: profile.unknown_decision === 'review' ? profile.default_constraints : undefined,
+      purpose_declared: true,
+      has_unknown_tokens: true,
+      unknown_tokens: unknownTokens,
+      profile_id: profileId,
+    };
+  }
+
+  // We have at least some known tokens - allow with the first canonical/legacy purpose
+  const enforcedPurpose = canonicalTokens[0] ?? LEGACY_PURPOSE_MAP[legacyTokens[0]];
+
+  return {
+    decision: 'allow',
+    purpose_enforced: enforcedPurpose,
+    purpose_reason: unknownTokens.length > 0 ? 'unknown_preserved' : 'allowed',
+    purpose_declared: true,
+    has_unknown_tokens: unknownTokens.length > 0,
+    unknown_tokens: unknownTokens,
+    profile_id: profileId,
+  };
+}
+
+/**
+ * Get the HTTP status code for a purpose evaluation result.
+ *
+ * @param result - Purpose evaluation result
+ * @returns HTTP status code (200, 402, 403)
+ */
+export function getPurposeStatusCode(result: PurposeEvaluationResult): 200 | 402 | 403 {
+  switch (result.decision) {
+    case 'allow':
+      return 200;
+    case 'review':
+      return 402;
+    case 'deny':
+      return 403;
+  }
+}
+
+/**
+ * Get the Retry-After header value from constraints.
+ *
+ * @param constraints - Policy constraints
+ * @returns Retry-After seconds or undefined
+ */
+export function getRetryAfter(constraints: PolicyConstraints | undefined): number | undefined {
+  return constraints?.rate_limit?.retry_after_s;
+}

--- a/packages/policy-kit/src/index.ts
+++ b/packages/policy-kit/src/index.ts
@@ -51,6 +51,11 @@ export {
   // Profile system (v0.9.23+)
   type ProfileParameter,
   type ProfileDefinition,
+  // Policy constraints (v0.9.24+)
+  type PolicyConstraints,
+  // Enforcement profiles (v0.9.24+)
+  type EnforcementProfileId,
+  type EnforcementProfile,
   // Schemas for advanced validation
   SubjectMatcherSchema,
   PolicyRuleSchema,
@@ -60,6 +65,8 @@ export {
   DecisionRequirementsSchema,
   ProfileParameterSchema,
   ProfileDefinitionSchema,
+  PolicyConstraintsSchema,
+  EnforcementProfileSchema,
 } from './types';
 
 // Loader
@@ -126,3 +133,23 @@ export {
   type EnforcementContext,
   type EnforcementResult,
 } from './enforce';
+
+// Enforcement profiles (v0.9.24+)
+export {
+  // Profile definitions
+  STRICT_PROFILE,
+  BALANCED_PROFILE,
+  OPEN_PROFILE,
+  ENFORCEMENT_PROFILES,
+  ENFORCEMENT_PROFILE_IDS,
+  DEFAULT_ENFORCEMENT_PROFILE,
+  // Profile lookup
+  getEnforcementProfile,
+  isEnforcementProfileId,
+  getDefaultEnforcementProfile,
+  // Purpose evaluation
+  evaluatePurpose,
+  getPurposeStatusCode,
+  getRetryAfter,
+  type PurposeEvaluationResult,
+} from './enforcement-profiles';

--- a/packages/policy-kit/tests/enforcement-profiles.test.ts
+++ b/packages/policy-kit/tests/enforcement-profiles.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Enforcement Profiles Tests (v0.9.24+)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  // Profile definitions
+  STRICT_PROFILE,
+  BALANCED_PROFILE,
+  OPEN_PROFILE,
+  ENFORCEMENT_PROFILES,
+  ENFORCEMENT_PROFILE_IDS,
+  DEFAULT_ENFORCEMENT_PROFILE,
+  // Profile lookup
+  getEnforcementProfile,
+  isEnforcementProfileId,
+  getDefaultEnforcementProfile,
+  // Purpose evaluation
+  evaluatePurpose,
+  getPurposeStatusCode,
+  getRetryAfter,
+  // Types
+  type PolicyConstraints,
+} from '../src';
+
+describe('Enforcement Profiles (v0.9.24+)', () => {
+  describe('Profile Definitions', () => {
+    it('should have three canonical profiles', () => {
+      expect(ENFORCEMENT_PROFILE_IDS).toEqual(['strict', 'balanced', 'open']);
+      expect(Object.keys(ENFORCEMENT_PROFILES)).toHaveLength(3);
+    });
+
+    it('should have balanced as default', () => {
+      expect(DEFAULT_ENFORCEMENT_PROFILE).toBe('balanced');
+    });
+
+    describe('strict profile', () => {
+      it('should deny undeclared purposes', () => {
+        expect(STRICT_PROFILE.id).toBe('strict');
+        expect(STRICT_PROFILE.undeclared_decision).toBe('deny');
+        expect(STRICT_PROFILE.unknown_decision).toBe('deny');
+        expect(STRICT_PROFILE.receipts).toBe('required');
+      });
+
+      it('should not have default constraints', () => {
+        expect(STRICT_PROFILE.default_constraints).toBeUndefined();
+      });
+    });
+
+    describe('balanced profile', () => {
+      it('should review undeclared purposes', () => {
+        expect(BALANCED_PROFILE.id).toBe('balanced');
+        expect(BALANCED_PROFILE.undeclared_decision).toBe('review');
+        expect(BALANCED_PROFILE.unknown_decision).toBe('review');
+        expect(BALANCED_PROFILE.receipts).toBe('optional');
+      });
+
+      it('should have default rate limit constraints', () => {
+        expect(BALANCED_PROFILE.default_constraints).toBeDefined();
+        expect(BALANCED_PROFILE.default_constraints?.rate_limit).toEqual({
+          window_s: 3600,
+          max: 100,
+          retry_after_s: 60,
+        });
+      });
+    });
+
+    describe('open profile', () => {
+      it('should allow undeclared purposes', () => {
+        expect(OPEN_PROFILE.id).toBe('open');
+        expect(OPEN_PROFILE.undeclared_decision).toBe('allow');
+        expect(OPEN_PROFILE.unknown_decision).toBe('allow');
+        expect(OPEN_PROFILE.receipts).toBe('optional');
+      });
+
+      it('should not have default constraints', () => {
+        expect(OPEN_PROFILE.default_constraints).toBeUndefined();
+      });
+    });
+  });
+
+  describe('Profile Lookup', () => {
+    describe('getEnforcementProfile', () => {
+      it('should return strict profile', () => {
+        const profile = getEnforcementProfile('strict');
+        expect(profile).toBe(STRICT_PROFILE);
+      });
+
+      it('should return balanced profile', () => {
+        const profile = getEnforcementProfile('balanced');
+        expect(profile).toBe(BALANCED_PROFILE);
+      });
+
+      it('should return open profile', () => {
+        const profile = getEnforcementProfile('open');
+        expect(profile).toBe(OPEN_PROFILE);
+      });
+
+      it('should throw for invalid profile ID', () => {
+        expect(() => getEnforcementProfile('invalid' as never)).toThrow(
+          'Invalid enforcement profile ID: invalid'
+        );
+      });
+    });
+
+    describe('isEnforcementProfileId', () => {
+      it('should return true for valid IDs', () => {
+        expect(isEnforcementProfileId('strict')).toBe(true);
+        expect(isEnforcementProfileId('balanced')).toBe(true);
+        expect(isEnforcementProfileId('open')).toBe(true);
+      });
+
+      it('should return false for invalid IDs', () => {
+        expect(isEnforcementProfileId('invalid')).toBe(false);
+        expect(isEnforcementProfileId('')).toBe(false);
+        expect(isEnforcementProfileId('STRICT')).toBe(false);
+      });
+    });
+
+    describe('getDefaultEnforcementProfile', () => {
+      it('should return balanced profile', () => {
+        const profile = getDefaultEnforcementProfile();
+        expect(profile).toBe(BALANCED_PROFILE);
+        expect(profile.id).toBe('balanced');
+      });
+    });
+  });
+
+  describe('Purpose Evaluation', () => {
+    describe('with no declared purposes (undeclared)', () => {
+      it('strict: should deny', () => {
+        const result = evaluatePurpose([], 'strict');
+        expect(result.decision).toBe('deny');
+        expect(result.purpose_reason).toBe('undeclared_default');
+        expect(result.purpose_declared).toBe(false);
+        expect(result.has_unknown_tokens).toBe(false);
+        expect(result.profile_id).toBe('strict');
+      });
+
+      it('balanced: should review with constraints', () => {
+        const result = evaluatePurpose([], 'balanced');
+        expect(result.decision).toBe('review');
+        expect(result.purpose_reason).toBe('undeclared_default');
+        expect(result.purpose_declared).toBe(false);
+        expect(result.constraints).toBeDefined();
+        expect(result.constraints?.rate_limit?.max).toBe(100);
+        expect(result.profile_id).toBe('balanced');
+      });
+
+      it('open: should allow', () => {
+        const result = evaluatePurpose([], 'open');
+        expect(result.decision).toBe('allow');
+        expect(result.purpose_reason).toBe('undeclared_default');
+        expect(result.purpose_declared).toBe(false);
+        expect(result.profile_id).toBe('open');
+      });
+
+      it('should use balanced as default profile', () => {
+        const result = evaluatePurpose([]);
+        expect(result.decision).toBe('review');
+        expect(result.profile_id).toBe('balanced');
+      });
+    });
+
+    describe('with canonical purposes', () => {
+      const canonicalPurposes = ['train', 'search', 'user_action', 'inference', 'index'];
+
+      for (const purpose of canonicalPurposes) {
+        it(`should allow ${purpose}`, () => {
+          const result = evaluatePurpose([purpose], 'balanced');
+          expect(result.decision).toBe('allow');
+          expect(result.purpose_enforced).toBe(purpose);
+          expect(result.purpose_declared).toBe(true);
+          expect(result.has_unknown_tokens).toBe(false);
+        });
+      }
+
+      it('should use first canonical purpose as enforced', () => {
+        const result = evaluatePurpose(['train', 'search', 'inference'], 'balanced');
+        expect(result.decision).toBe('allow');
+        expect(result.purpose_enforced).toBe('train');
+      });
+    });
+
+    describe('with legacy purposes', () => {
+      it('should map crawl to index', () => {
+        const result = evaluatePurpose(['crawl'], 'balanced');
+        expect(result.decision).toBe('allow');
+        expect(result.purpose_enforced).toBe('index');
+      });
+
+      it('should map ai_input to inference', () => {
+        const result = evaluatePurpose(['ai_input'], 'balanced');
+        expect(result.decision).toBe('allow');
+        expect(result.purpose_enforced).toBe('inference');
+      });
+
+      it('should map ai_index to index', () => {
+        const result = evaluatePurpose(['ai_index'], 'balanced');
+        expect(result.decision).toBe('allow');
+        expect(result.purpose_enforced).toBe('index');
+      });
+    });
+
+    describe('with unknown purpose tokens', () => {
+      it('strict: should deny unknown-only tokens', () => {
+        const result = evaluatePurpose(['vendor:custom'], 'strict');
+        expect(result.decision).toBe('deny');
+        expect(result.purpose_reason).toBe('unknown_preserved');
+        expect(result.has_unknown_tokens).toBe(true);
+        expect(result.unknown_tokens).toEqual(['vendor:custom']);
+      });
+
+      it('balanced: should review unknown-only tokens', () => {
+        const result = evaluatePurpose(['acme:special'], 'balanced');
+        expect(result.decision).toBe('review');
+        expect(result.purpose_reason).toBe('unknown_preserved');
+        expect(result.has_unknown_tokens).toBe(true);
+        expect(result.unknown_tokens).toEqual(['acme:special']);
+        expect(result.constraints).toBeDefined();
+      });
+
+      it('open: should allow unknown-only tokens', () => {
+        const result = evaluatePurpose(['vendor:custom'], 'open');
+        expect(result.decision).toBe('allow');
+        expect(result.purpose_reason).toBe('unknown_preserved');
+        expect(result.has_unknown_tokens).toBe(true);
+      });
+
+      it('should allow when mix of canonical and unknown', () => {
+        const result = evaluatePurpose(['train', 'vendor:custom'], 'strict');
+        expect(result.decision).toBe('allow');
+        expect(result.purpose_enforced).toBe('train');
+        expect(result.purpose_reason).toBe('unknown_preserved');
+        expect(result.has_unknown_tokens).toBe(true);
+        expect(result.unknown_tokens).toEqual(['vendor:custom']);
+      });
+
+      it('should preserve multiple unknown tokens', () => {
+        const result = evaluatePurpose(['vendor:a', 'vendor:b', 'other:x'], 'balanced');
+        expect(result.unknown_tokens).toEqual(['vendor:a', 'vendor:b', 'other:x']);
+      });
+    });
+
+    describe('with vendor-prefixed tokens', () => {
+      it('should treat cf:ai_crawler as unknown', () => {
+        const result = evaluatePurpose(['cf:ai_crawler'], 'balanced');
+        expect(result.has_unknown_tokens).toBe(true);
+        expect(result.unknown_tokens).toEqual(['cf:ai_crawler']);
+      });
+    });
+  });
+
+  describe('HTTP Status Codes', () => {
+    describe('getPurposeStatusCode', () => {
+      it('should return 200 for allow', () => {
+        const result = evaluatePurpose(['train'], 'balanced');
+        expect(getPurposeStatusCode(result)).toBe(200);
+      });
+
+      it('should return 402 for review', () => {
+        const result = evaluatePurpose([], 'balanced');
+        expect(getPurposeStatusCode(result)).toBe(402);
+      });
+
+      it('should return 403 for deny', () => {
+        const result = evaluatePurpose([], 'strict');
+        expect(getPurposeStatusCode(result)).toBe(403);
+      });
+    });
+  });
+
+  describe('Retry-After Header', () => {
+    describe('getRetryAfter', () => {
+      it('should return retry_after_s from constraints', () => {
+        const constraints: PolicyConstraints = {
+          rate_limit: { window_s: 3600, max: 100, retry_after_s: 60 },
+        };
+        expect(getRetryAfter(constraints)).toBe(60);
+      });
+
+      it('should return undefined when no rate_limit', () => {
+        const constraints: PolicyConstraints = {
+          budget: { max_requests: 100 },
+        };
+        expect(getRetryAfter(constraints)).toBeUndefined();
+      });
+
+      it('should return undefined when constraints undefined', () => {
+        expect(getRetryAfter(undefined)).toBeUndefined();
+      });
+
+      it('should return undefined when no retry_after_s', () => {
+        const constraints: PolicyConstraints = {
+          rate_limit: { window_s: 3600, max: 100 },
+        };
+        expect(getRetryAfter(constraints)).toBeUndefined();
+      });
+    });
+  });
+
+  describe('PolicyConstraints Schema', () => {
+    it('should validate rate_limit only', () => {
+      const constraints: PolicyConstraints = {
+        rate_limit: { window_s: 3600, max: 100 },
+      };
+      expect(constraints.rate_limit?.window_s).toBe(3600);
+      expect(constraints.budget).toBeUndefined();
+    });
+
+    it('should validate budget only', () => {
+      const constraints: PolicyConstraints = {
+        budget: { max_tokens: 10000, max_requests: 1000 },
+      };
+      expect(constraints.budget?.max_tokens).toBe(10000);
+      expect(constraints.rate_limit).toBeUndefined();
+    });
+
+    it('should validate both rate_limit and budget', () => {
+      const constraints: PolicyConstraints = {
+        rate_limit: { window_s: 60, max: 10 },
+        budget: { max_requests: 100 },
+      };
+      expect(constraints.rate_limit?.max).toBe(10);
+      expect(constraints.budget?.max_requests).toBe(100);
+    });
+  });
+
+  describe('Integration with Policy Evaluation', () => {
+    it('balanced profile should have sensible defaults', () => {
+      // A request with no purpose should be rate-limited, not blocked
+      const result = evaluatePurpose([], 'balanced');
+      expect(result.decision).toBe('review');
+      expect(result.constraints?.rate_limit?.max).toBe(100);
+      expect(result.constraints?.rate_limit?.window_s).toBe(3600);
+    });
+
+    it('strict profile should block undeclared', () => {
+      // A request with no purpose should be denied
+      const result = evaluatePurpose([], 'strict');
+      expect(result.decision).toBe('deny');
+      expect(result.constraints).toBeUndefined();
+    });
+
+    it('open profile should allow everything', () => {
+      // A request with no purpose should be allowed (recorded)
+      const result = evaluatePurpose([], 'open');
+      expect(result.decision).toBe('allow');
+      expect(result.purpose_reason).toBe('undeclared_default');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add strict/balanced/open enforcement profiles for handling undeclared and unknown purpose tokens (v0.9.24).

**Three canonical profiles:**

| Profile | Undeclared | Unknown | Receipts | Use Case |
|---------|------------|---------|----------|----------|
| `strict` | deny | deny | required | Regulated data, private APIs |
| `balanced` (DEFAULT) | review | review | optional | General web, gradual compliance |
| `open` | allow | allow | optional | Public content, research |

**Changes:**

- Add `PolicyConstraints` type for rate limits and budgets in [types.ts](packages/policy-kit/src/types.ts)
- Add `EnforcementProfile` type and `EnforcementProfileSchema` validation
- Create [enforcement-profiles.ts](packages/policy-kit/src/enforcement-profiles.ts) with:
  - `STRICT_PROFILE`, `BALANCED_PROFILE`, `OPEN_PROFILE` definitions
  - `getEnforcementProfile()`, `isEnforcementProfileId()`, `getDefaultEnforcementProfile()` lookup functions
  - `evaluatePurpose()` for evaluating declared purposes against profiles
  - `getPurposeStatusCode()` and `getRetryAfter()` HTTP helpers
- Export new types and functions from index.ts
- Add 47 comprehensive tests

**Key design decisions:**

- `balanced` is the default profile (adoption-friendly)
- Balanced profile includes default rate limit constraints (100/hour, 60s retry)
- Unknown purpose tokens are preserved for forward compatibility
- Legacy purposes (crawl, ai_input, ai_index) are mapped to canonical purposes

Part of v0.9.24 purpose support. PR 3 of 5.

## Test plan

- [x] Build passes
- [x] 244 policy-kit tests pass (47 new enforcement profile tests)
- [x] Lint passes
- [x] TypeScript passes
- [x] Format check passes