### PR TITLE
test: public @peac/schema import

### DIFF
--- a/tests/conformance/dispute.spec.ts
+++ b/tests/conformance/dispute.spec.ts
@@ -14,7 +14,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { validateDisputeAttestation } from '../../packages/schema/src/dispute';
+import { validateDisputeAttestation } from '@peac/schema';
 
 const FIXTURES_DIR = join(__dirname, '..', '..', 'specs', 'conformance', 'fixtures', 'dispute');
 


### PR DESCRIPTION
## Summary
- Import `validateDisputeAttestation` from `@peac/schema` public surface instead of internal file path

## Why
Conformance tests should validate the **exported API**, not internal file paths. This ensures:
- Tests break if the export is removed (good)
- Tests don't couple to internal directory structure (good)
- Public API surface is tested, not implementation details

## Changes
- Changed import from `../../packages/schema/src/dispute` to `@peac/schema`

## Test plan
- [x] `pnpm vitest run tests/conformance/dispute.spec.ts` - 16 tests pass
- [x] `pnpm lint` - pass
- [x] `pnpm build` - pass
- [x] `pnpm typecheck:core` - pass