### PR TITLE
docs: A2A Receipt Profile and MCP Evidence Profile specs

### DIFF
--- a/docs/specs/A2A-RECEIPT-PROFILE.md
+++ b/docs/specs/A2A-RECEIPT-PROFILE.md
@@ -9,7 +9,7 @@
 
 This document specifies how PEAC evidence carriers are placed within A2A (Agent-to-Agent Protocol) messages and metadata. It covers Agent Card declaration, metadata layout, header conventions, and security considerations.
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 (RFC 2119, RFC 8174) when, and only when, they appear in all capitals, as shown here.
 
 ## 1. Overview
 
@@ -36,7 +36,7 @@ Agents that support PEAC evidence MUST declare the extension in their Agent Card
         "params": {
           "supported_kinds": ["peac-receipt/0.1"],
           "carrier_formats": ["embed", "reference"],
-          "jwks_uri": "https://agent.example.com/.well-known/jwks.json"
+          "issuer_config_url": "https://agent.example.com/.well-known/peac-issuer.json"
         }
       }
     ]
@@ -55,11 +55,11 @@ Agents that support PEAC evidence MUST declare the extension in their Agent Card
 
 **Params schema:**
 
-| Field             | Type       | Description                                     |
-| ----------------- | ---------- | ----------------------------------------------- |
-| `supported_kinds` | `string[]` | Wire format versions (e.g., `peac-receipt/0.1`) |
-| `carrier_formats` | `string[]` | Supported carrier formats: `embed`, `reference` |
-| `jwks_uri`        | `string`   | URI for public keys used to verify receipts     |
+| Field               | Type       | Description                                       |
+| ------------------- | ---------- | ------------------------------------------------- |
+| `supported_kinds`   | `string[]` | Wire format versions (e.g., `peac-receipt/0.1`)   |
+| `carrier_formats`   | `string[]` | Supported carrier formats: `embed`, `reference`   |
+| `issuer_config_url` | `string`   | URI for issuer configuration (`peac-issuer.json`) |
 
 ### 2.2 Discovery
 

--- a/docs/specs/MCP-EVIDENCE-PROFILE.md
+++ b/docs/specs/MCP-EVIDENCE-PROFILE.md
@@ -8,7 +8,7 @@
 
 This document specifies how PEAC evidence carriers are placed within MCP (Model Context Protocol) tool responses using the `_meta` field. It covers key naming, reserved key guards, legacy compatibility, and security considerations.
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 (RFC 2119, RFC 8174) when, and only when, they appear in all capitals, as shown here.
 
 ## 1. Overview
 


### PR DESCRIPTION
## Summary

- New A2A Receipt Profile spec: extension registration, metadata layout, header conventions, lifecycle, security
- New MCP Evidence Profile spec: _meta key schema, reserved key guard rule, legacy compatibility (DD-125), migration guide

## New files
- `docs/specs/A2A-RECEIPT-PROFILE.md`: Normative spec for A2A extension placement
- `docs/specs/MCP-EVIDENCE-PROFILE.md`: Normative spec for MCP _meta key placement

## Design decisions
- DD-124: Evidence Carrier Contract
- DD-125: MCP legacy `peac_receipt` deprecation (3-phase)
- DD-126: No runtime dependency on @a2a-js/sdk
- DD-127: Carrier size limits (64 KB for both)
- DD-128: A2A spec v0.3.0 pinning
- DD-131: Carrier validation as ASI-04 defense

## Test plan
- [x] Docs-only PR; no code changes
- [x] guard.sh, check-planning-leak.sh pass
- [x] Tables formatted via pnpm format

## Stacked on
- PR #414 (feat/evidence-carrier-types)