### PR TITLE
fix: bump hono and @hono/node-server for audit

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -29,26 +29,26 @@
     "perf": "node scripts/perf-test.js"
   },
   "dependencies": {
+    "@hono/node-server": "^1.19.11",
     "@peac/core": "workspace:*",
     "@peac/crypto": "workspace:*",
     "@peac/disc": "workspace:*",
     "@peac/jwks-cache": "workspace:*",
     "@peac/middleware-core": "workspace:*",
+    "@peac/pay402": "workspace:*",
     "@peac/protocol": "workspace:*",
     "@peac/receipts": "workspace:*",
-    "@peac/pay402": "workspace:*",
-    "hono": "^4.12.2",
-    "@hono/node-server": "^1.19.9",
+    "hono": "^4.12.5",
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@types/node": "^22.19.11",
-    "typescript": "^5.0.0",
-    "jest": "^30.2.0",
     "@types/jest": "^30.0.0",
+    "@types/node": "^22.19.11",
+    "jest": "^30.2.0",
     "ts-jest": "^29.0.0",
+    "tsup": "^8.0.0",
     "tsx": "^4.21.0",
-    "tsup": "^8.0.0"
+    "typescript": "^5.0.0"
   },
   "keywords": [
     "peac",

--- a/apps/bridge/package.json
+++ b/apps/bridge/package.json
@@ -30,20 +30,20 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@hono/node-server": "^1.19.11",
     "@peac/core": "workspace:*",
     "@peac/disc": "workspace:*",
-    "@peac/receipts": "workspace:*",
     "@peac/pay402": "workspace:*",
-    "hono": "^4.12.2",
-    "@hono/node-server": "^1.19.9",
+    "@peac/receipts": "workspace:*",
+    "hono": "^4.12.5",
     "jose": "^5.0.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.19.11",
-    "typescript": "^5.0.0",
+    "tsup": "^8.0.0",
     "tsx": "^4.21.0",
-    "tsup": "^8.0.0"
+    "typescript": "^5.0.0"
   },
   "keywords": [
     "peac",

--- a/apps/sandbox-issuer/package.json
+++ b/apps/sandbox-issuer/package.json
@@ -15,18 +15,18 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@hono/node-server": "^1.19.11",
     "@peac/crypto": "workspace:*",
     "@peac/middleware-core": "workspace:*",
     "@peac/schema": "workspace:*",
-    "hono": "^4.12.2",
-    "@hono/node-server": "^1.19.9",
+    "hono": "^4.12.5",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.19.11",
-    "typescript": "^5.3.3",
-    "tsx": "^4.21.0",
     "tsup": "^8.0.0",
+    "tsx": "^4.21.0",
+    "typescript": "^5.3.3",
     "vitest": "^4.0.0"
   },
   "author": "jithinraj <7850727+jithinraj@users.noreply.github.com>",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -34,10 +34,10 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@peac/schema": "workspace:*",
+    "@hono/node-server": "^1.19.11",
     "@peac/protocol": "workspace:*",
-    "@hono/node-server": "^1.19.9",
-    "hono": "^4.12.2"
+    "@peac/schema": "workspace:*",
+    "hono": "^4.12.5"
   },
   "devDependencies": {
     "@types/node": "^22.19.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
   apps/api:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.19.9
-        version: 1.19.9(hono@4.12.2)
+        specifier: ^1.19.11
+        version: 1.19.11(hono@4.12.5)
       '@peac/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -96,8 +96,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/receipts
       hono:
-        specifier: ^4.12.2
-        version: 4.12.2
+        specifier: ^4.12.5
+        version: 4.12.5
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -127,8 +127,8 @@ importers:
   apps/bridge:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.19.9
-        version: 1.19.9(hono@4.12.2)
+        specifier: ^1.19.11
+        version: 1.19.11(hono@4.12.5)
       '@peac/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -142,8 +142,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/receipts
       hono:
-        specifier: ^4.12.2
-        version: 4.12.2
+        specifier: ^4.12.5
+        version: 4.12.5
       jose:
         specifier: ^5.0.0
         version: 5.10.0
@@ -167,8 +167,8 @@ importers:
   apps/sandbox-issuer:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.19.9
-        version: 1.19.9(hono@4.12.2)
+        specifier: ^1.19.11
+        version: 1.19.11(hono@4.12.5)
       '@peac/crypto':
         specifier: workspace:*
         version: link:../../packages/crypto
@@ -179,8 +179,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/schema
       hono:
-        specifier: ^4.12.2
-        version: 4.12.2
+        specifier: ^4.12.5
+        version: 4.12.5
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1612,8 +1612,8 @@ importers:
   packages/server:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.19.9
-        version: 1.19.9(hono@4.12.2)
+        specifier: ^1.19.11
+        version: 1.19.11(hono@4.12.5)
       '@peac/protocol':
         specifier: workspace:*
         version: link:../protocol
@@ -1621,8 +1621,8 @@ importers:
         specifier: workspace:*
         version: link:../schema
       hono:
-        specifier: ^4.12.2
-        version: 4.12.2
+        specifier: ^4.12.5
+        version: 4.12.5
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -3510,13 +3510,13 @@ packages:
       typescript: 5.9.3
     dev: true
 
-  /@hono/node-server@1.19.9(hono@4.12.2):
-    resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
+  /@hono/node-server@1.19.11(hono@4.12.5):
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
     dependencies:
-      hono: 4.12.2
+      hono: 4.12.5
     dev: false
 
   /@humanfs/core@0.19.1:
@@ -4287,7 +4287,7 @@ packages:
       '@cfworker/json-schema':
         optional: true
     dependencies:
-      '@hono/node-server': 1.19.9(hono@4.12.2)
+      '@hono/node-server': 1.19.11(hono@4.12.5)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -4297,7 +4297,7 @@ packages:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.2.1(express@5.2.1)
-      hono: 4.12.2
+      hono: 4.12.5
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -7541,8 +7541,8 @@ packages:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
     dev: true
 
-  /hono@4.12.2:
-    resolution: {integrity: sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==}
+  /hono@4.12.5:
+    resolution: {integrity: sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==}
     engines: {node: '>=16.9.0'}
     dev: false
 


### PR DESCRIPTION
## Summary

- Bump `hono` from `^4.12.2` to `^4.12.5` (fixes GHSA-q5qw-h33p-qvwr: serveStatic arbitrary file access)
- Bump `@hono/node-server` from `^1.19.9` to `^1.19.11` (fixes encoded slash bypass in Serve Static Middleware)
- Affects `apps/api`, `apps/bridge`, `apps/sandbox-issuer`, `packages/server` (internal, not published)

## Test plan

- [ ] `pnpm audit --prod` shows no high/critical vulnerabilities
- [ ] `pnpm build && pnpm test` passes