### PR TITLE
fix(ci): publish preflight main fetch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Fetch main branch for reachability check
         run: |
-          git fetch origin main --depth=1
+          git fetch origin main
           echo "Fetched origin/main for reachability validation"
 
       - name: Extract version from tag


### PR DESCRIPTION
## Summary

- Remove `--depth=1` from `git fetch origin main` in the publish workflow preflight job
- The checkout step already uses `fetch-depth: 0` (full history), but the shallow main fetch was replacing `origin/main` with a single-commit ref
- This broke `git merge-base --is-ancestor` when the tag commit wasn't the tip of main (e.g., after Dependabot PRs were merged post-release)

## Test plan

- [ ] Merge this PR
- [ ] Re-run publish workflow with `tag_override=v0.10.11`, `dry_run=false`
- [ ] Verify preflight passes and all 20 packages publish