### PR TITLE
fix(adapter-x402): bump to 0.10.6 to fix broken release

### DIFF
--- a/packages/adapters/x402/package.json
+++ b/packages/adapters/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "x402 offer/receipt verification, term-matching, and PEAC record mapping",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Bumps `@peac/adapter-x402` from 0.10.5 to 0.10.6

## Context

v0.10.5 was published to npm with unresolved `workspace:*` dependencies because it was published using `npm publish` instead of `pnpm publish`. This made the package unusable for consumers.

**Actions taken:**
1. Deprecated `@peac/adapter-x402@0.10.5` on npm with message explaining the issue
2. Published `@peac/adapter-x402@0.10.6` with correctly resolved dependencies
3. This PR updates the repo to match the published version

## Verification

```bash
# v0.10.5 (broken - deprecated)
curl -s https://registry.npmjs.org/@peac%2fadapter-x402/0.10.5 | jq '.dependencies'
# Shows: workspace:*

# v0.10.6 (fixed)
curl -s https://registry.npmjs.org/@peac%2fadapter-x402/0.10.6 | jq '.dependencies'
# Shows: "@peac/kernel": "0.10.5", etc.
```

## Test plan

- [x] Package published to npm with correct dependencies
- [x] Deprecated broken version with clear message