### PR TITLE
test: add repeated-run benchmark aggregation and CI artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,15 +240,20 @@ jobs:
           fi
           echo "OK: Working tree is clean after tests"
 
-      - name: Performance gate (advisory)
+      - name: Performance SLO gate (advisory)
         continue-on-error: true
         run: |
-          # Advisory benchmark for verify performance. Can be tightened once bench harness is updated.
-          if ! pnpm exec tsx --help >/dev/null 2>&1; then
-            echo "Skipping performance bench: tsx not available or not installed correctly."
-            exit 0
-          fi
-          pnpm exec tsx scripts/bench-verify.ts
+          PEAC_BENCH_JSON="tests/perf/ci-bench-result.json" \
+            pnpm exec vitest run tests/perf/wire02-slo.test.ts --reporter=dot
+
+      - name: Upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: benchmark-results-${{ github.sha }}
+          path: tests/perf/ci-bench-result.json
+          if-no-files-found: ignore
+          retention-days: 90
 
   # Windows smoke test for audit gate (validates pnpm.cmd, ENOENT handling,
   # cwd pinning, and noisy-stdout parsing work cross-platform)

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ test-results/
 .test-output/
 playwright-report/
 perf-results.json
+tests/perf/ci-bench-result.json
+tests/perf/repeated-results.json
 
 # Environment
 .env

--- a/scripts/bench-repeated.sh
+++ b/scripts/bench-repeated.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Repeated-run benchmark aggregation (DD-159 follow-up)
+#
+# Runs the Wire 0.2 SLO gate N times (default 5), collects JSON metrics
+# from each run, and aggregates cross-run statistics (median, min, max p95).
+#
+# Output: writes aggregated results to tests/perf/repeated-results.json
+# (or the path specified by --output).
+#
+# Usage:
+#   bash scripts/bench-repeated.sh
+#   bash scripts/bench-repeated.sh --runs 10
+#   bash scripts/bench-repeated.sh --output /tmp/bench.json
+#
+# Flags:
+#   --runs <N>       Number of runs (default: 5)
+#   --output <path>  Output file path (default: tests/perf/repeated-results.json)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+RUNS=5
+OUTPUT="tests/perf/repeated-results.json"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --runs)
+      RUNS="$2"
+      shift 2
+      ;;
+    --output)
+      OUTPUT="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      echo "Usage: $0 [--runs <N>] [--output <path>]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+TEMP_DIR=$(mktemp -d)
+cleanup() {
+  rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
+
+echo "=== Repeated Benchmark Run ==="
+echo "  Runs: $RUNS"
+echo "  Output: $OUTPUT"
+echo ""
+
+FAILED_RUNS=0
+
+for i in $(seq 1 "$RUNS"); do
+  JSON_FILE="$TEMP_DIR/run-${i}.json"
+  echo -n "  Run $i/$RUNS... "
+  if PEAC_BENCH_JSON="$JSON_FILE" pnpm exec vitest run tests/perf/wire02-slo.test.ts --reporter=dot > /dev/null 2>&1; then
+    if [ -f "$JSON_FILE" ]; then
+      echo "OK"
+    else
+      echo "PASS (no JSON output)"
+      FAILED_RUNS=$((FAILED_RUNS + 1))
+    fi
+  else
+    echo "FAIL (SLO gate failed)"
+    FAILED_RUNS=$((FAILED_RUNS + 1))
+  fi
+done
+
+echo ""
+
+if [ "$FAILED_RUNS" -eq "$RUNS" ]; then
+  echo "ERROR: All $RUNS runs failed. No results to aggregate."
+  exit 1
+fi
+
+# Aggregate results
+node -e '
+  const fs = require("fs");
+  const path = require("path");
+  const os = require("os");
+
+  const tempDir = process.argv[1];
+  const runs = parseInt(process.argv[2], 10);
+  const outputPath = process.argv[3];
+
+  const results = [];
+  for (let i = 1; i <= runs; i++) {
+    const file = path.join(tempDir, `run-${i}.json`);
+    if (fs.existsSync(file)) {
+      results.push(JSON.parse(fs.readFileSync(file, "utf-8")));
+    }
+  }
+
+  if (results.length === 0) {
+    console.error("No valid run results found.");
+    process.exit(1);
+  }
+
+  function median(arr) {
+    const s = [...arr].sort((a, b) => a - b);
+    const mid = Math.floor(s.length / 2);
+    return s.length % 2 === 0 ? (s[mid - 1] + s[mid]) / 2 : s[mid];
+  }
+
+  function aggregate(key) {
+    const values = results
+      .filter(r => r.metrics && r.metrics[key])
+      .map(r => r.metrics[key]);
+    if (values.length === 0) return null;
+    const p95s = values.map(v => v.p95_ms);
+    const p50s = values.map(v => v.p50_ms);
+    const means = values.map(v => v.mean_ms);
+    return {
+      runs: values.length,
+      iterations_per_run: values[0].iterations,
+      p95_ms: {
+        median: +median(p95s).toFixed(4),
+        min: +Math.min(...p95s).toFixed(4),
+        max: +Math.max(...p95s).toFixed(4),
+        values: p95s.map(v => +v.toFixed(4)),
+      },
+      p50_ms: {
+        median: +median(p50s).toFixed(4),
+        min: +Math.min(...p50s).toFixed(4),
+        max: +Math.max(...p50s).toFixed(4),
+      },
+      mean_ms: {
+        median: +median(means).toFixed(4),
+        min: +Math.min(...means).toFixed(4),
+        max: +Math.max(...means).toFixed(4),
+      },
+    };
+  }
+
+  const output = {
+    timestamp: new Date().toISOString(),
+    node_version: process.version,
+    platform: `${process.platform}-${process.arch}`,
+    cpu: os.cpus()[0] ? os.cpus()[0].model : "unknown",
+    total_runs: runs,
+    successful_runs: results.length,
+    git_ref: "unknown",
+    peac_version: "unknown",
+    verifyLocal: aggregate("verifyLocal"),
+    issueWire02: aggregate("issueWire02"),
+  };
+
+  // Try to fill in git ref and version
+  try {
+    const pkg = JSON.parse(fs.readFileSync("package.json", "utf-8"));
+    output.peac_version = pkg.version || "unknown";
+  } catch {}
+  try {
+    const { execSync } = require("child_process");
+    output.git_ref = execSync("git rev-parse --short HEAD", { encoding: "utf-8" }).trim();
+  } catch {}
+
+  fs.writeFileSync(outputPath, JSON.stringify(output, null, 2) + "\n");
+  console.log("--- Aggregated Results ---");
+  if (output.verifyLocal) {
+    console.log(`  verifyLocal p95: median=${output.verifyLocal.p95_ms.median}ms, range=[${output.verifyLocal.p95_ms.min}, ${output.verifyLocal.p95_ms.max}]ms (${output.verifyLocal.runs} runs)`);
+  }
+  if (output.issueWire02) {
+    console.log(`  issueWire02 p95: median=${output.issueWire02.p95_ms.median}ms, range=[${output.issueWire02.p95_ms.min}, ${output.issueWire02.p95_ms.max}]ms (${output.issueWire02.runs} runs)`);
+  }
+  console.log(`  Output: ${outputPath}`);
+' "$TEMP_DIR" "$RUNS" "$OUTPUT"
+
+echo ""
+echo "=== Repeated Benchmark Complete ==="

--- a/tests/perf/wire02-slo.test.ts
+++ b/tests/perf/wire02-slo.test.ts
@@ -6,12 +6,17 @@
  *
  * This test uses the same percentile approach as verify.bench.ts
  * but targets Wire 0.2 via issueWire02() and verifyLocal().
+ *
+ * Set PEAC_BENCH_JSON to a file path to write structured metrics
+ * (used by scripts/bench-repeated.sh for multi-run aggregation).
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterAll } from 'vitest';
 import { generateKeypair } from '@peac/crypto';
 import { issueWire02 } from '@peac/protocol';
 import { verifyLocal } from '@peac/protocol';
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 function percentile(sorted: number[], p: number): number {
   const index = Math.ceil((sorted.length * p) / 100) - 1;
@@ -31,7 +36,22 @@ function calculateMetrics(timings: number[]) {
   };
 }
 
+// Collected metrics for optional JSON output
+const collectedMetrics: Record<string, ReturnType<typeof calculateMetrics>> = {};
+
 describe('Wire 0.2 performance SLO (DD-159)', () => {
+  afterAll(() => {
+    const jsonPath = process.env.PEAC_BENCH_JSON;
+    if (!jsonPath) return;
+    const output = {
+      timestamp: new Date().toISOString(),
+      node_version: process.version,
+      platform: `${process.platform}-${process.arch}`,
+      metrics: collectedMetrics,
+    };
+    writeFileSync(resolve(jsonPath), JSON.stringify(output, null, 2) + '\n');
+  });
+
   it('verifyLocal p95 MUST be <= 10ms', async () => {
     const { privateKey, publicKey } = await generateKeypair();
 
@@ -67,6 +87,7 @@ describe('Wire 0.2 performance SLO (DD-159)', () => {
     }
 
     const metrics = calculateMetrics(timings);
+    collectedMetrics['verifyLocal'] = metrics;
 
     // CI gate: p95 <= 10ms
     expect(metrics.p95_ms).toBeLessThanOrEqual(10);
@@ -102,6 +123,7 @@ describe('Wire 0.2 performance SLO (DD-159)', () => {
     }
 
     const metrics = calculateMetrics(timings);
+    collectedMetrics['issueWire02'] = metrics;
 
     // Soft target: p95 <= 50ms
     expect(metrics.p95_ms).toBeLessThanOrEqual(50);


### PR DESCRIPTION
## Summary

Adds repeated-run benchmark aggregation and CI artifact capture for the performance SLO gate. This strengthens benchmark evidence by adding structured output, repeated-run aggregation, and Linux CI artifacts.

This PR:
- adds `PEAC_BENCH_JSON` env var to the SLO test for structured JSON metric output
- creates `scripts/bench-repeated.sh` for multi-run aggregation (median, min, max p95 across N runs)
- replaces the advisory CI benchmark step with the canonical SLO gate and uploads results as GitHub Actions artifacts

No runtime behavior, protocol surface, or public API contract is changed by this PR.

## Changes

- `tests/perf/wire02-slo.test.ts`: collect metrics into map; write JSON to `PEAC_BENCH_JSON` path in `afterAll` if set
- `scripts/bench-repeated.sh`: new script; runs SLO test N times (default 5), aggregates cross-run p95/p50/mean
- `.github/workflows/ci.yml`: replace legacy advisory benchmark with canonical SLO gate + artifact upload
- `.gitignore`: exclude generated benchmark result files

## Validation (sample local runs, not stable baselines)

Single run with JSON output:
```
verifyLocal p95: 1.51ms (500 iterations)
issueWire02 p95: 0.49ms (500 iterations)
```

Repeated run (3 runs, local validation):
```
verifyLocal p95: median=1.65ms, range=[1.59, 1.66]ms
issueWire02 p95: median=0.50ms, range=[0.49, 0.51]ms
```

Full repo checks pass: lint, build, test (5675), guard.

Closes #485