### PR TITLE
fix: wire-02-minimal example version (0.0.0)

### DIFF
--- a/examples/wire-02-minimal/package.json
+++ b/examples/wire-02-minimal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/example-wire-02-minimal",
-  "version": "0.12.0-preview.1",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "demo": "tsx demo.ts"


### PR DESCRIPTION
## Summary
- Fix wire-02-minimal example version from `0.12.0-preview.1` to `0.0.0` per repo convention
- All examples use `0.0.0` (enforced by version-coherence gate)
- Unblocks v0.12.0-preview.1 release gate (14/14 gates)

## Test plan
- [x] `node scripts/check-version-sync.mjs` passes (18 examples at 0.0.0)
- [x] `bash scripts/release-gate-0.12.0-preview.1.sh` passes 14/14