### PR TITLE
fix: sync metadata to v0.12.0 stable

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,14 +1,14 @@
 cff-version: 1.2.0
-title: "PEAC: Verifiable Interaction Records for Machine-to-Machine Systems"
-message: "If you use PEAC, please cite this repository."
+title: 'PEAC: Verifiable Interaction Records for Machine-to-Machine Systems'
+message: 'If you use PEAC, please cite this repository.'
 type: software
 authors:
   - family-names: Raj
     given-names: Jithin
     email: contact@peacprotocol.org
-    orcid: "https://orcid.org/0009-0009-7602-1629"
-repository-code: "https://github.com/peacprotocol/peac"
-url: "https://www.peacprotocol.org"
+    orcid: 'https://orcid.org/0009-0009-7602-1629'
+repository-code: 'https://github.com/peacprotocol/peac'
+url: 'https://www.peacprotocol.org'
 abstract: >-
   PEAC is an open standard for verifiable interaction records across automated
   systems. It provides a transport-neutral receipt format built on JWS with
@@ -21,6 +21,6 @@ keywords:
   - api-billing
   - content-licensing
   - agent-protocols
-license: MIT
-version: "0.10.5"
-date-released: "2026-01-30"
+license: Apache-2.0
+version: '0.12.0'
+date-released: '2026-03-08'

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 .PHONY: help install dev build test lint typecheck clean conformance perf sbom release dep-check
 
 help: ## Show this help message
-	@echo "PEAC Protocol v0.10.9 - Monorepo"
+	@echo "PEAC Protocol v$$(grep '\"version\"' package.json | head -1 | sed -E 's/.*\"([^\"]+)\".*/\1/') - Monorepo"
 	@echo ""
 	@echo "Available commands:"
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/docs/VERIFY-RELEASE.md
+++ b/docs/VERIFY-RELEASE.md
@@ -20,7 +20,7 @@ The `--write-release-artifacts` flag is the authoritative gate path. Without it,
 
 PEAC packages published via GitHub Actions OIDC include npm provenance attestations. This cryptographically links each package version to the specific workflow run that produced it.
 
-**Current state (v0.12.0-preview.2):** 9 of 28 publishable packages are configured for OIDC trusted publishing. The remaining 19 are pending migration via `npm trust` CLI (tracked in PR 6a). All packages published through the CI workflow receive `--provenance` attestations regardless of OIDC status.
+**Current state (v0.12.0-preview.2):** All 28 publishable packages are configured for OIDC trusted publishing (PR #490). Two packages (`@peac/net-node`, `@peac/adapter-eat`) are deferred because they are not yet published to npm. All packages published through the CI workflow receive `--provenance` attestations.
 
 ```bash
 # Verify provenance for published packages


### PR DESCRIPTION
## Summary

Fixes factually incorrect metadata discovered during post-merge release-truth audit.

- **Makefile:** hard-coded `v0.10.9` -> dynamic version read from `package.json`
- **docs/VERIFY-RELEASE.md:** OIDC count "9 of 28" -> "all 28" (PR #490 completed migration)
-  CITATION.cff: Apache-2.0, version 0.10.5 -> 0.12.0


## Context

These files were independently stale (not related to the PR #493 release-prep changes). Found during systematic >15-day staleness audit of root-level files.

## Test plan

- [ ] `make help` shows correct dynamic version
- [ ] `CITATION.cff` passes GitHub citation widget validation
- [ ] No other file changes