### PR TITLE
chore: harden quality gates

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -22,6 +22,14 @@ fi
 echo "[pre-commit] Running lint-staged (auto-format)..."
 pnpm exec lint-staged --concurrent false
 
+# Auto-sync error codegen when errors.json is staged
+if git diff --cached --name-only | grep -q 'specs/kernel/errors.json'; then
+  echo "[pre-commit] Detected staged errors.json: running codegen:errors..."
+  pnpm codegen:errors
+  git add packages/kernel/src/errors.generated.ts
+  echo "[pre-commit] errors.generated.ts updated and staged"
+fi
+
 echo "[pre-commit] Checking for planning leaks..."
 bash scripts/check-planning-leak.sh
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "verify:spec-drift": "node scripts/verify-spec-drift.mjs",
     "verify:bundle-drift": "node scripts/verify-bundle-drift.mjs",
     "codegen:errors": "tsx scripts/codegen-errors.ts",
+    "fixtures:new": "node scripts/fixtures-new.mjs",
     "conformance:regen:bundle": "tsx scripts/generate-bundle-vectors.ts",
     "bench": "pnpm --filter @peac/crypto bench && pnpm --filter @peac/schema bench && pnpm --filter @peac/protocol bench",
     "bench:capture": "node scripts/bench-capture.mjs",

--- a/scripts/check-publish-list.sh
+++ b/scripts/check-publish-list.sh
@@ -54,56 +54,15 @@ for (const p of pkgPaths) {
 console.log(pub.sort().join('\n'));
 ")
 
-# Expected packages (updated for v0.11.2 + content-signals + openai-compatible)
-EXPECTED_PACKAGES=$(cat <<'EOF'
-@peac/adapter-core
-@peac/adapter-openai-compatible
-@peac/adapter-openclaw
-@peac/adapter-x402
-@peac/adapter-x402-daydreams
-@peac/adapter-x402-fluora
-@peac/adapter-x402-pinata
-@peac/attribution
-@peac/audit
-@peac/capture-core
-@peac/capture-node
-@peac/cli
-@peac/contracts
-@peac/control
-@peac/core
-@peac/crypto
-@peac/disc
-@peac/http-signatures
-@peac/jwks-cache
-@peac/kernel
-@peac/mappings-a2a
-@peac/mappings-acp
-@peac/mappings-aipref
-@peac/mappings-content-signals
-@peac/mappings-mcp
-@peac/mappings-rsl
-@peac/mappings-tap
-@peac/mappings-ucp
-@peac/mcp-server
-@peac/middleware-core
-@peac/middleware-express
-@peac/net-node
-@peac/pay402
-@peac/policy-kit
-@peac/pref
-@peac/protocol
-@peac/rails-card
-@peac/rails-stripe
-@peac/rails-x402
-@peac/receipts
-@peac/schema
-@peac/sdk
-@peac/server
-@peac/telemetry
-@peac/telemetry-otel
-@peac/worker-core
-EOF
-)
+# Expected packages: derived from publish-manifest.json (single source of truth).
+# Combines packages[] (published) + pendingTrustedPublishing[] (pending).
+# When adding a new public package, update publish-manifest.json only.
+EXPECTED_PACKAGES=$(node -e "
+const manifest = require('./scripts/publish-manifest.json');
+const all = [...(manifest.packages || []), ...(manifest.pendingTrustedPublishing || [])];
+const sorted = [...new Set(all)].sort();
+console.log(sorted.join('\n'));
+")
 
 # Compare
 DIFF=$(diff <(echo "$EXPECTED_PACKAGES") <(echo "$ACTUAL_PACKAGES") || true)
@@ -114,10 +73,11 @@ if [ -n "$DIFF" ]; then
   echo "Difference (expected vs actual):"
   echo "$DIFF"
   echo ""
-  echo "Update the EXPECTED_PACKAGES list in this script or fix package.json files."
+  echo "Update scripts/publish-manifest.json (packages[] or pendingTrustedPublishing[]) or fix package.json files."
   exit 1
 else
-  echo "OK: All 46 public packages match"
+  TOTAL=$(echo "$ACTUAL_PACKAGES" | wc -l | tr -d ' ')
+  echo "OK: All $TOTAL public packages match"
   echo "$ACTUAL_PACKAGES" | wc -l | xargs -I{} echo "Total: {} packages"
 fi
 
@@ -181,7 +141,9 @@ echo ""
 echo "Packages without tests (17) - rationale:"
 echo "$NO_TESTS_RATIONALE" | sed 's/^/  /'
 echo ""
-echo "OK: All 46 packages accounted for (29 tested + 17 type/wrapper packages)"
+TESTED_COUNT=$(echo "$TESTED_PACKAGES" | wc -l | tr -d ' ')
+UNTESTED_COUNT=$(echo "$NO_TESTS_RATIONALE" | wc -l | tr -d ' ')
+echo "OK: All $((TESTED_COUNT + UNTESTED_COUNT)) packages accounted for ($TESTED_COUNT tested + $UNTESTED_COUNT type/wrapper packages)"
 
 echo ""
 echo "=== Checking for duplicate package names ==="

--- a/scripts/fixtures-new.mjs
+++ b/scripts/fixtures-new.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * scripts/fixtures-new.mjs
+ *
+ * Scaffold a new conformance fixture with correct structure and manifest entry.
+ * Prevents the "forgot schema_version" and "forgot manifest entry" failure modes.
+ *
+ * Usage:
+ *   node scripts/fixtures-new.mjs --category wire-02 --path replay-prevention/boundary-jti-length
+ *   node scripts/fixtures-new.mjs --category valid --path new-fixture
+ *
+ * Options:
+ *   --category    Top-level manifest category (e.g., wire-02, valid, invalid, edge)
+ *   --path        Fixture path relative to category (e.g., replay-prevention/boundary-jti-length)
+ *   --description Description for manifest entry (prompted if omitted)
+ *   --version     Protocol version (default: read from publish-manifest.json)
+ *   --count       Initial fixture_count for manifest (default: 1)
+ *   --dry-run     Print what would be created without writing
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { createInterface } from 'readline';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..');
+const FIXTURES_DIR = join(REPO_ROOT, 'specs', 'conformance', 'fixtures');
+const MANIFEST_PATH = join(FIXTURES_DIR, 'manifest.json');
+const PUBLISH_MANIFEST = join(REPO_ROOT, 'scripts', 'publish-manifest.json');
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const opts = { count: 1, dryRun: false };
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--category': opts.category = args[++i]; break;
+      case '--path': opts.path = args[++i]; break;
+      case '--description': opts.description = args[++i]; break;
+      case '--version': opts.version = args[++i]; break;
+      case '--count': opts.count = parseInt(args[++i], 10); break;
+      case '--dry-run': opts.dryRun = true; break;
+      case '--help': case '-h':
+        console.log('Usage: node scripts/fixtures-new.mjs --category <cat> --path <path> [--description <desc>] [--version <ver>] [--count <n>] [--dry-run]');
+        process.exit(0);
+    }
+  }
+  return opts;
+}
+
+async function prompt(question) {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+function getDefaultVersion() {
+  try {
+    const manifest = JSON.parse(readFileSync(PUBLISH_MANIFEST, 'utf-8'));
+    return manifest.version || '0.12.0-preview.1';
+  } catch {
+    return '0.12.0-preview.1';
+  }
+}
+
+async function main() {
+  const opts = parseArgs();
+
+  if (!opts.category) {
+    console.error('Error: --category is required');
+    process.exit(1);
+  }
+  if (!opts.path) {
+    console.error('Error: --path is required');
+    process.exit(1);
+  }
+
+  const version = opts.version || getDefaultVersion();
+  const description = opts.description || await prompt('Fixture description: ');
+
+  if (!description) {
+    console.error('Error: description is required');
+    process.exit(1);
+  }
+
+  // Determine file path
+  const fixturePath = opts.path.endsWith('.json') ? opts.path : `${opts.path}.json`;
+  const fullFixturePath = join(FIXTURES_DIR, opts.category, fixturePath);
+  const manifestKey = fixturePath;
+
+  // Build fixture content
+  const fixture = {
+    $comment: description,
+    version,
+    schema_version: version,
+    fixtures: [],
+  };
+
+  // Build manifest entry
+  const manifestEntry = {
+    description,
+    version,
+    fixture_count: opts.count,
+  };
+
+  if (opts.dryRun) {
+    console.log('\n--- DRY RUN ---\n');
+    console.log(`Fixture file: ${fullFixturePath}`);
+    console.log(JSON.stringify(fixture, null, 2));
+    console.log(`\nManifest entry [${opts.category}][${manifestKey}]:`);
+    console.log(JSON.stringify(manifestEntry, null, 2));
+    return;
+  }
+
+  // Create fixture file
+  const fixtureDir = dirname(fullFixturePath);
+  if (!existsSync(fixtureDir)) {
+    mkdirSync(fixtureDir, { recursive: true });
+    console.log(`Created directory: ${fixtureDir}`);
+  }
+
+  if (existsSync(fullFixturePath)) {
+    console.error(`Error: fixture already exists at ${fullFixturePath}`);
+    process.exit(1);
+  }
+
+  writeFileSync(fullFixturePath, JSON.stringify(fixture, null, 2) + '\n');
+  console.log(`Created fixture: ${fullFixturePath}`);
+
+  // Update manifest
+  const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf-8'));
+  if (!manifest[opts.category]) {
+    manifest[opts.category] = {};
+  }
+  manifest[opts.category][manifestKey] = manifestEntry;
+  writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2) + '\n');
+  console.log(`Updated manifest: added [${opts.category}][${manifestKey}]`);
+
+  // Validate
+  console.log('\nRunning fixture validation...');
+  const { execSync } = await import('child_process');
+  try {
+    execSync('node scripts/validate-fixtures.mjs', { cwd: REPO_ROOT, stdio: 'inherit' });
+    console.log('\nFixture validation passed.');
+  } catch {
+    console.error('\nFixture validation failed. Please fix issues above.');
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/guard.sh
+++ b/scripts/guard.sh
@@ -274,6 +274,39 @@ else
   echo "OK"
 fi
 
+echo "== MCP distribution surfaces =="
+# Validate server.json (MCP Registry schema), smithery.yaml, llms.txt existence
+MCP_DIST_OK=1
+if [ ! -f packages/mcp-server/server.json ]; then
+  echo "FAIL: packages/mcp-server/server.json missing"
+  MCP_DIST_OK=0
+elif ! node -e "JSON.parse(require('fs').readFileSync('packages/mcp-server/server.json','utf8'))" 2>/dev/null; then
+  echo "FAIL: packages/mcp-server/server.json is not valid JSON"
+  MCP_DIST_OK=0
+fi
+if [ ! -f packages/mcp-server/smithery.yaml ]; then
+  echo "FAIL: packages/mcp-server/smithery.yaml missing"
+  MCP_DIST_OK=0
+fi
+if [ ! -f llms.txt ]; then
+  echo "FAIL: llms.txt missing (repo root)"
+  MCP_DIST_OK=0
+fi
+# Verify server.json version matches monorepo version
+if [ -f packages/mcp-server/server.json ]; then
+  SERVER_VER=$(node -e "console.log(JSON.parse(require('fs').readFileSync('packages/mcp-server/server.json','utf8')).version)")
+  MONO_VER=$(node -e "console.log(JSON.parse(require('fs').readFileSync('package.json','utf8')).version)")
+  if [ "$SERVER_VER" != "$MONO_VER" ]; then
+    echo "FAIL: server.json version ($SERVER_VER) != monorepo version ($MONO_VER)"
+    MCP_DIST_OK=0
+  fi
+fi
+if [ "$MCP_DIST_OK" = "1" ]; then
+  echo "OK"
+else
+  bad=1
+fi
+
 echo "== no-network guard (DD-55) =="
 if [ -f scripts/check-no-network.mjs ]; then
   if node scripts/check-no-network.mjs > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- **Single source of truth for publish list:** `check-publish-list.sh` now derives its expected package list from `publish-manifest.json` instead of a hardcoded heredoc. Adding a new public package only requires updating `publish-manifest.json`.
- **Error codegen auto-sync:** Pre-commit hook detects staged `errors.json` and auto-runs `pnpm codegen:errors`, eliminating the "forgot to regenerate" failure mode.
- **Fixture scaffold helper:** `pnpm fixtures:new --category wire-02 --path ...` creates fixtures with correct `schema_version` + manifest entry, preventing the exact failures seen in PR #470.
- **MCP distribution surface gate:** Guard validates `server.json` (valid JSON + version coherence), `smithery.yaml`, and `llms.txt` existence.
- **Dynamic counts:** Package counts in check output are computed, not hardcoded.

## Motivation

These changes address three failure modes observed during v0.12.0-preview.2 PR review:
1. Publish list drift when adding `@peac/adapter-eat` (PR #474)
2. Fixture missing `schema_version` and manifest entry (PR #470)
3. Error codegen drift requiring manual `pnpm codegen:errors` (PR #474)

## Test plan

- [ ] `bash scripts/check-publish-list.sh` passes
- [ ] `bash scripts/guard.sh` passes (including new MCP distribution gate)
- [ ] `pnpm fixtures:new --dry-run --category wire-02 --path test --description "test"` prints expected output
- [ ] CI passes