### PR TITLE
fix: error category parity; dispute conformance tests

### DIFF
--- a/docs/specs/PROTOCOL-BEHAVIOR.md
+++ b/docs/specs/PROTOCOL-BEHAVIOR.md
@@ -356,7 +356,7 @@ Output: policy (JSON) or PEACError
    CATCH parse_error:
      RETURN PEACError(
        code: "E_POLICY_FETCH_FAILED",
-       category: "network",
+       category: "infrastructure",
        severity: "error",
        retryable: true,
        remediation: "Policy document is not valid JSON"
@@ -444,7 +444,7 @@ Output: content (string) or PEACError
      IF parsed.hostname NOT IN ["localhost", "127.0.0.1", "::1"]:
        RETURN PEACError(
          code: "E_SSRF_BLOCKED",
-         category: "security",
+         category: "verification",
          severity: "error",
          retryable: false,
          remediation: "HTTP URLs only allowed for localhost; use HTTPS"
@@ -452,7 +452,7 @@ Output: content (string) or PEACError
    ELSE IF parsed.scheme != "https":
      RETURN PEACError(
        code: "E_SSRF_BLOCKED",
-       category: "security",
+       category: "verification",
        remediation: "Only HTTPS URLs allowed"
      )
 
@@ -464,7 +464,7 @@ Output: content (string) or PEACError
      IF ip IN blocked_ip_ranges:  // See Section 6.2
        RETURN PEACError(
          code: "E_SSRF_BLOCKED",
-         category: "security",
+         category: "verification",
          severity: "error",
          retryable: false,
          remediation: "SSRF protection blocked request to private/metadata IP: " + ip,
@@ -484,7 +484,7 @@ Output: content (string) or PEACError
    CATCH network_error:
      RETURN PEACError(
        code: "E_POLICY_FETCH_FAILED",  // or E_JWKS_FETCH_FAILED
-       category: "network",
+       category: "infrastructure",
        severity: "error",
        retryable: true,
        remediation: "Network error fetching resource"
@@ -535,7 +535,7 @@ Output: boolean or PEACError
    CATCH parse_error:
      RETURN PEACError(
        code: "E_DPOP_INVALID",
-       category: "security",
+       category: "verification",
        severity: "error",
        retryable: false,
        remediation: "DPoP proof is not a valid JWT"
@@ -607,7 +607,7 @@ Output: boolean or PEACError
     IF NonceAlreadyUsed(claims.nonce):
       RETURN PEACError(
         code: "E_DPOP_REPLAY",
-        category: "security",
+        category: "verification",
         severity: "error",
         retryable: false,
         remediation: "DPoP nonce has already been used"

--- a/docs/specs/TEST_VECTORS.md
+++ b/docs/specs/TEST_VECTORS.md
@@ -248,7 +248,7 @@ tests/vectors/
 ```json
 {
   "code": "E_SSRF_BLOCKED",
-  "category": "security",
+  "category": "verification",
   "severity": "error",
   "retryable": false,
   "remediation": "SSRF protection blocked request to private/metadata IP: 169.254.169.254"
@@ -279,7 +279,7 @@ tests/vectors/
 ```json
 {
   "code": "E_INVALID_SIGNATURE",
-  "category": "security",
+  "category": "verification",
   "severity": "error",
   "retryable": false,
   "remediation": "JWS signature verification failed"
@@ -311,7 +311,7 @@ These vectors require HTTP request context (method, URI, headers) for validation
 ```json
 {
   "code": "E_DPOP_REPLAY",
-  "category": "security",
+  "category": "verification",
   "severity": "error",
   "retryable": false,
   "remediation": "DPoP nonce has already been used"
@@ -342,7 +342,7 @@ These vectors require HTTP request context (method, URI, headers) for validation
 ```json
 {
   "code": "E_DPOP_INVALID",
-  "category": "security",
+  "category": "verification",
   "severity": "error",
   "retryable": false,
   "remediation": "DPoP jkt does not match public key thumbprint"

--- a/packages/schema/__tests__/error-category-parity.test.ts
+++ b/packages/schema/__tests__/error-category-parity.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Error Category Parity Tests
+ *
+ * Ensures ErrorCategory type stays in sync with specs/kernel/errors.json.
+ * This prevents category drift between TypeScript and the normative registry.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { ERROR_CATEGORIES_CANONICAL } from '../src/errors';
+
+// Load the normative error registry
+const ERRORS_JSON_PATH = join(__dirname, '..', '..', '..', 'specs', 'kernel', 'errors.json');
+
+interface ErrorEntry {
+  code: string;
+  category: string;
+  http_status: number;
+  title: string;
+  description: string;
+  retriable: boolean;
+}
+
+interface ErrorsRegistry {
+  $schema: string;
+  version: string;
+  description: string;
+  errors: ErrorEntry[];
+}
+
+describe('Error Category Parity', () => {
+  let registry: ErrorsRegistry;
+  let registryCategories: Set<string>;
+
+  beforeAll(() => {
+    const content = readFileSync(ERRORS_JSON_PATH, 'utf8');
+    registry = JSON.parse(content) as ErrorsRegistry;
+    registryCategories = new Set(registry.errors.map((e) => e.category));
+  });
+
+  it('TypeScript categories exactly match registry categories', () => {
+    const canonicalSet = new Set(ERROR_CATEGORIES_CANONICAL);
+
+    // Print diff for easier debugging if test fails
+    const missingInTS = [...registryCategories].filter((c) => !canonicalSet.has(c));
+    const extraInTS = [...canonicalSet].filter((c) => !registryCategories.has(c));
+
+    if (missingInTS.length > 0 || extraInTS.length > 0) {
+      console.error('Category drift detected:');
+      if (missingInTS.length > 0) {
+        console.error('  Missing in TypeScript:', missingInTS);
+      }
+      if (extraInTS.length > 0) {
+        console.error('  Extra in TypeScript (not in registry):', extraInTS);
+      }
+    }
+
+    expect(canonicalSet).toEqual(registryCategories);
+  });
+
+  it('registry version is valid semver', () => {
+    // Future-proof: accepts any semver version
+    expect(registry.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});

--- a/packages/schema/src/errors.ts
+++ b/packages/schema/src/errors.ts
@@ -6,18 +6,24 @@
  */
 
 /**
- * Error category - broad classification of error type
+ * Canonical error categories from specs/kernel/errors.json.
+ * This is the normative source of truth for category names.
  */
-export type ErrorCategory =
-  | 'validation' // Schema/structure validation failures
-  | 'security' // Security violations (SSRF, signature, etc.)
-  | 'network' // Network/transport failures
-  | 'authorization' // Authorization/control failures
-  | 'rate_limit' // Rate limiting
-  | 'internal' // Internal server errors
-  | 'attribution' // Attribution attestation failures (v0.9.26+)
-  | 'identity' // Agent identity attestation failures (v0.9.25+)
-  | 'dispute'; // Dispute attestation failures (v0.9.27+)
+export const ERROR_CATEGORIES_CANONICAL = [
+  'validation', // Schema/structure validation failures
+  'verification', // Signature/authentication failures
+  'infrastructure', // Network/transport failures
+  'control', // Authorization/access control failures
+  'attribution', // Attribution attestation failures
+  'identity', // Agent identity attestation failures
+  'dispute', // Dispute attestation failures
+] as const;
+
+/**
+ * Error category - broad classification of error type.
+ * Categories match specs/kernel/errors.json (normative).
+ */
+export type ErrorCategory = (typeof ERROR_CATEGORIES_CANONICAL)[number];
 
 /**
  * Error severity
@@ -77,10 +83,9 @@ export interface PEACError {
    * Maps error to appropriate HTTP response code.
    * Examples:
    * - 400: Validation errors
-   * - 401: Signature/authentication failures
-   * - 403: Authorization/control denials
-   * - 429: Rate limit exceeded
-   * - 502: Network failures (JWKS fetch, etc.)
+   * - 401: Verification failures (signature, attestation temporal)
+   * - 403: Control denials (authorization)
+   * - 502: Infrastructure failures (JWKS fetch, etc.)
    */
   http_status?: number;
 
@@ -130,23 +135,19 @@ export const ERROR_CODES = {
   E_EXPIRED_RECEIPT: 'E_EXPIRED_RECEIPT',
   E_EVIDENCE_NOT_JSON: 'E_EVIDENCE_NOT_JSON',
 
-  // Security errors (401/403)
+  // Verification errors (401)
   E_INVALID_SIGNATURE: 'E_INVALID_SIGNATURE',
   E_SSRF_BLOCKED: 'E_SSRF_BLOCKED',
   E_DPOP_REPLAY: 'E_DPOP_REPLAY',
   E_DPOP_INVALID: 'E_DPOP_INVALID',
+
+  // Control errors (403)
   E_CONTROL_DENIED: 'E_CONTROL_DENIED',
 
-  // Network errors (502/503)
+  // Infrastructure errors (502/503)
   E_JWKS_FETCH_FAILED: 'E_JWKS_FETCH_FAILED',
   E_POLICY_FETCH_FAILED: 'E_POLICY_FETCH_FAILED',
   E_NETWORK_ERROR: 'E_NETWORK_ERROR',
-
-  // Rate limit errors (429)
-  E_RATE_LIMIT: 'E_RATE_LIMIT',
-
-  // Internal errors (500)
-  E_INTERNAL_ERROR: 'E_INTERNAL_ERROR',
 } as const;
 
 /**

--- a/specs/conformance/fixtures/dispute/edge-cases.json
+++ b/specs/conformance/fixtures/dispute/edge-cases.json
@@ -48,7 +48,7 @@
           "target_ref": "jti:rec_abc123",
           "target_type": "receipt",
           "grounds": [{ "code": "terms_violated" }],
-          "description": "This is exactly 50 characters for other type!!!",
+          "description": "This is exactly fifty characters for other type!!!",
           "state": "filed"
         }
       },

--- a/specs/conformance/fixtures/dispute/valid.json
+++ b/specs/conformance/fixtures/dispute/valid.json
@@ -305,7 +305,7 @@
         "type": "peac/dispute",
         "issuer": "https://publisher.example.com",
         "issued_at": "2026-01-06T12:00:00Z",
-        "ref": "01ARZ3NDEKTSV4RRFFQ69G5FL5",
+        "ref": "01ARZ3NDEKTSV4RRFFQ69G5FK5",
         "evidence": {
           "dispute_type": "attribution_incorrect",
           "target_ref": "https://ai.example.com/attributions/attr_wrong",

--- a/tests/conformance/dispute.spec.ts
+++ b/tests/conformance/dispute.spec.ts
@@ -1,0 +1,371 @@
+/**
+ * Dispute Conformance Tests
+ *
+ * Tests that dispute golden fixtures match the expected validation behavior.
+ * Uses the @peac/schema package for schema validation.
+ *
+ * Fixtures are in specs/conformance/fixtures/dispute/
+ *
+ * Conformance layers:
+ * - Schema: JSON structure, types, required fields (this file)
+ * - Runtime: State transitions, target resolution, duplicate detection (future)
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { validateDisputeAttestation } from '../../packages/schema/src/dispute';
+
+const FIXTURES_DIR = join(__dirname, '..', '..', 'specs', 'conformance', 'fixtures', 'dispute');
+
+// ULID validation: Crockford Base32 (excludes I, L, O, U)
+const ULID_REGEX = /^[0-7][0-9A-HJKMNP-TV-Z]{25}$/;
+
+// Fixture file types
+interface ValidFixture {
+  name: string;
+  description: string;
+  input: unknown;
+  expected: {
+    valid: boolean;
+    state?: string;
+    dispute_type?: string;
+    outcome?: string;
+    grounds_count?: number;
+    has_contact?: boolean;
+    has_expiry?: boolean;
+    has_window_hint?: boolean;
+    has_remediation?: boolean;
+    remediation_has_deadline?: boolean;
+    contact_method?: string;
+    description_length_gte?: number;
+    supporting_receipts_count?: number;
+    supporting_attributions_count?: number;
+    supporting_documents_count?: number;
+  };
+}
+
+interface InvalidFixture {
+  name: string;
+  description: string;
+  input: unknown;
+  expected: {
+    valid: boolean;
+    error_code: string;
+  };
+}
+
+interface EdgeCaseFixture {
+  name: string;
+  description: string;
+  input?: unknown;
+  transition_test?: boolean;
+  multi_input?: boolean;
+  runtime_test?: boolean;
+  from_state?: string;
+  to_state?: string;
+  inputs?: unknown[];
+  test_sequence?: unknown[];
+  resolution?: unknown;
+  expected: {
+    valid?: boolean;
+    schema_valid?: boolean;
+    runtime_valid?: boolean;
+    valid_transition?: boolean;
+    all_valid?: boolean;
+    state?: string;
+    grounds_count?: number;
+    description_length?: number;
+    to_state?: string;
+    requires_resolution?: boolean;
+    resolution_cleared?: boolean;
+    error_code?: string;
+    target_types_count?: number;
+    dispute_types_count?: number;
+    grounds_codes_count?: number;
+    outcomes_count?: number;
+    remediation_types_count?: number;
+    valid_transitions?: string[];
+    note?: string;
+    retriable?: boolean;
+    success?: boolean;
+  };
+}
+
+interface FixtureFile<T> {
+  $comment: string;
+  version: string;
+  fixtures: T[];
+}
+
+// Load fixture files once
+function loadValidFixtures(): FixtureFile<ValidFixture> {
+  const content = readFileSync(join(FIXTURES_DIR, 'valid.json'), 'utf8');
+  return JSON.parse(content) as FixtureFile<ValidFixture>;
+}
+
+function loadInvalidFixtures(): FixtureFile<InvalidFixture> {
+  const content = readFileSync(join(FIXTURES_DIR, 'invalid.json'), 'utf8');
+  return JSON.parse(content) as FixtureFile<InvalidFixture>;
+}
+
+function loadEdgeCaseFixtures(): FixtureFile<EdgeCaseFixture> {
+  const content = readFileSync(join(FIXTURES_DIR, 'edge-cases.json'), 'utf8');
+  return JSON.parse(content) as FixtureFile<EdgeCaseFixture>;
+}
+
+describe('Dispute Conformance', () => {
+  let validFixtures: FixtureFile<ValidFixture>;
+  let invalidFixtures: FixtureFile<InvalidFixture>;
+  let edgeCaseFixtures: FixtureFile<EdgeCaseFixture>;
+
+  beforeAll(() => {
+    validFixtures = loadValidFixtures();
+    invalidFixtures = loadInvalidFixtures();
+    edgeCaseFixtures = loadEdgeCaseFixtures();
+  });
+
+  describe('Fixture Hygiene', () => {
+    it('valid fixture names are unique', () => {
+      const names = validFixtures.fixtures.map((f) => f.name);
+      const uniqueNames = new Set(names);
+      expect(uniqueNames.size).toBe(names.length);
+    });
+
+    it('invalid fixture names are unique', () => {
+      const names = invalidFixtures.fixtures.map((f) => f.name);
+      const uniqueNames = new Set(names);
+      expect(uniqueNames.size).toBe(names.length);
+    });
+
+    it('edge-case fixture names are unique', () => {
+      const names = edgeCaseFixtures.fixtures.map((f) => f.name);
+      const uniqueNames = new Set(names);
+      expect(uniqueNames.size).toBe(names.length);
+    });
+
+    it('all ULIDs in valid fixtures are well-formed', () => {
+      for (const fixture of validFixtures.fixtures) {
+        const input = fixture.input as { ref?: string };
+        if (input.ref) {
+          expect(ULID_REGEX.test(input.ref), `Invalid ULID in ${fixture.name}: ${input.ref}`).toBe(
+            true
+          );
+        }
+      }
+    });
+
+    it('all ULIDs in invalid fixtures are well-formed (except ULID-specific tests)', () => {
+      for (const fixture of invalidFixtures.fixtures) {
+        // Skip fixtures specifically testing invalid ULIDs
+        if (fixture.name.includes('ulid')) continue;
+
+        const input = fixture.input as { ref?: string };
+        if (input.ref) {
+          expect(ULID_REGEX.test(input.ref), `Invalid ULID in ${fixture.name}: ${input.ref}`).toBe(
+            true
+          );
+        }
+      }
+    });
+
+    it('fixture versions are semver-compatible', () => {
+      const semverPattern = /^\d+\.\d+\.\d+$/;
+      expect(validFixtures.version).toMatch(semverPattern);
+      expect(invalidFixtures.version).toMatch(semverPattern);
+      expect(edgeCaseFixtures.version).toMatch(semverPattern);
+    });
+
+    it('fixture versions are consistent across all files', () => {
+      expect(validFixtures.version).toBe(invalidFixtures.version);
+      expect(validFixtures.version).toBe(edgeCaseFixtures.version);
+    });
+  });
+
+  describe('Valid Fixtures', () => {
+    it('has fixtures to test', () => {
+      expect(validFixtures.fixtures.length).toBeGreaterThan(0);
+    });
+
+    it('all valid fixtures pass schema validation', () => {
+      for (const fixture of validFixtures.fixtures) {
+        const result = validateDisputeAttestation(fixture.input);
+        expect(
+          result.ok,
+          `${fixture.name} should be valid but got: ${JSON.stringify(result)}`
+        ).toBe(true);
+
+        if (result.ok) {
+          // Verify specific expectations when present
+          if (fixture.expected.state !== undefined) {
+            expect(result.value.evidence.state).toBe(fixture.expected.state);
+          }
+
+          if (fixture.expected.dispute_type !== undefined) {
+            expect(result.value.evidence.dispute_type).toBe(fixture.expected.dispute_type);
+          }
+
+          if (fixture.expected.outcome !== undefined) {
+            expect(result.value.evidence.resolution?.outcome).toBe(fixture.expected.outcome);
+          }
+
+          if (fixture.expected.grounds_count !== undefined) {
+            expect(result.value.evidence.grounds.length).toBe(fixture.expected.grounds_count);
+          }
+
+          if (fixture.expected.has_contact) {
+            expect(result.value.evidence.contact).toBeDefined();
+          }
+
+          if (fixture.expected.has_expiry) {
+            expect(result.value.expires_at).toBeDefined();
+          }
+
+          if (fixture.expected.has_window_hint) {
+            expect(result.value.evidence.window_hint_days).toBeDefined();
+          }
+
+          if (fixture.expected.has_remediation) {
+            expect(result.value.evidence.resolution?.remediation).toBeDefined();
+          }
+
+          if (fixture.expected.remediation_has_deadline) {
+            expect(result.value.evidence.resolution?.remediation?.deadline).toBeDefined();
+          }
+
+          if (fixture.expected.contact_method !== undefined) {
+            expect(result.value.evidence.contact?.method).toBe(fixture.expected.contact_method);
+          }
+
+          if (fixture.expected.description_length_gte !== undefined) {
+            expect(result.value.evidence.description.length).toBeGreaterThanOrEqual(
+              fixture.expected.description_length_gte
+            );
+          }
+
+          if (fixture.expected.supporting_receipts_count !== undefined) {
+            expect(result.value.evidence.supporting_receipts?.length).toBe(
+              fixture.expected.supporting_receipts_count
+            );
+          }
+
+          if (fixture.expected.supporting_attributions_count !== undefined) {
+            expect(result.value.evidence.supporting_attributions?.length).toBe(
+              fixture.expected.supporting_attributions_count
+            );
+          }
+
+          if (fixture.expected.supporting_documents_count !== undefined) {
+            expect(result.value.evidence.supporting_documents?.length).toBe(
+              fixture.expected.supporting_documents_count
+            );
+          }
+        }
+      }
+    });
+  });
+
+  describe('Invalid Fixtures', () => {
+    it('has fixtures to test', () => {
+      expect(invalidFixtures.fixtures.length).toBeGreaterThan(0);
+    });
+
+    it('all invalid fixtures fail schema validation', () => {
+      for (const fixture of invalidFixtures.fixtures) {
+        const result = validateDisputeAttestation(fixture.input);
+        expect(result.ok, `${fixture.name} should be invalid but passed validation`).toBe(false);
+
+        // Verify error contains expected category/path when error_code hints at it
+        if (!result.ok && fixture.expected.error_code) {
+          // Extract category from error code (e.g., E_DISPUTE_INVALID_FORMAT -> DISPUTE)
+          const errorCategory = fixture.expected.error_code.split('_')[1]?.toLowerCase();
+          // Just verify we got an error - specific error code matching would require
+          // the validator to return structured errors with codes
+          expect(result.error).toBeDefined();
+          expect(typeof result.error).toBe('string');
+          expect(result.error.length).toBeGreaterThan(0);
+        }
+      }
+    });
+  });
+
+  describe('Edge Case Fixtures', () => {
+    it('has fixtures to test', () => {
+      expect(edgeCaseFixtures.fixtures.length).toBeGreaterThan(0);
+    });
+
+    it('testable edge cases pass schema validation', () => {
+      for (const fixture of edgeCaseFixtures.fixtures) {
+        // Skip special test types that don't have standard input
+        if (fixture.transition_test || fixture.multi_input || fixture.runtime_test) {
+          continue;
+        }
+
+        if (!fixture.input) {
+          continue;
+        }
+
+        const result = validateDisputeAttestation(fixture.input);
+
+        // Edge cases with expected.valid explicitly set
+        if (fixture.expected.valid !== undefined) {
+          expect(result.ok, `${fixture.name}: expected valid=${fixture.expected.valid}`).toBe(
+            fixture.expected.valid
+          );
+        } else {
+          // Default expectation for edge cases with input: should be valid
+          expect(
+            result.ok,
+            `${fixture.name} should be valid but got: ${JSON.stringify(result)}`
+          ).toBe(true);
+        }
+
+        if (result.ok) {
+          if (fixture.expected.grounds_count !== undefined) {
+            expect(result.value.evidence.grounds.length).toBe(fixture.expected.grounds_count);
+          }
+
+          if (fixture.expected.state !== undefined) {
+            expect(result.value.evidence.state).toBe(fixture.expected.state);
+          }
+
+          if (fixture.expected.description_length !== undefined) {
+            expect(result.value.evidence.description.length).toBe(
+              fixture.expected.description_length
+            );
+          }
+        }
+      }
+    });
+
+    it('transition test fixtures are properly structured', () => {
+      const transitionFixtures = edgeCaseFixtures.fixtures.filter((f) => f.transition_test);
+      expect(transitionFixtures.length).toBeGreaterThan(0);
+
+      for (const fixture of transitionFixtures) {
+        expect(fixture.from_state, `${fixture.name} missing from_state`).toBeDefined();
+        expect(fixture.to_state, `${fixture.name} missing to_state`).toBeDefined();
+      }
+    });
+
+    it('runtime test fixtures are properly structured', () => {
+      const runtimeFixtures = edgeCaseFixtures.fixtures.filter((f) => f.runtime_test);
+      expect(runtimeFixtures.length).toBeGreaterThan(0);
+
+      for (const fixture of runtimeFixtures) {
+        expect(fixture.expected.schema_valid, `${fixture.name} missing schema_valid`).toBe(true);
+        expect(fixture.expected.runtime_valid, `${fixture.name} missing runtime_valid`).toBe(false);
+      }
+    });
+
+    it('multi-input fixtures have inputs array', () => {
+      const multiInputFixtures = edgeCaseFixtures.fixtures.filter((f) => f.multi_input);
+      expect(multiInputFixtures.length).toBeGreaterThan(0);
+
+      for (const fixture of multiInputFixtures) {
+        expect(Array.isArray(fixture.inputs), `${fixture.name} missing inputs array`).toBe(true);
+        expect(fixture.inputs!.length).toBeGreaterThan(0);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Quality improvements based on review feedback. All suggested changes implemented.

## Changes

### 1. Dispute Conformance Tests (Non-Brittle)

**Before**: Hardcoded fixture names, hardcoded counts, re-read JSON per test
**After**: Dynamic iteration, hygiene tests, loaded once in `beforeAll`

Improvements:
- Iterate over all fixtures dynamically (no hardcoded names/counts)
- Fixture hygiene tests: uniqueness, ULID validation, version consistency
- Use `beforeAll`-loaded fixtures (no re-reading per test)
- Handle `expected.error_code` without strict matching (verify error exists)
- Semver-tolerant version check (`/^\d+\.\d+\.\d+$/`)

### 2. Error Category Parity Test (Simplified)

- Single assertion: "sets are exactly equal" with diff output for debugging
- Future-proof version check (any valid semver)
- Removed redundant assertions

### 3. 401 Documentation (RFC-Compliant)

Added:
- **HTTP Status Semantics (401 vs 403)**: Clear distinction table
- **WWW-Authenticate Parameters**: RFC 9110 auth-param syntax
- **Error tokens table**: `missing`, `expired`, `not_yet_valid`, etc.
- Renamed `type` parameter to `attestation_type` (clearer, RFC-compliant token)

### 4. Repo-Wide Legacy Category Cleanup

Updated all docs to use canonical categories:
- `security` -> `verification`
- `network` -> `infrastructure`
- `authorization` -> `control`

Files updated:
- `docs/specs/ERRORS.md` (section headers + tables + category list)
- `docs/specs/PROTOCOL-BEHAVIOR.md` (all error examples)
- `docs/specs/TEST_VECTORS.md` (all expected error JSON)

### 5. Fixture ULID Hygiene Test

Added hygiene tests that:
- Validate all ULIDs against Crockford Base32 regex
- Skip ULID-specific invalid fixtures (those testing bad ULIDs)
- Catch future fixture corruption early

### Fixture Fixes
- Invalid ULID `01ARZ3NDEKTSV4RRFFQ69G5FL5` -> `01ARZ3NDEKTSV4RRFFQ69G5FK5` (L not allowed in Crockford Base32)
- Description length 47 -> 50 for "other" type edge case

## Test plan

- [x] Error category parity test passes (2 tests)
- [x] Dispute conformance tests pass (16 tests)
- [x] Build passes
- [x] Lint passes
- [x] TypeScript check passes