### PR TITLE
docs: distribution surface sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.2] - 2026-02-25
 
-### Error Recovery Semantics + Evidence Locators + Content Signals + Distribution
+### Content Signals + Evidence Locators
 
 v0.11.2 adds agent-actionable error recovery hints, an optional receipt locator on
 evidence carriers, a new content signals observation package, an OpenAI-compatible

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -8,11 +8,28 @@ PEAC uses a single canonical HTTP header for receipts:
 
 - `PEAC-Receipt`: JWS-encoded receipt envelope (see `specs/kernel/constants.json`)
 
-HTTP header names are case-insensitive per RFC 7230. Implementations MUST accept `PEAC-Receipt` and SHOULD tolerate lowercase variants (e.g., `peac-receipt`) as seen in HTTP/2 or gRPC metadata.
+HTTP header names are case-insensitive per [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110) (HTTP Semantics). Implementations MUST accept `PEAC-Receipt` and SHOULD tolerate lowercase variants (e.g., `peac-receipt`) as seen in HTTP/2 or gRPC metadata.
 
 **Note:** All legacy `X-`-prefixed PEAC headers were removed in v0.9.15. Do not use or implement them.
 
+## Error Responses
+
+Error responses use [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) Problem Details (`application/problem+json`). See [Error Response Registry](errors.md) for the full problem type registry.
+
 ## Endpoints
 
-- Discovery: `/.well-known/peac.json` (see `docs/specs/` for format)
-- Verification: Defined by the `verify` URL in discovery response
+- Issuer configuration: `/.well-known/peac-issuer.json` (see [PEAC-ISSUER spec](specs/PEAC-ISSUER.md))
+- Policy discovery: `/.well-known/peac.txt` (see [PEAC-TXT spec](specs/PEAC-TXT.md))
+- JWKS: referenced via `jwks_uri` in `peac-issuer.json` (typically `/.well-known/jwks.json`)
+- Verification: defined by the verifier implementation
+
+### Verifier Resolution Flow
+
+1. Extract `iss` claim from receipt
+2. Fetch `<iss>/.well-known/peac-issuer.json` for issuer configuration
+3. Fetch `jwks_uri` from issuer config to obtain public keys
+4. Verify receipt signature against JWKS
+
+## MCP Server Registry
+
+The `@peac/mcp-server` package registers with the MCP Registry using the namespace `io.github.peacprotocol/peac`. This namespace uses the reverse-DNS convention based on the GitHub organization. See `packages/mcp-server/server.json` for the full registry manifest.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,8 +1,8 @@
 # Error Response Registry
 
-## RFC 7807 Problem Details
+## RFC 9457 Problem Details
 
-PEAC Protocol uses RFC 7807 Problem Details for structured error responses. All error responses use the `application/problem+json` media type.
+PEAC Protocol uses [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) Problem Details for structured error responses. All error responses use the `application/problem+json` media type.
 
 ## Problem Type Registry
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,12 +3,12 @@
 ## Hello Receipt - 10-Line Example
 
 ```javascript
-import { generateEdDSAKeyPair, signDetached, verifyDetached } from '@peac/core';
+import { generateKeypair, sign, verify } from '@peac/crypto';
 
 // 1. Generate Ed25519 key pair
-const { publicKey, privateKey } = await generateEdDSAKeyPair();
+const { publicKey, privateKey } = await generateKeypair();
 
-// 2. Create a simple receipt
+// 2. Create a simple receipt payload
 const receipt = {
   iss: 'https://peac-authority.example.com',
   sub: 'https://example.com/content',
@@ -20,8 +20,8 @@ const receipt = {
 };
 
 // 3. Sign and verify
-const jws = await signDetached(receipt, privateKey);
-const result = await verifyDetached(jws, publicKey);
+const jws = await sign(receipt, privateKey);
+const result = await verify(jws, publicKey);
 console.log('Receipt valid:', result.valid);
 ```
 
@@ -98,8 +98,8 @@ peac verify receipt.jws --resource https://example.com
 ## Installation
 
 ```bash
-# Install CLI tools
-pnpm add -g @peac/cli @peac/core
+# Install core packages
+pnpm add @peac/crypto @peac/protocol
 
 # Or for development
 git clone https://github.com/peacprotocol/peac.git
@@ -121,6 +121,6 @@ The verifier includes SSRF protection by default:
 ## Next Steps
 
 - Read [Policy Hash Algorithm](policy-hash.md) for canonicalization details
-- See [Error Handling](errors.md) for RFC 7807 Problem Details
+- See [Error Handling](errors.md) for RFC 9457 Problem Details
 - Review [Receipt Claims](receipts.md) for complete schema
 - Check [Examples](examples.md) for production deployment patterns

--- a/llms.txt
+++ b/llms.txt
@@ -29,6 +29,8 @@ PEAC Protocol provides cryptographically signed, offline-verifiable receipts tha
 - ACP Mapping: `@peac/mappings-acp` for Agentforce/ACP protocol evidence
 - UCP Mapping: `@peac/mappings-ucp` for Universal Commerce Protocol evidence
 - x402 Adapter: `@peac/adapter-x402` for payment-required HTTP evidence
+- Content Signals: `@peac/mappings-content-signals` for robots.txt, Content-Usage (AIPREF), and tdmrep.json signal parsing
+- OpenAI Adapter: `@peac/adapter-openai-compatible` for hash-first inference receipts from any OpenAI-compatible provider
 - HTTP: `PEAC-Receipt` response header carries compact JWS for any HTTP API
 - Evidence Carrier Contract: universal carry interface across MCP, A2A, ACP, UCP, x402, and HTTP
 


### PR DESCRIPTION
## Summary

Post-release docs sync for v0.11.2. Fixes stale RFC references, deprecated package imports, and incorrect discovery endpoints in public-facing documentation.

- **CHANGELOG.md**: align section header with PR #428 title
- **docs/api-reference.md**: RFC 7230 -> RFC 9110 (HTTP Semantics), discovery endpoint `/.well-known/peac.json` -> `/.well-known/peac-issuer.json`, add verifier resolution flow, add MCP Registry namespace documentation
- **docs/errors.md**: RFC 7807 -> RFC 9457 (Problem Details)
- **docs/quickstart.md**: migrate deprecated `@peac/core` imports to `@peac/crypto` (`generateKeypair`, `sign`, `verify`), fix install command (`pnpm add @peac/crypto @peac/protocol` instead of `pnpm add -g @peac/cli @peac/core`)
- **llms.txt**: add `@peac/mappings-content-signals` and `@peac/adapter-openai-compatible` to agent integration section

## Test plan

- [x] `pnpm lint && pnpm build && pnpm typecheck:core && pnpm test` (4642 tests pass)
- [x] `scripts/guard.sh` passes
- [x] `scripts/check-planning-leak.sh` passes
- [x] No code changes; docs only