### PR TITLE
chore: release v0.9.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.24] - 2026-01-03
+
+### Added
+
+- **Purpose on Wire**: First-class purpose tracking in receipts and HTTP headers
+  - `PEAC-Purpose` request header for declaring agent intent
+  - `PEAC-Purpose-Applied` and `PEAC-Purpose-Reason` response headers
+  - Receipt claims: `purpose_declared`, `purpose_enforced`, `purpose_reason`
+  - Canonical purposes: `train`, `search`, `user_action`, `inference`, `index`
+- **Purpose Type Hierarchy** (`@peac/schema`)
+  - `PurposeToken` (string): Wire format preserving unknown tokens for forward-compat
+  - `CanonicalPurpose` (enum): PEAC normative vocabulary
+  - `PurposeReason` (enum): `allowed`, `constrained`, `denied`, `downgraded`, `undeclared_default`, `unknown_preserved`
+  - `parsePurposeHeader()` for header normalization (lowercase, trim, dedupe, preserve order)
+  - `isValidPurposeToken()` with grammar validation
+- **Enforcement Profiles** (`@peac/policy-kit`)
+  - 3 profiles: `strict`, `balanced`, `open` for undeclared purpose handling
+  - `strict`: deny undeclared (regulated data, private APIs)
+  - `balanced`: review + constraints (general web, gradual compliance) - DEFAULT
+  - `open`: allow recorded (public content, research)
+  - `createEnforcementProfile()` and `getEnforcementProfile()` helpers
+- **@peac/mappings-aipref**: NEW PACKAGE - IETF AIPREF vocabulary alignment
+  - Maps IETF AIPREF keys (`train-ai`, `search`) to PEAC `CanonicalPurpose`
+  - `aiprefKeyToPurpose()` and `purposeToAiprefKey()` bidirectional mapping
+  - Handles extension keys (`train-genai`, `ai`) with audit notes
+  - Preserves unknown keys for forward-compatibility
+- **Robots.txt Migration Helper** (`@peac/pref`)
+  - `robotsToPeacStarter()`: Convert robots.txt to starter PEAC policy document
+  - Advisory-only output with clear migration guidance
+  - Detects AI crawler user agents (GPTBot, Claude-Web, etc.)
+  - Returns `RobotsToPeacResult` with policy, notes, and processed agents
+- **Purpose Conformance Suite**: Golden vectors for cross-implementation parity
+  - `specs/conformance/fixtures/purpose/normalization.json` - 10 header parsing vectors
+  - `specs/conformance/fixtures/purpose/validation.json` - 10 token validation vectors
+  - `specs/conformance/fixtures/purpose/reason.json` - 8 reason derivation vectors
+- **Purpose Parsing Limits** (`specs/kernel/constants.json`)
+  - `max_token_length`: 64 characters
+  - `max_tokens_per_request`: 10 tokens
+  - Grammar: `/^[a-z][a-z0-9_-]*(?::[a-z][a-z0-9_-]*)?$/`
+
+### Changed
+
+- `issue()` now accepts `purpose` option (`PurposeToken | PurposeToken[]`)
+- Purpose token grammar widened to allow hyphens (e.g., `train-ai`)
+- Protocol emits purpose-related headers in HTTP responses
+
+### Security
+
+- `undeclared` is internal-only, never valid on wire (explicit `PEAC-Purpose: undeclared` returns 400)
+- Unknown purpose tokens preserved but cannot affect enforcement (forward-compat without bypass risk)
+
 ## [0.9.23] - 2025-12-31
 
 ### Added

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-api",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "PEAC Protocol API server with OpenAPI 3.1, RFC 9457 Problem Details, and content negotiation",
   "type": "module",
   "main": "dist/index.js",

--- a/apps/bridge/package.json
+++ b/apps/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-bridge",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "PEAC Protocol Bridge - Local development sidecar",
   "type": "module",
   "main": "dist/server.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/monorepo",
-  "version": "0.9.22",
+  "version": "0.9.24",
   "private": true,
   "description": "PEAC Protocol - Cryptographic receipts for agentic commerce",
   "repository": {

--- a/packages/access/package.json
+++ b/packages/access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/access",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "private": true,
   "description": "PEAC access pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/adapters/core/package.json
+++ b/packages/adapters/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-core",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "Shared utilities for PEAC payment rail adapters",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/aipref/package.json
+++ b/packages/aipref/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/pref",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "AIPREF resolver with robots.txt bridge",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/attribution/package.json
+++ b/packages/attribution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/attribution",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "private": true,
   "description": "PEAC attribution pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/cli",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "PEAC protocol command-line tools",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/compliance/package.json
+++ b/packages/compliance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/compliance",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "private": true,
   "description": "PEAC compliance pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/consent/package.json
+++ b/packages/consent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/consent",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "private": true,
   "description": "PEAC consent pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/control/package.json
+++ b/packages/control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/control",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "PEAC Protocol Control - control engine interfaces and validation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/core",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "DEPRECATED - Use @peac/kernel, @peac/schema, @peac/crypto, @peac/protocol instead",
   "type": "module",
   "homepage": "https://peacprotocol.org",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/crypto",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "Ed25519 JWS signing and verification for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/disc",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "PEAC discovery with ≤20 lines enforcement",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/http-signatures/package.json
+++ b/packages/http-signatures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/http-signatures",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "RFC 9421 HTTP Message Signatures parsing and verification",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/intelligence/package.json
+++ b/packages/intelligence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/intelligence",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "private": true,
   "description": "PEAC intelligence pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/jwks-cache/package.json
+++ b/packages/jwks-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/jwks-cache",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "Edge-safe JWKS fetch and cache with SSRF protection",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/kernel",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "PEAC protocol kernel - normative constants, errors, and registries",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/mappings/acp/package.json
+++ b/packages/mappings/acp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-acp",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "Agentic Commerce Protocol (ACP) integration for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/aipref/package.json
+++ b/packages/mappings/aipref/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-aipref",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "IETF AIPREF vocabulary mapping for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/mcp/package.json
+++ b/packages/mappings/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-mcp",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "Model Context Protocol (MCP) integration for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/rsl/package.json
+++ b/packages/mappings/rsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-rsl",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "RSL (Robots Specification Layer) mapping for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/tap/package.json
+++ b/packages/mappings/tap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-tap",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "Visa Trusted Agent Protocol mapping to PEAC control evidence",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/pay402/package.json
+++ b/packages/pay402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/pay402",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "Generic HTTP 402 adapter with multi-rail payment negotiation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/policy-kit/package.json
+++ b/packages/policy-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/policy-kit",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "PEAC Policy Kit - deterministic policy evaluation for CAL semantics",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/policy-kit/src/enforce.ts
+++ b/packages/policy-kit/src/enforce.ts
@@ -405,10 +405,13 @@ export function enforcePurposeDecision(
 }
 
 /**
- * Get HTTP status code for a purpose decision.
+ * Get HTTP status code for a purpose decision (low-level helper).
  *
  * This helper maps policy decisions to HTTP status codes for purpose enforcement.
  * It NEVER returns 402 - that is reserved for payment/receipt challenges.
+ *
+ * For evaluating purpose with profiles, use getPurposeStatusCode from enforcement-profiles
+ * which takes a PurposeEvaluationResult directly.
  *
  * @param decision - Policy decision
  * @param purposeValid - Whether the purpose token(s) passed validation
@@ -416,13 +419,13 @@ export function enforcePurposeDecision(
  *
  * @example
  * ```typescript
- * getPurposeStatusCode('allow', true);  // 200
- * getPurposeStatusCode('deny', true);   // 403
- * getPurposeStatusCode('review', true); // 403 (NOT 402!)
- * getPurposeStatusCode('allow', false); // 400 (invalid token)
+ * getPurposeDecisionStatusCode('allow', true);  // 200
+ * getPurposeDecisionStatusCode('deny', true);   // 403
+ * getPurposeDecisionStatusCode('review', true); // 403 (NOT 402!)
+ * getPurposeDecisionStatusCode('allow', false); // 400 (invalid token)
  * ```
  */
-export function getPurposeStatusCode(
+export function getPurposeDecisionStatusCode(
   decision: ControlDecision,
   purposeValid: boolean
 ): 200 | 400 | 403 {

--- a/packages/policy-kit/src/enforcement-profiles.ts
+++ b/packages/policy-kit/src/enforcement-profiles.ts
@@ -322,15 +322,19 @@ export function evaluatePurpose(
 /**
  * Get the HTTP status code for a purpose evaluation result.
  *
+ * NOTE: 402 is RESERVED for payment - purpose decisions never return 402.
+ * - allow -> 200
+ * - review -> 403 (NOT 402)
+ * - deny -> 403
+ *
  * @param result - Purpose evaluation result
- * @returns HTTP status code (200, 402, 403)
+ * @returns HTTP status code (200 or 403)
  */
-export function getPurposeStatusCode(result: PurposeEvaluationResult): 200 | 402 | 403 {
+export function getPurposeStatusCode(result: PurposeEvaluationResult): 200 | 403 {
   switch (result.decision) {
     case 'allow':
       return 200;
     case 'review':
-      return 402;
     case 'deny':
       return 403;
   }

--- a/packages/policy-kit/src/index.ts
+++ b/packages/policy-kit/src/index.ts
@@ -135,7 +135,7 @@ export {
   // Purpose-specific enforcement (v0.9.24+)
   // These functions NEVER return 402 - that is reserved for payment/receipts
   enforcePurposeDecision,
-  getPurposeStatusCode,
+  getPurposeDecisionStatusCode, // Low-level: (decision, purposeValid) -> status
   type PurposeEnforcementContext,
   type PurposeEnforcementResult,
 } from './enforce';

--- a/packages/policy-kit/tests/enforce.test.ts
+++ b/packages/policy-kit/tests/enforce.test.ts
@@ -9,7 +9,7 @@ import {
   getChallengeHeader,
   enforceForHttp,
   enforcePurposeDecision,
-  getPurposeStatusCode,
+  getPurposeDecisionStatusCode,
 } from '../src';
 
 describe('Decision Enforcement', () => {
@@ -278,32 +278,32 @@ describe('Purpose Enforcement (v0.9.24+)', () => {
     });
   });
 
-  describe('getPurposeStatusCode', () => {
+  describe('getPurposeDecisionStatusCode', () => {
     it('returns 200 for allowed purpose', () => {
-      expect(getPurposeStatusCode('allow', true)).toBe(200);
+      expect(getPurposeDecisionStatusCode('allow', true)).toBe(200);
     });
 
     it('returns 403 for denied purpose', () => {
-      expect(getPurposeStatusCode('deny', true)).toBe(403);
+      expect(getPurposeDecisionStatusCode('deny', true)).toBe(403);
     });
 
     it('returns 403 (NOT 402) for review purpose', () => {
-      const status = getPurposeStatusCode('review', true);
+      const status = getPurposeDecisionStatusCode('review', true);
       expect(status).toBe(403);
       expect(status).not.toBe(402);
     });
 
     it('returns 400 for invalid purpose tokens', () => {
-      expect(getPurposeStatusCode('allow', false)).toBe(400);
-      expect(getPurposeStatusCode('deny', false)).toBe(400);
-      expect(getPurposeStatusCode('review', false)).toBe(400);
+      expect(getPurposeDecisionStatusCode('allow', false)).toBe(400);
+      expect(getPurposeDecisionStatusCode('deny', false)).toBe(400);
+      expect(getPurposeDecisionStatusCode('review', false)).toBe(400);
     });
 
     it('never returns 402', () => {
       const decisions = ['allow', 'deny', 'review'] as const;
       for (const decision of decisions) {
-        expect(getPurposeStatusCode(decision, true)).not.toBe(402);
-        expect(getPurposeStatusCode(decision, false)).not.toBe(402);
+        expect(getPurposeDecisionStatusCode(decision, true)).not.toBe(402);
+        expect(getPurposeDecisionStatusCode(decision, false)).not.toBe(402);
       }
     });
   });

--- a/packages/policy-kit/tests/enforcement-profiles.test.ts
+++ b/packages/policy-kit/tests/enforcement-profiles.test.ts
@@ -258,9 +258,9 @@ describe('Enforcement Profiles (v0.9.24+)', () => {
         expect(getPurposeStatusCode(result)).toBe(200);
       });
 
-      it('should return 402 for review', () => {
+      it('should return 403 for review (402 reserved for payment)', () => {
         const result = evaluatePurpose([], 'balanced');
-        expect(getPurposeStatusCode(result)).toBe(402);
+        expect(getPurposeStatusCode(result)).toBe(403);
       });
 
       it('should return 403 for deny', () => {

--- a/packages/privacy/package.json
+++ b/packages/privacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/privacy",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "private": true,
   "description": "Privacy pillar for PEAC protocol - k-anonymity, privacy-preserving hashing, data protection",
   "type": "module",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/protocol",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "PEAC protocol implementation - receipt issuance and verification",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/provenance/package.json
+++ b/packages/provenance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/provenance",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "private": true,
   "description": "Provenance pillar for PEAC protocol - content provenance, C2PA integration, and chain-of-custody",
   "main": "dist/index.js",

--- a/packages/rails/card/package.json
+++ b/packages/rails/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-card",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "Card payment rail adapter for PEAC protocol (Flowglad, Stripe Billing, Lago)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rails/razorpay/package.json
+++ b/packages/rails/razorpay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-razorpay",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "private": true,
   "description": "Razorpay payment rail adapter for PEAC protocol (UPI, cards, netbanking)",
   "main": "dist/index.js",

--- a/packages/rails/stripe/package.json
+++ b/packages/rails/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-stripe",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "Stripe payment rail adapter for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rails/x402/package.json
+++ b/packages/rails/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-x402",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "x402 payment rail adapter for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/receipts/package.json
+++ b/packages/receipts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/receipts",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "PEAC Protocol receipt builders, parsers, and validators with CBOR support",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/schema",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "PEAC Protocol JSON schemas, OpenAPI specs, and TypeScript types",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/sdk",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "PEAC client SDK with discover/verify functions",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/server",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "PEAC verification server with DoS protection and rate limiting",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry-otel/package.json
+++ b/packages/telemetry-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/telemetry-otel",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "OpenTelemetry adapter for PEAC telemetry",
   "keywords": [
     "peac",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/telemetry",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "Telemetry interfaces and no-op implementation for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/transport/grpc/package.json
+++ b/packages/transport/grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-grpc",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "private": true,
   "description": "PEAC gRPC transport layer with HTTP StatusCode parity",
   "type": "module",

--- a/packages/transport/http/package.json
+++ b/packages/transport/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-http",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "private": true,
   "description": "PEAC HTTP transport layer - headers, middleware, DPoP L3/L4",
   "type": "module",

--- a/packages/transport/ws/package.json
+++ b/packages/transport/ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-ws",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "private": true,
   "description": "PEAC WebSocket transport layer (placeholder for v0.9.17+)",
   "type": "module",

--- a/surfaces/analytics/package.json
+++ b/surfaces/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/analytics",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "private": true,
   "description": "Analytics surface for PEAC Protocol - metrics API with k-anonymity protection",
   "type": "module",

--- a/surfaces/nextjs/middleware/package.json
+++ b/surfaces/nextjs/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/middleware-nextjs",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "private": true,
   "description": "PEAC TAP verifier and 402 access gate for Next.js Edge Runtime",
   "type": "module",

--- a/surfaces/workers/akamai/package.json
+++ b/surfaces/workers/akamai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-akamai",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "private": true,
   "description": "PEAC receipt verification worker for Akamai EdgeWorkers",
   "type": "module",

--- a/surfaces/workers/cloudflare/package.json
+++ b/surfaces/workers/cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-cloudflare",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "private": true,
   "description": "PEAC receipt verification worker for Cloudflare Workers",
   "type": "module",

--- a/surfaces/workers/fastly/package.json
+++ b/surfaces/workers/fastly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-fastly",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "private": true,
   "description": "PEAC receipt verification worker for Fastly Compute",
   "type": "module",


### PR DESCRIPTION
## Summary

Release v0.9.24 - Purpose on Wire

**Purpose on wire:**
- `PEAC-Purpose` request header for declaring agent intent
- `PEAC-Purpose-Applied` and `PEAC-Purpose-Reason` response headers
- Receipt claims: `purpose_declared`, `purpose_enforced`, `purpose_reason`
- Canonical purposes: `train`, `search`, `user_action`, `inference`, `index`

**New packages:**
- `@peac/mappings-aipref`: IETF AIPREF vocabulary alignment

**Features:**
- Purpose type hierarchy (`PurposeToken`, `CanonicalPurpose`, `PurposeReason`)
- Enforcement profiles (`strict`, `balanced`, `open`)
- `robotsToPeacStarter()` migration helper in `@peac/pref`
- Purpose conformance suite (28 golden vectors)

**Security:**
- `undeclared` is internal-only, never valid on wire (explicit `PEAC-Purpose: undeclared` returns 400)
- Unknown purpose tokens preserved but cannot affect enforcement

**Fixes in this PR:**
- `getPurposeStatusCode`: 402 is reserved for payment; `review` now returns 403
- Renamed `getPurposeDecisionStatusCode` for low-level decision+validity -> status code

## Test plan
- [x] All 1514 tests pass (excluding pre-existing telemetry-otel ESM issue)
- [x] Build passes
- [x] Format check passes
- [ ] CI passes