### PR TITLE
feat: evidence carrier types and schemas

### DIFF
--- a/packages/kernel/src/__tests__/carrier.test.ts
+++ b/packages/kernel/src/__tests__/carrier.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Kernel carrier types compilation and shape tests.
+ *
+ * These tests verify that the carrier types compile correctly and
+ * that the type shapes are usable as expected. Since kernel types
+ * are pure TypeScript (zero runtime), we test assignability and
+ * structure rather than runtime behavior.
+ */
+import { describe, expect, it } from 'vitest';
+
+import type {
+  CarrierAdapter,
+  CarrierFormat,
+  CarrierMeta,
+  CarrierValidationResult,
+  PeacEvidenceCarrier,
+  ReceiptRef,
+} from '../carrier.js';
+
+describe('carrier types', () => {
+  describe('ReceiptRef', () => {
+    it('accepts valid sha256 template literal', () => {
+      const ref: ReceiptRef =
+        'sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+      expect(ref).toMatch(/^sha256:/);
+    });
+
+    it('is assignable from string with sha256 prefix', () => {
+      const raw = 'sha256:abcd' as ReceiptRef;
+      const _check: string = raw;
+      expect(typeof _check).toBe('string');
+    });
+  });
+
+  describe('CarrierFormat', () => {
+    it('accepts embed', () => {
+      const format: CarrierFormat = 'embed';
+      expect(format).toBe('embed');
+    });
+
+    it('accepts reference', () => {
+      const format: CarrierFormat = 'reference';
+      expect(format).toBe('reference');
+    });
+  });
+
+  describe('PeacEvidenceCarrier', () => {
+    it('accepts minimal carrier (receipt_ref only)', () => {
+      const carrier: PeacEvidenceCarrier = {
+        receipt_ref: 'sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+      };
+      expect(carrier.receipt_ref).toBeDefined();
+      expect(carrier.receipt_jws).toBeUndefined();
+    });
+
+    it('accepts full carrier with all optional fields', () => {
+      const carrier: PeacEvidenceCarrier = {
+        receipt_ref: 'sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+        receipt_jws: 'eyJ.eyJ.sig',
+        policy_binding: 'sha256:dead',
+        actor_binding: 'did:key:z6Mk',
+        request_nonce: 'nonce-123',
+        verification_report_ref: 'sha256:cafe',
+        use_policy_ref: 'https://example.com/policy',
+        representation_ref: 'sha256:0123',
+        attestation_ref: 'sha256:fedc',
+      };
+      expect(carrier.receipt_jws).toBe('eyJ.eyJ.sig');
+      expect(carrier.policy_binding).toBe('sha256:dead');
+      expect(carrier.actor_binding).toBe('did:key:z6Mk');
+      expect(carrier.request_nonce).toBe('nonce-123');
+      expect(carrier.verification_report_ref).toBe('sha256:cafe');
+      expect(carrier.use_policy_ref).toBe('https://example.com/policy');
+      expect(carrier.representation_ref).toBe('sha256:0123');
+      expect(carrier.attestation_ref).toBe('sha256:fedc');
+    });
+  });
+
+  describe('CarrierMeta', () => {
+    it('accepts valid meta with required fields', () => {
+      const meta: CarrierMeta = {
+        transport: 'mcp',
+        format: 'embed',
+        max_size: 65536,
+      };
+      expect(meta.transport).toBe('mcp');
+      expect(meta.format).toBe('embed');
+      expect(meta.max_size).toBe(65536);
+      expect(meta.redaction).toBeUndefined();
+    });
+
+    it('accepts meta with redaction array', () => {
+      const meta: CarrierMeta = {
+        transport: 'a2a',
+        format: 'embed',
+        max_size: 65536,
+        redaction: ['actor_binding', 'policy_binding'],
+      };
+      expect(meta.redaction).toEqual(['actor_binding', 'policy_binding']);
+    });
+  });
+
+  describe('CarrierValidationResult', () => {
+    it('accepts valid result', () => {
+      const result: CarrierValidationResult = {
+        valid: true,
+        violations: [],
+      };
+      expect(result.valid).toBe(true);
+      expect(result.violations).toHaveLength(0);
+    });
+
+    it('accepts invalid result with violations', () => {
+      const result: CarrierValidationResult = {
+        valid: false,
+        violations: ['size exceeded', 'invalid format'],
+      };
+      expect(result.valid).toBe(false);
+      expect(result.violations).toHaveLength(2);
+    });
+  });
+
+  describe('CarrierAdapter interface', () => {
+    it('can be implemented with concrete types', () => {
+      // Verify the interface is implementable with concrete input/output types
+      type TestInput = { metadata?: Record<string, unknown> };
+      type TestOutput = { metadata?: Record<string, unknown> };
+
+      const adapter: CarrierAdapter<TestInput, TestOutput> = {
+        extract(input: TestInput) {
+          if (!input.metadata) return null;
+          return {
+            receipts: [],
+            meta: { transport: 'test', format: 'embed' as CarrierFormat, max_size: 65536 },
+          };
+        },
+        attach(output: TestOutput, carriers: PeacEvidenceCarrier[]) {
+          return { ...output, metadata: { carriers } };
+        },
+        validateConstraints(_carrier: PeacEvidenceCarrier, _meta: CarrierMeta) {
+          return { valid: true, violations: [] };
+        },
+      };
+
+      expect(adapter.extract({})).toBeNull();
+      expect(adapter.extract({ metadata: {} })).toBeTruthy();
+
+      const attached = adapter.attach({}, [
+        { receipt_ref: 'sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2' },
+      ]);
+      expect(attached.metadata).toBeDefined();
+
+      const validation = adapter.validateConstraints(
+        { receipt_ref: 'sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2' },
+        { transport: 'test', format: 'embed', max_size: 65536 }
+      );
+      expect(validation.valid).toBe(true);
+    });
+  });
+});

--- a/packages/kernel/src/carrier.ts
+++ b/packages/kernel/src/carrier.ts
@@ -1,0 +1,128 @@
+/**
+ * Evidence Carrier Contract types (DD-124)
+ *
+ * Pure TypeScript types for the universal evidence carry interface.
+ * Zero runtime dependencies: this module exports only types.
+ *
+ * The Evidence Carrier Contract defines how any protocol (MCP, A2A, ACP,
+ * UCP, x402, HTTP) carries PEAC receipts without kernel changes.
+ */
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical HTTP header name for PEAC receipts (DD-127).
+ *
+ * The wire token is exactly "PEAC-Receipt" (mixed-case, hyphenated).
+ * This is the only valid spelling in conformance fixtures and attach() output.
+ * HTTP header lookups SHOULD be case-insensitive per RFC 9110, but conformance
+ * fixtures and attach() output MUST use this exact spelling.
+ */
+export const PEAC_RECEIPT_HEADER = 'PEAC-Receipt' as const;
+
+// ---------------------------------------------------------------------------
+// Primitives
+// ---------------------------------------------------------------------------
+
+/** Content-addressed receipt reference: SHA-256 of the compact JWS bytes */
+export type ReceiptRef = `sha256:${string}`;
+
+/** Carrier format: embed (inline) or reference (URL/pointer) */
+export type CarrierFormat = 'embed' | 'reference';
+
+// ---------------------------------------------------------------------------
+// Core carrier type
+// ---------------------------------------------------------------------------
+
+/**
+ * Universal evidence carrier.
+ *
+ * Every protocol-specific adapter produces and consumes this shape.
+ * Fields marked optional are SHOULD or MAY per the carrier contract spec.
+ */
+export interface PeacEvidenceCarrier {
+  /** Content-addressed receipt reference (MUST): sha256:<hex64> */
+  receipt_ref: ReceiptRef;
+  /** Compact JWS of the signed receipt (SHOULD for embed format) */
+  receipt_jws?: string;
+  /** Policy binding hash for verification (MAY) */
+  policy_binding?: string;
+  /** Actor binding identifier (MAY) */
+  actor_binding?: string;
+  /** Request nonce for replay protection (MAY) */
+  request_nonce?: string;
+  /** Reference to a verification report (MAY) */
+  verification_report_ref?: string;
+  /** Reference to a use policy (MAY) */
+  use_policy_ref?: string;
+  /** Reference to a representation (MAY) */
+  representation_ref?: string;
+  /** Reference to an attestation (MAY) */
+  attestation_ref?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Carrier metadata
+// ---------------------------------------------------------------------------
+
+/**
+ * Transport-level metadata describing how a carrier is placed.
+ *
+ * Used by validateConstraints() to enforce transport-specific size limits
+ * and format requirements (DD-127).
+ */
+export interface CarrierMeta {
+  /** Transport identifier (e.g. 'mcp', 'a2a', 'acp', 'ucp', 'x402', 'http') */
+  transport: string;
+  /** Carrier format: embed or reference */
+  format: CarrierFormat;
+  /** Maximum carrier size in bytes for this transport */
+  max_size: number;
+  /** Fields that have been redacted (MAY) */
+  redaction?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Validation result
+// ---------------------------------------------------------------------------
+
+/** Result of carrier constraint validation */
+export interface CarrierValidationResult {
+  valid: boolean;
+  violations: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Adapter interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Protocol-specific carrier adapter (DD-124).
+ *
+ * Each protocol mapping implements this interface to attach/extract
+ * PEAC evidence carriers in the protocol's native format.
+ *
+ * @typeParam TInput - The protocol-specific input type (e.g. A2A TaskStatus)
+ * @typeParam TOutput - The protocol-specific output type
+ */
+export interface CarrierAdapter<TInput, TOutput> {
+  /**
+   * Extract PEAC evidence carriers from a protocol message.
+   * Returns null if no carrier is present.
+   */
+  extract(input: TInput): { receipts: PeacEvidenceCarrier[]; meta: CarrierMeta } | null;
+
+  /**
+   * Attach PEAC evidence carriers to a protocol message.
+   * Returns the modified output with carriers placed per protocol conventions.
+   */
+  attach(output: TOutput, carriers: PeacEvidenceCarrier[], meta?: CarrierMeta): TOutput;
+
+  /**
+   * Validate a carrier against transport-specific constraints (DD-127, DD-129).
+   * Takes CarrierMeta for transport-aware size and format validation.
+   */
+  validateConstraints(carrier: PeacEvidenceCarrier, meta: CarrierMeta): CarrierValidationResult;
+}

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -77,3 +77,14 @@ export {
 
 // Export HTTP utilities (cache safety, header management)
 export { VARY_HEADERS, applyPurposeVary, getPeacVaryHeaders, needsPurposeVary } from './http.js';
+
+// Evidence Carrier Contract types (v0.11.1+ DD-124)
+export { PEAC_RECEIPT_HEADER } from './carrier.js';
+export type {
+  ReceiptRef,
+  CarrierFormat,
+  PeacEvidenceCarrier,
+  CarrierMeta,
+  CarrierValidationResult,
+  CarrierAdapter,
+} from './carrier.js';

--- a/packages/schema/__tests__/carrier.test.ts
+++ b/packages/schema/__tests__/carrier.test.ts
@@ -1,0 +1,432 @@
+/**
+ * Schema carrier module tests.
+ *
+ * Tests Zod schemas, computeReceiptRef(), validateCarrierConstraints(),
+ * verifyReceiptRefConsistency(), and conformance fixture validation.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  CARRIER_TRANSPORT_LIMITS,
+  CarrierFormatSchema,
+  CarrierMetaSchema,
+  CompactJwsSchema,
+  PeacEvidenceCarrierSchema,
+  ReceiptRefSchema,
+  computeReceiptRef,
+  validateCarrierConstraints,
+  verifyReceiptRefConsistency,
+} from '../src/carrier';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const FIXTURES_DIR = join(__dirname, '../../../specs/conformance/fixtures/carrier');
+
+function loadFixture(name: string): {
+  carrier: Record<string, unknown>;
+  meta: Record<string, unknown>;
+  expected_valid: boolean;
+  expected_violation?: string;
+} {
+  return JSON.parse(readFileSync(join(FIXTURES_DIR, name), 'utf-8'));
+}
+
+// A known JWS for deterministic receipt_ref testing
+const TEST_JWS = 'eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJkaWQ6a2V5OnoxMjMifQ.c2lnbmF0dXJl';
+
+// ---------------------------------------------------------------------------
+// ReceiptRefSchema
+// ---------------------------------------------------------------------------
+
+describe('ReceiptRefSchema', () => {
+  it('accepts valid sha256 receipt ref', () => {
+    const result = ReceiptRefSchema.safeParse(
+      'sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2'
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects receipt ref without sha256: prefix', () => {
+    const result = ReceiptRefSchema.safeParse(
+      'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2'
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects receipt ref with wrong length', () => {
+    const result = ReceiptRefSchema.safeParse('sha256:a1b2c3');
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects receipt ref with uppercase hex', () => {
+    const result = ReceiptRefSchema.safeParse(
+      'sha256:A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2'
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    expect(ReceiptRefSchema.safeParse('').success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CompactJwsSchema
+// ---------------------------------------------------------------------------
+
+describe('CompactJwsSchema', () => {
+  it('accepts valid compact JWS', () => {
+    const result = CompactJwsSchema.safeParse(TEST_JWS);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects JWS with only two parts', () => {
+    const result = CompactJwsSchema.safeParse(
+      'eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJkaWQ6a2V5OnoxMjMifQ'
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects JWS with spaces', () => {
+    const result = CompactJwsSchema.safeParse('eyJ hbGci.eyJpc3M.sig');
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    expect(CompactJwsSchema.safeParse('').success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CarrierFormatSchema
+// ---------------------------------------------------------------------------
+
+describe('CarrierFormatSchema', () => {
+  it('accepts embed', () => {
+    expect(CarrierFormatSchema.safeParse('embed').success).toBe(true);
+  });
+
+  it('accepts reference', () => {
+    expect(CarrierFormatSchema.safeParse('reference').success).toBe(true);
+  });
+
+  it('rejects unknown format', () => {
+    expect(CarrierFormatSchema.safeParse('inline').success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PeacEvidenceCarrierSchema
+// ---------------------------------------------------------------------------
+
+describe('PeacEvidenceCarrierSchema', () => {
+  it('accepts minimal carrier', () => {
+    const result = PeacEvidenceCarrierSchema.safeParse({
+      receipt_ref: 'sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts full carrier', () => {
+    const result = PeacEvidenceCarrierSchema.safeParse({
+      receipt_ref: 'sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+      receipt_jws: TEST_JWS,
+      policy_binding: 'sha256:deadbeef',
+      actor_binding: 'did:key:z6Mk',
+      request_nonce: 'nonce-123',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects carrier without receipt_ref', () => {
+    const result = PeacEvidenceCarrierSchema.safeParse({
+      receipt_jws: TEST_JWS,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects carrier with invalid receipt_ref', () => {
+    const result = PeacEvidenceCarrierSchema.safeParse({
+      receipt_ref: 'not-a-valid-ref',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CarrierMetaSchema
+// ---------------------------------------------------------------------------
+
+describe('CarrierMetaSchema', () => {
+  it('accepts valid meta', () => {
+    const result = CarrierMetaSchema.safeParse({
+      transport: 'mcp',
+      format: 'embed',
+      max_size: 65536,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts meta with redaction', () => {
+    const result = CarrierMetaSchema.safeParse({
+      transport: 'a2a',
+      format: 'reference',
+      max_size: 8192,
+      redaction: ['actor_binding'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects meta with empty transport', () => {
+    const result = CarrierMetaSchema.safeParse({
+      transport: '',
+      format: 'embed',
+      max_size: 65536,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects meta with negative max_size', () => {
+    const result = CarrierMetaSchema.safeParse({
+      transport: 'mcp',
+      format: 'embed',
+      max_size: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects meta with zero max_size', () => {
+    const result = CarrierMetaSchema.safeParse({
+      transport: 'mcp',
+      format: 'embed',
+      max_size: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeReceiptRef
+// ---------------------------------------------------------------------------
+
+describe('computeReceiptRef', () => {
+  it('produces deterministic sha256 output', async () => {
+    const ref = await computeReceiptRef(TEST_JWS);
+    expect(ref).toMatch(/^sha256:[a-f0-9]{64}$/);
+  });
+
+  it('produces same result for same input', async () => {
+    const ref1 = await computeReceiptRef(TEST_JWS);
+    const ref2 = await computeReceiptRef(TEST_JWS);
+    expect(ref1).toBe(ref2);
+  });
+
+  it('produces different result for different input', async () => {
+    const ref1 = await computeReceiptRef(TEST_JWS);
+    const ref2 = await computeReceiptRef('eyJ.eyJ.different');
+    expect(ref1).not.toBe(ref2);
+  });
+
+  it('produces valid ReceiptRef format', async () => {
+    const ref = await computeReceiptRef(TEST_JWS);
+    expect(ReceiptRefSchema.safeParse(ref).success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateCarrierConstraints
+// ---------------------------------------------------------------------------
+
+describe('validateCarrierConstraints', () => {
+  const validCarrier = {
+    receipt_ref: 'sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2' as const,
+  };
+
+  const validMeta = {
+    transport: 'mcp' as const,
+    format: 'embed' as const,
+    max_size: 65536,
+  };
+
+  it('validates minimal valid carrier', () => {
+    const result = validateCarrierConstraints(validCarrier, validMeta);
+    expect(result.valid).toBe(true);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('validates full valid carrier', () => {
+    const carrier = {
+      ...validCarrier,
+      receipt_jws: TEST_JWS,
+      policy_binding: 'sha256:dead',
+      actor_binding: 'did:key:z6Mk',
+    };
+    const result = validateCarrierConstraints(carrier, validMeta);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects invalid receipt_ref format', () => {
+    const carrier = { receipt_ref: 'not-valid' as `sha256:${string}` };
+    const result = validateCarrierConstraints(carrier, validMeta);
+    expect(result.valid).toBe(false);
+    expect(result.violations.some((v) => v.includes('receipt_ref'))).toBe(true);
+  });
+
+  it('rejects invalid receipt_jws format', () => {
+    const carrier = { ...validCarrier, receipt_jws: 'not-a-jws' };
+    const result = validateCarrierConstraints(carrier, validMeta);
+    expect(result.valid).toBe(false);
+    expect(result.violations.some((v) => v.includes('receipt_jws'))).toBe(true);
+  });
+
+  it('rejects carrier exceeding max_size', () => {
+    const result = validateCarrierConstraints(validCarrier, {
+      ...validMeta,
+      max_size: 10, // very small
+    });
+    expect(result.valid).toBe(false);
+    expect(result.violations.some((v) => v.includes('carrier size'))).toBe(true);
+  });
+
+  it('rejects string field exceeding MAX_STRING_LENGTH', () => {
+    const carrier = {
+      ...validCarrier,
+      policy_binding: 'x'.repeat(65537), // > 65536
+    };
+    const result = validateCarrierConstraints(carrier, { ...validMeta, max_size: 1_000_000 });
+    expect(result.valid).toBe(false);
+    expect(result.violations.some((v) => v.includes('policy_binding'))).toBe(true);
+  });
+
+  it('collects multiple violations', () => {
+    const carrier = {
+      receipt_ref: 'bad-ref' as `sha256:${string}`,
+      receipt_jws: 'bad-jws',
+    };
+    const result = validateCarrierConstraints(carrier, validMeta);
+    expect(result.valid).toBe(false);
+    expect(result.violations.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyReceiptRefConsistency
+// ---------------------------------------------------------------------------
+
+describe('verifyReceiptRefConsistency', () => {
+  it('returns null when no receipt_jws is present', async () => {
+    const carrier = {
+      receipt_ref:
+        'sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2' as const,
+    };
+    const result = await verifyReceiptRefConsistency(carrier);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when receipt_ref matches receipt_jws', async () => {
+    const ref = await computeReceiptRef(TEST_JWS);
+    const carrier = { receipt_ref: ref, receipt_jws: TEST_JWS };
+    const result = await verifyReceiptRefConsistency(carrier);
+    expect(result).toBeNull();
+  });
+
+  it('returns error when receipt_ref does not match receipt_jws', async () => {
+    const carrier = {
+      receipt_ref:
+        'sha256:0000000000000000000000000000000000000000000000000000000000000000' as const,
+      receipt_jws: TEST_JWS,
+    };
+    const result = await verifyReceiptRefConsistency(carrier);
+    expect(result).not.toBeNull();
+    expect(result).toContain('mismatch');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CARRIER_TRANSPORT_LIMITS
+// ---------------------------------------------------------------------------
+
+describe('CARRIER_TRANSPORT_LIMITS', () => {
+  it('has expected transport entries', () => {
+    expect(CARRIER_TRANSPORT_LIMITS.mcp).toBe(65536);
+    expect(CARRIER_TRANSPORT_LIMITS.a2a).toBe(65536);
+    expect(CARRIER_TRANSPORT_LIMITS.http).toBe(8192);
+    expect(CARRIER_TRANSPORT_LIMITS.acp_embed).toBe(65536);
+    expect(CARRIER_TRANSPORT_LIMITS.acp_headers).toBe(8192);
+    expect(CARRIER_TRANSPORT_LIMITS.ucp).toBe(65536);
+    expect(CARRIER_TRANSPORT_LIMITS.x402_embed).toBe(65536);
+    expect(CARRIER_TRANSPORT_LIMITS.x402_headers).toBe(8192);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conformance fixtures
+// ---------------------------------------------------------------------------
+
+describe('conformance fixtures', () => {
+  const validFixtures = [
+    'valid-minimal.json',
+    'valid-full.json',
+    'valid-embed-no-optional.json',
+    'valid-http-reference.json',
+    'valid-with-redaction.json',
+  ];
+
+  const invalidFixtures = [
+    'invalid-receipt-ref.json',
+    'invalid-jws-format.json',
+    'invalid-oversize.json',
+  ];
+
+  for (const name of validFixtures) {
+    it(`validates ${name}`, () => {
+      const fixture = loadFixture(name);
+      expect(fixture.expected_valid).toBe(true);
+
+      // Validate carrier schema
+      const schemaResult = PeacEvidenceCarrierSchema.safeParse(fixture.carrier);
+      expect(schemaResult.success).toBe(true);
+
+      // Validate meta schema
+      const metaResult = CarrierMetaSchema.safeParse(fixture.meta);
+      expect(metaResult.success).toBe(true);
+
+      // Validate constraints
+      const constraintResult = validateCarrierConstraints(
+        fixture.carrier as Parameters<typeof validateCarrierConstraints>[0],
+        fixture.meta as Parameters<typeof validateCarrierConstraints>[1]
+      );
+      expect(constraintResult.valid).toBe(true);
+    });
+  }
+
+  for (const name of invalidFixtures) {
+    it(`rejects ${name}`, () => {
+      const fixture = loadFixture(name);
+      expect(fixture.expected_valid).toBe(false);
+
+      // At least one of schema validation or constraint validation should fail
+      const schemaResult = PeacEvidenceCarrierSchema.safeParse(fixture.carrier);
+      const constraintResult = validateCarrierConstraints(
+        fixture.carrier as Parameters<typeof validateCarrierConstraints>[0],
+        fixture.meta as Parameters<typeof validateCarrierConstraints>[1]
+      );
+
+      const failed = !schemaResult.success || !constraintResult.valid;
+      expect(failed).toBe(true);
+
+      // If there's an expected_violation hint, check constraint violations contain it
+      if (fixture.expected_violation && !constraintResult.valid) {
+        const hasExpected = constraintResult.violations.some((v) =>
+          v.includes(fixture.expected_violation!)
+        );
+        expect(hasExpected).toBe(true);
+      }
+    });
+  }
+});

--- a/packages/schema/src/carrier.ts
+++ b/packages/schema/src/carrier.ts
@@ -1,0 +1,208 @@
+/**
+ * Evidence Carrier Contract schemas and helpers (DD-124)
+ *
+ * Zod validation schemas for PeacEvidenceCarrier and CarrierMeta,
+ * plus the canonical computeReceiptRef() and validateCarrierConstraints()
+ * functions used by all carrier adapters.
+ */
+import { z } from 'zod';
+
+import type {
+  CarrierFormat,
+  CarrierMeta,
+  CarrierValidationResult,
+  PeacEvidenceCarrier,
+  ReceiptRef,
+} from '@peac/kernel';
+
+import { KERNEL_CONSTRAINTS } from './constraints';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Maximum carrier size per transport (DD-127) */
+export const CARRIER_TRANSPORT_LIMITS = {
+  /** MCP _meta: 64 KB */
+  mcp: 65_536,
+  /** A2A metadata: 64 KB */
+  a2a: 65_536,
+  /** ACP embed in body: 64 KB; headers only: 8 KB */
+  acp_embed: 65_536,
+  acp_headers: 8_192,
+  /** UCP webhook body: 64 KB */
+  ucp: 65_536,
+  /** x402 embed in body: 64 KB; headers only: 8 KB */
+  x402_embed: 65_536,
+  x402_headers: 8_192,
+  /** HTTP headers only: 8 KB */
+  http: 8_192,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+/** Validates a content-addressed receipt reference: sha256:<64 hex chars> */
+export const ReceiptRefSchema = z
+  .string()
+  .regex(/^sha256:[a-f0-9]{64}$/, 'receipt_ref must be sha256:<64 hex chars>');
+
+/** Validates a compact JWS: header.payload.signature (base64url parts) */
+export const CompactJwsSchema = z
+  .string()
+  .regex(
+    /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/,
+    'receipt_jws must be a valid compact JWS (header.payload.signature)'
+  );
+
+/** Carrier format schema */
+export const CarrierFormatSchema = z.enum(['embed', 'reference']);
+
+/** Schema for PeacEvidenceCarrier */
+export const PeacEvidenceCarrierSchema = z.object({
+  receipt_ref: ReceiptRefSchema,
+  receipt_jws: CompactJwsSchema.optional(),
+  policy_binding: z.string().max(KERNEL_CONSTRAINTS.MAX_STRING_LENGTH).optional(),
+  actor_binding: z.string().max(KERNEL_CONSTRAINTS.MAX_STRING_LENGTH).optional(),
+  request_nonce: z.string().max(KERNEL_CONSTRAINTS.MAX_STRING_LENGTH).optional(),
+  verification_report_ref: z.string().max(KERNEL_CONSTRAINTS.MAX_STRING_LENGTH).optional(),
+  use_policy_ref: z.string().max(KERNEL_CONSTRAINTS.MAX_STRING_LENGTH).optional(),
+  representation_ref: z.string().max(KERNEL_CONSTRAINTS.MAX_STRING_LENGTH).optional(),
+  attestation_ref: z.string().max(KERNEL_CONSTRAINTS.MAX_STRING_LENGTH).optional(),
+});
+
+/** Schema for CarrierMeta */
+export const CarrierMetaSchema = z.object({
+  transport: z.string().min(1),
+  format: CarrierFormatSchema,
+  max_size: z.number().int().positive(),
+  redaction: z.array(z.string()).optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical receipt_ref computation (single source of truth).
+ *
+ * Computes SHA-256 of the UTF-8 bytes of the compact JWS string as emitted.
+ * All carrier adapters MUST use this function rather than computing SHA-256
+ * locally, to ensure consistency across protocols (correction item 4).
+ */
+export async function computeReceiptRef(jws: string): Promise<ReceiptRef> {
+  if (!globalThis.crypto?.subtle) {
+    throw new Error(
+      'computeReceiptRef requires WebCrypto (crypto.subtle). ' +
+        'Supported runtimes: Node >= 20, Cloudflare Workers, Deno, Bun.'
+    );
+  }
+  const data = new TextEncoder().encode(jws);
+  const hash = await globalThis.crypto.subtle.digest('SHA-256', data);
+  const hex = Array.from(new Uint8Array(hash))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  return `sha256:${hex}` as ReceiptRef;
+}
+
+/**
+ * Canonical carrier constraint validator (DD-127, DD-129, DD-131).
+ *
+ * Validates a carrier against transport-specific constraints using
+ * the provided CarrierMeta. This is the single validation function
+ * that all CarrierAdapter.validateConstraints() implementations delegate to.
+ *
+ * Checks performed:
+ * 1. receipt_ref format (sha256:<hex64>)
+ * 2. receipt_jws format (if present): valid compact JWS
+ * 3. Total serialized size within meta.max_size
+ * 4. If receipt_jws present: receipt_ref consistency (DD-129)
+ * 5. All string fields within MAX_STRING_LENGTH
+ */
+export function validateCarrierConstraints(
+  carrier: PeacEvidenceCarrier,
+  meta: CarrierMeta
+): CarrierValidationResult {
+  const violations: string[] = [];
+
+  // 1. receipt_ref format
+  const refResult = ReceiptRefSchema.safeParse(carrier.receipt_ref);
+  if (!refResult.success) {
+    violations.push(`invalid receipt_ref format: ${carrier.receipt_ref}`);
+  }
+
+  // 2. receipt_jws format (if present)
+  if (carrier.receipt_jws !== undefined) {
+    const jwsResult = CompactJwsSchema.safeParse(carrier.receipt_jws);
+    if (!jwsResult.success) {
+      violations.push('invalid receipt_jws format: not a valid compact JWS');
+    }
+  }
+
+  // 3. Total serialized size check
+  const serialized = JSON.stringify(carrier);
+  const sizeBytes = new TextEncoder().encode(serialized).byteLength;
+  if (sizeBytes > meta.max_size) {
+    violations.push(
+      `carrier size ${sizeBytes} bytes exceeds transport limit ${meta.max_size} bytes for ${meta.transport}`
+    );
+  }
+
+  // 4. String field length checks
+  const stringFields: Array<[string, string | undefined]> = [
+    ['policy_binding', carrier.policy_binding],
+    ['actor_binding', carrier.actor_binding],
+    ['request_nonce', carrier.request_nonce],
+    ['verification_report_ref', carrier.verification_report_ref],
+    ['use_policy_ref', carrier.use_policy_ref],
+    ['representation_ref', carrier.representation_ref],
+    ['attestation_ref', carrier.attestation_ref],
+  ];
+
+  for (const [name, value] of stringFields) {
+    if (value !== undefined && value.length > KERNEL_CONSTRAINTS.MAX_STRING_LENGTH) {
+      violations.push(
+        `${name} length ${value.length} exceeds MAX_STRING_LENGTH ${KERNEL_CONSTRAINTS.MAX_STRING_LENGTH}`
+      );
+    }
+  }
+
+  return { valid: violations.length === 0, violations };
+}
+
+/**
+ * Verify receipt_ref consistency with receipt_jws (DD-129).
+ *
+ * If both receipt_ref and receipt_jws are present, verifies that
+ * sha256(receipt_jws) equals receipt_ref. This prevents carrier
+ * tampering after attachment.
+ *
+ * Returns null if consistent or receipt_jws is absent;
+ * returns an error string if inconsistent.
+ */
+export async function verifyReceiptRefConsistency(
+  carrier: PeacEvidenceCarrier
+): Promise<string | null> {
+  if (carrier.receipt_jws === undefined) {
+    return null;
+  }
+  const computed = await computeReceiptRef(carrier.receipt_jws);
+  if (computed !== carrier.receipt_ref) {
+    return `receipt_ref mismatch: expected ${computed}, got ${carrier.receipt_ref}`;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Re-export types for convenience
+// ---------------------------------------------------------------------------
+
+export type {
+  CarrierFormat,
+  CarrierMeta,
+  CarrierValidationResult,
+  PeacEvidenceCarrier,
+  ReceiptRef,
+  CarrierAdapter,
+} from '@peac/kernel';

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -390,6 +390,27 @@ export type {
   CreateAttestationReceiptParams,
 } from './attestation-receipt';
 
+// Evidence Carrier Contract schemas + helpers (v0.11.1+ DD-124)
+export {
+  ReceiptRefSchema,
+  CompactJwsSchema,
+  CarrierFormatSchema,
+  PeacEvidenceCarrierSchema,
+  CarrierMetaSchema,
+  CARRIER_TRANSPORT_LIMITS,
+  computeReceiptRef,
+  validateCarrierConstraints,
+  verifyReceiptRefConsistency,
+} from './carrier';
+export type {
+  ReceiptRef,
+  CarrierFormat,
+  PeacEvidenceCarrier,
+  CarrierMeta,
+  CarrierValidationResult,
+  CarrierAdapter,
+} from './carrier';
+
 // Unified receipt parser (v0.10.9+)
 export { parseReceiptClaims } from './receipt-parser';
 export type {

--- a/specs/conformance/category-tracking.json
+++ b/specs/conformance/category-tracking.json
@@ -3,6 +3,7 @@
   "tracked": ["agent-identity", "attribution", "interaction"],
   "untracked": {
     "bundle": "Not yet migrated to tracked validation; fixture_count needs reconciliation",
+    "carrier": "Single-carrier fixtures with per-file expected_valid/expected_violation; not fixture packs",
     "crypto": "Deterministic golden vectors (Ed25519 sign/verify); not fixture packs",
     "discovery": "Not yet migrated to tracked validation; needs fixture pack audit",
     "dispute": "Not yet migrated to tracked validation; fixture_count needs reconciliation",

--- a/specs/conformance/fixtures/carrier/invalid-jws-format.json
+++ b/specs/conformance/fixtures/carrier/invalid-jws-format.json
@@ -1,0 +1,14 @@
+{
+  "description": "Invalid receipt_jws: not a compact JWS (missing signature segment)",
+  "carrier": {
+    "receipt_ref": "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    "receipt_jws": "eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJkaWQ6a2V5OnoxMjMifQ"
+  },
+  "meta": {
+    "transport": "mcp",
+    "format": "embed",
+    "max_size": 65536
+  },
+  "expected_valid": false,
+  "expected_violation": "invalid receipt_jws format"
+}

--- a/specs/conformance/fixtures/carrier/invalid-oversize.json
+++ b/specs/conformance/fixtures/carrier/invalid-oversize.json
@@ -1,0 +1,21 @@
+{
+  "description": "Carrier exceeds transport max_size (8KB HTTP header limit)",
+  "carrier": {
+    "receipt_ref": "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    "receipt_jws": "eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJkaWQ6a2V5OnoxMjMifQ.c2lnbmF0dXJl",
+    "policy_binding": "sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+    "actor_binding": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+    "request_nonce": "nonce-abc-123-very-long-nonce-that-along-with-other-fields-pushes-the-carrier-well-over-the-limit",
+    "verification_report_ref": "sha256:cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe",
+    "use_policy_ref": "https://example.com/policies/ai-train-v1",
+    "representation_ref": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    "attestation_ref": "sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+  },
+  "meta": {
+    "transport": "http",
+    "format": "reference",
+    "max_size": 256
+  },
+  "expected_valid": false,
+  "expected_violation": "carrier size"
+}

--- a/specs/conformance/fixtures/carrier/invalid-receipt-ref.json
+++ b/specs/conformance/fixtures/carrier/invalid-receipt-ref.json
@@ -1,0 +1,13 @@
+{
+  "description": "Invalid receipt_ref: missing sha256: prefix",
+  "carrier": {
+    "receipt_ref": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+  },
+  "meta": {
+    "transport": "mcp",
+    "format": "reference",
+    "max_size": 65536
+  },
+  "expected_valid": false,
+  "expected_violation": "invalid receipt_ref format"
+}

--- a/specs/conformance/fixtures/carrier/valid-embed-no-optional.json
+++ b/specs/conformance/fixtures/carrier/valid-embed-no-optional.json
@@ -1,0 +1,13 @@
+{
+  "description": "Embed format carrier with JWS but no other optional fields",
+  "carrier": {
+    "receipt_ref": "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    "receipt_jws": "eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJkaWQ6a2V5OnoxMjMifQ.c2lnbmF0dXJl"
+  },
+  "meta": {
+    "transport": "mcp",
+    "format": "embed",
+    "max_size": 65536
+  },
+  "expected_valid": true
+}

--- a/specs/conformance/fixtures/carrier/valid-full.json
+++ b/specs/conformance/fixtures/carrier/valid-full.json
@@ -1,0 +1,20 @@
+{
+  "description": "Full carrier with all optional fields populated",
+  "carrier": {
+    "receipt_ref": "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    "receipt_jws": "eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJkaWQ6a2V5OnoxMjMifQ.c2lnbmF0dXJl",
+    "policy_binding": "sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+    "actor_binding": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+    "request_nonce": "nonce-abc-123",
+    "verification_report_ref": "sha256:cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe",
+    "use_policy_ref": "https://example.com/policies/ai-train-v1",
+    "representation_ref": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    "attestation_ref": "sha256:fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+  },
+  "meta": {
+    "transport": "a2a",
+    "format": "embed",
+    "max_size": 65536
+  },
+  "expected_valid": true
+}

--- a/specs/conformance/fixtures/carrier/valid-http-reference.json
+++ b/specs/conformance/fixtures/carrier/valid-http-reference.json
@@ -1,0 +1,12 @@
+{
+  "description": "HTTP reference-only carrier (no JWS, within 8KB header limit)",
+  "carrier": {
+    "receipt_ref": "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+  },
+  "meta": {
+    "transport": "http",
+    "format": "reference",
+    "max_size": 8192
+  },
+  "expected_valid": true
+}

--- a/specs/conformance/fixtures/carrier/valid-minimal.json
+++ b/specs/conformance/fixtures/carrier/valid-minimal.json
@@ -1,0 +1,12 @@
+{
+  "description": "Minimal valid carrier with only required receipt_ref",
+  "carrier": {
+    "receipt_ref": "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+  },
+  "meta": {
+    "transport": "mcp",
+    "format": "reference",
+    "max_size": 65536
+  },
+  "expected_valid": true
+}

--- a/specs/conformance/fixtures/carrier/valid-with-redaction.json
+++ b/specs/conformance/fixtures/carrier/valid-with-redaction.json
@@ -1,0 +1,14 @@
+{
+  "description": "Carrier with redacted fields listed in meta",
+  "carrier": {
+    "receipt_ref": "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    "receipt_jws": "eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJkaWQ6a2V5OnoxMjMifQ.c2lnbmF0dXJl"
+  },
+  "meta": {
+    "transport": "a2a",
+    "format": "embed",
+    "max_size": 65536,
+    "redaction": ["actor_binding", "policy_binding"]
+  },
+  "expected_valid": true
+}

--- a/specs/conformance/fixtures/manifest.json
+++ b/specs/conformance/fixtures/manifest.json
@@ -324,5 +324,39 @@
       "version": "0.10.9",
       "expected_error": "E_PARSE_ATTESTATION_INVALID"
     }
+  },
+  "carrier": {
+    "valid-minimal.json": {
+      "description": "Minimal carrier with only receipt_ref",
+      "version": "0.11.1"
+    },
+    "valid-full.json": {
+      "description": "Full carrier with all optional fields",
+      "version": "0.11.1"
+    },
+    "valid-embed-no-optional.json": {
+      "description": "Embed carrier with receipt_jws but no other optional fields",
+      "version": "0.11.1"
+    },
+    "valid-http-reference.json": {
+      "description": "HTTP reference-only carrier within 8KB header limit",
+      "version": "0.11.1"
+    },
+    "valid-with-redaction.json": {
+      "description": "Carrier with redaction metadata",
+      "version": "0.11.1"
+    },
+    "invalid-receipt-ref.json": {
+      "description": "Carrier with malformed receipt_ref",
+      "version": "0.11.1"
+    },
+    "invalid-jws-format.json": {
+      "description": "Carrier with invalid receipt_jws format",
+      "version": "0.11.1"
+    },
+    "invalid-oversize.json": {
+      "description": "Carrier exceeding transport max_size",
+      "version": "0.11.1"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Ships `PeacEvidenceCarrier` pure types in `@peac/kernel` (Layer 0, zero runtime) and Zod schemas + shared helpers in `@peac/schema` (Layer 1)
- Implements `computeReceiptRef()` (SHA-256 of compact JWS via WebCrypto) with runtime portability guard (Node >= 20, CF Workers, Deno, Bun)
- Adds `validateCarrierConstraints()` for transport-aware size enforcement and `verifyReceiptRefConsistency()` for DD-129 tamper detection
- Ships 8 conformance fixtures (5 valid, 3 invalid) in `specs/conformance/fixtures/carrier/`
- Exports `PEAC_RECEIPT_HEADER` canonical constant (`"PEAC-Receipt"`) per DD-127

## Design Decisions

- **DD-124:** `PeacEvidenceCarrier`, `CarrierAdapter<T,U>`, `CarrierMeta` types in kernel; Zod schemas + helpers in schema
- **DD-127:** `CARRIER_TRANSPORT_LIMITS` per-transport size constants (MCP 64KB, A2A 64KB, HTTP 8KB headers)
- **DD-129:** `verifyReceiptRefConsistency()` async check: `sha256(receipt_jws) === receipt_ref`

## Key Types

```typescript
export type ReceiptRef = `sha256:${string}`;
export type CarrierFormat = 'embed' | 'reference';

export interface PeacEvidenceCarrier {
  receipt_ref: ReceiptRef;
  receipt_jws?: string;
  policy_binding?: string;
  actor_binding?: string;
  // ... additional optional fields
}

export interface CarrierAdapter<TInput, TOutput> {
  extract(input: TInput): { receipts: PeacEvidenceCarrier[]; meta: CarrierMeta } | null;
  attach(output: TOutput, carriers: PeacEvidenceCarrier[], meta?: CarrierMeta): TOutput;
  validateConstraints(carrier: PeacEvidenceCarrier, meta: CarrierMeta): CarrierValidationResult;
}
```

## Test plan

- [x] Kernel carrier types compile with zero runtime deps (11 tests)
- [x] Zod schemas validate all 8 fixtures (5 valid, 3 invalid)
- [x] `computeReceiptRef()` produces deterministic `sha256:<hex64>` output
- [x] `validateCarrierConstraints()` enforces transport size limits from CarrierMeta
- [x] `verifyReceiptRefConsistency()` detects tampered JWS (DD-129)
- [x] WebCrypto runtime guard throws clear error on missing `crypto.subtle`
- [x] `pnpm build && pnpm lint && pnpm typecheck:core && pnpm test` passes (77/77 build, 4246 tests)
- [x] `guard.sh` and `check-planning-leak.sh` pass