### PR TITLE
chore: version alignment, publish manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/monorepo",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "private": true,
   "description": "PEAC Protocol - Cryptographic receipts for agentic commerce",
   "repository": {

--- a/packages/access/package.json
+++ b/packages/access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/access",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "private": true,
   "description": "PEAC access pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/adapters/core/package.json
+++ b/packages/adapters/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-core",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Shared utilities for PEAC payment rail adapters",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/openclaw/package.json
+++ b/packages/adapters/openclaw/package.json
@@ -1,10 +1,18 @@
 {
   "name": "@peac/adapter-openclaw",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "OpenClaw adapter for PEAC interaction evidence capture",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/peacprotocol/peac.git",
@@ -23,7 +31,8 @@
     "README.md"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "build": "tsc",

--- a/packages/adapters/x402/daydreams/package.json
+++ b/packages/adapters/x402/daydreams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402-daydreams",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Daydreams AI inference event normalizer for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/fluora/package.json
+++ b/packages/adapters/x402/fluora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402-fluora",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Fluora MCP marketplace event normalizer for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/package.json
+++ b/packages/adapters/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "x402 offer/receipt verification, term-matching, and PEAC record mapping",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/pinata/package.json
+++ b/packages/adapters/x402/pinata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402-pinata",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Pinata private IPFS objects event normalizer for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/aipref/package.json
+++ b/packages/aipref/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/pref",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "AIPREF resolver with robots.txt bridge",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/attribution/package.json
+++ b/packages/attribution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/attribution",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "PEAC attribution attestation - content derivation and usage proofs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/audit",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "private": true,
   "description": "Audit logging and case bundle generation for PEAC protocol disputes",
   "main": "dist/index.js",

--- a/packages/capture/core/package.json
+++ b/packages/capture/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/capture-core",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Runtime-neutral capture pipeline for PEAC interaction evidence",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -34,7 +34,8 @@
     "README.md"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "build": "tsc",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/cli",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "PEAC protocol command-line tools",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,8 +22,17 @@
     "dist",
     "README.md"
   ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "build": "tsc",

--- a/packages/compliance/package.json
+++ b/packages/compliance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/compliance",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "private": true,
   "description": "PEAC compliance pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/consent/package.json
+++ b/packages/consent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/consent",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "private": true,
   "description": "PEAC consent pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/contracts",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "PEAC canonical error codes and verification mode contracts",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/control/package.json
+++ b/packages/control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/control",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "PEAC Protocol Control - control engine interfaces and validation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/core",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "DEPRECATED - Use @peac/kernel, @peac/schema, @peac/crypto, @peac/protocol instead",
   "type": "module",
   "homepage": "https://www.peacprotocol.org",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/crypto",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Ed25519 JWS signing and verification for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/disc",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "PEAC discovery with ≤20 lines enforcement",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/http-signatures/package.json
+++ b/packages/http-signatures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/http-signatures",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "RFC 9421 HTTP Message Signatures parsing and verification",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/intelligence/package.json
+++ b/packages/intelligence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/intelligence",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "private": true,
   "description": "PEAC intelligence pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/jwks-cache/package.json
+++ b/packages/jwks-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/jwks-cache",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Edge-safe JWKS fetch and cache with SSRF protection",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/kernel",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "PEAC protocol kernel - normative constants, errors, and registries",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/mappings/acp/package.json
+++ b/packages/mappings/acp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-acp",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Agentic Commerce Protocol (ACP) integration for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/aipref/package.json
+++ b/packages/mappings/aipref/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-aipref",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "IETF AIPREF vocabulary mapping for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/mcp/package.json
+++ b/packages/mappings/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-mcp",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Model Context Protocol (MCP) integration for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/rsl/package.json
+++ b/packages/mappings/rsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-rsl",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "RSL (Robots Specification Layer) mapping for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/tap/package.json
+++ b/packages/mappings/tap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-tap",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Visa Trusted Agent Protocol mapping to PEAC control evidence",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mappings/ucp/package.json
+++ b/packages/mappings/ucp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-ucp",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Google Universal Commerce Protocol (UCP) mapping to PEAC receipts and dispute evidence",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/net/node/package.json
+++ b/packages/net/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/net-node",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "SSRF-safe network utilities for PEAC Protocol with DNS resolution pinning (Node.js only)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/pay402/package.json
+++ b/packages/pay402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/pay402",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Generic HTTP 402 adapter with multi-rail payment negotiation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/policy-kit/package.json
+++ b/packages/policy-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/policy-kit",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "PEAC Policy Kit - deterministic policy evaluation for CAL semantics",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/privacy/package.json
+++ b/packages/privacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/privacy",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "private": true,
   "description": "Privacy pillar for PEAC protocol - k-anonymity, privacy-preserving hashing, data protection",
   "main": "dist/index.js",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/protocol",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "PEAC protocol implementation - receipt issuance and verification",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/provenance/package.json
+++ b/packages/provenance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/provenance",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "private": true,
   "description": "Provenance pillar for PEAC protocol - content provenance, C2PA integration, and chain-of-custody",
   "main": "dist/index.js",

--- a/packages/rails/card/package.json
+++ b/packages/rails/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-card",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Card payment rail adapter for PEAC protocol (Flowglad, Stripe Billing, Lago)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rails/razorpay/package.json
+++ b/packages/rails/razorpay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-razorpay",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "private": true,
   "description": "Razorpay payment rail adapter for PEAC protocol (UPI, cards, netbanking)",
   "main": "dist/index.js",

--- a/packages/rails/stripe/package.json
+++ b/packages/rails/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-stripe",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Stripe payment rail adapter for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rails/x402/package.json
+++ b/packages/rails/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-x402",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "x402 payment rail adapter for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/receipts/package.json
+++ b/packages/receipts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/receipts",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "PEAC Protocol receipt builders, parsers, and validators with CBOR support",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/schema",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "PEAC Protocol JSON schemas, OpenAPI specs, and TypeScript types",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/sdk",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "PEAC client SDK with discover/verify functions",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/server",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "PEAC verification server with DoS protection and rate limiting",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry-otel/package.json
+++ b/packages/telemetry-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/telemetry-otel",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "OpenTelemetry adapter for PEAC telemetry",
   "keywords": [
     "peac",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/telemetry",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Telemetry interfaces and no-op implementation for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/transport/grpc/package.json
+++ b/packages/transport/grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-grpc",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "private": true,
   "description": "PEAC gRPC transport layer with HTTP StatusCode parity",
   "type": "module",

--- a/packages/transport/http/package.json
+++ b/packages/transport/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-http",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "private": true,
   "description": "PEAC HTTP transport layer - headers, middleware, DPoP L3/L4",
   "type": "module",

--- a/packages/transport/ws/package.json
+++ b/packages/transport/ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-ws",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "private": true,
   "description": "PEAC WebSocket transport layer (placeholder for v0.9.17+)",
   "type": "module",

--- a/packages/worker-core/package.json
+++ b/packages/worker-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-core",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Runtime-neutral TAP verification handler for edge workers",
   "type": "module",
   "main": "./dist/index.js",

--- a/scripts/publish-manifest.json
+++ b/scripts/publish-manifest.json
@@ -1,30 +1,37 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Single source of truth for PEAC Protocol npm publish order",
-  "version": "0.10.5",
-  "lastUpdated": "2026-01-30",
-  "totalPackages": 13,
+  "version": "0.10.8",
+  "lastUpdated": "2026-02-06",
+  "totalPackages": 18,
   "packages": [
     "@peac/kernel",
     "@peac/schema",
     "@peac/crypto",
     "@peac/telemetry",
+    "@peac/capture-core",
     "@peac/protocol",
     "@peac/control",
+    "@peac/middleware-core",
+    "@peac/middleware-express",
     "@peac/contracts",
     "@peac/http-signatures",
     "@peac/jwks-cache",
     "@peac/policy-kit",
     "@peac/adapter-core",
     "@peac/mappings-mcp",
-    "@peac/rails-x402"
+    "@peac/rails-x402",
+    "@peac/adapter-openclaw",
+    "@peac/cli"
   ],
   "layers": {
     "0-kernel": ["@peac/kernel"],
     "1-schema": ["@peac/schema"],
     "2-crypto": ["@peac/crypto"],
     "2.5-telemetry": ["@peac/telemetry"],
+    "2.5-capture": ["@peac/capture-core"],
     "3-protocol": ["@peac/protocol", "@peac/control"],
+    "3.5-middleware": ["@peac/middleware-core", "@peac/middleware-express"],
     "4-infra": [
       "@peac/contracts",
       "@peac/http-signatures",
@@ -32,7 +39,8 @@
       "@peac/policy-kit",
       "@peac/adapter-core"
     ],
-    "5-adapters": ["@peac/mappings-mcp", "@peac/rails-x402"]
+    "5-adapters": ["@peac/mappings-mcp", "@peac/rails-x402", "@peac/adapter-openclaw"],
+    "6-cli": ["@peac/cli"]
   },
   "trustedPublisher": {
     "repository": "peacprotocol/peac",
@@ -60,7 +68,6 @@
     "@peac/receipts",
     "@peac/pay402",
     "@peac/server",
-    "@peac/cli",
     "@peac/core",
     "@peac/sdk"
   ]


### PR DESCRIPTION
## Summary

- Bump all 50 workspace packages from 0.10.7 to 0.10.8
- Update publish manifest (13 -> 18 packages) with 5 newly-published packages
- Add `provenance: true` to 3 packages missing it
- Add explicit `exports` field to 2 packages missing it

## Details

### Version alignment

All 50 workspace packages at 0.10.7 bumped to 0.10.8. Apps and middleware packages were already at 0.10.8 from prior PRs.

### Publish manifest (`scripts/publish-manifest.json`)

- Version: 0.10.5 -> 0.10.8
- totalPackages: 13 -> 18
- Added 5 packages in layer order:
  - `@peac/capture-core` (Layer 2.5)
  - `@peac/middleware-core` (Layer 3.5)
  - `@peac/middleware-express` (Layer 3.5)
  - `@peac/adapter-openclaw` (Layer 5)
  - `@peac/cli` (Layer 6)
- New layers: `2.5-capture`, `3.5-middleware`, `6-cli`
- Removed `@peac/cli` from `pendingTrustedPublishing`

### Provenance consistency

Added `publishConfig.provenance: true` to:
- `@peac/cli`
- `@peac/capture-core`
- `@peac/adapter-openclaw`

(`@peac/middleware-core` and `@peac/middleware-express` already had it)

### Exports field

Added explicit `exports` map (types/import/require/default) to:
- `@peac/cli`
- `@peac/adapter-openclaw`

### Verified consumer-facing fields

All 5 newly-published packages confirmed to have: `exports`, `types`, `files`, `provenance`, and `bin` (where applicable).

## Manual prerequisite (npmjs.com, not code)

Before tagging v0.10.8, configure OIDC Trusted Publisher on npmjs.com for the 5 new packages:
- `@peac/cli`, `@peac/middleware-core`, `@peac/middleware-express`
- `@peac/capture-core`, `@peac/adapter-openclaw`
- Each: repository=peacprotocol/peac, workflow=publish.yml, environment=npm-production

## Test plan

- [x] `pnpm build` -- 71/71 successful
- [x] `pnpm lint` -- clean
- [x] `pnpm typecheck:core` -- clean
- [x] `pnpm test` -- 3486 tests passed (126 files)
- [x] `./scripts/guard.sh` -- all checks passed
- [x] `./scripts/check-planning-leak.sh` -- clean
- [x] `./scripts/check-publish-list.sh` -- clean
- [ ] After merge: tag v0.10.8, push tag -> auto-publish via publish.yml
- [ ] Post-release: `npm view @peac/cli@0.10.8` resolves