### PR TITLE
chore(release): v0.10.12

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-api",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "PEAC Protocol API server with OpenAPI 3.1, RFC 9457 Problem Details, and content negotiation",
   "type": "module",
   "main": "dist/index.js",

--- a/apps/bridge/package.json
+++ b/apps/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-bridge",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "PEAC Protocol Bridge - Local development sidecar",
   "type": "module",
   "main": "dist/server.js",

--- a/apps/sandbox-issuer/package.json
+++ b/apps/sandbox-issuer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-sandbox-issuer",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "PEAC Protocol Sandbox Issuer - Test receipt issuance for development",
   "type": "module",
   "main": "dist/node.js",

--- a/apps/verifier/package.json
+++ b/apps/verifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-verifier",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "PEAC Protocol Browser Verifier - Client-side receipt verification",
   "type": "module",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/monorepo",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "private": true,
   "description": "PEAC Protocol - Cryptographic receipts for agentic commerce",
   "repository": {

--- a/packages/access/package.json
+++ b/packages/access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/access",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "private": true,
   "description": "PEAC access pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/adapters/core/package.json
+++ b/packages/adapters/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-core",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Shared utilities for PEAC payment rail adapters",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/openclaw/package.json
+++ b/packages/adapters/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-openclaw",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "OpenClaw adapter for PEAC interaction evidence capture",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/daydreams/package.json
+++ b/packages/adapters/x402/daydreams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402-daydreams",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Daydreams AI inference event normalizer for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/fluora/package.json
+++ b/packages/adapters/x402/fluora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402-fluora",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Fluora MCP marketplace event normalizer for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/package.json
+++ b/packages/adapters/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "x402 offer/receipt verification, term-matching, and PEAC record mapping",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/pinata/package.json
+++ b/packages/adapters/x402/pinata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402-pinata",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Pinata private IPFS objects event normalizer for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/aipref/package.json
+++ b/packages/aipref/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/pref",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "AIPREF resolver with robots.txt bridge",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/attribution/package.json
+++ b/packages/attribution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/attribution",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "PEAC attribution attestation - content derivation and usage proofs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/audit",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Audit logging and case bundle generation for PEAC protocol disputes",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/capture/core/package.json
+++ b/packages/capture/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/capture-core",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Runtime-neutral capture pipeline for PEAC interaction evidence",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/capture/node/package.json
+++ b/packages/capture/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/capture-node",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Node.js durable storage for PEAC capture pipeline (filesystem spool store and dedupe index)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/cli",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "PEAC protocol command-line tools",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/compliance/package.json
+++ b/packages/compliance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/compliance",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "private": true,
   "description": "PEAC compliance pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/consent/package.json
+++ b/packages/consent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/consent",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "private": true,
   "description": "PEAC consent pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/contracts",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "PEAC canonical error codes and verification mode contracts",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/control/package.json
+++ b/packages/control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/control",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "PEAC Protocol Control - control engine interfaces and validation",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/core",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "DEPRECATED - Use @peac/kernel, @peac/schema, @peac/crypto, @peac/protocol instead",
   "type": "module",
   "homepage": "https://www.peacprotocol.org",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/crypto",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Ed25519 JWS signing and verification for PEAC protocol",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/disc",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "PEAC discovery with ≤20 lines enforcement",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/http-signatures/package.json
+++ b/packages/http-signatures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/http-signatures",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "RFC 9421 HTTP Message Signatures parsing and verification",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/intelligence/package.json
+++ b/packages/intelligence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/intelligence",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "private": true,
   "description": "PEAC intelligence pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/jwks-cache/package.json
+++ b/packages/jwks-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/jwks-cache",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Edge-safe JWKS fetch and cache with SSRF protection",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/kernel",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "PEAC protocol kernel - normative constants, errors, and registries",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/mappings/acp/package.json
+++ b/packages/mappings/acp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-acp",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Agentic Commerce Protocol (ACP) integration for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/aipref/package.json
+++ b/packages/mappings/aipref/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-aipref",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "IETF AIPREF vocabulary mapping for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/mcp/package.json
+++ b/packages/mappings/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-mcp",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Model Context Protocol (MCP) integration for PEAC",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/mappings/rsl/package.json
+++ b/packages/mappings/rsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-rsl",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "RSL (Robots Specification Layer) mapping for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/tap/package.json
+++ b/packages/mappings/tap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-tap",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Visa Trusted Agent Protocol mapping to PEAC control evidence",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mappings/ucp/package.json
+++ b/packages/mappings/ucp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-ucp",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Google Universal Commerce Protocol (UCP) mapping to PEAC receipts and dispute evidence",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/middleware-core/package.json
+++ b/packages/middleware-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/middleware-core",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Framework-agnostic middleware primitives for PEAC receipt issuance",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/middleware-express/package.json
+++ b/packages/middleware-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/middleware-express",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Express.js middleware for automatic PEAC receipt issuance",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/net/node/package.json
+++ b/packages/net/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/net-node",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "SSRF-safe network utilities for PEAC Protocol with DNS resolution pinning (Node.js only)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/pay402/package.json
+++ b/packages/pay402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/pay402",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Generic HTTP 402 adapter with multi-rail payment negotiation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/policy-kit/package.json
+++ b/packages/policy-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/policy-kit",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "PEAC Policy Kit - deterministic policy evaluation for CAL semantics",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/privacy/package.json
+++ b/packages/privacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/privacy",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "private": true,
   "description": "Privacy pillar for PEAC protocol - k-anonymity, privacy-preserving hashing, data protection",
   "main": "dist/index.js",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/protocol",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "PEAC protocol implementation - receipt issuance and verification",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/provenance/package.json
+++ b/packages/provenance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/provenance",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "private": true,
   "description": "Provenance pillar for PEAC protocol - content provenance, C2PA integration, and chain-of-custody",
   "main": "dist/index.js",

--- a/packages/rails/card/package.json
+++ b/packages/rails/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-card",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Card payment rail adapter for PEAC protocol (Flowglad, Stripe Billing, Lago)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rails/razorpay/package.json
+++ b/packages/rails/razorpay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-razorpay",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "private": true,
   "description": "Razorpay payment rail adapter for PEAC protocol (UPI, cards, netbanking)",
   "main": "dist/index.js",

--- a/packages/rails/stripe/package.json
+++ b/packages/rails/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-stripe",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Stripe payment rail adapter for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rails/x402/package.json
+++ b/packages/rails/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-x402",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "x402 payment rail adapter for PEAC protocol",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/receipts/package.json
+++ b/packages/receipts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/receipts",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "PEAC Protocol receipt builders, parsers, and validators with CBOR support",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/schema",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "PEAC Protocol JSON schemas, OpenAPI specs, and TypeScript types",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/sdk",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "PEAC client SDK with discover/verify functions",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/server",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "PEAC verification server with DoS protection and rate limiting",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry-otel/package.json
+++ b/packages/telemetry-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/telemetry-otel",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "OpenTelemetry adapter for PEAC telemetry",
   "keywords": [
     "peac",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/telemetry",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Telemetry interfaces and no-op implementation for PEAC protocol",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/transport/grpc/package.json
+++ b/packages/transport/grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-grpc",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "private": true,
   "description": "PEAC gRPC transport layer with HTTP StatusCode parity",
   "type": "module",

--- a/packages/transport/http/package.json
+++ b/packages/transport/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-http",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "private": true,
   "description": "PEAC HTTP transport layer - headers, middleware, DPoP L3/L4",
   "type": "module",

--- a/packages/transport/ws/package.json
+++ b/packages/transport/ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-ws",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "private": true,
   "description": "PEAC WebSocket transport layer (placeholder for v0.9.17+)",
   "type": "module",

--- a/packages/worker-core/package.json
+++ b/packages/worker-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-core",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Runtime-neutral TAP verification handler for edge workers",
   "type": "module",
   "main": "./dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1544,8 +1544,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/contracts
       next:
-        specifier: ^15.0.0
-        version: 15.5.9(react-dom@19.2.4)(react@19.2.4)
+        specifier: ^15.5.12
+        version: 15.5.12(react-dom@19.2.4)(react@19.2.4)
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
@@ -1600,8 +1600,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(tsx@4.21.0)
       wrangler:
-        specifier: ^3.93.0
-        version: 3.114.15(@cloudflare/workers-types@4.20260214.0)
+        specifier: ^3.114.17
+        version: 3.114.17(@cloudflare/workers-types@4.20260214.0)
 
   surfaces/workers/fastly:
     dependencies:
@@ -4265,12 +4265,12 @@ packages:
     dev: true
     optional: true
 
-  /@next/env@15.5.9:
-    resolution: {integrity: sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg==}
+  /@next/env@15.5.12:
+    resolution: {integrity: sha512-pUvdJN1on574wQHjaBfNGDt9Mz5utDSZFsIIQkMzPgNS8ZvT4H2mwOrOIClwsQOb6EGx5M76/CZr6G8i6pSpLg==}
     dev: true
 
-  /@next/swc-darwin-arm64@15.5.7:
-    resolution: {integrity: sha512-IZwtxCEpI91HVU/rAUOOobWSZv4P2DeTtNaCdHqLcTJU4wdNXgAySvKa/qJCgR5m6KI8UsKDXtO2B31jcaw1Yw==}
+  /@next/swc-darwin-arm64@15.5.12:
+    resolution: {integrity: sha512-RnRjBtH8S8eXCpUNkQ+543DUc7ys8y15VxmFU9HRqlo9BG3CcBUiwNtF8SNoi2xvGCVJq1vl2yYq+3oISBS0Zg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -4278,8 +4278,8 @@ packages:
     dev: true
     optional: true
 
-  /@next/swc-darwin-x64@15.5.7:
-    resolution: {integrity: sha512-UP6CaDBcqaCBuiq/gfCEJw7sPEoX1aIjZHnBWN9v9qYHQdMKvCKcAVs4OX1vIjeE+tC5EIuwDTVIoXpUes29lg==}
+  /@next/swc-darwin-x64@15.5.12:
+    resolution: {integrity: sha512-nqa9/7iQlboF1EFtNhWxQA0rQstmYRSBGxSM6g3GxvxHxcoeqVXfGNr9stJOme674m2V7r4E3+jEhhGvSQhJRA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -4287,8 +4287,8 @@ packages:
     dev: true
     optional: true
 
-  /@next/swc-linux-arm64-gnu@15.5.7:
-    resolution: {integrity: sha512-NCslw3GrNIw7OgmRBxHtdWFQYhexoUCq+0oS2ccjyYLtcn1SzGzeM54jpTFonIMUjNbHmpKpziXnpxhSWLcmBA==}
+  /@next/swc-linux-arm64-gnu@15.5.12:
+    resolution: {integrity: sha512-dCzAjqhDHwmoB2M4eYfVKqXs99QdQxNQVpftvP1eGVppamXh/OkDAwV737Zr0KPXEqRUMN4uCjh6mjO+XtF3Mw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -4296,8 +4296,8 @@ packages:
     dev: true
     optional: true
 
-  /@next/swc-linux-arm64-musl@15.5.7:
-    resolution: {integrity: sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==}
+  /@next/swc-linux-arm64-musl@15.5.12:
+    resolution: {integrity: sha512-+fpGWvQiITgf7PUtbWY1H7qUSnBZsPPLyyq03QuAKpVoTy/QUx1JptEDTQMVvQhvizCEuNLEeghrQUyXQOekuw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -4305,8 +4305,8 @@ packages:
     dev: true
     optional: true
 
-  /@next/swc-linux-x64-gnu@15.5.7:
-    resolution: {integrity: sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw==}
+  /@next/swc-linux-x64-gnu@15.5.12:
+    resolution: {integrity: sha512-jSLvgdRRL/hrFAPqEjJf1fFguC719kmcptjNVDJl26BnJIpjL3KH5h6mzR4mAweociLQaqvt4UyzfbFjgAdDcw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -4314,8 +4314,8 @@ packages:
     dev: true
     optional: true
 
-  /@next/swc-linux-x64-musl@15.5.7:
-    resolution: {integrity: sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==}
+  /@next/swc-linux-x64-musl@15.5.12:
+    resolution: {integrity: sha512-/uaF0WfmYqQgLfPmN6BvULwxY0dufI2mlN2JbOKqqceZh1G4hjREyi7pg03zjfyS6eqNemHAZPSoP84x17vo6w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -4323,8 +4323,8 @@ packages:
     dev: true
     optional: true
 
-  /@next/swc-win32-arm64-msvc@15.5.7:
-    resolution: {integrity: sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==}
+  /@next/swc-win32-arm64-msvc@15.5.12:
+    resolution: {integrity: sha512-xhsL1OvQSfGmlL5RbOmU+FV120urrgFpYLq+6U8C6KIym32gZT6XF/SDE92jKzzlPWskkbjOKCpqk5m4i8PEfg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -4332,8 +4332,8 @@ packages:
     dev: true
     optional: true
 
-  /@next/swc-win32-x64-msvc@15.5.7:
-    resolution: {integrity: sha512-gMzgBX164I6DN+9/PGA+9dQiwmTkE4TloBNx8Kv9UiGARsr9Nba7IpcBRA1iTV9vwlYnrE3Uy6I7Aj6qLjQuqw==}
+  /@next/swc-win32-x64-msvc@15.5.12:
+    resolution: {integrity: sha512-Z1Dh6lhFkxvBDH1FoW6OU/L6prYwPSlwjLiZkExIAh8fbP6iI/M7iGTQAJPYJ9YFlWobCZ1PHbchFhFYb2ADkw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -8116,8 +8116,8 @@ packages:
     engines: {node: '>=18'}
     dev: true
 
-  /miniflare@3.20250718.2:
-    resolution: {integrity: sha512-cW/NQPBKc+fb0FwcEu+z/v93DZd+/6q/AF0iR0VFELtNPOsCvLalq6ndO743A7wfZtFxMxvuDQUXNx3aKQhOwA==}
+  /miniflare@3.20250718.3:
+    resolution: {integrity: sha512-JuPrDJhwLrNLEJiNLWO7ZzJrv/Vv9kZuwMYCfv0LskQDM6Eonw4OvywO3CH/wCGjgHzha/qyjUh8JQ068TjDgQ==}
     engines: {node: '>=16.13'}
     hasBin: true
     dependencies:
@@ -8229,8 +8229,8 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: true
 
-  /next@15.5.9(react-dom@19.2.4)(react@19.2.4):
-    resolution: {integrity: sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==}
+  /next@15.5.12(react-dom@19.2.4)(react@19.2.4):
+    resolution: {integrity: sha512-Fi/wQ4Etlrn60rz78bebG1i1SR20QxvV8tVp6iJspjLUSHcZoeUXCt+vmWoEcza85ElZzExK/jJ/F6SvtGktjA==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -8250,7 +8250,7 @@ packages:
       sass:
         optional: true
     dependencies:
-      '@next/env': 15.5.9
+      '@next/env': 15.5.12
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001756
       postcss: 8.4.31
@@ -8258,14 +8258,14 @@ packages:
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(react@19.2.4)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.5.7
-      '@next/swc-darwin-x64': 15.5.7
-      '@next/swc-linux-arm64-gnu': 15.5.7
-      '@next/swc-linux-arm64-musl': 15.5.7
-      '@next/swc-linux-x64-gnu': 15.5.7
-      '@next/swc-linux-x64-musl': 15.5.7
-      '@next/swc-win32-arm64-msvc': 15.5.7
-      '@next/swc-win32-x64-msvc': 15.5.7
+      '@next/swc-darwin-arm64': 15.5.12
+      '@next/swc-darwin-x64': 15.5.12
+      '@next/swc-linux-arm64-gnu': 15.5.12
+      '@next/swc-linux-arm64-musl': 15.5.12
+      '@next/swc-linux-x64-gnu': 15.5.12
+      '@next/swc-linux-x64-musl': 15.5.12
+      '@next/swc-win32-arm64-msvc': 15.5.12
+      '@next/swc-win32-x64-msvc': 15.5.12
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -10341,8 +10341,8 @@ packages:
       '@cloudflare/workerd-windows-64': 1.20250718.0
     dev: true
 
-  /wrangler@3.114.15(@cloudflare/workers-types@4.20260214.0):
-    resolution: {integrity: sha512-OpGikaV6t7AGXZImtGnVXI8WUnqBMFBCQcZzqKmQi0T/pZ5h8iSKhEZf7ItVB8bAG56yswHnWWYyANWF/Jj/JA==}
+  /wrangler@3.114.17(@cloudflare/workers-types@4.20260214.0):
+    resolution: {integrity: sha512-tAvf7ly+tB+zwwrmjsCyJ2pJnnc7SZhbnNwXbH+OIdVas3zTSmjcZOjmLKcGGptssAA3RyTKhcF9BvKZzMUycA==}
     engines: {node: '>=16.17.0'}
     hasBin: true
     peerDependencies:
@@ -10358,7 +10358,7 @@ packages:
       '@esbuild-plugins/node-modules-polyfill': 0.2.2(esbuild@0.17.19)
       blake3-wasm: 2.1.5
       esbuild: 0.17.19
-      miniflare: 3.20250718.2
+      miniflare: 3.20250718.3
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.14
       workerd: 1.20250718.0

--- a/scripts/publish-manifest.json
+++ b/scripts/publish-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Single source of truth for PEAC Protocol npm publish order",
-  "version": "0.10.11",
-  "lastUpdated": "2026-02-14",
+  "version": "0.10.12",
+  "lastUpdated": "2026-02-15",
   "totalPackages": 21,
   "packages": [
     "@peac/kernel",

--- a/surfaces/analytics/package.json
+++ b/surfaces/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/analytics",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "private": true,
   "description": "Analytics surface for PEAC Protocol - metrics API with k-anonymity protection",
   "type": "module",

--- a/surfaces/nextjs/middleware/package.json
+++ b/surfaces/nextjs/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/middleware-nextjs",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "private": true,
   "description": "PEAC TAP verifier and 402 access gate for Next.js Edge Runtime",
   "type": "module",
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@peac/contracts": "workspace:*",
-    "next": "^15.0.0",
+    "next": "^15.5.12",
     "typescript": "^5.3.0",
     "vitest": "^4.0.0"
   },

--- a/surfaces/workers/akamai/package.json
+++ b/surfaces/workers/akamai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-akamai",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "private": true,
   "description": "PEAC receipt verification worker for Akamai EdgeWorkers",
   "type": "module",

--- a/surfaces/workers/cloudflare/package.json
+++ b/surfaces/workers/cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-cloudflare",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "private": true,
   "description": "PEAC receipt verification worker for Cloudflare Workers",
   "type": "module",
@@ -42,6 +42,6 @@
     "@cloudflare/workers-types": "^4.20260214.0",
     "typescript": "^5.3.0",
     "vitest": "^4.0.0",
-    "wrangler": "^3.93.0"
+    "wrangler": "^3.114.17"
   }
 }

--- a/surfaces/workers/fastly/package.json
+++ b/surfaces/workers/fastly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-fastly",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "private": true,
   "description": "PEAC receipt verification worker for Fastly Compute",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump all workspace packages to v0.10.12
- CHANGELOG entry for v0.10.12

## v0.10.12 Changes

- **@peac/capture-node**: Filesystem-backed durable capture stores (#376)
- **@peac/adapter-openclaw**: `activate()` one-call setup, `generateSigningKey()`, structured verification counters, dual-representation mismatch check (#377, #378)
- **RFC 9421 proof capture profile**: Normative spec, extension schema, 5 conformance vectors (#379)
- **Profiles taxonomy**: Transport, Proof Capture, Wire Format categories (#379)
- **CI**: promote-latest workflow, publish preflight fix (#373, #374, #375)
- Node baseline docs aligned to >= 22

## Verification

```
pnpm lint          -- pass
pnpm build         -- 74 targets
pnpm typecheck:core -- pass
pnpm test          -- 3749 tests passing (144 files)
guard.sh           -- pass
check-publish-list -- pass
check-manifest-topo -- pass
version:check      -- all in sync
check-planning-leak -- pass
format:check       -- pass
```