### PR TITLE
fix: incremental OIDC rollout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -396,12 +396,12 @@ jobs:
           # Run publish script with:
           #   --skip-existing: Idempotent (safe reruns)
           #   --provenance: Generate provenance attestation
-          #   --strict: Fail if manifest mismatch
+          # Note: --strict removed to allow incremental OIDC rollout
+          # (only packages in manifest with Trusted Publishing configured are published)
           node scripts/publish-public.mjs \
             --tag=${{ env.NPM_TAG }} \
             --skip-existing \
-            --provenance \
-            --strict
+            --provenance
 
       - name: Verify published packages
         run: |


### PR DESCRIPTION
## Summary
- Remove `--strict` flag from publish workflow to allow incremental OIDC rollout
- The strict flag was requiring ALL public packages to be in manifest
- Since we're rolling out OIDC Trusted Publishing incrementally (6 packages so far), we need to allow partial manifest

## Test plan
- [ ] Merge this PR
- [ ] Move v0.10.4 tag to include this commit
- [ ] Re-run publish workflow - should pass with only 6 packages