### PR TITLE
fix: mcp-server spec hardening

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -162,7 +162,8 @@ Optional JSON file to customize behavior:
   "allow_network": false,
   "redaction": {
     "strip_evidence": false,
-    "strip_payment": false
+    "strip_payment": false,
+    "inspect_full_claims": false
   },
   "tools": {
     "peac_verify": { "enabled": true },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -53,7 +53,7 @@
     "@peac/crypto": "workspace:*",
     "@peac/protocol": "workspace:*",
     "@peac/schema": "workspace:*",
-    "@modelcontextprotocol/sdk": "~1.26.0",
+    "@modelcontextprotocol/sdk": "~1.27.0",
     "commander": "^11.0.0",
     "zod": "^3.22.4"
   },

--- a/packages/mcp-server/src/handlers/bundle.ts
+++ b/packages/mcp-server/src/handlers/bundle.ts
@@ -169,6 +169,11 @@ export async function handleCreateBundle(
     const receiptHashes: string[] = [];
 
     for (let i = 0; i < input.receipts.length; i++) {
+      // Check cancellation at each iteration to avoid unnecessary disk I/O
+      if (params.signal?.aborted) {
+        throw new McpServerError('E_MCP_CANCELLED', 'Request cancelled during bundle creation');
+      }
+
       const jws = input.receipts[i];
       const data = new TextEncoder().encode(jws);
       const hash = await sha256Hex(data);

--- a/packages/mcp-server/src/handlers/inspect.ts
+++ b/packages/mcp-server/src/handlers/inspect.ts
@@ -70,7 +70,9 @@ export async function handleInspect(params: HandlerParams<InspectInput>): Promis
   let redacted = false;
   let fullPayload: Record<string, unknown> | undefined;
 
-  if (input.full_claims) {
+  // Gate: full_claims only honored when policy permits (inspect_full_claims)
+  const effectiveFullClaims = input.full_claims && policy.redaction.inspect_full_claims;
+  if (effectiveFullClaims) {
     fullPayload = { ...payload };
 
     if (policy.redaction.strip_evidence && 'evidence' in fullPayload) {

--- a/packages/mcp-server/src/infra/errors.ts
+++ b/packages/mcp-server/src/infra/errors.ts
@@ -23,7 +23,8 @@ export type McpServerErrorCode =
   | 'E_MCP_ISSUE_FAILED'
   | 'E_MCP_BUNDLE_FAILED'
   | 'E_MCP_PATH_TRAVERSAL'
-  | 'E_MCP_BUNDLE_DIR_REQUIRED';
+  | 'E_MCP_BUNDLE_DIR_REQUIRED'
+  | 'E_MCP_CANCELLED';
 
 export class McpServerError extends Error {
   readonly code: McpServerErrorCode;

--- a/packages/mcp-server/src/infra/policy.ts
+++ b/packages/mcp-server/src/infra/policy.ts
@@ -15,6 +15,7 @@ const ToolPolicySchema = z.object({
 const RedactionSchema = z.object({
   strip_evidence: z.boolean().default(false),
   strip_payment: z.boolean().default(false),
+  inspect_full_claims: z.boolean().default(false),
 });
 
 const LimitsSchema = z.object({
@@ -49,7 +50,7 @@ export type PolicyConfig = z.infer<typeof PolicySchema>;
 const DEFAULT_POLICY: PolicyConfig = {
   version: '1',
   allow_network: false,
-  redaction: { strip_evidence: false, strip_payment: false },
+  redaction: { strip_evidence: false, strip_payment: false, inspect_full_claims: false },
   tools: {},
   limits: {
     max_jws_bytes: 16_384,

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -21,11 +21,11 @@ import type { InspectInput } from './schemas/inspect.js';
 import type { DecodeInput } from './schemas/decode.js';
 import type { IssueInput } from './schemas/issue.js';
 import type { BundleInput } from './schemas/bundle.js';
-import { VerifyInputSchema } from './schemas/verify.js';
-import { InspectInputSchema } from './schemas/inspect.js';
-import { DecodeInputSchema } from './schemas/decode.js';
-import { IssueInputSchema } from './schemas/issue.js';
-import { BundleInputSchema } from './schemas/bundle.js';
+import { VerifyInputSchema, VerifyOutputSchema } from './schemas/verify.js';
+import { InspectInputSchema, InspectOutputSchema } from './schemas/inspect.js';
+import { DecodeInputSchema, DecodeOutputSchema } from './schemas/decode.js';
+import { IssueInputSchema, IssueOutputSchema } from './schemas/issue.js';
+import { BundleInputSchema, BundleOutputSchema } from './schemas/bundle.js';
 
 export interface ServerOptions {
   version: string;
@@ -113,6 +113,7 @@ type RegisterToolBridge = (
     title?: string;
     description?: string;
     inputSchema?: unknown;
+    outputSchema?: unknown;
     annotations?: ToolAnnotations;
   },
   cb: (args: Record<string, unknown>, extra: Record<string, unknown>) => Promise<CallToolResult>
@@ -137,8 +138,14 @@ export function createPeacMcpServer(options: ServerOptions): McpServer {
   async function wrapHandler(
     toolName: string,
     args: Record<string, unknown>,
-    handlerFn: () => Promise<HandlerResult>
+    handlerFn: (signal?: AbortSignal) => Promise<HandlerResult>,
+    signal?: AbortSignal
   ): Promise<CallToolResult> {
+    // Cancellation: if already aborted before we start, return immediately
+    if (signal?.aborted) {
+      return errorCallToolResult(meta, 'E_MCP_CANCELLED', 'Request cancelled');
+    }
+
     // Concurrency guard
     if (activeHandlers >= maxConcurrency) {
       return errorCallToolResult(
@@ -176,7 +183,7 @@ export function createPeacMcpServer(options: ServerOptions): McpServer {
     // If leaked slots become an operational concern, add a watchdog that logs
     // when a handler exceeds 2x tool_timeout_ms without settling.
     activeHandlers++;
-    const handlerPromise = handlerFn();
+    const handlerPromise = handlerFn(signal);
 
     // Detached slot release: fires when handler settles, regardless of timeout.
     // The void + catch ensure no unhandled rejection if handler throws.
@@ -186,20 +193,39 @@ export function createPeacMcpServer(options: ServerOptions): McpServer {
       })
       .catch(() => {});
 
-    // Timeout race -- handlerPromise keeps running even if timeout fires.
-    // Timer is cleared when the handler resolves to avoid unnecessary timers
-    // accumulating under load.
+    // Timeout + cancellation race -- handlerPromise keeps running even if
+    // timeout or cancellation fires. Timer is cleared when the handler
+    // resolves to avoid unnecessary timers accumulating under load.
     let timedOut = false;
+    let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeoutPromise = new Promise<never>((_resolve, reject) => {
       timer = setTimeout(() => {
         timedOut = true;
         reject(new Error(`Tool "${toolName}" timed out after ${policy.limits.tool_timeout_ms}ms`));
       }, policy.limits.tool_timeout_ms);
+      // Prevent timeout timer from keeping Node.js alive during shutdown
+      timer.unref?.();
     });
 
+    // Build race participants: handler vs timeout vs (optional) cancellation
+    const raceParticipants: Promise<HandlerResult>[] = [handlerPromise, timeoutPromise];
+
+    let abortCleanup: (() => void) | undefined;
+    if (signal && !signal.aborted) {
+      const cancelPromise = new Promise<never>((_resolve, reject) => {
+        const onAbort = () => {
+          cancelled = true;
+          reject(new Error('Request cancelled'));
+        };
+        signal.addEventListener('abort', onAbort, { once: true });
+        abortCleanup = () => signal.removeEventListener('abort', onAbort);
+      });
+      raceParticipants.push(cancelPromise);
+    }
+
     try {
-      const result = await Promise.race([handlerPromise, timeoutPromise]);
+      const result = await Promise.race(raceParticipants);
 
       // Output size cap -- measure the full JSON-RPC envelope that will be
       // serialized to stdout, not just the tool result. This is the actual
@@ -219,18 +245,24 @@ export function createPeacMcpServer(options: ServerOptions): McpServer {
       return callResult;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+      if (cancelled) {
+        return errorCallToolResult(meta, 'E_MCP_CANCELLED', 'Request cancelled');
+      }
       if (timedOut) {
         return errorCallToolResult(meta, 'E_MCP_TOOL_TIMEOUT', message);
       }
       return errorCallToolResult(meta, 'E_MCP_INTERNAL', message);
     } finally {
       clearTimeout(timer);
+      abortCleanup?.();
     }
   }
 
   const server = new McpServer(
     { name: SERVER_NAME, version },
-    { capabilities: { tools: { listChanged: true } } }
+    // listChanged: false -- tool set is static per server instance (determined
+    // at startup from CLI flags). The server never emits notifications/tools/list_changed.
+    { capabilities: { tools: { listChanged: false } } }
   );
 
   // Bind with narrowed types to bridge workspace Zod <-> SDK Zod boundary
@@ -244,11 +276,15 @@ export function createPeacMcpServer(options: ServerOptions): McpServer {
       description:
         'Verify a PEAC receipt JWS signature and validate claims. Returns structured check results.',
       inputSchema: VerifyInputSchema,
+      outputSchema: VerifyOutputSchema,
       annotations: PURE_TOOL_ANNOTATIONS,
     },
-    async (args) =>
-      wrapHandler('peac_verify', args, () =>
-        handleVerify({ input: args as VerifyInput, policy, context })
+    async (args, extra) =>
+      wrapHandler(
+        'peac_verify',
+        args,
+        (signal) => handleVerify({ input: args as VerifyInput, policy, context, signal }),
+        (extra as { signal?: AbortSignal }).signal
       )
   );
 
@@ -260,11 +296,15 @@ export function createPeacMcpServer(options: ServerOptions): McpServer {
       description:
         'Decode and inspect a PEAC receipt without verifying the signature. Shows header, payload metadata, and optionally full claims.',
       inputSchema: InspectInputSchema,
+      outputSchema: InspectOutputSchema,
       annotations: PURE_TOOL_ANNOTATIONS,
     },
-    async (args) =>
-      wrapHandler('peac_inspect', args, () =>
-        handleInspect({ input: args as InspectInput, policy, context })
+    async (args, extra) =>
+      wrapHandler(
+        'peac_inspect',
+        args,
+        (signal) => handleInspect({ input: args as InspectInput, policy, context, signal }),
+        (extra as { signal?: AbortSignal }).signal
       )
   );
 
@@ -276,11 +316,15 @@ export function createPeacMcpServer(options: ServerOptions): McpServer {
       description:
         'Raw decode of a PEAC receipt JWS. Returns header and payload without signature verification.',
       inputSchema: DecodeInputSchema,
+      outputSchema: DecodeOutputSchema,
       annotations: PURE_TOOL_ANNOTATIONS,
     },
-    async (args) =>
-      wrapHandler('peac_decode', args, () =>
-        handleDecode({ input: args as DecodeInput, policy, context })
+    async (args, extra) =>
+      wrapHandler(
+        'peac_decode',
+        args,
+        (signal) => handleDecode({ input: args as DecodeInput, policy, context, signal }),
+        (extra as { signal?: AbortSignal }).signal
       )
   );
 
@@ -295,11 +339,15 @@ export function createPeacMcpServer(options: ServerOptions): McpServer {
         description:
           'Sign and return a PEAC receipt JWS. Requires server to be configured with --issuer-key and --issuer-id.',
         inputSchema: IssueInputSchema,
+        outputSchema: IssueOutputSchema,
         annotations: ISSUE_TOOL_ANNOTATIONS,
       },
-      async (args) =>
-        wrapHandler('peac_issue', args, () =>
-          handleIssue({ input: args as IssueInput, policy, context })
+      async (args, extra) =>
+        wrapHandler(
+          'peac_issue',
+          args,
+          (signal) => handleIssue({ input: args as IssueInput, policy, context, signal }),
+          (extra as { signal?: AbortSignal }).signal
         )
     );
 
@@ -312,11 +360,15 @@ export function createPeacMcpServer(options: ServerOptions): McpServer {
           description:
             'Create a signed evidence bundle directory from receipt JWS strings. Requires --issuer-key, --issuer-id, and --bundle-dir.',
           inputSchema: BundleInputSchema,
+          outputSchema: BundleOutputSchema,
           annotations: BUNDLE_TOOL_ANNOTATIONS,
         },
-        async (args) =>
-          wrapHandler('peac_create_bundle', args, () =>
-            handleCreateBundle({ input: args as BundleInput, policy, context })
+        async (args, extra) =>
+          wrapHandler(
+            'peac_create_bundle',
+            args,
+            (signal) => handleCreateBundle({ input: args as BundleInput, policy, context, signal }),
+            (extra as { signal?: AbortSignal }).signal
           )
       );
     }

--- a/packages/mcp-server/tests/handlers/bundle.test.ts
+++ b/packages/mcp-server/tests/handlers/bundle.test.ts
@@ -510,6 +510,36 @@ describe('handlers/bundle', () => {
     expect(files1).toEqual(files2);
   });
 
+  it('cancellation via pre-aborted signal returns E_MCP_CANCELLED and cleans up', async () => {
+    const context = await makeIssuerContext(testDir);
+    const receipts = await createTestReceipts(3);
+    const policy = getDefaultPolicy();
+    const input: BundleInput = { receipts };
+
+    // Create a pre-aborted signal
+    const controller = new AbortController();
+    controller.abort();
+
+    const params: HandlerParams<BundleInput> = {
+      input,
+      policy,
+      context,
+      signal: controller.signal,
+    };
+    const result = await handleCreateBundle(params);
+
+    expect(result.isError).toBe(true);
+    expect(result.structured.ok).toBe(false);
+    expect(result.structured.code).toBe('E_MCP_CANCELLED');
+
+    // No bundle directories should have been created (only temp dirs, cleaned up)
+    const { readdir } = await import('node:fs/promises');
+    const entries = await readdir(testDir);
+    // Only temp dirs might remain (should be cleaned up), but no bundle dirs
+    const bundleDirs = entries.filter((e) => e.startsWith('bundle-'));
+    expect(bundleDirs).toHaveLength(0);
+  });
+
   it('duplicate receipts are deduped by sha256', async () => {
     const context = await makeIssuerContext(testDir);
     const receipts = await createTestReceipts(2);

--- a/packages/mcp-server/tests/handlers/inspect.test.ts
+++ b/packages/mcp-server/tests/handlers/inspect.test.ts
@@ -44,7 +44,7 @@ describe('handlers/inspect', () => {
     expect(meta.audience).toBe('https://client.example.com');
   });
 
-  it('includes full payload when requested', async () => {
+  it('includes full payload when requested and policy permits', async () => {
     const { privateKey } = await generateKeypair();
     const { jws } = await issue({
       iss: 'https://api.example.com',
@@ -57,12 +57,32 @@ describe('handlers/inspect', () => {
       kid: 'test-kid',
     });
 
-    const result = await handleInspect(makeParams({ jws, full_claims: true }));
+    const params = makeParams({ jws, full_claims: true });
+    params.policy.redaction.inspect_full_claims = true;
+    const result = await handleInspect(params);
 
     expect(result.structured.fullPayload).toBeDefined();
     const payload = result.structured.fullPayload as Record<string, unknown>;
     expect(payload.iss).toBe('https://api.example.com');
     expect(payload.amt).toBe(500);
+  });
+
+  it('ignores full_claims when policy inspect_full_claims is false (default)', async () => {
+    const { privateKey } = await generateKeypair();
+    const { jws } = await issue({
+      iss: 'https://api.example.com',
+      aud: 'https://client.example.com',
+      amt: 100,
+      cur: 'USD',
+      rail: 'stripe',
+      reference: 'tx_test123',
+      privateKey,
+      kid: 'test-kid',
+    });
+
+    // Default policy has inspect_full_claims: false
+    const result = await handleInspect(makeParams({ jws, full_claims: true }));
+    expect(result.structured.fullPayload).toBeUndefined();
   });
 
   it('omits full payload when not requested', async () => {
@@ -98,6 +118,7 @@ describe('handlers/inspect', () => {
 
     const policy = getDefaultPolicy();
     policy.redaction.strip_payment = true;
+    policy.redaction.inspect_full_claims = true;
 
     const result = await handleInspect({
       input: { jws, full_claims: true },

--- a/packages/mcp-server/tests/infra/errors.test.ts
+++ b/packages/mcp-server/tests/infra/errors.test.ts
@@ -79,6 +79,15 @@ describe('infra/errors', () => {
     });
   });
 
+  describe('E_MCP_CANCELLED', () => {
+    it('is a valid McpServerError code', () => {
+      const err = new McpServerError('E_MCP_CANCELLED', 'Request cancelled');
+      expect(err.code).toBe('E_MCP_CANCELLED');
+      expect(err.message).toBe('Request cancelled');
+      expect(err).toBeInstanceOf(Error);
+    });
+  });
+
   describe('sanitizeOutput', () => {
     it('replaces matching patterns with [REDACTED]', () => {
       const result = sanitizeOutput('key=abc123secret value=safe', [/abc123secret/g]);

--- a/packages/mcp-server/tests/infra/policy.test.ts
+++ b/packages/mcp-server/tests/infra/policy.test.ts
@@ -32,6 +32,7 @@ describe('infra/policy', () => {
       expect(policy.limits.max_bundle_receipts).toBe(256);
       expect(policy.limits.max_bundle_bytes).toBe(16_777_216);
       expect(policy.limits.max_ttl_seconds).toBe(86_400);
+      expect(policy.redaction.inspect_full_claims).toBe(false);
     });
 
     it('passes schema validation', () => {
@@ -151,7 +152,7 @@ describe('infra/policy', () => {
       const policy2: Record<string, unknown> = {
         version: '1',
         tools: {},
-        redaction: { strip_payment: false, strip_evidence: false },
+        redaction: { strip_payment: false, strip_evidence: false, inspect_full_claims: false },
         limits: {
           max_concurrency: 10,
           tool_timeout_ms: 30_000,

--- a/packages/mcp-server/tests/integration/privileged-e2e.test.ts
+++ b/packages/mcp-server/tests/integration/privileged-e2e.test.ts
@@ -302,6 +302,56 @@ describe.skipIf(!CLI_EXISTS && !IS_CI)('integration/privileged-e2e', () => {
     }
   }, 15_000);
 
+  it('all tools include outputSchema in tools/list response', async () => {
+    const client = createStdioClient([
+      '--issuer-key',
+      `file:${keyPath}`,
+      '--issuer-id',
+      'https://test.example.com',
+      '--bundle-dir',
+      bundleDir,
+    ]);
+
+    try {
+      await initClient(client);
+
+      client.send({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/list',
+        params: {},
+      });
+
+      const listResponse = await client.receive();
+      const listResult = listResponse.result as Record<string, unknown>;
+      const tools = listResult.tools as Array<Record<string, unknown>>;
+
+      for (const tool of tools) {
+        expect(tool.outputSchema).toBeDefined();
+        expect(typeof tool.outputSchema).toBe('object');
+        // outputSchema should have JSON Schema structure
+        const schema = tool.outputSchema as Record<string, unknown>;
+        expect(schema.type).toBe('object');
+        // All output schemas include _meta
+        const properties = schema.properties as Record<string, unknown>;
+        expect(properties._meta).toBeDefined();
+      }
+    } catch (err) {
+      const stderr = client.getStderr();
+      if (stderr) {
+        const augmented =
+          err instanceof Error
+            ? new Error(`${err.message}\n\n--- stderr ---\n${stderr}`)
+            : new Error(`${String(err)}\n\n--- stderr ---\n${stderr}`);
+        if (err instanceof Error) augmented.stack = err.stack;
+        throw augmented;
+      }
+      throw err;
+    } finally {
+      client.close();
+    }
+  }, 15_000);
+
   it('annotations snapshot: all tools have expected annotations', async () => {
     const client = createStdioClient([
       '--issuer-key',

--- a/packages/mcp-server/tests/schemas/schemas.test.ts
+++ b/packages/mcp-server/tests/schemas/schemas.test.ts
@@ -304,4 +304,22 @@ describe('schemas', () => {
       });
     }
   });
+
+  describe('no $defs in output schemas (client compatibility)', () => {
+    const outputSchemas = [
+      { name: 'VerifyOutputSchema', schema: VerifyOutputSchema },
+      { name: 'InspectOutputSchema', schema: InspectOutputSchema },
+      { name: 'DecodeOutputSchema', schema: DecodeOutputSchema },
+      { name: 'IssueOutputSchema', schema: IssueOutputSchema },
+      { name: 'BundleOutputSchema', schema: BundleOutputSchema },
+    ];
+
+    for (const { name, schema } of outputSchemas) {
+      it(`${name} produces no $defs or $ref`, () => {
+        const jsonStr = JSON.stringify(schema);
+        expect(jsonStr).not.toContain('"$defs"');
+        expect(jsonStr).not.toContain('"$ref"');
+      });
+    }
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,7 +107,7 @@ importers:
         version: 29.4.5(@babel/core@7.29.0)(esbuild@0.27.0)(jest@30.2.0)(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -147,7 +147,7 @@ importers:
         version: 20.19.33
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -181,7 +181,7 @@ importers:
         version: 20.19.33
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -521,7 +521,7 @@ importers:
         version: 20.19.33
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -555,7 +555,7 @@ importers:
         version: 22.19.11
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -700,7 +700,7 @@ importers:
         version: 3.3.0
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -722,7 +722,7 @@ importers:
         version: 20.19.33
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -741,7 +741,7 @@ importers:
         version: 22.19.11
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -781,7 +781,7 @@ importers:
         version: 20.19.33
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -805,7 +805,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -827,7 +827,7 @@ importers:
         version: 20.19.33
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -864,7 +864,7 @@ importers:
         version: 29.4.5(@babel/core@7.29.0)(esbuild@0.27.0)(jest@30.2.0)(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.2.0
         version: 5.9.3
@@ -883,7 +883,7 @@ importers:
         version: 20.19.33
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -895,7 +895,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -904,7 +904,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
@@ -926,7 +926,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
@@ -938,7 +938,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.6.2
         version: 5.9.3
@@ -995,7 +995,7 @@ importers:
         version: 20.19.33
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -1054,8 +1054,8 @@ importers:
   packages/mcp-server:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ~1.26.0
-        version: 1.26.0(zod@3.25.76)
+        specifier: ~1.27.0
+        version: 1.27.0(zod@3.25.76)
       '@peac/crypto':
         specifier: workspace:*
         version: link:../crypto
@@ -1077,7 +1077,7 @@ importers:
         version: 22.19.11
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -1105,7 +1105,7 @@ importers:
         version: 20.19.33
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -1139,7 +1139,7 @@ importers:
         version: 6.3.4
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -1194,7 +1194,7 @@ importers:
         version: 29.4.5(@babel/core@7.29.0)(esbuild@0.27.0)(jest@30.2.0)(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -1262,7 +1262,7 @@ importers:
         version: 20.19.33
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -1357,7 +1357,7 @@ importers:
         version: 20.19.33
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -1394,7 +1394,7 @@ importers:
         version: 29.4.5(@babel/core@7.29.0)(esbuild@0.27.0)(jest@30.2.0)(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -1413,7 +1413,7 @@ importers:
         version: 20.19.33
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -1469,7 +1469,7 @@ importers:
         version: 20.19.33
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -4111,8 +4111,8 @@ packages:
       '@braidai/lang': 1.1.2
     dev: true
 
-  /@modelcontextprotocol/sdk@1.26.0(zod@3.25.76):
-    resolution: {integrity: sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==}
+  /@modelcontextprotocol/sdk@1.27.0(zod@3.25.76):
+    resolution: {integrity: sha512-qOdO524oPMkUsOJTrsH9vz/HN3B5pKyW+9zIW51A9kDMVe7ON70drz1ouoyoyOcfzc+oxhkQ6jWmbyKnlWmYqA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -5965,16 +5965,6 @@ packages:
       esbuild: '>=0.18'
     dependencies:
       esbuild: 0.27.0
-      load-tsconfig: 0.2.5
-    dev: true
-
-  /bundle-require@5.1.0(esbuild@0.27.3):
-    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    peerDependencies:
-      esbuild: '>=0.18'
-    dependencies:
-      esbuild: 0.27.3
       load-tsconfig: 0.2.5
     dev: true
 
@@ -9913,7 +9903,7 @@ packages:
     requiresBuild: true
     dev: true
 
-  /tsup@8.5.1(tsx@4.21.0)(typescript@5.9.3):
+  /tsup@8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
     resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
     engines: {node: '>=18'}
     hasBin: true
@@ -9938,50 +9928,6 @@ packages:
       consola: 3.4.2
       debug: 4.4.3
       esbuild: 0.27.0
-      fix-dts-default-cjs-exports: 1.0.1
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(tsx@4.21.0)(yaml@2.8.2)
-      resolve-from: 5.0.0
-      rollup: 4.53.2
-      source-map: 0.7.6
-      sucrase: 3.35.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tree-kill: 1.2.2
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
-    dev: true
-
-  /tsup@8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
-    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
-    engines: {node: '>=18'}
-    hasBin: true
-    peerDependencies:
-      '@microsoft/api-extractor': ^7.36.0
-      '@swc/core': ^1
-      postcss: ^8.4.12
-      typescript: '>=4.5.0'
-    peerDependenciesMeta:
-      '@microsoft/api-extractor':
-        optional: true
-      '@swc/core':
-        optional: true
-      postcss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      bundle-require: 5.1.0(esbuild@0.27.3)
-      cac: 6.7.14
-      chokidar: 4.0.3
-      consola: 3.4.2
-      debug: 4.4.3
-      esbuild: 0.27.3
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1


### PR DESCRIPTION
## Summary

Closes spec gaps and review findings from PR #394 and #395 before v0.10.13 release.

- **MCP SDK bump:** `@modelcontextprotocol/sdk` ~1.26.0 -> ~1.27.0
- **`inspect_full_claims` policy gate:** `peac_inspect` now requires `redaction.inspect_full_claims: true` in policy to honor `full_claims` input (default: false)
- **`outputSchema` on all tools:** All 5 tool registrations pass Zod output schemas to `registerTool()`, making structured output shapes discoverable via `tools/list`
- **Cancellation support:** `wrapHandler` accepts SDK `AbortSignal`, adds cancellation to timeout race with `E_MCP_CANCELLED` error code. Bundle handler checks `signal.aborted` between receipt iterations
- **`tools.listChanged: false`:** Tool set is static per server instance (determined at startup from CLI flags), server never emits `notifications/tools/list_changed`
- **`timer.unref()`:** Timeout timers no longer keep Node.js alive during shutdown
- **README:** Added `inspect_full_claims` to policy configuration example

## Scope

14 files changed, 258 insertions, 121 deletions. All changes within `packages/mcp-server/`.

## Test plan

- [x] 226 mcp-server tests pass (18 test files)
- [x] 3975 total tests pass (162 test files)
- [x] Lint, typecheck, format all clean
- [x] guard.sh + check-planning-leak.sh pass
- [x] New tests: inspect_full_claims policy gate, bundle cancellation, E_MCP_CANCELLED error code, output schema $defs check, outputSchema E2E