### PR TITLE
crypto: add testkit subpath export and export-surface guard

### DIFF
--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -4,6 +4,20 @@
   "description": "Ed25519 JWS signing and verification for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./testkit": {
+      "types": "./dist/testkit.d.ts",
+      "import": "./dist/testkit.js",
+      "require": "./dist/testkit.js",
+      "default": "./dist/testkit.js"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/peacprotocol/peac.git",

--- a/packages/crypto/src/errors.ts
+++ b/packages/crypto/src/errors.ts
@@ -16,6 +16,7 @@
  */
 export type CryptoErrorCode =
   | 'CRYPTO_INVALID_KEY_LENGTH'
+  | 'CRYPTO_INVALID_SEED_LENGTH'
   | 'CRYPTO_INVALID_JWS_FORMAT'
   | 'CRYPTO_INVALID_TYP'
   | 'CRYPTO_INVALID_ALG'
@@ -51,6 +52,7 @@ export function isFormatError(code: CryptoErrorCode): boolean {
     code === 'CRYPTO_INVALID_JWS_FORMAT' ||
     code === 'CRYPTO_INVALID_TYP' ||
     code === 'CRYPTO_INVALID_ALG' ||
-    code === 'CRYPTO_INVALID_KEY_LENGTH'
+    code === 'CRYPTO_INVALID_KEY_LENGTH' ||
+    code === 'CRYPTO_INVALID_SEED_LENGTH'
   );
 }

--- a/packages/crypto/src/jws.ts
+++ b/packages/crypto/src/jws.ts
@@ -173,3 +173,7 @@ export async function generateKeypair(): Promise<{
 
   return { privateKey, publicKey };
 }
+
+// NOTE: generateKeypairFromSeed has been moved to @peac/crypto/testkit
+// It's intentionally NOT exported from the main module to prevent accidental
+// use in production. Use: import { generateKeypairFromSeed } from '@peac/crypto/testkit'

--- a/packages/crypto/src/testkit.ts
+++ b/packages/crypto/src/testkit.ts
@@ -1,0 +1,52 @@
+/**
+ * PEAC Crypto Test Kit
+ *
+ * This module contains utilities for TEST FIXTURES ONLY.
+ * These functions are NOT exported from the main entry point.
+ *
+ * Import path: @peac/crypto/testkit
+ *
+ * SECURITY: Never use these in production. Production bundlers can
+ * tree-shake this module away since it's a separate export path.
+ */
+
+import * as ed25519 from '@noble/ed25519';
+import { CryptoError } from './errors.js';
+
+/**
+ * Generate an Ed25519 keypair from a deterministic seed.
+ *
+ * WARNING: FOR TEST FIXTURES ONLY. DO NOT USE IN PRODUCTION.
+ * Production code should use generateKeypair() which uses cryptographically
+ * secure random bytes. Seeded keys are predictable and compromise security.
+ *
+ * This function is intentionally in a separate module (@peac/crypto/testkit)
+ * so that production bundlers can tree-shake it away.
+ *
+ * @param seed - 32-byte seed (e.g., SHA-256 hash of a known string)
+ * @returns Private key (32 bytes) and public key (32 bytes)
+ *
+ * @example
+ * ```ts
+ * // Use only in test fixtures for reproducibility
+ * import { generateKeypairFromSeed } from '@peac/crypto/testkit';
+ *
+ * const seed = sha256('peac-test-key-001');
+ * const { privateKey, publicKey } = await generateKeypairFromSeed(seed);
+ * ```
+ */
+export async function generateKeypairFromSeed(seed: Uint8Array): Promise<{
+  privateKey: Uint8Array;
+  publicKey: Uint8Array;
+}> {
+  if (seed.length !== 32) {
+    throw new CryptoError('CRYPTO_INVALID_SEED_LENGTH', 'Ed25519 seed must be 32 bytes');
+  }
+
+  // In Ed25519, the private key IS the seed (32 bytes)
+  // The public key is derived from it
+  const privateKey = seed;
+  const publicKey = await ed25519.getPublicKeyAsync(privateKey);
+
+  return { privateKey, publicKey };
+}

--- a/packages/crypto/tests/exports.test.ts
+++ b/packages/crypto/tests/exports.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Export surface tests for @peac/crypto
+ *
+ * These tests ensure that test-only utilities are NOT accidentally
+ * exported from the main entry point. Production bundlers should
+ * be able to tree-shake testkit away.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as crypto from '../src/index';
+
+describe('@peac/crypto export surface', () => {
+  it('should NOT export generateKeypairFromSeed from main entry', () => {
+    // generateKeypairFromSeed is test-only and lives in @peac/crypto/testkit
+    // It must NOT be exported from the main entry point
+    expect('generateKeypairFromSeed' in crypto).toBe(false);
+  });
+
+  it('should export generateKeypair from main entry', () => {
+    // The secure random-based keypair generator SHOULD be exported
+    expect('generateKeypair' in crypto).toBe(true);
+  });
+
+  it('should export sign from main entry', () => {
+    expect('sign' in crypto).toBe(true);
+  });
+
+  it('should export verify from main entry', () => {
+    expect('verify' in crypto).toBe(true);
+  });
+
+  it('should export canonicalize from main entry', () => {
+    expect('canonicalize' in crypto).toBe(true);
+  });
+
+  it('should export CryptoError from main entry', () => {
+    expect('CryptoError' in crypto).toBe(true);
+  });
+
+  it('should export base64urlEncode from main entry', () => {
+    expect('base64urlEncode' in crypto).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add @peac/crypto/testkit subpath export for test-only utilities
- Fix ESM import hygiene (./errors.js suffix)
- Add exports.test.ts to guard that generateKeypairFromSeed is NOT in main entry

## Key design

Production bundlers can tree-shake testkit away since it's a separate export path:

\`\`\`typescript
// Test fixtures only - NOT exported from main entry
import { generateKeypairFromSeed } from '@peac/crypto/testkit';
\`\`\`

## Test plan

- [ ] CI passes
- [ ] exports.test.ts passes (guards export surface)
- [ ] generateKeypairFromSeed NOT in main @peac/crypto exports

## Stacked PRs

1. PR1 -> main: kernel codegen + bundle error codes
2. PR2 -> PR1: audit dispute bundle verifier
3. **PR3** (this) -> PR2: crypto testkit subpath export
4. PR4 -> PR3: CI drift gate

Merge in order: PR1 -> PR2 -> PR3 -> PR4