### PR TITLE
feat(go/jws): add SigningKey for unambiguous key API

### DIFF
--- a/sdks/go/jws/sign.go
+++ b/sdks/go/jws/sign.go
@@ -4,21 +4,27 @@ import (
 	"crypto/ed25519"
 	"encoding/json"
 	"fmt"
+	"io"
 )
+
+// DefaultReceiptTyp is the default JWS type header for PEAC receipts.
+// This follows the wire format version and is stable within the v0.9.x series.
+const DefaultReceiptTyp = "peac.receipt/0.9"
 
 // SigningKey represents an Ed25519 private key for signing JWS.
 // This type clearly indicates a key used for signing (private key),
 // distinct from verification keys (public keys).
+//
+// Fields are unexported to prevent accidental logging or mutation.
+// Use the accessor methods to retrieve key information.
 type SigningKey struct {
-	// PrivateKey is the Ed25519 private key (64 bytes: 32-byte seed + 32-byte public).
-	PrivateKey ed25519.PrivateKey
-
-	// KeyID is the key identifier included in the JWS header.
-	KeyID string
+	privateKey ed25519.PrivateKey
+	keyID      string
 }
 
-// NewSigningKey creates a SigningKey from an Ed25519 private key and key ID.
-// Returns an error if the private key is invalid.
+// NewSigningKey creates a SigningKey from an Ed25519 private key (64 bytes) and key ID.
+// The private key must be exactly 64 bytes (32-byte seed + 32-byte public key).
+// For 32-byte seeds, use NewSigningKeyFromSeed instead.
 func NewSigningKey(privateKey ed25519.PrivateKey, keyID string) (*SigningKey, error) {
 	if len(privateKey) != ed25519.PrivateKeySize {
 		return nil, fmt.Errorf("invalid private key size: expected %d, got %d",
@@ -28,20 +34,42 @@ func NewSigningKey(privateKey ed25519.PrivateKey, keyID string) (*SigningKey, er
 		return nil, fmt.Errorf("key ID is required")
 	}
 	return &SigningKey{
-		PrivateKey: privateKey,
-		KeyID:      keyID,
+		privateKey: privateKey,
+		keyID:      keyID,
 	}, nil
+}
+
+// NewSigningKeyFromSeed creates a SigningKey from a 32-byte Ed25519 seed.
+// This is useful when keys are stored as seeds rather than full private keys.
+func NewSigningKeyFromSeed(seed []byte, keyID string) (*SigningKey, error) {
+	if len(seed) != ed25519.SeedSize {
+		return nil, fmt.Errorf("invalid seed size: expected %d, got %d",
+			ed25519.SeedSize, len(seed))
+	}
+	if keyID == "" {
+		return nil, fmt.Errorf("key ID is required")
+	}
+	privateKey := ed25519.NewKeyFromSeed(seed)
+	return &SigningKey{
+		privateKey: privateKey,
+		keyID:      keyID,
+	}, nil
+}
+
+// KeyID returns the key identifier for this signing key.
+func (k *SigningKey) KeyID() string {
+	return k.keyID
 }
 
 // PublicKey returns the public key corresponding to this signing key.
 func (k *SigningKey) PublicKey() ed25519.PublicKey {
-	return k.PrivateKey.Public().(ed25519.PublicKey)
+	return k.privateKey.Public().(ed25519.PublicKey)
 }
 
 // Sign creates a JWS compact serialization for the given payload.
-// The typ header is set to "peac.receipt/0.9" by default.
+// The typ header is set to DefaultReceiptTyp ("peac.receipt/0.9").
 func (k *SigningKey) Sign(payload []byte) (string, error) {
-	return k.SignWithType(payload, "peac.receipt/0.9")
+	return k.SignWithType(payload, DefaultReceiptTyp)
 }
 
 // SignWithType creates a JWS compact serialization with a custom type header.
@@ -49,7 +77,7 @@ func (k *SigningKey) SignWithType(payload []byte, typ string) (string, error) {
 	header := Header{
 		Algorithm: "EdDSA",
 		Type:      typ,
-		KeyID:     k.KeyID,
+		KeyID:     k.keyID,
 	}
 
 	headerBytes, err := json.Marshal(header)
@@ -61,7 +89,7 @@ func (k *SigningKey) SignWithType(payload []byte, typ string) (string, error) {
 	payloadB64 := Encode(payload)
 
 	signingInput := headerB64 + "." + payloadB64
-	signature := ed25519.Sign(k.PrivateKey, []byte(signingInput))
+	signature := ed25519.Sign(k.privateKey, []byte(signingInput))
 
 	return signingInput + "." + Encode(signature), nil
 }
@@ -75,12 +103,25 @@ func (k *SigningKey) SignClaims(claims any) (string, error) {
 	return k.Sign(payload)
 }
 
-// GenerateSigningKey generates a new Ed25519 signing key pair.
+// GenerateSigningKey generates a new Ed25519 signing key pair using crypto/rand.
 // The keyID should be a unique identifier for key management.
 func GenerateSigningKey(keyID string) (*SigningKey, error) {
-	_, privateKey, err := ed25519.GenerateKey(nil)
+	return GenerateSigningKeyWithRand(nil, keyID)
+}
+
+// GenerateSigningKeyWithRand generates a new Ed25519 signing key pair using the provided
+// random source. If rand is nil, crypto/rand.Reader is used.
+// Use a deterministic reader for reproducible test keys.
+func GenerateSigningKeyWithRand(rand io.Reader, keyID string) (*SigningKey, error) {
+	if keyID == "" {
+		return nil, fmt.Errorf("key ID is required")
+	}
+	_, privateKey, err := ed25519.GenerateKey(rand)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate key pair: %w", err)
 	}
-	return NewSigningKey(privateKey, keyID)
+	return &SigningKey{
+		privateKey: privateKey,
+		keyID:      keyID,
+	}, nil
 }


### PR DESCRIPTION
## Summary

PR2 of v0.9.29 Go SDK parity - adds JWS signing with clear key type distinction.

### SigningKey Type
- Wraps `ed25519.PrivateKey` with key ID
- Clear naming indicates signing (private) vs verification (public)
- `NewSigningKey()` validates key size and requires key ID
- `PublicKey()` accessor returns verification key

### Signing Methods
- `Sign(payload)` - creates JWS with default `typ: peac.receipt/0.9`
- `SignWithType(payload, typ)` - custom type header
- `SignClaims(claims)` - marshals any struct/map and signs

### Key Generation
- `GenerateSigningKey(keyID)` - generates new Ed25519 key pair

## Test plan
- [x] Run `go test ./jws/...` - 9 tests pass
- [x] Run `go test -race ./...` - no race conditions
- [ ] CI checks pass