### PR TITLE
security: fail guard.sh

### DIFF
--- a/scripts/guard.sh
+++ b/scripts/guard.sh
@@ -164,7 +164,8 @@ if [ -f scripts/find-invisible-unicode.mjs ]; then
     echo "OK"
   fi
 else
-  echo "SKIP: scripts/find-invisible-unicode.mjs not found"
+  echo "FAIL: scripts/find-invisible-unicode.mjs not found (required for Trojan Source detection)"
+  bad=1
 fi
 
 echo "== forbid header casing drift (Peac-Receipt) =="


### PR DESCRIPTION
## Summary

- Change `guard.sh` from `SKIP` (silent pass) to `FAIL` when `scripts/find-invisible-unicode.mjs` is absent
- The detector script exists and is tracked -- the skip was masking working directory issues
- Ensures Trojan Source detection (CVE-2021-42574) cannot be silently bypassed

## Context

Reviewed all 4 open PRs (#321-#324) for hidden/bidirectional Unicode. All PR diffs and full files are clean -- confirmed with both `perl` codepoint scan and the existing `find-invisible-unicode.mjs` scanner. GitHub's "hidden Unicode" banner is a generic informational warning, not an actual finding.

The real issue: `guard.sh` silently skipped the check with `SKIP: scripts/find-invisible-unicode.mjs not found` when run from a non-root working directory. This PR makes it a hard failure instead.

## Test plan

- [ ] `bash scripts/guard.sh` -- passes (unicode scanner runs, no findings)
- [ ] Remove the script temporarily -> guard.sh fails with clear error