### PR TITLE
fix: add repository field to contracts

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -29,6 +29,11 @@
   ],
   "author": "PEAC Protocol contributors",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/peacprotocol/peac.git",
+    "directory": "packages/contracts"
+  },
   "devDependencies": {
     "typescript": "^5.3.3",
     "vitest": "^2.0.0"


### PR DESCRIPTION
## Summary

- Add missing `repository` field to `@peac/contracts/package.json`

## Problem

npm provenance validation requires `package.json` to have a `repository.url` that matches the GitHub repository URL in the sigstore provenance bundle.

Without this field, `npm publish --provenance` fails with:

```
npm error 422 Unprocessable Entity - Error verifying sigstore provenance bundle: 
Failed to validate repository information: package.json: "repository.url" is "", 
expected to match "https://github.com/peacprotocol/peac" from provenance
```

## Test plan

- [x] Verified other packages in the manifest have the `repository` field
- [ ] Merge and re-run publish workflow