### PR TITLE
fix: bump MCP server version

### DIFF
--- a/packages/mcp-server/src/infra/constants.ts
+++ b/packages/mcp-server/src/infra/constants.ts
@@ -3,7 +3,7 @@
  */
 
 export const SERVER_NAME = 'peac-mcp-server';
-export const SERVER_VERSION = '0.10.12';
+export const SERVER_VERSION = '0.11.2';
 export const MCP_PROTOCOL_VERSION = '2025-11-25';
 export const DEFAULT_MAX_JWS_BYTES = 16_384; // 16 KB
 export const DEFAULT_MAX_RESPONSE_BYTES = 65_536; // 64 KB

--- a/packages/mcp-server/tests/handlers/bundle.test.ts
+++ b/packages/mcp-server/tests/handlers/bundle.test.ts
@@ -21,7 +21,7 @@ async function makeIssuerContext(bundleDirPath: string) {
   const { privateKey, publicKey } = await generateKeypair();
   const kid = 'test-kid-' + Date.now();
   return {
-    version: '0.10.12',
+    version: '0.11.2',
     policyHash: 'testhash',
     protocolVersion: '2025-11-25',
     issuerKey: { privateKey, publicKey, kid },
@@ -229,7 +229,7 @@ describe('handlers/bundle', () => {
     const { privateKey, publicKey } = await generateKeypair();
     const kid = 'test-kid-' + Date.now();
     const context = {
-      version: '0.10.12',
+      version: '0.11.2',
       policyHash: 'testhash',
       protocolVersion: '2025-11-25',
       issuerKey: { privateKey, publicKey, kid },
@@ -250,7 +250,7 @@ describe('handlers/bundle', () => {
 
   it('no issuerKey returns E_MCP_KEY_REQUIRED', async () => {
     const context = {
-      version: '0.10.12',
+      version: '0.11.2',
       policyHash: 'testhash',
       protocolVersion: '2025-11-25',
       issuerId: 'https://api.example.com',

--- a/packages/mcp-server/tests/handlers/decode.test.ts
+++ b/packages/mcp-server/tests/handlers/decode.test.ts
@@ -11,7 +11,7 @@ function makeParams(input: DecodeInput): HandlerParams<DecodeInput> {
     input,
     policy: getDefaultPolicy(),
     context: {
-      version: '0.10.12',
+      version: '0.11.2',
       policyHash: 'testhash',
       protocolVersion: '2025-11-25',
     },

--- a/packages/mcp-server/tests/handlers/inspect.test.ts
+++ b/packages/mcp-server/tests/handlers/inspect.test.ts
@@ -11,7 +11,7 @@ function makeParams(input: InspectInput): HandlerParams<InspectInput> {
     input,
     policy: getDefaultPolicy(),
     context: {
-      version: '0.10.12',
+      version: '0.11.2',
       policyHash: 'testhash',
       protocolVersion: '2025-11-25',
     },
@@ -124,7 +124,7 @@ describe('handlers/inspect', () => {
       input: { jws, full_claims: true },
       policy,
       context: {
-        version: '0.10.12',
+        version: '0.11.2',
         policyHash: 'testhash',
         protocolVersion: '2025-11-25',
       },

--- a/packages/mcp-server/tests/handlers/issue.test.ts
+++ b/packages/mcp-server/tests/handlers/issue.test.ts
@@ -11,7 +11,7 @@ async function makeIssuerContext() {
   const { privateKey, publicKey } = await generateKeypair();
   const kid = 'test-kid-' + Date.now();
   return {
-    version: '0.10.12',
+    version: '0.11.2',
     policyHash: 'testhash',
     protocolVersion: '2025-11-25',
     issuerKey: { privateKey, publicKey, kid },
@@ -130,7 +130,7 @@ describe('handlers/issue', () => {
 
   it('returns E_MCP_KEY_REQUIRED when issuerKey is missing', async () => {
     const context = {
-      version: '0.10.12',
+      version: '0.11.2',
       policyHash: 'testhash',
       protocolVersion: '2025-11-25',
     };
@@ -160,7 +160,7 @@ describe('handlers/issue', () => {
     const { privateKey, publicKey } = await generateKeypair();
     const kid = 'test-kid-' + Date.now();
     const context = {
-      version: '0.10.12',
+      version: '0.11.2',
       policyHash: 'testhash',
       protocolVersion: '2025-11-25',
       issuerKey: { privateKey, publicKey, kid },

--- a/packages/mcp-server/tests/handlers/verify.test.ts
+++ b/packages/mcp-server/tests/handlers/verify.test.ts
@@ -8,7 +8,7 @@ import { getDefaultPolicy } from '../../src/infra/policy.js';
 
 function makeContext() {
   return {
-    version: '0.10.12',
+    version: '0.11.2',
     policyHash: 'testhash',
     protocolVersion: '2025-11-25',
   };

--- a/packages/mcp-server/tests/infra/constants.test.ts
+++ b/packages/mcp-server/tests/infra/constants.test.ts
@@ -14,7 +14,7 @@ describe('infra/constants', () => {
   });
 
   it('exports version matching package.json', () => {
-    expect(SERVER_VERSION).toBe('0.10.12');
+    expect(SERVER_VERSION).toBe('0.11.2');
   });
 
   it('exports MCP protocol version', () => {

--- a/packages/mcp-server/tests/schemas/schemas.test.ts
+++ b/packages/mcp-server/tests/schemas/schemas.test.ts
@@ -5,7 +5,7 @@ import { DecodeInputSchema, DecodeOutputSchema } from '../../src/schemas/decode.
 import { IssueInputSchema, IssueOutputSchema } from '../../src/schemas/issue.js';
 import { BundleInputSchema, BundleOutputSchema } from '../../src/schemas/bundle.js';
 
-const META = { serverVersion: '0.10.12', policyHash: 'abc123', protocolVersion: '2025-11-25' };
+const META = { serverVersion: '0.11.2', policyHash: 'abc123', protocolVersion: '2025-11-25' };
 
 describe('schemas', () => {
   describe('VerifyInputSchema', () => {


### PR DESCRIPTION
## Summary

- Bump hardcoded `SERVER_VERSION` constant from `0.10.12` to `0.11.2`
- Update all MCP server test references

The constant was stale from when the MCP server was first introduced at v0.10.12. This caused the server to report `0.10.12` in JSON-RPC `initialize` responses (`serverInfo.version`) and `_meta.serverVersion`, while `package.json` and `server.json` both correctly say `0.11.2`.

## Test plan

- [x] MCP server stdio smoke test confirms `serverInfo.version: "0.11.2"` in initialize response
- [x] All 4642 tests pass (including `constants.test.ts` version assertion)
- [x] `check-distribution.sh` passes (server.json version consistency)
- [x] Full CI-equivalent: build 80/80, lint, typecheck, format clean