### PR TITLE
chore(release): Dispute Bundle + Deterministic Verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.30] - 2026-01-12
+
+### Added
+
+- **Dispute Bundle Format** (`@peac/audit`)
+  - ZIP-based archive format for offline verification (`peac.dispute-bundle/0.1`)
+  - `createDisputeBundle()`: Create bundles from receipts, keys, and optional policy
+  - `readDisputeBundle()`: Parse and validate bundle structure
+  - `verifyBundle()`: Offline verification with deterministic reports
+  - Content-layer hashing for cross-platform determinism (manifest-based, not ZIP bytes)
+  - Support for yazl (write) and yauzl (read) ZIP libraries
+- **Verification Reports** (`@peac/audit`)
+  - `VerificationReport` type with deterministic JCS canonicalization
+  - `formatReportText()`: Human-readable auditor summary
+  - `serializeReport()`: JSON serialization with stable ordering
+  - `report_hash`: SHA-256 of JCS-canonicalized report for cross-language parity
+- **CLI Bundle Commands** (`@peac/cli`)
+  - `peac bundle create`: Create dispute bundles from receipts and JWKS
+  - `peac bundle verify`: Offline verification with JSON/text output
+  - `peac bundle info`: Display bundle manifest information
+  - `--json` flag for automation-friendly output
+- **Error Codegen** (`scripts/codegen-errors.ts`)
+  - Auto-generate `errors.generated.ts` from `specs/kernel/errors.json`
+  - Type-safe error code constants with HTTP status mapping
+  - CI drift check to ensure codegen stays in sync
+- **Bundle Error Codes** (`specs/kernel/errors.json`)
+  - `E_BUNDLE_INVALID_FORMAT`: Bundle ZIP structure invalid
+  - `E_BUNDLE_MISSING_MANIFEST`: manifest.json not found
+  - `E_BUNDLE_INVALID_MANIFEST`: manifest.json schema invalid
+  - `E_BUNDLE_MISSING_RECEIPTS`: No receipts in bundle
+  - `E_BUNDLE_MISSING_KEYS`: No keys for verification
+  - `E_BUNDLE_KEY_NOT_FOUND`: Receipt references unknown key
+  - `E_BUNDLE_RECEIPT_INVALID`: Receipt JWS invalid
+  - `E_BUNDLE_HASH_MISMATCH`: Bundle integrity check failed
+  - `E_BUNDLE_VERSION_UNSUPPORTED`: Bundle version not supported
+- **Crypto Testkit** (`@peac/crypto/testkit`)
+  - `generateKeypairFromSeed()`: Deterministic keypair generation for tests
+  - Separate subpath export to prevent accidental production use
+  - Export surface guard test to verify main entry exclusion
+- **Conformance Vectors** (`specs/conformance/fixtures/bundle/`)
+  - 8 golden vector ZIPs (2 valid, 6 invalid)
+  - Expected report hashes for cross-implementation parity
+  - Determinism spec with fixed timestamps and seeded keys
+
+### CI/Quality
+
+- **Error Codes Drift Check**: Ensures `errors.generated.ts` matches `errors.json`
+- **Bundle Vectors Sanity Check**: Verifies generator runs without errors
+- **Guard Script Updates**: Allow `issued_at` in audit package, skip binary files
+
+### PRs
+
+- #262: Kernel error codegen and bundle error codes
+- #263: Audit dispute bundle verifier with deterministic conformance vectors
+- #264: Crypto testkit subpath export and export-surface guard
+- #265: CI bundle vector drift gate
+
 ## [0.9.29] - 2026-01-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Portable evidence for automated interactions**
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-0.9.29-blue.svg)](https://github.com/peacprotocol/peac/releases/tag/v0.9.29)
+[![Version](https://img.shields.io/badge/version-0.9.30-blue.svg)](https://github.com/peacprotocol/peac/releases/tag/v0.9.30)
 
 **What:** Signed receipts that prove who accessed what, when, under which terms, with which payment evidence.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/monorepo",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "private": true,
   "description": "PEAC Protocol - Cryptographic receipts for agentic commerce",
   "repository": {

--- a/packages/access/package.json
+++ b/packages/access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/access",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "private": true,
   "description": "PEAC access pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/adapters/core/package.json
+++ b/packages/adapters/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-core",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "Shared utilities for PEAC payment rail adapters",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/daydreams/package.json
+++ b/packages/adapters/x402/daydreams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402-daydreams",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "Daydreams AI inference event normalizer for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/fluora/package.json
+++ b/packages/adapters/x402/fluora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402-fluora",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "Fluora MCP marketplace event normalizer for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/pinata/package.json
+++ b/packages/adapters/x402/pinata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402-pinata",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "Pinata private IPFS objects event normalizer for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/aipref/package.json
+++ b/packages/aipref/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/pref",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "AIPREF resolver with robots.txt bridge",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/attribution/package.json
+++ b/packages/attribution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/attribution",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "PEAC attribution attestation - content derivation and usage proofs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/audit",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "private": true,
   "description": "Audit logging and case bundle generation for PEAC protocol disputes",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/cli",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "PEAC protocol command-line tools",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/compliance/package.json
+++ b/packages/compliance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/compliance",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "private": true,
   "description": "PEAC compliance pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/consent/package.json
+++ b/packages/consent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/consent",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "private": true,
   "description": "PEAC consent pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/contracts",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "PEAC canonical error codes and verification mode contracts",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/control/package.json
+++ b/packages/control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/control",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "PEAC Protocol Control - control engine interfaces and validation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/core",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "DEPRECATED - Use @peac/kernel, @peac/schema, @peac/crypto, @peac/protocol instead",
   "type": "module",
   "homepage": "https://peacprotocol.org",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/crypto",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "Ed25519 JWS signing and verification for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/disc",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "PEAC discovery with ≤20 lines enforcement",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/http-signatures/package.json
+++ b/packages/http-signatures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/http-signatures",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "RFC 9421 HTTP Message Signatures parsing and verification",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/intelligence/package.json
+++ b/packages/intelligence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/intelligence",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "private": true,
   "description": "PEAC intelligence pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/jwks-cache/package.json
+++ b/packages/jwks-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/jwks-cache",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "Edge-safe JWKS fetch and cache with SSRF protection",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/kernel",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "PEAC protocol kernel - normative constants, errors, and registries",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/mappings/acp/package.json
+++ b/packages/mappings/acp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-acp",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "Agentic Commerce Protocol (ACP) integration for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/aipref/package.json
+++ b/packages/mappings/aipref/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-aipref",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "IETF AIPREF vocabulary mapping for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/mcp/package.json
+++ b/packages/mappings/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-mcp",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "Model Context Protocol (MCP) integration for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/rsl/package.json
+++ b/packages/mappings/rsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-rsl",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "RSL (Robots Specification Layer) mapping for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/tap/package.json
+++ b/packages/mappings/tap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-tap",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "Visa Trusted Agent Protocol mapping to PEAC control evidence",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/pay402/package.json
+++ b/packages/pay402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/pay402",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "Generic HTTP 402 adapter with multi-rail payment negotiation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/policy-kit/package.json
+++ b/packages/policy-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/policy-kit",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "PEAC Policy Kit - deterministic policy evaluation for CAL semantics",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/privacy/package.json
+++ b/packages/privacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/privacy",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "private": true,
   "description": "Privacy pillar for PEAC protocol - k-anonymity, privacy-preserving hashing, data protection",
   "main": "dist/index.js",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/protocol",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "PEAC protocol implementation - receipt issuance and verification",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/provenance/package.json
+++ b/packages/provenance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/provenance",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "private": true,
   "description": "Provenance pillar for PEAC protocol - content provenance, C2PA integration, and chain-of-custody",
   "main": "dist/index.js",

--- a/packages/rails/card/package.json
+++ b/packages/rails/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-card",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "Card payment rail adapter for PEAC protocol (Flowglad, Stripe Billing, Lago)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rails/razorpay/package.json
+++ b/packages/rails/razorpay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-razorpay",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "private": true,
   "description": "Razorpay payment rail adapter for PEAC protocol (UPI, cards, netbanking)",
   "main": "dist/index.js",

--- a/packages/rails/stripe/package.json
+++ b/packages/rails/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-stripe",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "Stripe payment rail adapter for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rails/x402/package.json
+++ b/packages/rails/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-x402",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "x402 payment rail adapter for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/receipts/package.json
+++ b/packages/receipts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/receipts",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "PEAC Protocol receipt builders, parsers, and validators with CBOR support",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/schema",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "PEAC Protocol JSON schemas, OpenAPI specs, and TypeScript types",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/sdk",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "PEAC client SDK with discover/verify functions",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/server",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "PEAC verification server with DoS protection and rate limiting",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry-otel/package.json
+++ b/packages/telemetry-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/telemetry-otel",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "OpenTelemetry adapter for PEAC telemetry",
   "keywords": [
     "peac",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/telemetry",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "Telemetry interfaces and no-op implementation for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/transport/grpc/package.json
+++ b/packages/transport/grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-grpc",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "private": true,
   "description": "PEAC gRPC transport layer with HTTP StatusCode parity",
   "type": "module",

--- a/packages/transport/http/package.json
+++ b/packages/transport/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-http",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "private": true,
   "description": "PEAC HTTP transport layer - headers, middleware, DPoP L3/L4",
   "type": "module",

--- a/packages/transport/ws/package.json
+++ b/packages/transport/ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-ws",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "private": true,
   "description": "PEAC WebSocket transport layer (placeholder for v0.9.17+)",
   "type": "module",

--- a/packages/worker-core/package.json
+++ b/packages/worker-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-core",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "Runtime-neutral TAP verification handler for edge workers",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Version bump 0.9.29 → 0.9.30 for all 45 packages.

### v0.9.30 Theme: Dispute Bundle + Deterministic Verification

**Shipped:**

- **Dispute Bundle Format** (`@peac/audit`)
  - ZIP-based archive format for offline verification
  - `createDisputeBundle()`, `readDisputeBundle()`, `verifyBundle()`
  - Content-layer hashing for cross-platform determinism

- **CLI Bundle Commands** (`@peac/cli`)
  - `peac bundle create`: Create dispute bundles
  - `peac bundle verify`: Offline verification
  - `peac bundle info`: Display manifest

- **Verification Reports**
  - Deterministic JCS canonicalization
  - `report_hash` for cross-language parity

- **Error Codegen**
  - Auto-generate `errors.generated.ts` from `specs/kernel/errors.json`
  - 9 `E_BUNDLE_*` error codes

- **Crypto Testkit** (`@peac/crypto/testkit`)
  - `generateKeypairFromSeed()` for deterministic test keys

- **Conformance Vectors**
  - 8 golden vector ZIPs with expected report hashes

- **CI Gates**
  - Error codegen drift check
  - Bundle vectors sanity check

### PRs Included

- #260: verifyLocal helper with pack gates
- #261: Error codes and quickstart example
- #262: Kernel error codegen and bundle error codes
- #263: Audit dispute bundle verifier with conformance vectors
- #264: Crypto testkit subpath export
- #265: CI bundle vector drift gate

## How to Test

```bash
pnpm install
pnpm build
pnpm test:core
node packages/cli/dist/cli.js bundle --help
```

## Publish Checklist (after merge)

- [ ] Create git tag `v0.9.30` from merge commit
- [ ] Create GitHub Release with changelog
- [ ] npm publish deferred to v0.9.31 per NPM_PUBLISH_POLICY.md