### PR TITLE
docs: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 A record is the portable interaction artifact; a receipt is the signed file format.
 
-[Docs](https://www.peacprotocol.org) | [Spec Index](docs/SPEC_INDEX.md) | [Discussions](https://github.com/peacprotocol/peac/discussions) | [Releases](https://github.com/peacprotocol/peac/releases)
-
+[Website](https://www.peacprotocol.org) | [Spec Index](docs/SPEC_INDEX.md) | [Discussions](https://github.com/peacprotocol/peac/discussions) | [Releases](https://github.com/peacprotocol/peac/releases)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Latest Release](https://img.shields.io/github/v/release/peacprotocol/peac)](https://github.com/peacprotocol/peac/releases)
+[![npm downloads](https://img.shields.io/npm/dm/@peac/protocol?style=flat)](https://www.npmjs.com/package/@peac/protocol)
 
 **What:** PEAC standardizes a file-discoverable policy surface and a signed receipt format that make automated interactions provable -- consent, attribution, settlement references, decisions, outcomes.
 
@@ -29,15 +29,24 @@ Use **record(s)** when talking conceptually. Use **receipt(s)** when referring t
 
 ## The model
 
-```
-1. Publish terms        2. Attach records        3. Verify and export
-/.well-known/           Issue receipts on        Deterministic report;
-peac.txt                governed interactions    Dispute Bundle for handoff
+```mermaid
+flowchart LR
+    subgraph "1. Publish policy"
+        A[Service] -->|hosts| B["/.well-known/peac.txt"]
+    end
+    subgraph "2. Issue receipt"
+        C[Gateway] -->|signs| D[PEAC-Receipt]
+    end
+    subgraph "3. Verify + bundle"
+        E[Verifier] -->|exports| F[Dispute Bundle]
+    end
+    B -.->|policy discovery| C
+    D -.->|offline verify| E
 ```
 
-1. **Publish terms**: Services publish terms and record requirements (`/.well-known/peac.txt`)
-2. **Attach records**: Gateways issue receipts for governed interactions (identity, purpose, settlement)
-3. **Verify and export**: Outcomes are verified offline; Dispute Bundles provide portable evidence
+1. **Publish policy**: Services publish terms and record requirements (`/.well-known/peac.txt`)
+2. **Issue receipt**: Gateways issue signed receipts for governed interactions (identity, purpose, settlement, extensions)
+3. **Verify + bundle**: Receipts verified offline; Dispute Bundles provide portable evidence for audits
 
 ## Where it fits
 

--- a/docs/README_LONG.md
+++ b/docs/README_LONG.md
@@ -16,9 +16,13 @@ The protocol works with generic HTTP 402 services, paywalls, routers, and data s
 
 **Agent protocols:**
 
-- [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol) - Tool context for language models. Mapping with budget utilities.
-- [Agentic Commerce Protocol (ACP)](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol) - Agent-driven commerce. Mapping with budget utilities.
-- [A2A Project](https://github.com/a2aproject/A2A) - Agent-to-agent coordination. Planned.
+- [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol) - Tool context for language models. Mapping: `@peac/mappings-mcp`
+- [Agentic Commerce Protocol (ACP)](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol) - Agent-driven commerce. Mapping: `@peac/mappings-acp`
+- [Agent2Agent Protocol (A2A)](https://github.com/google/A2A) - Agent-to-agent coordination. Planned.
+
+**Agent frameworks/runtimes:**
+
+- [OpenClaw](https://github.com/anthropics/claude-code) - Agent execution framework. Adapter: `@peac/adapter-openclaw`
 
 **Web policy surfaces:**
 
@@ -302,6 +306,10 @@ peac/
 │  ├─ protocol/            # issue(), verify(), discovery
 │  ├─ server/              # HTTP verification server
 │  ├─ cli/                 # Command-line tools
+│  ├─ capture/
+│  │  └─ core/             # Runtime-neutral capture pipeline
+│  ├─ adapters/
+│  │  └─ openclaw/         # OpenClaw agent framework adapter
 │  ├─ rails/
 │  │  ├─ x402/             # HTTP 402 / x402 payment rail
 │  │  ├─ stripe/           # Stripe payment rail
@@ -333,7 +341,7 @@ Layer 0: @peac/kernel
 Layer 1: @peac/schema
 Layer 2: @peac/crypto
 Layer 3: @peac/protocol, @peac/control
-Layer 4: @peac/rails-*, @peac/mappings-*, @peac/transport-*
+Layer 4: @peac/rails-*, @peac/mappings-*, @peac/adapter-*, @peac/transport-*
 Layer 5: @peac/server, @peac/cli
 ```
 
@@ -399,6 +407,18 @@ Dependencies flow DOWN only. Never import from a higher layer.
 | `@peac/telemetry-otel`  | OpenTelemetry adapter with privacy modes         |
 | `@peac/privacy`         | Privacy-preserving hashing                       |
 | `@peac/transport-grpc`  | gRPC transport binding                           |
+
+**Capture:**
+
+| Package              | Description                                          |
+| -------------------- | ---------------------------------------------------- |
+| `@peac/capture-core` | Runtime-neutral capture pipeline for agent platforms |
+
+**Adapters:**
+
+| Package                  | Description                          |
+| ------------------------ | ------------------------------------ |
+| `@peac/adapter-openclaw` | OpenClaw agent framework integration |
 
 **Attestations:**
 


### PR DESCRIPTION
## Summary

- Add website badge linking to peacprotocol.org (prominent link to protocol docs)
- Add npm downloads badge with flat style
- Convert ASCII model diagram to Mermaid flowchart (cleaner rendering on GitHub)

## Test plan

- [ ] Verify badges render correctly on GitHub
- [ ] Verify Mermaid diagram renders in GitHub README preview