### PR TITLE
docs: update API snippets, AGENTS.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -29,7 +29,7 @@ We take security vulnerabilities seriously. If you discover a security issue, pl
 
 ### Cryptographic Security
 
-- EdDSA (Ed25519) signatures (recommended) and ES256 (ECDSA P-256)
+- EdDSA (Ed25519) signatures (RFC 8032)
 - JWS Compact Serialization
 - Key rotation support via JWKS `kid` matching
 - Hardware security module support

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,22 +5,18 @@ Agent-readable metadata for PEAC Protocol.
 ## Identity
 
 - **Protocol**: PEAC (wire format: `peac-receipt/0.1`)
-- **Specification**: https://www.peacprotocol.org/specs/agent-identity
-- **Key Directory**: Discovered via issuer config chain: `iss` -> `/.well-known/peac-issuer.json` -> `jwks_uri` -> JWKS (see [PEAC-ISSUER.md](docs/specs/PEAC-ISSUER.md) Section 3.4)
-- **Algorithms**: EdDSA (Ed25519), ES256 (ECDSA P-256)
+- **Specification**: <https://www.peacprotocol.org>
+- **Key Discovery**: `iss` -> `/.well-known/peac-issuer.json` -> `jwks_uri` -> JWKS
+- **Algorithm**: EdDSA (Ed25519)
 
 ## Capabilities
 
-PEAC Protocol provides:
-
-- **Receipt Verification**: Cryptographic proof of access decisions
+- **Receipt Issuance and Verification**: Signed receipts (`peac-receipt/0.1` JWS) for verifiable interaction evidence
 - **Purpose Declaration**: Structured intent via `PEAC-Purpose` header
-- **Agent Identity**: Proof-of-control binding with `operator` and `user-delegated` control types
-- **Policy Evaluation**: Profile-based access control (strict/balanced/open)
+- **Agent Identity**: Proof-of-control binding (see [AGENT-IDENTITY.md](docs/specs/AGENT-IDENTITY.md))
+- **Policy Discovery**: Machine-readable terms at `/.well-known/peac.txt`
 
 ## Proof Methods
-
-Supported agent proof methods:
 
 | Method                   | Standard | Description                   |
 | ------------------------ | -------- | ----------------------------- |
@@ -31,12 +27,9 @@ Supported agent proof methods:
 
 ## MCP Integration
 
-PEAC receipts are attached to MCP (Model Context Protocol) messages via the Evidence Carrier Contract.
+PEAC receipts attach to MCP tool responses via the Evidence Carrier Contract.
 
-**JSON-RPC Response (`_meta` carrier, v0.11.1+):**
-
-Per MCP specification (2025-11-25), use reverse-DNS keys in `_meta` to avoid collisions.
-The `org.peacprotocol/` prefix is not reserved (second label is `peacprotocol`, not `modelcontextprotocol` or `mcp`).
+**JSON-RPC Response (`_meta` carrier):**
 
 ```json
 {
@@ -46,15 +39,11 @@ The `org.peacprotocol/` prefix is not reserved (second label is `peacprotocol`, 
     "content": [...],
     "_meta": {
       "org.peacprotocol/receipt_ref": "sha256:abc123...",
-      "org.peacprotocol/receipt_jws": "eyJhbGciOiJFZERTQSIsInR5cCI6InBlYWMtcmVjZWlwdC8wLjEifQ...",
-      "org.peacprotocol/agent_id": "assistant:example",
-      "org.peacprotocol/verified_at": "2026-01-30T12:00:00Z"
+      "org.peacprotocol/receipt_jws": "eyJhbGciOiJFZERTQSIsInR5cCI6InBlYWMtcmVjZWlwdC8wLjEifQ..."
     }
   }
 }
 ```
-
-**Legacy format (v0.10.13):** The `org.peacprotocol/receipt` key (JWS string without `receipt_ref`) is still readable for backward compatibility. New integrations SHOULD use the carrier format above.
 
 **HTTP Transport:**
 
@@ -62,7 +51,7 @@ The `org.peacprotocol/` prefix is not reserved (second label is `peacprotocol`, 
 PEAC-Receipt: eyJhbGciOiJFZERTQSIsInR5cCI6InBlYWMtcmVjZWlwdC8wLjEifQ...
 ```
 
-The `PEAC-Receipt` header always carries a compact JWS (never a bare `receipt_ref`).
+The `PEAC-Receipt` header carries a compact JWS (never a bare `receipt_ref`).
 
 ## A2A Agent Card Extension
 
@@ -107,12 +96,11 @@ The extension URI key maps to a nested object containing the carrier array. This
 
 ## Discovery
 
-| Path                            | Content                              | Specification                                           |
-| ------------------------------- | ------------------------------------ | ------------------------------------------------------- |
-| `/.well-known/peac.txt`         | Policy manifest                      | [PEAC-TXT.md](docs/specs/PEAC-TXT.md)                   |
-| `/.well-known/peac-policy.yaml` | Policy document (fallback)           | [PEAC-TXT.md](docs/specs/PEAC-TXT.md)                   |
-| `/.well-known/peac-issuer.json` | Issuer config and key discovery      | [PEAC-ISSUER.md](docs/specs/PEAC-ISSUER.md)             |
-| `/.well-known/agent-card.json`  | A2A Agent Card (with PEAC extension) | [DISCOVERY-PROFILE.md](docs/specs/DISCOVERY-PROFILE.md) |
+| Path                            | Content                         | Specification                                           |
+| ------------------------------- | ------------------------------- | ------------------------------------------------------- |
+| `/.well-known/peac.txt`         | Policy manifest                 | [PEAC-TXT.md](docs/specs/PEAC-TXT.md)                   |
+| `/.well-known/peac-issuer.json` | Issuer config and key discovery | [PEAC-ISSUER.md](docs/specs/PEAC-ISSUER.md)             |
+| `/.well-known/agent-card.json`  | A2A Agent Card (PEAC extension) | [DISCOVERY-PROFILE.md](docs/specs/DISCOVERY-PROFILE.md) |
 
 ## Purpose Tokens
 
@@ -128,6 +116,6 @@ Canonical PEAC purpose vocabulary:
 
 ## Contact
 
-- **Specification**: https://www.peacprotocol.org
-- **Repository**: https://github.com/peacprotocol/peac
-- **Issues**: https://github.com/peacprotocol/peac/issues
+- **Specification**: <https://www.peacprotocol.org>
+- **Repository**: <https://github.com/peacprotocol/peac>
+- **Issues**: <https://github.com/peacprotocol/peac/issues>

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 **PEAC's approach:** Standardize machine-readable policies and cryptographically signed receipts that create verifiable evidence at interaction time. Verification is offline and deterministic; it doesn't require trusting the issuer's live systems.
 
-**Result:** Security teams get verifiable evidence for incident response. Compliance teams can prove what terms applied. Billing disputes resolve with cryptographic proof. AI safety reviews have portable artifacts to analyze.
+**Enables:** Verifiable evidence for incident response and compliance. Billing disputes resolve with cryptographic proof. AI safety reviews have portable artifacts to analyze.
 
 ## The model
 
@@ -94,15 +94,12 @@ flowchart LR
 `/.well-known/peac.txt`: machine-readable terms (YAML):
 
 ```yaml
-version: 0.9.2
-protocol: peac
-peac:
-  consent:
-    ai_training: conditional
-  economics:
-    pricing: $0.01/gb
-  attribution:
-    required: true
+version: 'peac-policy/0.1'
+usage: conditional
+purposes: [crawl, index, inference]
+receipts: required
+attribution: required
+rate_limit: '100/hour'
 ```
 
 `PEAC-Receipt` header: signed proof returned on governed responses:
@@ -131,9 +128,9 @@ This repository contains the **reference TypeScript implementation** and a **Go 
 
 ---
 
-## PEAC vs. alternatives
+## Internal logs vs. portable receipts
 
-| Concern                    | Internal Logs             | PEAC Receipts                               |
+| Property                   | Internal Logs             | Portable Receipts                           |
 | -------------------------- | ------------------------- | ------------------------------------------- |
 | **Portability**            | Locked in vendor systems  | Portable across orgs                        |
 | **Verifiability**          | Trust the log owner       | Cryptographic proof (offline)               |
@@ -148,7 +145,7 @@ PEAC is the evidence layer. It records what happened in a format that survives o
 
 - **Neutral by design:** Records what happened in a portable, verifiable format
 - **Offline-verifiable:** Verification is deterministic and can run without network access
-- **Interoperable:** Works alongside HTTP and MCP today (stdio and Streamable HTTP transports); A2A and streaming bindings are specified/planned
+- **Interoperable:** Works alongside HTTP, MCP (stdio and Streamable HTTP), and A2A today; additional transport mappings for ACP, UCP, and x402
 - **Privacy-aware:** Receipts are structured for auditability while supporting minimization and selective disclosure via bundles
 - **Open source:** Apache-2.0 licensed, designed for multiple independent implementations
 
@@ -171,26 +168,27 @@ pnpm add @peac/protocol
 ```typescript
 import { issue, verifyLocal, generateKeypair } from '@peac/protocol';
 
-// Generate a signing key
 const { privateKey, publicKey } = await generateKeypair();
 
-// Issue a receipt (minimal record)
 const { jws } = await issue({
   iss: 'https://api.example.com',
   aud: 'https://client.example.com',
+  amt: 100,
+  cur: 'USD',
+  rail: 'stripe',
+  reference: 'tx_abc123',
   subject: 'https://api.example.com/inference',
   privateKey,
-  kid: 'key-2026-01',
+  kid: 'key-2026-02-26',
 });
 
-// Verify with schema validation + binding checks
 const result = await verifyLocal(jws, publicKey, {
   issuer: 'https://api.example.com',
   audience: 'https://client.example.com',
 });
 
 if (result.valid) {
-  console.log('Verified:', result.claims.iss, result.claims.sub);
+  console.log(result.variant, result.claims.iss);
 }
 ```
 
@@ -218,7 +216,7 @@ See [examples/quickstart/](examples/quickstart/) for runnable code. For settleme
 
 ## CLI
 
-> **Note:** `@peac/cli` may not be published to npm yet. From this repo root: `pnpm install && pnpm --filter @peac/cli exec peac --help`.
+> Install: `pnpm add @peac/cli` or run from this repo: `pnpm --filter @peac/cli exec peac --help`.
 
 ```bash
 peac verify 'eyJhbGc...'                # Verify a receipt
@@ -311,7 +309,9 @@ Stewardship: [Originary](https://www.originary.xyz/) and the open source communi
 - **TypeScript** (this repo): `@peac/protocol`, `@peac/cli`, `@peac/sdk-js`
 - **Go**: [sdks/go/](sdks/go/) native implementation
 - **MCP**: [MCP server](packages/mcp-server/) (5 tools) and [MCP carrier mapping](packages/mappings/mcp/)
+- **A2A**: [A2A carrier mapping](packages/mappings/a2a/) for agent-to-agent evidence
 - **HTTP middleware**: [Express](packages/middleware-express/) automatic receipt issuance
+- **x402**: [x402 adapter](packages/adapters/x402/) for machine payment evidence
 
 Building an implementation? [Open an issue](https://github.com/peacprotocol/peac/issues/new).
 

--- a/docs/README_LONG.md
+++ b/docs/README_LONG.md
@@ -27,7 +27,7 @@ The protocol works with generic HTTP 402 services, paywalls, routers, and data s
 **Web policy surfaces:**
 
 - `/.well-known/peac.txt` - PEAC policy surface
-- Compatibility with robots.txt, ai.txt, llm.txt, and AIPREF-style manifests
+- Content signal parsing: robots.txt (RFC 9309), Content-Usage (AIPREF), tdmrep.json (EU TDM Directive). Package: `@peac/mappings-content-signals`
 
 _Names above are illustrative examples for interoperability. PEAC is vendor-neutral and does not imply endorsement by, or affiliation with, these projects._
 
@@ -45,13 +45,13 @@ PEAC works as the receipts and verification layer for [x402](https://x402.org) p
 4. Server issues a signed `PEAC-Receipt` header proving payment
 5. Client can verify the receipt offline and reuse it within its validity window
 
-**Package:** `@peac/rails-x402` provides the adapter with full x402 v2 support (v1 fallback via `X402Dialect`).
+**Package:** `@peac/rails-x402` provides the payment rail integration with full x402 v2 support (v1 fallback via `X402Dialect`). `@peac/adapter-x402` provides the evidence carrier placement for x402 responses.
 
 See [examples/x402-node-server](../examples/x402-node-server) for a working implementation.
 
 ---
 
-**Package availability:** Some packages referenced below (CLI, middleware, adapters) may exist in this repo but not yet be published to npm. If so, run commands via `pnpm --filter <pkg> exec ...` from this repo root, or use the lower-level `@peac/protocol` APIs shown.
+**Package availability:** All packages listed below are published to npm at v0.11.2. Install via `pnpm add <package>` or run from this repo root via `pnpm --filter <pkg> exec ...`.
 
 ## Integration examples
 
@@ -89,8 +89,12 @@ app.get('/data', async (req, res) => {
   const body = { items: ['a', 'b', 'c'] };
   const { jws } = await issue({
     iss: 'https://api.example.com',
-    aud: req.headers['origin'] || 'https://client.example.com',
-    subject: '/data',
+    aud: 'https://client.example.com', // Use authenticated client identity, not Origin header
+    amt: 0,
+    cur: 'USD',
+    rail: 'free',
+    reference: `req_${Date.now()}`,
+    subject: 'https://api.example.com/data',
     privateKey,
     kid: 'key-2026-01',
   });
@@ -99,7 +103,7 @@ app.get('/data', async (req, res) => {
 });
 ```
 
-Clients retrieve the receipt from the `PEAC-Receipt` header and verify offline or store for audit.
+Clients retrieve the receipt from the `PEAC-Receipt` response header and verify offline or store for audit.
 
 ### Express middleware
 
@@ -137,6 +141,9 @@ PEAC is transport-agnostic. The most common binding is **HTTP/REST**, where rece
 | HTTP/REST (default) | Response header `PEAC-Receipt: <jws>`                   | Implemented |
 | MCP                 | Tool result `_meta` (carrier format)                    | Implemented |
 | A2A                 | Task/message/artifact metadata (extension URI)          | Implemented |
+| ACP                 | State transition metadata (carrier format)              | Implemented |
+| UCP                 | Webhook verification metadata (carrier format)          | Implemented |
+| x402                | Settlement response evidence                            | Implemented |
 | WebSocket/streaming | Periodic or terminal receipts for long-running sessions | Planned     |
 | Queues/batches      | NDJSON receipts verified offline via bundles            | Implemented |
 
@@ -178,7 +185,7 @@ A bundle contains receipts, policy snapshots, and a deterministic verification r
 peac bundle create --receipts ./receipts.ndjson --policy ./policy.yaml --output ./evidence.peacbundle
 peac bundle verify ./evidence.peacbundle --offline
 
-# From this repo root (always works when CLI is not published)
+# Or from this repo root
 pnpm --filter @peac/cli exec peac bundle create --receipts ./receipts.ndjson --policy ./policy.yaml --output ./evidence.peacbundle
 pnpm --filter @peac/cli exec peac bundle verify ./evidence.peacbundle --offline
 ```
@@ -208,7 +215,7 @@ PEAC is not a paywall, billing engine, or storage system. It is the records laye
 
 - Receipt type: `typ: "peac-receipt/0.1"` (frozen across v0.x)
 - Envelope structure: `PEACEnvelope` with auth, payment evidence, and metadata
-- Signature: EdDSA (Ed25519, RFC 8032) or ES256 (ECDSA P-256)
+- Signature: EdDSA (Ed25519, RFC 8032)
 - Evidence model: `PaymentEvidence` captures rail, asset, environment, and rail-specific proof
 
 **HTTP:**
@@ -238,7 +245,7 @@ Declares allowed purposes, quotas, attribution requirements, payment terms, and 
 
 ```yaml
 # /.well-known/peac.txt
-version: '0.9'
+version: 'peac-policy/0.1'
 usage: open
 
 purposes: [crawl, index, search]
@@ -254,7 +261,7 @@ contact: docs@example.com
 **Example: Conditional API access**
 
 ```yaml
-version: '0.9'
+version: 'peac-policy/0.1'
 usage: conditional
 
 purposes: [inference, ai_input]
@@ -277,9 +284,10 @@ contact: api-support@example.com
 1. Agent fetches `/.well-known/peac.txt`
 2. Checks if purpose and volume comply with published policy
 3. If payment required, settles via rail (x402, Stripe, etc.)
-4. Obtains signed PEAC receipt
-5. Calls API with `PEAC-Receipt: <jws>` header
-6. Server verifies receipt and grants access
+4. Agent calls API; server returns `PEAC-Receipt: <jws>` response header as proof of the interaction
+5. Agent verifies receipt offline and stores for audit
+
+Optionally, if the service supports receipt-presented access, clients may present a previously obtained receipt on subsequent requests. This is not required by the protocol.
 
 For the complete peac.txt specification, see `docs/specs/PEAC-TXT.md`.
 
@@ -305,7 +313,7 @@ Enables verifiers to discover JWKS endpoints and verification configuration for 
   "jwks_uri": "https://api.example.com/.well-known/jwks.json",
   "verify_endpoint": "https://api.example.com/verify",
   "receipt_versions": ["peac-receipt/0.1"],
-  "algorithms": ["EdDSA", "ES256"],
+  "algorithms": ["EdDSA"],
   "payment_rails": ["x402", "stripe"],
   "security_contact": "security@example.com"
 }
@@ -328,7 +336,7 @@ For the complete specification, see `docs/specs/PEAC-ISSUER.md`.
 PEAC sits alongside existing policy mechanisms rather than replacing them. A PEAC-aware agent or enforcement service can:
 
 1. Read peac.txt for economic and receipt requirements.
-2. Read robots.txt, ai.txt, llm.txt, and AIPREF-style manifests for crawl and AI usage guidance.
+2. Read robots.txt (RFC 9309), Content-Usage headers (AIPREF), and tdmrep.json (EU TDM Directive) for crawl and AI usage guidance. The `@peac/mappings-content-signals` package parses all three with source precedence resolution.
 3. Combine these inputs into a single internal policy view before negotiating or sending a request.
 
 ---
@@ -465,7 +473,8 @@ peac/
 │  ├─ middleware-express/   # Express middleware
 │  ├─ adapters/
 │  │  ├─ openclaw/         # OpenClaw agent framework adapter
-│  │  └─ x402/             # x402 adapter (v1/v2 with dialect detection)
+│  │  ├─ x402/             # x402 adapter (v1/v2 with dialect detection)
+│  │  └─ openai-compatible/ # Hash-first inference receipt adapter
 │  ├─ rails/
 │  │  ├─ x402/             # HTTP 402 / x402 payment rail
 │  │  ├─ stripe/           # Stripe payment rail
@@ -475,7 +484,8 @@ peac/
 │  │  ├─ acp/              # Agentic Commerce Protocol mapping
 │  │  ├─ a2a/              # A2A Protocol mapping
 │  │  ├─ ucp/              # Universal Commerce Protocol mapping
-│  │  └─ rsl/              # RSL usage token mapping
+│  │  ├─ rsl/              # RSL usage token mapping
+│  │  └─ content-signals/  # Content use policy signal parsing
 │  ├─ policy-kit/          # Policy authoring and artifact generation
 │  ├─ transport/
 │  │  ├─ grpc/             # gRPC transport binding
@@ -486,6 +496,8 @@ peac/
 │  └─ ...                  # Additional packages
 ├─ sdks/
 │  └─ go/                  # Go SDK (verifier + middleware)
+├─ surfaces/               # Distribution artifacts (plugin-pack, analytics, workers)
+├─ integrator-kits/        # Integration checklists for ecosystem transports
 ├─ examples/               # Canonical flow examples
 └─ archive/                # Legacy pre-v0.9.15 materials (historical)
 ```
@@ -517,7 +529,7 @@ Dependencies flow DOWN only. Never import from a higher layer.
 | ---------------- | --------------------------------------------- |
 | `@peac/kernel`   | Zero-dependency constants and registries      |
 | `@peac/schema`   | TypeScript types, Zod validators, JSON Schema |
-| `@peac/crypto`   | EdDSA/ES256 JWS signing and verification      |
+| `@peac/crypto`   | EdDSA (Ed25519) JWS signing and verification  |
 | `@peac/protocol` | High-level issue() and verify() functions     |
 | `@peac/control`  | Constraint types and enforcement (CAL)        |
 
@@ -540,15 +552,16 @@ Dependencies flow DOWN only. Never import from a higher layer.
 
 **Mappings (stable):**
 
-| Package                 | Description                                                 |
-| ----------------------- | ----------------------------------------------------------- |
-| `@peac/mappings-mcp`    | Model Context Protocol integration with carrier format      |
-| `@peac/mappings-acp`    | Agentic Commerce Protocol integration with budget utilities |
-| `@peac/mappings-a2a`    | A2A Protocol mapping with agent card discovery              |
-| `@peac/mappings-rsl`    | RSL (Robots Standard Language) mapping to CAL purposes      |
-| `@peac/mappings-tap`    | Visa TAP mapping                                            |
-| `@peac/mappings-aipref` | IETF AIPREF vocabulary mapping                              |
-| `@peac/mappings-ucp`    | Universal Commerce Protocol webhook verification            |
+| Package                          | Description                                                         |
+| -------------------------------- | ------------------------------------------------------------------- |
+| `@peac/mappings-mcp`             | Model Context Protocol integration with carrier format              |
+| `@peac/mappings-acp`             | Agentic Commerce Protocol integration with budget utilities         |
+| `@peac/mappings-a2a`             | A2A Protocol mapping with agent card discovery                      |
+| `@peac/mappings-rsl`             | RSL (Robots Standard Language) mapping to CAL purposes              |
+| `@peac/mappings-tap`             | Visa TAP mapping                                                    |
+| `@peac/mappings-aipref`          | IETF AIPREF vocabulary mapping                                      |
+| `@peac/mappings-ucp`             | Universal Commerce Protocol webhook verification                    |
+| `@peac/mappings-content-signals` | Content use policy signal parsing (robots.txt, AIPREF, tdmrep.json) |
 
 **Policy (stable):**
 
@@ -587,10 +600,11 @@ Dependencies flow DOWN only. Never import from a higher layer.
 
 **Adapters:**
 
-| Package                  | Description                                 |
-| ------------------------ | ------------------------------------------- |
-| `@peac/adapter-openclaw` | OpenClaw agent framework integration        |
-| `@peac/adapter-x402`     | x402 adapter (v1/v2 with dialect detection) |
+| Package                           | Description                                                     |
+| --------------------------------- | --------------------------------------------------------------- |
+| `@peac/adapter-openclaw`          | OpenClaw agent framework integration                            |
+| `@peac/adapter-x402`              | x402 adapter (v1/v2 with dialect detection)                     |
+| `@peac/adapter-openai-compatible` | Hash-first inference receipt adapter for OpenAI-compatible APIs |
 
 **Attestations:**
 
@@ -624,7 +638,11 @@ const stepId = generateStepId();
 const { jws } = await issue({
   iss: 'https://api.example.com',
   aud: 'https://client.example.com',
-  subject: '/tools/search',
+  amt: 10,
+  cur: 'USD',
+  rail: 'x402',
+  reference: 'tx_search_001',
+  subject: 'https://api.example.com/tools/search',
   privateKey,
   kid: 'key-2026-01',
   ext: {

--- a/docs/integrations/openclaw.md
+++ b/docs/integrations/openclaw.md
@@ -337,7 +337,7 @@ aws s3 sync .peac/receipts s3://my-bucket/peac-receipts/
 
 1. Ensure JWKS includes the signing key
 2. Check `kid` matches between receipt and JWKS
-3. Verify algorithm compatibility (EdDSA, ES256, etc.)
+3. Verify algorithm compatibility (EdDSA/Ed25519 only)
 
 ### Performance issues
 

--- a/docs/specs/ISSUER-OPS-BASELINE.md
+++ b/docs/specs/ISSUER-OPS-BASELINE.md
@@ -15,11 +15,8 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 ### 2.1 Algorithm
 
 - Issuers MUST support Ed25519 (EdDSA, RFC 8032) for signing
-- Issuers MAY additionally support ES256 (ECDSA with P-256) for interoperability
-- Issuers MUST NOT use RSA or other algorithms for PEAC receipts
+- Issuers MUST NOT use RSA, ES256, or other algorithms for PEAC receipts
 - Ed25519 key size: 256 bits (32 bytes) for private key, 256 bits for public key
-
-**Recommendation**: Use Ed25519 as the default. ES256 is permitted for environments where Ed25519 is not available (e.g., some HSMs, legacy integrations).
 
 ### 2.2 Key generation
 

--- a/docs/specs/PEAC-ISSUER.md
+++ b/docs/specs/PEAC-ISSUER.md
@@ -121,10 +121,9 @@ Default if not specified: `["EdDSA"]`
 
 Supported algorithms:
 
-| Algorithm | Description                  |
-| --------- | ---------------------------- |
-| `EdDSA`   | Ed25519 (recommended)        |
-| `ES256`   | ECDSA with P-256 and SHA-256 |
+| Algorithm | Description        |
+| --------- | ------------------ |
+| `EdDSA`   | Ed25519 (RFC 8032) |
 
 ---
 
@@ -410,7 +409,7 @@ A verifier implementation MUST:
   "jwks_uri": "https://api.example.com/.well-known/jwks.json",
   "verify_endpoint": "https://api.example.com/peac/verify",
   "receipt_versions": ["peac-receipt/0.1"],
-  "algorithms": ["EdDSA", "ES256"],
+  "algorithms": ["EdDSA"],
   "payment_rails": ["x402", "stripe", "razorpay"],
   "security_contact": "https://api.example.com/.well-known/security.txt"
 }

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -98,7 +98,7 @@ Encoding: JWS Compact Serialization (RFC 7515)
 
 ## Algorithm Requirements
 
-- Signing: Ed25519 (RFC 8032) is REQUIRED; ES256 MAY be supported for interoperability
+- Signing: Ed25519 (RFC 8032) is REQUIRED (EdDSA only)
 - Digest: SHA-256 is REQUIRED for pointer profiles and content hashing
 - Encoding: Base64url (RFC 4648) for JWS components
 - JWK Thumbprint: RFC 7638 with SHA-256, base64url (no padding)


### PR DESCRIPTION
## Summary

- Fix `issue()` examples in README.md and docs/README_LONG.md with required commerce fields (`amt`, `cur`, `rail`, `reference`) and absolute `https://` subject URIs
- Clarify `PEAC-Receipt` as a response header in the protocol flow documentation

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm build` passes (81/81)
- [x] `pnpm test` passes (4642/4642)
- [x] `pnpm format:check` passes
- [x] `scripts/guard.sh` passes