### PR TITLE
chore: move pending items to TrustedPublishing

### DIFF
--- a/scripts/publish-manifest.json
+++ b/scripts/publish-manifest.json
@@ -3,7 +3,7 @@
   "description": "Single source of truth for PEAC Protocol npm publish order",
   "version": "0.10.5",
   "lastUpdated": "2026-01-30",
-  "totalPackages": 14,
+  "totalPackages": 13,
   "packages": [
     "@peac/kernel",
     "@peac/schema",
@@ -17,8 +17,7 @@
     "@peac/policy-kit",
     "@peac/adapter-core",
     "@peac/mappings-mcp",
-    "@peac/rails-x402",
-    "@peac/adapter-x402"
+    "@peac/rails-x402"
   ],
   "layers": {
     "0-kernel": ["@peac/kernel"],
@@ -33,7 +32,7 @@
       "@peac/policy-kit",
       "@peac/adapter-core"
     ],
-    "5-adapters": ["@peac/mappings-mcp", "@peac/rails-x402", "@peac/adapter-x402"]
+    "5-adapters": ["@peac/mappings-mcp", "@peac/rails-x402"]
   },
   "trustedPublisher": {
     "repository": "peacprotocol/peac",
@@ -41,6 +40,7 @@
     "environment": "npm-production"
   },
   "pendingTrustedPublishing": [
+    "@peac/adapter-x402",
     "@peac/telemetry-otel",
     "@peac/mappings-acp",
     "@peac/mappings-aipref",


### PR DESCRIPTION
## Summary

- Removes `@peac/adapter-x402` from the publish manifest
- Adds it to `pendingTrustedPublishing` list

## Context

The package was removed from npm after a broken publish (manual `npm publish` didn't resolve `workspace:*` dependencies). 

Once Trusted Publishing is configured on npm for this package, it can be added back to the manifest and published properly via GitHub Actions.

## Current state

- **13 packages** published at v0.10.5 via GitHub Actions ✓
- **@peac/adapter-x402** removed from npm, pending OIDC configuration

## Next steps

1. Configure Trusted Publishing for `@peac/adapter-x402` on npmjs.com
2. Add it back to the manifest
3. Re-run publish workflow