### PR TITLE
feat: migrate workspace to Zod 4 (DD-120)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -39,7 +39,7 @@
     "@peac/pay402": "workspace:*",
     "hono": "^4.12.0",
     "@hono/node-server": "^1.19.9",
-    "zod": "^3.22.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.19.11",

--- a/apps/bridge/package.json
+++ b/apps/bridge/package.json
@@ -37,7 +37,7 @@
     "hono": "^4.12.0",
     "@hono/node-server": "^1.19.9",
     "jose": "^5.0.0",
-    "zod": "^3.22.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.19.11",

--- a/apps/sandbox-issuer/package.json
+++ b/apps/sandbox-issuer/package.json
@@ -20,7 +20,7 @@
     "@peac/schema": "workspace:*",
     "hono": "^4.12.0",
     "@hono/node-server": "^1.19.9",
-    "zod": "^3.22.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.19.11",

--- a/package.json
+++ b/package.json
@@ -85,11 +85,13 @@
   "pnpm": {
     "overrides": {
       "minimatch": "10.2.2",
-      "qs@>=6.7.0 <=6.14.1": "6.14.2"
+      "qs@>=6.7.0 <=6.14.1": "6.14.2",
+      "zod": "^4.3.6"
     },
     "overridesComments": {
       "minimatch": "Cross-major pin: typescript-estree requires ^9.0.4 but 9.x has no patch for GHSA-3ppc-4f35-3m26. minimatch 10.x is API-compatible (same globbing interface). Drops Node 18 (fine: repo baseline is >=22.0.0). Lint verified clean.",
-      "qs": "Range-scoped: only overrides vulnerable 6.7.0-6.14.1 to 6.14.2 (fixes GHSA-w7fw-mjwx-w883 arrayLimit bypass). Minimal blast radius."
+      "qs": "Range-scoped: only overrides vulnerable 6.7.0-6.14.1 to 6.14.2 (fixes GHSA-w7fw-mjwx-w883 arrayLimit bypass). Minimal blast radius.",
+      "zod": "Workspace-wide Zod 4 enforcement: prevents mixed Zod 3/4 which causes runtime TypeError (incompatible internal _parse API). All workspace packages must use Zod 4."
     }
   }
 }

--- a/packages/cli/src/lib/conformance/validators.ts
+++ b/packages/cli/src/lib/conformance/validators.ts
@@ -52,7 +52,7 @@ export function validateReceiptPayload(payload: unknown): ValidationResultWithPa
 
   const firstIssue = result.error.issues[0];
   const zodPath = firstIssue?.path ?? [];
-  const errorPath = zodPathToJsonPointer(zodPath);
+  const errorPath = zodPathToJsonPointer(zodPath as (string | number)[]);
   const errorKeyword = zodCodeToKeyword(firstIssue?.code ?? 'unknown');
 
   // Map paths to canonical error codes

--- a/packages/control/package.json
+++ b/packages/control/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@peac/schema": "workspace:*",
-    "zod": "^3.22.4"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.19.11",

--- a/packages/control/src/validators.ts
+++ b/packages/control/src/validators.ts
@@ -154,7 +154,7 @@ export const ConstraintSchema = z.discriminatedUnion('type', [
 export const ControlBlockSchema = z.object({
   mandate: ConstraintSchema,
   scope: z.string().url().optional(),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 /**
@@ -167,7 +167,7 @@ export const ControlStateSchema = z.object({
   spent_amount: z.number().int().nonnegative().optional(),
   first_use: z.number().int().positive().optional(),
   last_use: z.number().int().positive().optional(),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 // -----------------------------------------------------------------------------

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,7 +51,7 @@
     "@peac/kernel": "workspace:*",
     "jose": "^5.2.0",
     "lru-cache": "^10.0.0",
-    "zod": "^3.22.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.19.11",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -55,7 +55,7 @@
     "@peac/schema": "workspace:*",
     "@modelcontextprotocol/sdk": "~1.27.0",
     "commander": "^11.0.0",
-    "zod": "^3.22.4"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/mcp-server/src/infra/policy.ts
+++ b/packages/mcp-server/src/infra/policy.ts
@@ -39,9 +39,9 @@ const JwksConfigSchema = z.object({
 export const PolicySchema = z.object({
   version: z.literal('1'),
   allow_network: z.boolean().default(false),
-  redaction: RedactionSchema.default({}),
-  tools: z.record(z.string(), ToolPolicySchema).default({}),
-  limits: LimitsSchema.default({}),
+  redaction: RedactionSchema.prefault({}),
+  tools: z.record(z.string(), ToolPolicySchema).prefault({}),
+  limits: LimitsSchema.prefault({}),
   jwks: JwksConfigSchema.optional(),
 });
 

--- a/packages/mcp-server/src/schemas/bundle.ts
+++ b/packages/mcp-server/src/schemas/bundle.ts
@@ -11,7 +11,7 @@ export const BundleInputSchema = z.object({
     .max(256)
     .describe('Receipt JWS strings to bundle (1-256)'),
   metadata: z
-    .record(z.unknown())
+    .record(z.string(), z.unknown())
     .optional()
     .describe('Optional metadata to include in the manifest'),
   output_path: z

--- a/packages/policy-kit/package.json
+++ b/packages/policy-kit/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@peac/schema": "workspace:*",
     "yaml": "^2.3.4",
-    "zod": "^3.22.4"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.19.11",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -51,7 +51,7 @@
     "@peac/schema": "workspace:*",
     "@peac/crypto": "workspace:*",
     "uuidv7": "^0.6.3",
-    "zod": "^3.22.4"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.19.11",

--- a/packages/protocol/src/issue.ts
+++ b/packages/protocol/src/issue.ts
@@ -298,12 +298,14 @@ export async function issue(options: IssueOptions): Promise<IssueResult> {
   } catch (err: unknown) {
     if (err instanceof ZodError) {
       // Check if any error path touches evidence
-      const evidenceIssue = err.issues.find(
-        (issue: { path: (string | number)[]; message: string }) =>
-          issue.path.some((p: string | number) => p === 'evidence' || p === 'payment')
+      const evidenceIssue = err.issues.find((issue) =>
+        issue.path.some((p) => p === 'evidence' || p === 'payment')
       );
       if (evidenceIssue && evidenceIssue.path.includes('evidence')) {
-        const peacError = createEvidenceNotJsonError(evidenceIssue.message, evidenceIssue.path);
+        const peacError = createEvidenceNotJsonError(
+          evidenceIssue.message,
+          evidenceIssue.path as (string | number)[]
+        );
         throw new IssueError(peacError);
       }
     }

--- a/packages/schema/__tests__/dispute.test.ts
+++ b/packages/schema/__tests__/dispute.test.ts
@@ -645,7 +645,7 @@ describe('DisputeEvidenceSchema invariants', () => {
       const result = DisputeEvidenceSchema.safeParse(evidence);
       expect(result.success).toBe(false);
       if (!result.success) {
-        const errorMessages = result.error.errors.map((e) => e.message);
+        const errorMessages = result.error.issues.map((e) => e.message);
         expect(errorMessages).toContain('Resolution is required when state is "resolved"');
       }
     });
@@ -655,7 +655,7 @@ describe('DisputeEvidenceSchema invariants', () => {
       const result = DisputeEvidenceSchema.safeParse(evidence);
       expect(result.success).toBe(false);
       if (!result.success) {
-        const errorMessages = result.error.errors.map((e) => e.message);
+        const errorMessages = result.error.issues.map((e) => e.message);
         expect(errorMessages).toContain('Resolution is required when state is "rejected"');
       }
     });
@@ -665,7 +665,7 @@ describe('DisputeEvidenceSchema invariants', () => {
       const result = DisputeEvidenceSchema.safeParse(evidence);
       expect(result.success).toBe(false);
       if (!result.success) {
-        const errorMessages = result.error.errors.map((e) => e.message);
+        const errorMessages = result.error.issues.map((e) => e.message);
         expect(errorMessages).toContain('Resolution is required when state is "final"');
       }
     });
@@ -690,7 +690,7 @@ describe('DisputeEvidenceSchema invariants', () => {
       const result = DisputeEvidenceSchema.safeParse(evidence);
       expect(result.success).toBe(false);
       if (!result.success) {
-        const errorMessages = result.error.errors.map((e) => e.message);
+        const errorMessages = result.error.issues.map((e) => e.message);
         expect(
           errorMessages.some((m) => m.includes('Resolution is only valid for terminal states'))
         ).toBe(true);
@@ -706,7 +706,7 @@ describe('DisputeEvidenceSchema invariants', () => {
       const result = DisputeEvidenceSchema.safeParse(evidence);
       expect(result.success).toBe(false);
       if (!result.success) {
-        const errorMessages = result.error.errors.map((e) => e.message);
+        const errorMessages = result.error.issues.map((e) => e.message);
         expect(
           errorMessages.some((m) => m.includes('Resolution is only valid for terminal states'))
         ).toBe(true);
@@ -722,7 +722,7 @@ describe('DisputeEvidenceSchema invariants', () => {
       const result = DisputeEvidenceSchema.safeParse(evidence);
       expect(result.success).toBe(false);
       if (!result.success) {
-        const errorMessages = result.error.errors.map((e) => e.message);
+        const errorMessages = result.error.issues.map((e) => e.message);
         expect(
           errorMessages.some((m) => m.includes('Resolution is only valid for terminal states'))
         ).toBe(true);
@@ -738,7 +738,7 @@ describe('DisputeEvidenceSchema invariants', () => {
       const result = DisputeEvidenceSchema.safeParse(evidence);
       expect(result.success).toBe(false);
       if (!result.success) {
-        const errorMessages = result.error.errors.map((e) => e.message);
+        const errorMessages = result.error.issues.map((e) => e.message);
         expect(
           errorMessages.some((m) => m.includes('Resolution is only valid for terminal states'))
         ).toBe(true);
@@ -756,7 +756,7 @@ describe('DisputeEvidenceSchema invariants', () => {
       const result = DisputeEvidenceSchema.safeParse(evidence);
       expect(result.success).toBe(false);
       if (!result.success) {
-        const errorMessages = result.error.errors.map((e) => e.message);
+        const errorMessages = result.error.issues.map((e) => e.message);
         expect(errorMessages.some((m) => m.includes('requires description of at least'))).toBe(
           true
         );
@@ -1166,7 +1166,7 @@ describe('transitionDisputeState schema safety', () => {
         expect(parseResult.success).toBe(true);
         if (!parseResult.success) {
           // Helpful debug output if test fails
-          console.error('Schema validation failed:', parseResult.error.errors);
+          console.error('Schema validation failed:', parseResult.error.issues);
         }
       }
     });

--- a/packages/schema/__tests__/interaction.test.ts
+++ b/packages/schema/__tests__/interaction.test.ts
@@ -475,7 +475,7 @@ describe('InteractionEvidenceV01Schema', () => {
         const result = InteractionEvidenceV01Schema.safeParse(evidence);
         expect(result.success).toBe(false);
         if (!result.success) {
-          const messages = result.error.errors.map((e) => e.message);
+          const messages = result.error.issues.map((e) => e.message);
           expect(messages).toContain('completed_at must be >= started_at');
         }
       });
@@ -491,7 +491,7 @@ describe('InteractionEvidenceV01Schema', () => {
         const result = InteractionEvidenceV01Schema.safeParse(evidence);
         expect(result.success).toBe(false);
         if (!result.success) {
-          const messages = result.error.errors.map((e) => e.message);
+          const messages = result.error.issues.map((e) => e.message);
           expect(messages).toContain('result.status is required when output is present');
         }
       });
@@ -507,7 +507,7 @@ describe('InteractionEvidenceV01Schema', () => {
         const result = InteractionEvidenceV01Schema.safeParse(evidence);
         expect(result.success).toBe(false);
         if (!result.success) {
-          const messages = result.error.errors.map((e) => e.message);
+          const messages = result.error.issues.map((e) => e.message);
           expect(messages).toContain(
             'error_code or non-empty extensions required when status is error'
           );
@@ -523,7 +523,7 @@ describe('InteractionEvidenceV01Schema', () => {
         const result = InteractionEvidenceV01Schema.safeParse(evidence);
         expect(result.success).toBe(false);
         if (!result.success) {
-          const messages = result.error.errors.map((e) => e.message);
+          const messages = result.error.issues.map((e) => e.message);
           expect(messages).toContain(
             'error_code or non-empty extensions required when status is error'
           );
@@ -559,7 +559,7 @@ describe('InteractionEvidenceV01Schema', () => {
         const result = InteractionEvidenceV01Schema.safeParse(evidence);
         expect(result.success).toBe(false);
         if (!result.success) {
-          const messages = result.error.errors.map((e) => e.message);
+          const messages = result.error.issues.map((e) => e.message);
           expect(messages.some((m) => m.includes('Invalid extension key format'))).toBe(true);
         }
       });
@@ -586,7 +586,7 @@ describe('InteractionEvidenceV01Schema', () => {
         const result = InteractionEvidenceV01Schema.safeParse(evidence);
         expect(result.success).toBe(false);
         if (!result.success) {
-          const messages = result.error.errors.map((e) => e.message);
+          const messages = result.error.issues.map((e) => e.message);
           expect(messages.some((m) => m.includes('uses reserved prefix'))).toBe(true);
         }
       });
@@ -599,7 +599,7 @@ describe('InteractionEvidenceV01Schema', () => {
         const result = InteractionEvidenceV01Schema.safeParse(evidence);
         expect(result.success).toBe(false);
         if (!result.success) {
-          const messages = result.error.errors.map((e) => e.message);
+          const messages = result.error.issues.map((e) => e.message);
           expect(messages.some((m) => m.includes('uses reserved prefix'))).toBe(true);
         }
       });
@@ -615,7 +615,7 @@ describe('InteractionEvidenceV01Schema', () => {
         const result = InteractionEvidenceV01Schema.safeParse(evidence);
         expect(result.success).toBe(false);
         if (!result.success) {
-          const messages = result.error.errors.map((e) => e.message);
+          const messages = result.error.issues.map((e) => e.message);
           expect(messages.some((m) => m.includes('requires tool field'))).toBe(true);
         }
       });
@@ -629,7 +629,7 @@ describe('InteractionEvidenceV01Schema', () => {
         const result = InteractionEvidenceV01Schema.safeParse(evidence);
         expect(result.success).toBe(false);
         if (!result.success) {
-          const messages = result.error.errors.map((e) => e.message);
+          const messages = result.error.issues.map((e) => e.message);
           expect(messages.some((m) => m.includes('requires resource field'))).toBe(true);
         }
       });
@@ -643,7 +643,7 @@ describe('InteractionEvidenceV01Schema', () => {
         const result = InteractionEvidenceV01Schema.safeParse(evidence);
         expect(result.success).toBe(false);
         if (!result.success) {
-          const messages = result.error.errors.map((e) => e.message);
+          const messages = result.error.issues.map((e) => e.message);
           expect(messages.some((m) => m.includes('requires resource field'))).toBe(true);
         }
       });

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@peac/kernel": "workspace:*",
-    "zod": "^3.22.4"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.19.11",

--- a/packages/schema/src/interaction.ts
+++ b/packages/schema/src/interaction.ts
@@ -362,7 +362,7 @@ const InteractionEvidenceV01BaseSchema = z
     refs: RefsSchema.optional(),
 
     /** Platform-specific extensions (MUST be namespaced) */
-    extensions: z.record(z.unknown()).optional(),
+    extensions: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 

--- a/packages/schema/src/json.ts
+++ b/packages/schema/src/json.ts
@@ -70,7 +70,7 @@ export const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
     z.array(JsonValueSchema),
     // Plain object check then record validation
     PlainObjectSchema.transform((obj) => obj as Record<string, unknown>).pipe(
-      z.record(JsonValueSchema)
+      z.record(z.string(), JsonValueSchema)
     ),
   ])
 ) as z.ZodType<JsonValue>;
@@ -82,7 +82,7 @@ export const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
  */
 export const JsonObjectSchema: z.ZodType<JsonObject> = PlainObjectSchema.transform(
   (obj) => obj as Record<string, unknown>
-).pipe(z.record(JsonValueSchema)) as z.ZodType<JsonObject>;
+).pipe(z.record(z.string(), JsonValueSchema)) as z.ZodType<JsonObject>;
 
 /**
  * JSON array schema - array of JSON values

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   minimatch: 10.2.2
   qs@>=6.7.0 <=6.14.1: 6.14.2
+  zod: ^4.3.6
 
 importers:
 
@@ -88,8 +89,8 @@ importers:
         specifier: ^4.12.0
         version: 4.12.0
       zod:
-        specifier: ^3.22.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/jest':
         specifier: ^30.0.0
@@ -137,8 +138,8 @@ importers:
         specifier: ^5.0.0
         version: 5.10.0
       zod:
-        specifier: ^3.22.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -171,8 +172,8 @@ importers:
         specifier: ^4.12.0
         version: 4.12.0
       zod:
-        specifier: ^3.22.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -817,8 +818,8 @@ importers:
         specifier: workspace:*
         version: link:../schema
       zod:
-        specifier: ^3.22.4
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -845,8 +846,8 @@ importers:
         specifier: ^10.0.0
         version: 10.4.3
       zod:
-        specifier: ^3.22.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/jest':
         specifier: ^30.0.0
@@ -1053,7 +1054,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: ~1.27.0
-        version: 1.27.0(zod@3.25.76)
+        version: 1.27.0(zod@4.3.6)
       '@peac/crypto':
         specifier: workspace:*
         version: link:../crypto
@@ -1067,8 +1068,8 @@ importers:
         specifier: ^11.0.0
         version: 11.1.0
       zod:
-        specifier: ^3.22.4
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -1206,8 +1207,8 @@ importers:
         specifier: ^2.3.4
         version: 2.8.2
       zod:
-        specifier: ^3.22.4
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -1252,8 +1253,8 @@ importers:
         specifier: ^0.6.3
         version: 0.6.3
       zod:
-        specifier: ^3.22.4
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -1403,8 +1404,8 @@ importers:
         specifier: workspace:*
         version: link:../kernel
       zod:
-        specifier: ^3.22.4
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -4096,12 +4097,12 @@ packages:
       '@braidai/lang': 1.1.2
     dev: true
 
-  /@modelcontextprotocol/sdk@1.27.0(zod@3.25.76):
+  /@modelcontextprotocol/sdk@1.27.0(zod@4.3.6):
     resolution: {integrity: sha512-qOdO524oPMkUsOJTrsH9vz/HN3B5pKyW+9zIW51A9kDMVe7ON70drz1ouoyoyOcfzc+oxhkQ6jWmbyKnlWmYqA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
+      zod: ^4.3.6
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -4121,8 +4122,8 @@ packages:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -5528,7 +5529,7 @@ packages:
     resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
     peerDependencies:
       typescript: '>=5.0.4'
-      zod: ^3.22.0 || ^4.0.0
+      zod: ^4.3.6
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -8301,7 +8302,7 @@ packages:
       workerd: 1.20250718.0
       ws: 8.18.0
       youch: 3.3.4
-      zod: 3.22.3
+      zod: 4.3.6
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -10612,18 +10613,13 @@ packages:
       stacktracey: 2.1.8
     dev: true
 
-  /zod-to-json-schema@3.25.1(zod@3.25.76):
+  /zod-to-json-schema@3.25.1(zod@4.3.6):
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
     peerDependencies:
-      zod: ^3.25 || ^4
+      zod: ^4.3.6
     dependencies:
-      zod: 3.25.76
+      zod: 4.3.6
     dev: false
 
-  /zod@3.22.3:
-    resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==}
-    dev: true
-
-  /zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-    dev: false
+  /zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}


### PR DESCRIPTION
## Summary

- Migrate all 9 Zod-consuming packages from Zod 3.25.x to Zod 4.3.6 (DD-120)
- Enforce single Zod major across workspace via `pnpm.overrides`
- Breaking for downstream TS consumers: `.d.ts` types change (Zod 3/4 types are not assignment-compatible)

## Key migration patterns

- `z.record(ValueSchema)` -> `z.record(z.string(), ValueSchema)` (single-arg form removed in Zod 4)
- `.default({})` -> `.prefault({})` for input-type defaults (Zod 4 `.default()` requires output-type values)
- `ZodError.errors` -> `ZodError.issues` (`.errors` alias removed)
- `issue.path` type: `PropertyKey[]` in Zod 4 (includes `symbol`); cast to `(string | number)[]` at 2 call sites

## Changed files

- 9 `package.json` files: `zod` bumped to `^4.3.6`
- Root `package.json`: Added `pnpm.overrides.zod: "^4.3.6"`
- `packages/schema/src/json.ts`: 2x `z.record()` 2-arg form
- `packages/schema/src/interaction.ts`: 1x `z.record()` 2-arg form
- `packages/control/src/validators.ts`: 2x `z.record()` 2-arg form
- `packages/mcp-server/src/schemas/bundle.ts`: 1x `z.record()` 2-arg form
- `packages/mcp-server/src/infra/policy.ts`: 3x `.default({})` -> `.prefault({})`
- `packages/protocol/src/issue.ts`: Zod issue path type cast
- `packages/cli/src/lib/conformance/validators.ts`: Zod issue path type cast
- `packages/schema/__tests__/dispute.test.ts`: 9x `.error.errors` -> `.error.issues`
- `packages/schema/__tests__/interaction.test.ts`: 10x `.error.errors` -> `.error.issues`

## Test plan

- [x] All 4138+ tests pass
- [x] Build: 76/76 targets pass
- [x] Lint, typecheck, format: clean
- [x] guard.sh + check-planning-leak.sh: clean
- [x] No Zod 3 imports remain anywhere in workspace
- [x] `.superRefine()` verified NOT deprecated in Zod 4 (no churn needed)