### PR TITLE
fix: adapter-eat ESM interop and issuer property-test determinism

### DIFF
--- a/packages/adapters/eat/src/passport.ts
+++ b/packages/adapters/eat/src/passport.ts
@@ -18,7 +18,10 @@
  *   - No network I/O (DD-55)
  */
 
-import { decode as cborDecode, encode as cborEncode } from 'cbor';
+import cbor from 'cbor';
+
+const cborDecode = cbor.decode;
+const cborEncode = cbor.encode;
 import { ed25519Verify } from '@peac/crypto';
 import type { CoseSign1, CoseProtectedHeaders, EatClaims, EatPassportResult } from './types.js';
 import { COSE_ALG, EAT_SIZE_LIMIT } from './types.js';

--- a/packages/schema/__tests__/wire02-claims.property.test.ts
+++ b/packages/schema/__tests__/wire02-claims.property.test.ts
@@ -18,10 +18,11 @@ import { Wire02ClaimsSchema, isCanonicalIss, isValidReceiptType } from '../src/i
 /** Generate a valid canonical issuer (https:// origin) */
 const validIss = fc
   .tuple(
-    fc.stringMatching(/^[a-z][a-z0-9-]{0,20}$/),
+    fc.stringMatching(/^[a-z][a-z0-9]{0,20}$/),
     fc.constantFrom('.com', '.org', '.net', '.io', '.dev')
   )
-  .map(([host, tld]) => `https://${host}${tld}`);
+  .map(([host, tld]) => `https://${host}${tld}`)
+  .filter(isCanonicalIss);
 
 /** Generate a valid reverse-DNS receipt type */
 const validType = fc


### PR DESCRIPTION
## Summary

Fixes two code-level issues surfaced during stable-gate verification.

This PR:
- restores Node ESM/CJS interop in `@peac/adapter-eat`
- makes the issuer property test deterministic against canonical issuer constraints

No protocol surface, release scope, or public documentation contract is changed by this PR.

## Changes

### `@peac/adapter-eat`: ESM/CJS interop

The `cbor` package is CommonJS-only. Named-export destructuring under Node ESM (`import { decode } from 'cbor'`) is not reliable for this package.

This PR switches to default-import interop:

- before: `import { decode } from 'cbor'`
- after: `import cbor from 'cbor'`

This restores build/install compatibility for the adapter package under the current Node ESM path.

### Issuer property-test determinism

The `validIss` arbitrary in `wire02-claims.property.test.ts` could generate issuer labels accepted by the regex but later rejected by `isCanonicalIss()` during URL canonicalization.

This PR tightens the generator and adds a predicate guard:

- removes `-` from the generated label character class
- applies `isCanonicalIss()` as an additional filter

This keeps the property focused on canonical issuer inputs and removes invalid-generator noise from the test path.

## Validation

- `pnpm --filter @peac/adapter-eat build` passes
- `scripts/release/pack-install-smoke.sh` reports `@peac/adapter-eat` passing
- `@peac/adapter-eat` unit tests pass
- property tests pass
- `bash scripts/release/run-gates.sh --target stable` passes all code-driven gates