### PR TITLE
fix: add mcp-server to publish manifest

### DIFF
--- a/scripts/publish-manifest.json
+++ b/scripts/publish-manifest.json
@@ -3,7 +3,7 @@
   "description": "Single source of truth for PEAC Protocol npm publish order",
   "version": "0.11.2",
   "lastUpdated": "2026-02-24",
-  "totalPackages": 27,
+  "totalPackages": 28,
   "packages": [
     "@peac/kernel",
     "@peac/schema",
@@ -31,6 +31,7 @@
     "@peac/adapter-openclaw",
     "@peac/mappings-content-signals",
     "@peac/adapter-openai-compatible",
+    "@peac/mcp-server",
     "@peac/cli"
   ],
   "layers": {
@@ -61,6 +62,7 @@
       "@peac/mappings-content-signals",
       "@peac/adapter-openai-compatible"
     ],
+    "5-server": ["@peac/mcp-server"],
     "6-cli": ["@peac/cli"]
   },
   "trustedPublisher": {


### PR DESCRIPTION
## Summary

- Adds `@peac/mcp-server` to `scripts/publish-manifest.json` (was missing, causing the package to stay at 0.10.13 on npm while all other 27 packages were at 0.11.2)
- Introduces `"5-server"` layer between `5-adapters` and `6-cli`, matching the package layering architecture
- Updates `totalPackages` from 27 to 28

## Test plan

- [ ] `pnpm build` passes
- [ ] `./scripts/check-publish-list.sh` passes with 28 packages
- [ ] `npm view @peac/mcp-server dist-tags` shows `latest: 0.11.2, next: 0.11.2`