### PR TITLE
docs: readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A record is the portable interaction artifact; a receipt is the signed file form
 
 **Why:** Internal logs are not neutral proof and integrations do not interoperate. PEAC makes terms machine-readable and outcomes verifiable, without replacing your auth, rails, or observability.
 
-Works over HTTP/REST (headers), MCP/A2A, and streaming transports; verification is offline and deterministic.
+HTTP/REST is the primary binding today (receipt header + well-known policy). MCP mapping is implemented; A2A and streaming bindings are specified/planned. Verification is offline and deterministic.
 
 ## The model
 
@@ -61,6 +61,8 @@ This repository contains the **reference TypeScript implementation** and a **Go 
 pnpm add @peac/protocol
 ```
 
+Requires Node ESM or top-level await.
+
 ```typescript
 import { issue, verifyLocal, generateKeypair } from '@peac/protocol';
 
@@ -93,7 +95,7 @@ See [examples/quickstart/](examples/quickstart/) for runnable code. For settleme
 
 ## CLI
 
-> **Note:** `@peac/cli` publishes to npm with v0.10.9. Until then, run from source: `pnpm --filter @peac/cli exec peac`.
+> **Note:** `@peac/cli` may not be published to npm yet. From this repo root: `pnpm install && pnpm --filter @peac/cli exec peac --help`.
 
 ```bash
 peac verify 'eyJhbGc...'                # Verify a receipt
@@ -110,6 +112,8 @@ See [packages/cli/README.md](packages/cli/README.md) for the full command refere
 ---
 
 ## Core primitives
+
+**Stable** = wire identifiers and spec are stable and conformance-gated; implementations may evolve.
 
 | Primitive           | Stable | Description                                           |
 | ------------------- | ------ | ----------------------------------------------------- |

--- a/docs/README_LONG.md
+++ b/docs/README_LONG.md
@@ -51,6 +51,8 @@ See [examples/x402-node-server](../examples/x402-node-server) for a working impl
 
 ---
 
+**Package availability:** Some packages referenced below (CLI, middleware, adapters) may exist in this repo but not yet be published to npm. If so, run commands via `pnpm --filter <pkg> exec ...` from this repo root, or use the lower-level `@peac/protocol` APIs shown.
+
 ## Integration examples
 
 ### Settlement fields
@@ -172,8 +174,13 @@ A bundle contains receipts, policy snapshots, and a deterministic verification r
 - Cross-language parity: TypeScript and Go produce identical verification reports
 
 ```bash
+# If peac is on PATH
 peac bundle create --receipts ./receipts.ndjson --policy ./policy.yaml --output ./evidence.peacbundle
 peac bundle verify ./evidence.peacbundle --offline
+
+# From this repo root (always works when CLI is not published)
+pnpm --filter @peac/cli exec peac bundle create --receipts ./receipts.ndjson --policy ./policy.yaml --output ./evidence.peacbundle
+pnpm --filter @peac/cli exec peac bundle verify ./evidence.peacbundle --offline
 ```
 
 See [specs/DISPUTE.md](specs/DISPUTE.md) for the specification.
@@ -199,7 +206,7 @@ PEAC is not a paywall, billing engine, or storage system. It is the records laye
 
 **Receipts:**
 
-- Receipt type: `typ: "peac-receipt/0.1"` (frozen across v0.9.x)
+- Receipt type: `typ: "peac-receipt/0.1"` (frozen across v0.x)
 - Envelope structure: `PEACEnvelope` with auth, payment evidence, and metadata
 - Signature: Ed25519 JWS (RFC 8032)
 - Evidence model: `PaymentEvidence` captures rail, asset, environment, and rail-specific proof
@@ -701,8 +708,8 @@ These are optional higher-layer helpers built on top of the core receipt/kernel 
 
 **Wire format:**
 
-- `peac-receipt/0.1` is frozen throughout the v0.9.x series
-- Libraries may evolve APIs but must emit/accept 0.9 receipts
+- `peac-receipt/0.1` is frozen throughout the v0.x series
+- Libraries may evolve APIs but must emit/accept `peac-receipt/0.1`
 
 **Library surface:**
 


### PR DESCRIPTION
## Summary

- Trim main README, move detail to README_LONG
- CLI install caveat (publishes with v0.10.9)
- Fix ERC-8004 status accuracy

## Test plan

- CI green (build, lint, typecheck, tests, guards)