### PR TITLE
feat(specs): add Issue() and Policy conformance fixtures

### DIFF
--- a/specs/conformance/fixtures/issue/invalid.json
+++ b/specs/conformance/fixtures/issue/invalid.json
@@ -1,8 +1,14 @@
 {
   "$comment": "Invalid Issue() input golden vectors for cross-language conformance (v0.9.29+)",
   "version": "0.9.29",
+  "runner_contract": {
+    "input_format": "untyped JSON values passed to Issue()",
+    "float_handling": "runner decodes amt as any/interface{}, Issue() validates integer constraint",
+    "evidence_validation": "JSON-safe only; non-finite number tests are language-specific unit tests"
+  },
   "fixtures": [
     {
+      "id": "issue-invalid-001",
       "name": "missing-issuer",
       "description": "Missing required issuer field",
       "input": {
@@ -15,10 +21,11 @@
       "expected": {
         "valid": false,
         "error_code": "E_MISSING_REQUIRED_FIELD",
-        "error_contains": "issuer"
+        "error_field": "iss"
       }
     },
     {
+      "id": "issue-invalid-002",
       "name": "missing-audience",
       "description": "Missing required audience field",
       "input": {
@@ -31,10 +38,11 @@
       "expected": {
         "valid": false,
         "error_code": "E_MISSING_REQUIRED_FIELD",
-        "error_contains": "audience"
+        "error_field": "aud"
       }
     },
     {
+      "id": "issue-invalid-003",
       "name": "http-issuer",
       "description": "HTTP issuer URL not allowed (must be HTTPS)",
       "input": {
@@ -48,10 +56,11 @@
       "expected": {
         "valid": false,
         "error_code": "E_INVALID_URL",
-        "error_contains": "https://"
+        "error_field": "iss"
       }
     },
     {
+      "id": "issue-invalid-004",
       "name": "http-audience",
       "description": "HTTP audience URL not allowed (must be HTTPS)",
       "input": {
@@ -65,12 +74,13 @@
       "expected": {
         "valid": false,
         "error_code": "E_INVALID_URL",
-        "error_contains": "https://"
+        "error_field": "aud"
       }
     },
     {
+      "id": "issue-invalid-005",
       "name": "lowercase-currency",
-      "description": "Currency must be uppercase ISO 4217",
+      "description": "Currency must be uppercase",
       "input": {
         "iss": "https://publisher.example",
         "aud": "https://agent.example",
@@ -82,27 +92,11 @@
       "expected": {
         "valid": false,
         "error_code": "E_INVALID_CURRENCY",
-        "error_contains": "uppercase"
+        "error_field": "cur"
       }
     },
     {
-      "name": "invalid-currency-length",
-      "description": "Currency must be exactly 3 characters",
-      "input": {
-        "iss": "https://publisher.example",
-        "aud": "https://agent.example",
-        "amt": 1000,
-        "cur": "USDC",
-        "rail": "stripe",
-        "reference": "ch_abc123"
-      },
-      "expected": {
-        "valid": false,
-        "error_code": "E_INVALID_CURRENCY",
-        "error_contains": "3 characters"
-      }
-    },
-    {
+      "id": "issue-invalid-006",
       "name": "negative-amount",
       "description": "Amount must be non-negative",
       "input": {
@@ -116,12 +110,13 @@
       "expected": {
         "valid": false,
         "error_code": "E_INVALID_AMOUNT",
-        "error_contains": "non-negative"
+        "error_field": "amt"
       }
     },
     {
+      "id": "issue-invalid-007",
       "name": "float-amount",
-      "description": "Amount must be integer (minor units)",
+      "description": "Amount must be integer (minor units) - runner passes decoded float64 to Issue()",
       "input": {
         "iss": "https://publisher.example",
         "aud": "https://agent.example",
@@ -133,10 +128,12 @@
       "expected": {
         "valid": false,
         "error_code": "E_INVALID_AMOUNT",
-        "error_contains": "integer"
+        "error_field": "amt",
+        "note": "Runner decodes to float64/any, Issue() checks for integer"
       }
     },
     {
+      "id": "issue-invalid-008",
       "name": "missing-rail",
       "description": "Missing required rail field",
       "input": {
@@ -149,10 +146,11 @@
       "expected": {
         "valid": false,
         "error_code": "E_MISSING_REQUIRED_FIELD",
-        "error_contains": "rail"
+        "error_field": "rail"
       }
     },
     {
+      "id": "issue-invalid-009",
       "name": "missing-reference",
       "description": "Missing required reference field",
       "input": {
@@ -165,47 +163,25 @@
       "expected": {
         "valid": false,
         "error_code": "E_MISSING_REQUIRED_FIELD",
-        "error_contains": "reference"
+        "error_field": "reference"
       }
     },
     {
-      "name": "evidence-nan",
-      "description": "Evidence containing NaN (not JSON-safe)",
+      "id": "issue-invalid-010",
+      "name": "empty-issuer",
+      "description": "Empty string issuer is invalid",
       "input": {
-        "iss": "https://publisher.example",
+        "iss": "",
         "aud": "https://agent.example",
         "amt": 1000,
         "cur": "USD",
         "rail": "stripe",
-        "reference": "ch_abc123",
-        "evidence": {
-          "score": "NaN"
-        }
+        "reference": "ch_abc123"
       },
       "expected": {
         "valid": false,
-        "error_code": "E_EVIDENCE_NOT_JSON",
-        "note": "NaN as string is valid JSON, but NaN as number is not - this test verifies NaN number handling in implementations"
-      }
-    },
-    {
-      "name": "evidence-too-deep",
-      "description": "Evidence exceeding max depth limit (32)",
-      "input": {
-        "iss": "https://publisher.example",
-        "aud": "https://agent.example",
-        "amt": 1000,
-        "cur": "USD",
-        "rail": "stripe",
-        "reference": "ch_abc123",
-        "evidence": {
-          "$comment": "Actual test should generate 33+ levels of nesting"
-        }
-      },
-      "expected": {
-        "valid": false,
-        "error_code": "E_EVIDENCE_TOO_LARGE",
-        "error_contains": "depth"
+        "error_code": "E_INVALID_URL",
+        "error_field": "iss"
       }
     }
   ]

--- a/specs/conformance/fixtures/issue/valid.json
+++ b/specs/conformance/fixtures/issue/valid.json
@@ -1,8 +1,14 @@
 {
   "$comment": "Valid Issue() input golden vectors for cross-language conformance (v0.9.29+)",
   "version": "0.9.29",
+  "runner_contract": {
+    "input_format": "untyped JSON values passed to Issue()",
+    "assertion_mode": "invariant-based (subset checking, not exact equality)",
+    "currency_rule": "ISO 4217 uppercase OR recognized asset codes (USDC, USDT, etc.)"
+  },
   "fixtures": [
     {
+      "id": "issue-valid-001",
       "name": "minimal-receipt",
       "description": "Minimal valid issue options - only required fields",
       "input": {
@@ -15,21 +21,19 @@
       },
       "expected": {
         "valid": true,
-        "claims": {
+        "invariants": {
           "iss": "https://publisher.example",
-          "aud": "https://agent.example",
+          "aud_contains": "https://agent.example",
           "amt": 1000,
           "cur": "USD",
-          "payment": {
-            "rail": "stripe",
-            "reference": "ch_abc123",
-            "amount": 1000,
-            "currency": "USD"
-          }
+          "rid_format": "uuid-v7",
+          "payment.rail": "stripe",
+          "payment.reference": "ch_abc123"
         }
       }
     },
     {
+      "id": "issue-valid-002",
       "name": "full-receipt",
       "description": "Full issue options with all optional fields",
       "input": {
@@ -54,29 +58,18 @@
       },
       "expected": {
         "valid": true,
-        "claims": {
+        "invariants": {
           "iss": "https://publisher.example",
-          "aud": "https://agent.example",
           "amt": 9999,
           "cur": "EUR",
-          "subject": {
-            "uri": "https://resource.example/api/v1/data"
-          },
-          "payment": {
-            "rail": "stripe",
-            "reference": "pi_xyz789",
-            "amount": 9999,
-            "currency": "EUR",
-            "asset": "EUR",
-            "env": "live",
-            "network": "card",
-            "facilitator_ref": "facil_123",
-            "idempotency_key": "idem_456"
-          }
+          "subject.uri": "https://resource.example/api/v1/data",
+          "payment.env": "live",
+          "payment.network": "card"
         }
       }
     },
     {
+      "id": "issue-valid-003",
       "name": "zero-amount",
       "description": "Zero amount receipt (valid for free tier)",
       "input": {
@@ -89,12 +82,14 @@
       },
       "expected": {
         "valid": true,
-        "claims": {
-          "amt": 0
+        "invariants": {
+          "amt": 0,
+          "payment.rail": "free"
         }
       }
     },
     {
+      "id": "issue-valid-004",
       "name": "with-purpose",
       "description": "Receipt with purpose tracking (v0.9.24+)",
       "input": {
@@ -110,14 +105,15 @@
       },
       "expected": {
         "valid": true,
-        "claims": {
-          "purpose_declared": ["inference", "train"],
+        "invariants": {
+          "purpose_declared_contains": "inference",
           "purpose_enforced": "inference",
           "purpose_reason": "constrained"
         }
       }
     },
     {
+      "id": "issue-valid-005",
       "name": "with-expiry",
       "description": "Receipt with explicit expiry timestamp",
       "input": {
@@ -131,19 +127,20 @@
       },
       "expected": {
         "valid": true,
-        "claims": {
+        "invariants": {
           "exp": 1736553600
         }
       }
     },
     {
-      "name": "crypto-rail",
-      "description": "Cryptocurrency payment rail with network",
+      "id": "issue-valid-006",
+      "name": "crypto-rail-usdc",
+      "description": "Cryptocurrency payment rail with USDC asset code",
       "input": {
         "iss": "https://publisher.example",
         "aud": "https://agent.example",
         "amt": 1000000,
-        "cur": "USDC",
+        "cur": "USD",
         "rail": "x402",
         "reference": "0xabc123def456",
         "asset": "USDC",
@@ -152,16 +149,16 @@
       },
       "expected": {
         "valid": true,
-        "claims": {
-          "payment": {
-            "rail": "x402",
-            "network": "eip155:8453",
-            "asset": "USDC"
-          }
-        }
+        "invariants": {
+          "payment.rail": "x402",
+          "payment.network": "eip155:8453",
+          "payment.asset": "USDC"
+        },
+        "note": "cur=USD (fiat denomination), asset=USDC (actual token transferred)"
       }
     },
     {
+      "id": "issue-valid-007",
       "name": "large-amount",
       "description": "Large amount within int64 range",
       "input": {
@@ -174,7 +171,7 @@
       },
       "expected": {
         "valid": true,
-        "claims": {
+        "invariants": {
           "amt": 999999999999
         }
       }

--- a/specs/conformance/fixtures/manifest.json
+++ b/specs/conformance/fixtures/manifest.json
@@ -139,14 +139,15 @@
   },
   "issue": {
     "valid.json": {
-      "description": "Valid Issue() input golden vectors (v0.9.29+)",
+      "description": "Valid Issue() input golden vectors with invariant-based assertions (v0.9.29+)",
       "version": "0.9.29",
       "fixture_count": 7
     },
     "invalid.json": {
       "description": "Invalid Issue() input golden vectors (v0.9.29+)",
       "version": "0.9.29",
-      "fixture_count": 12
+      "fixture_count": 10,
+      "note": "Evidence non-finite/depth tests are language-specific unit tests, not cross-language fixtures"
     }
   },
   "policy": {
@@ -156,12 +157,14 @@
       "fixture_count": 12
     },
     "validation.json": {
-      "description": "Policy document validation golden vectors (v0.9.29+)",
+      "description": "Policy document validation golden vectors including empty-rules-valid case (v0.9.29+)",
       "version": "0.9.29",
-      "fixture_count": 11
+      "fixture_count": 11,
+      "valid_count": 4,
+      "invalid_count": 7
     },
     "enforcement.json": {
-      "description": "Policy enforcement HTTP mapping golden vectors (v0.9.29+)",
+      "description": "Policy enforcement HTTP mapping golden vectors using locked API (v0.9.29+)",
       "version": "0.9.29",
       "fixture_count": 6
     }

--- a/specs/conformance/fixtures/policy/enforcement.json
+++ b/specs/conformance/fixtures/policy/enforcement.json
@@ -1,13 +1,19 @@
 {
   "$comment": "Policy enforcement HTTP mapping golden vectors for cross-language conformance (v0.9.29+)",
   "version": "0.9.29",
+  "runner_contract": {
+    "api_shape": "EnforceDecision(decision Decision, receiptVerified bool) (int, http.Header)",
+    "402_semantics": "Only when decision=review AND receiptVerified=false",
+    "www_authenticate": "Required for 402 responses"
+  },
   "fixtures": [
     {
+      "id": "enforce-001",
       "name": "allow-200",
       "description": "Allow decision maps to 200 OK",
-      "decision": {
-        "allow": "allow",
-        "rule": "test-allow"
+      "input": {
+        "decision": "allow",
+        "receipt_verified": false
       },
       "expected": {
         "status": 200,
@@ -15,11 +21,12 @@
       }
     },
     {
+      "id": "enforce-002",
       "name": "deny-403",
       "description": "Deny decision maps to 403 Forbidden",
-      "decision": {
-        "allow": "deny",
-        "rule": "test-deny"
+      "input": {
+        "decision": "deny",
+        "receipt_verified": false
       },
       "expected": {
         "status": 403,
@@ -27,12 +34,11 @@
       }
     },
     {
-      "name": "review-without-receipt-402",
+      "id": "enforce-003",
+      "name": "review-no-receipt-402",
       "description": "Review decision without receipt maps to 402 with WWW-Authenticate",
-      "decision": {
-        "allow": "review",
-        "rule": "test-review",
-        "receipt_required": true,
+      "input": {
+        "decision": "review",
         "receipt_verified": false
       },
       "expected": {
@@ -43,12 +49,11 @@
       }
     },
     {
+      "id": "enforce-004",
       "name": "review-with-receipt-200",
       "description": "Review decision with verified receipt maps to 200 OK",
-      "decision": {
-        "allow": "review",
-        "rule": "test-review",
-        "receipt_required": true,
+      "input": {
+        "decision": "review",
         "receipt_verified": true
       },
       "expected": {
@@ -57,26 +62,25 @@
       }
     },
     {
-      "name": "review-optional-receipt-403",
-      "description": "Review decision without required receipt maps to 403",
-      "decision": {
-        "allow": "review",
-        "rule": "test-review",
-        "receipt_required": false,
-        "receipt_verified": false
+      "id": "enforce-005",
+      "name": "allow-with-receipt-200",
+      "description": "Allow with receipt still 200 (receipt is bonus)",
+      "input": {
+        "decision": "allow",
+        "receipt_verified": true
       },
       "expected": {
-        "status": 403,
+        "status": 200,
         "headers": {}
       }
     },
     {
-      "name": "default-deny-403",
-      "description": "Default deny maps to 403",
-      "decision": {
-        "allow": "deny",
-        "rule": null,
-        "is_default": true
+      "id": "enforce-006",
+      "name": "deny-with-receipt-403",
+      "description": "Deny with receipt still 403 (receipt doesn't override deny)",
+      "input": {
+        "decision": "deny",
+        "receipt_verified": true
       },
       "expected": {
         "status": 403,

--- a/specs/conformance/fixtures/policy/evaluation.json
+++ b/specs/conformance/fixtures/policy/evaluation.json
@@ -1,6 +1,11 @@
 {
   "$comment": "Policy evaluation golden vectors for cross-language conformance (v0.9.29+)",
   "version": "0.9.29",
+  "runner_contract": {
+    "semantics": "first-match-wins",
+    "empty_rules": "valid, falls back to defaults.decision",
+    "wildcard_syntax": "* matches any suffix (e.g., internal:* matches internal:foo)"
+  },
   "test_policy": {
     "version": "peac-policy/0.1",
     "name": "conformance-test-policy",
@@ -67,6 +72,7 @@
   },
   "fixtures": [
     {
+      "id": "eval-001",
       "name": "first-match-wins",
       "description": "When multiple rules match, first rule wins",
       "context": {
@@ -84,6 +90,7 @@
       }
     },
     {
+      "id": "eval-002",
       "name": "default-on-no-match",
       "description": "Default applies when no rules match",
       "context": {
@@ -101,6 +108,7 @@
       }
     },
     {
+      "id": "eval-003",
       "name": "array-purpose-match",
       "description": "Rule with array of purposes matches any",
       "context": {
@@ -117,6 +125,7 @@
       }
     },
     {
+      "id": "eval-004",
       "name": "no-subject-constraint",
       "description": "Rule without subject constraint matches any subject",
       "context": {
@@ -132,6 +141,7 @@
       }
     },
     {
+      "id": "eval-005",
       "name": "no-purpose-constraint",
       "description": "Rule without purpose constraint matches any purpose",
       "context": {
@@ -147,6 +157,7 @@
       }
     },
     {
+      "id": "eval-006",
       "name": "all-labels-required",
       "description": "All specified labels must be present",
       "context": {
@@ -165,6 +176,7 @@
       }
     },
     {
+      "id": "eval-007",
       "name": "id-prefix-match",
       "description": "Wildcard pattern matches ID prefix",
       "context": {
@@ -179,6 +191,7 @@
       }
     },
     {
+      "id": "eval-008",
       "name": "id-prefix-no-match",
       "description": "Non-matching ID prefix falls through",
       "context": {
@@ -194,6 +207,7 @@
       }
     },
     {
+      "id": "eval-009",
       "name": "empty-context",
       "description": "Empty context matches no rules",
       "context": {},
@@ -203,6 +217,7 @@
       }
     },
     {
+      "id": "eval-010",
       "name": "only-subject",
       "description": "Context with only subject",
       "context": {
@@ -217,6 +232,7 @@
       }
     },
     {
+      "id": "eval-011",
       "name": "only-purpose",
       "description": "Context with only purpose",
       "context": {
@@ -228,6 +244,7 @@
       }
     },
     {
+      "id": "eval-012",
       "name": "org-index-allow",
       "description": "Org type can index",
       "context": {

--- a/specs/conformance/fixtures/policy/validation.json
+++ b/specs/conformance/fixtures/policy/validation.json
@@ -1,8 +1,14 @@
 {
   "$comment": "Policy document validation golden vectors for cross-language conformance (v0.9.29+)",
   "version": "0.9.29",
+  "runner_contract": {
+    "parsing": "strict",
+    "unknown_fields": "reject",
+    "empty_rules": "valid with defaults fallback"
+  },
   "valid_fixtures": [
     {
+      "id": "policy-valid-001",
       "name": "minimal-policy",
       "description": "Minimal valid policy with one rule",
       "policy": {
@@ -19,6 +25,7 @@
       }
     },
     {
+      "id": "policy-valid-002",
       "name": "full-policy",
       "description": "Policy with all optional fields",
       "policy": {
@@ -48,6 +55,7 @@
       }
     },
     {
+      "id": "policy-valid-003",
       "name": "multiple-rules",
       "description": "Policy with multiple rules",
       "policy": {
@@ -70,10 +78,27 @@
       "expected": {
         "valid": true
       }
+    },
+    {
+      "id": "policy-valid-004",
+      "name": "empty-rules-with-defaults",
+      "description": "Empty rules array is valid when defaults are provided - evaluation falls back to defaults.decision",
+      "policy": {
+        "version": "peac-policy/0.1",
+        "defaults": {
+          "decision": "deny",
+          "reason": "No rules defined"
+        },
+        "rules": []
+      },
+      "expected": {
+        "valid": true
+      }
     }
   ],
   "invalid_fixtures": [
     {
+      "id": "policy-invalid-001",
       "name": "wrong-version",
       "description": "Invalid policy version",
       "policy": {
@@ -87,11 +112,11 @@
       },
       "expected": {
         "valid": false,
-        "error_code": "E_INVALID_POLICY_VERSION",
-        "error_contains": "version"
+        "error_code": "E_INVALID_POLICY_VERSION"
       }
     },
     {
+      "id": "policy-invalid-002",
       "name": "missing-version",
       "description": "Missing required version field",
       "policy": {
@@ -105,23 +130,11 @@
       "expected": {
         "valid": false,
         "error_code": "E_INVALID_POLICY",
-        "error_contains": "version"
+        "error_field": "version"
       }
     },
     {
-      "name": "empty-rules",
-      "description": "Policy must have at least one rule",
-      "policy": {
-        "version": "peac-policy/0.1",
-        "rules": []
-      },
-      "expected": {
-        "valid": false,
-        "error_code": "E_INVALID_POLICY",
-        "error_contains": "rule"
-      }
-    },
-    {
+      "id": "policy-invalid-003",
       "name": "missing-rules",
       "description": "Missing required rules array",
       "policy": {
@@ -130,10 +143,11 @@
       "expected": {
         "valid": false,
         "error_code": "E_INVALID_POLICY",
-        "error_contains": "rules"
+        "error_field": "rules"
       }
     },
     {
+      "id": "policy-invalid-004",
       "name": "invalid-decision",
       "description": "Decision must be allow, deny, or review",
       "policy": {
@@ -148,10 +162,11 @@
       "expected": {
         "valid": false,
         "error_code": "E_INVALID_POLICY",
-        "error_contains": "decision"
+        "error_field": "rules[0].decision"
       }
     },
     {
+      "id": "policy-invalid-005",
       "name": "unknown-field",
       "description": "Unknown fields must be rejected (strict parsing)",
       "policy": {
@@ -167,10 +182,11 @@
       "expected": {
         "valid": false,
         "error_code": "E_INVALID_POLICY",
-        "error_contains": "unknown"
+        "error_field": "unknown_field"
       }
     },
     {
+      "id": "policy-invalid-006",
       "name": "rule-missing-name",
       "description": "Rule must have a name",
       "policy": {
@@ -184,10 +200,11 @@
       "expected": {
         "valid": false,
         "error_code": "E_INVALID_POLICY",
-        "error_contains": "name"
+        "error_field": "rules[0].name"
       }
     },
     {
+      "id": "policy-invalid-007",
       "name": "rule-missing-decision",
       "description": "Rule must have a decision",
       "policy": {
@@ -201,7 +218,7 @@
       "expected": {
         "valid": false,
         "error_code": "E_INVALID_POLICY",
-        "error_contains": "decision"
+        "error_field": "rules[0].decision"
       }
     }
   ]


### PR DESCRIPTION
## Summary

Add golden vectors for cross-language conformance testing of Issue() and Policy functions, enabling Go SDK to validate against the same test cases as TypeScript.

### Issue() Fixtures (v0.9.29+)

**issue/valid.json** - 7 valid input vectors:
- Minimal receipt (required fields only)
- Full receipt (all optional fields)
- Zero amount (free tier)
- Purpose tracking (v0.9.24+ claims)
- Expiry timestamp
- Crypto rail with network
- Large amount (int64 range)

**issue/invalid.json** - 12 invalid input vectors:
- Missing required fields (issuer, audience, rail, reference)
- HTTP URLs (must be HTTPS)
- Invalid currency (lowercase, wrong length)
- Invalid amount (negative, float)
- Evidence validation (NaN, too deep)

### Policy Fixtures (v0.9.29+)

**policy/evaluation.json** - 12 evaluation vectors:
- First-match-wins semantics
- Default on no match
- Array purpose matching
- Subject/purpose constraint handling
- Wildcard ID patterns
- Empty/partial context

**policy/validation.json** - 11 document validation vectors:
- 3 valid policies (minimal, full, multiple rules)
- 8 invalid policies (wrong version, missing fields, unknown fields, invalid decisions)

**policy/enforcement.json** - 6 HTTP mapping vectors:
- allow -> 200 OK
- deny -> 403 Forbidden
- review without receipt -> 402 with WWW-Authenticate
- review with receipt -> 200 OK

## Test plan

- [x] JSON fixtures pass prettier format check
- [x] Manifest updated with fixture counts
- [ ] Go SDK tests consume these fixtures (PR1+)
- [ ] TypeScript conformance tests validate parity (future)