### PR TITLE
fix: ensure upgraded npm for actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -170,6 +170,12 @@ jobs:
           echo "Installing npm@${{ env.NPM_VERSION }} for Trusted Publishing support..."
           npm install -g npm@${{ env.NPM_VERSION }}
 
+          # Add global npm bin to PATH for subsequent steps
+          NPM_PREFIX=$(npm config get prefix)
+          echo "$NPM_PREFIX/bin" >> $GITHUB_PATH
+          # Also update current step's PATH
+          export PATH="$NPM_PREFIX/bin:$PATH"
+
           echo "Toolchain versions:"
           echo "  Node: $(node --version)"
           echo "  npm: $(npm --version)"
@@ -285,6 +291,10 @@ jobs:
       - name: Upgrade npm for consistency
         run: |
           npm install -g npm@${{ env.NPM_VERSION }}
+          # Add global npm bin to PATH for subsequent steps
+          NPM_PREFIX=$(npm config get prefix)
+          echo "$NPM_PREFIX/bin" >> $GITHUB_PATH
+          export PATH="$NPM_PREFIX/bin:$PATH"
           echo "npm version: $(npm --version)"
 
       - name: Install dependencies
@@ -359,6 +369,11 @@ jobs:
       - name: Upgrade npm for Trusted Publishing
         run: |
           npm install -g npm@${{ env.NPM_VERSION }}
+          # Add global npm bin to PATH for subsequent steps
+          NPM_PREFIX=$(npm config get prefix)
+          echo "$NPM_PREFIX/bin" >> $GITHUB_PATH
+          # Verify in current step
+          export PATH="$NPM_PREFIX/bin:$PATH"
           echo "npm version: $(npm --version)"
 
       - name: Assert toolchain versions


### PR DESCRIPTION
## Summary

- Fix npm version check failure in publish workflow
- Use `GITHUB_PATH` to persist npm global bin directory across workflow steps
- Applied to all 3 places where npm is upgraded (preflight, dry-run, production)

## Problem

After `npm install -g npm@11.5.1`, subsequent steps still saw the old npm version because GitHub Actions runs each step in a new shell.

## Solution

Write the npm global prefix bin directory to `$GITHUB_PATH`, which persists across all subsequent steps.

## Test plan

- Re-run publish workflow after merge
- Verify npm version check passes in production job