### PR TITLE
chore: add packages to publish manifest

### DIFF
--- a/scripts/check-publish-closure.ts
+++ b/scripts/check-publish-closure.ts
@@ -47,6 +47,7 @@ function packageDir(npmName: string): string {
     'rails-card': 'packages/rails/card',
     'rails-razorpay': 'packages/rails/razorpay',
     'mappings-mcp': 'packages/mappings/mcp',
+    'mappings-a2a': 'packages/mappings/a2a',
     'mappings-acp': 'packages/mappings/acp',
     'mappings-aipref': 'packages/mappings/aipref',
     'mappings-rsl': 'packages/mappings/rsl',

--- a/scripts/publish-manifest.json
+++ b/scripts/publish-manifest.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Single source of truth for PEAC Protocol npm publish order",
   "version": "0.11.1",
-  "lastUpdated": "2026-02-23",
-  "totalPackages": 21,
+  "lastUpdated": "2026-02-24",
+  "totalPackages": 25,
   "packages": [
     "@peac/kernel",
     "@peac/schema",
@@ -23,7 +23,11 @@
     "@peac/policy-kit",
     "@peac/adapter-core",
     "@peac/mappings-mcp",
+    "@peac/mappings-acp",
+    "@peac/mappings-ucp",
+    "@peac/mappings-a2a",
     "@peac/rails-x402",
+    "@peac/adapter-x402",
     "@peac/adapter-openclaw",
     "@peac/cli"
   ],
@@ -44,7 +48,15 @@
       "@peac/policy-kit",
       "@peac/adapter-core"
     ],
-    "5-adapters": ["@peac/mappings-mcp", "@peac/rails-x402", "@peac/adapter-openclaw"],
+    "5-adapters": [
+      "@peac/mappings-mcp",
+      "@peac/mappings-acp",
+      "@peac/mappings-ucp",
+      "@peac/mappings-a2a",
+      "@peac/rails-x402",
+      "@peac/adapter-x402",
+      "@peac/adapter-openclaw"
+    ],
     "6-cli": ["@peac/cli"]
   },
   "trustedPublisher": {
@@ -53,14 +65,10 @@
     "environment": "npm-production"
   },
   "pendingTrustedPublishing": [
-    "@peac/adapter-x402",
     "@peac/telemetry-otel",
-    "@peac/mappings-a2a",
-    "@peac/mappings-acp",
     "@peac/mappings-aipref",
     "@peac/mappings-rsl",
     "@peac/mappings-tap",
-    "@peac/mappings-ucp",
     "@peac/worker-core",
     "@peac/net-node",
     "@peac/attribution",


### PR DESCRIPTION
## Summary

- Add `@peac/mappings-acp`, `@peac/mappings-ucp`, `@peac/mappings-a2a`, and `@peac/adapter-x402` to the publish manifest (21 -> 25 packages)
- Remove them from `pendingTrustedPublishing` (now bootstrapped on npm)
- Update layers map to include new packages in `5-adapters`

These packages were manually published at 0.11.1 and promoted to `latest` dist-tag.

## Test plan

- [x] `node -e "const m = require('./scripts/publish-manifest.json'); console.log(m.totalPackages === m.packages.length)"` returns `true`
- [x] `bash scripts/check-publish-list.sh` passes
- [x] All 25 packages verified at `latest: 0.11.1` on npm