### PR TITLE
feat(schema,kernel): add attribution and purpose extension groups

### DIFF
--- a/docs/specs/WIRE-0.2.md
+++ b/docs/specs/WIRE-0.2.md
@@ -697,7 +697,7 @@ This ensures forward compatibility: new extension groups can be defined without 
 
 ### 12.9 Typed Accessor Helpers
 
-Ten typed accessor functions are provided by `@peac/schema`:
+Twelve typed accessor functions are provided by `@peac/schema`:
 
 - `getCommerceExtension(extensions)`
 - `getAccessExtension(extensions)`
@@ -709,6 +709,8 @@ Ten typed accessor functions are provided by `@peac/schema`:
 - `getSafetyExtension(extensions)`
 - `getComplianceExtension(extensions)`
 - `getProvenanceExtension(extensions)`
+- `getAttributionExtension(extensions)`
+- `getPurposeExtension(extensions)`
 
 Each returns `undefined` if the key is absent from the extensions record. If the key is present but the value fails schema validation, the accessor throws a `PEACError` with a leaf-precise RFC 6901 JSON Pointer identifying the invalid field (e.g., `/extensions/org.peacprotocol~1commerce/amount_minor`). Accessors use `Object.prototype.hasOwnProperty.call()` to prevent prototype pollution.
 
@@ -851,11 +853,57 @@ Records origin tracking and chain of custody as observations.
 
 `source_ref` string optional: opaque source reference identifier.
 
+`source_uri` and `build_provenance_uri` HTTPS URI hint optional: locator hints only; callers MUST NOT auto-fetch. Validated by HttpsUriHintSchema.
+
 `custody_chain` CustodyEntry[] optional max 16 items: ordered chain of custody events. Each entry is `.strict()` with custodian, action, and RFC 3339 timestamp.
 
 `slsa` SlsaLevel optional: structured SLSA-aligned metadata. Uses a track-based model; records metadata, does not certify compliance.
 
 `.strict()` rejects unknown properties: the provenance extension and all nested schemas use `.strict()` mode.
+
+### 12.15 Attribution Extension [WIRE02-EXT-055] [WIRE02-EXT-056] [WIRE02-EXT-057] [WIRE02-EXT-058] [WIRE02-EXT-059] [WIRE02-EXT-060]
+
+Records credit, obligations, and content signal observations. Not an identity attestation; records observed attribution metadata.
+
+| Field                   | Type           | Required | Max Length | Description                                                                                 |
+| ----------------------- | -------------- | -------- | ---------- | ------------------------------------------------------------------------------------------- |
+| `creator_ref`           | string         | REQUIRED | 256        | Creator identifier (DID, URI, or opaque ID)                                                 |
+| `license_spdx`          | SPDX expr      | OPTIONAL | 128        | SPDX license expression (parser-grade structural validator)                                 |
+| `obligation_type`       | string         | OPTIONAL | 128        | Obligation type (e.g., attribution_required, share_alike)                                   |
+| `attribution_text`      | string         | OPTIONAL | 1024       | Required attribution text                                                                   |
+| `content_signal_source` | enum           | OPTIONAL | N/A        | Signal source: tdmrep_json, content_signal_header, content_usage_header, robots_txt, custom |
+| `content_digest`        | SHA-256 digest | OPTIONAL | 71         | SHA-256 digest of the attributed content                                                    |
+
+`creator_ref` string REQUIRED: identifies the creator. Accepts DIDs, URIs, or opaque identifiers. Not an identity attestation.
+
+`license_spdx` SPDX expression optional: uses the parser-grade SPDX license expression validator.
+
+`content_signal_source` enum optional: tdmrep_json, content_signal_header, content_usage_header, robots_txt, custom. Closed vocabulary mapping to known content signal observation sources.
+
+`content_digest` SHA-256 digest optional: uses `Sha256DigestSchema` for typed digest validation.
+
+`.strict()` rejects unknown properties: the attribution extension uses `.strict()` mode; unrecognized fields are rejected.
+
+### 12.16 Purpose Extension [WIRE02-EXT-061] [WIRE02-EXT-062] [WIRE02-EXT-063] [WIRE02-EXT-064] [WIRE02-EXT-065] [WIRE02-EXT-066]
+
+Records external/legal/business purpose declarations as observations. Explicitly separated from PEAC operational purpose tokens.
+
+| Field                  | Type            | Required | Max Length | Description                                                |
+| ---------------------- | --------------- | -------- | ---------- | ---------------------------------------------------------- |
+| `external_purposes`    | array of string | REQUIRED | 32 items   | External purpose labels (token-based, machine-safe)        |
+| `purpose_basis`        | string          | OPTIONAL | 128        | Legal or policy basis (e.g., consent, legitimate_interest) |
+| `purpose_limitation`   | boolean         | OPTIONAL | N/A        | Whether purpose limitation applies                         |
+| `data_minimization`    | boolean         | OPTIONAL | N/A        | Whether data minimization was applied                      |
+| `compatible_purposes`  | array of string | OPTIONAL | 32 items   | Compatible purposes for secondary use (token-based)        |
+| `peac_purpose_mapping` | string          | OPTIONAL | 64         | Mapping to PEAC operational CanonicalPurpose token         |
+
+`external_purposes` string[] REQUIRED min 1 max 32 items: external/legal/business purpose labels. Each item MUST match the machine-safe token grammar and items MUST be unique. Not PEAC operational tokens.
+
+`purpose_basis` string optional: legal or policy basis for the declared purposes. Open vocabulary.
+
+`peac_purpose_mapping` string optional: explicit bridge to a PEAC operational CanonicalPurpose token. Validated against PURPOSE_TOKEN_REGEX.
+
+`.strict()` rejects unknown properties: the purpose extension uses `.strict()` mode; unrecognized fields are rejected.
 
 ---
 

--- a/packages/kernel/src/registries.generated.ts
+++ b/packages/kernel/src/registries.generated.ts
@@ -268,7 +268,7 @@ export const RECEIPT_TYPES: readonly ReceiptTypeEntry[] = [
     id: 'org.peacprotocol/attribution-event',
     pillar: 'attribution',
     description: 'Content or action attribution evidence',
-    extension_group: null,
+    extension_group: 'org.peacprotocol/attribution',
     status: 'informational',
   },
   {
@@ -317,7 +317,7 @@ export const RECEIPT_TYPES: readonly ReceiptTypeEntry[] = [
     id: 'org.peacprotocol/purpose-declaration',
     pillar: 'purpose',
     description: 'Purpose declaration or limitation evidence',
-    extension_group: null,
+    extension_group: 'org.peacprotocol/purpose',
     status: 'informational',
   },
   {
@@ -334,6 +334,12 @@ export const EXTENSION_GROUPS: readonly ExtensionGroupEntry[] = [
   {
     id: 'org.peacprotocol/access',
     description: 'Access extension: resource, action, decision (allow/deny/review)',
+    status: 'informational',
+  },
+  {
+    id: 'org.peacprotocol/attribution',
+    description:
+      'Attribution extension: creator_ref, license_spdx, obligation_type, attribution_text, content_signal_source, content_digest',
     status: 'informational',
   },
   {
@@ -381,6 +387,12 @@ export const EXTENSION_GROUPS: readonly ExtensionGroupEntry[] = [
     status: 'informational',
   },
   {
+    id: 'org.peacprotocol/purpose',
+    description:
+      'Purpose extension: external_purposes, purpose_basis, purpose_limitation, data_minimization, compatible_purposes, peac_purpose_mapping',
+    status: 'informational',
+  },
+  {
     id: 'org.peacprotocol/safety',
     description:
       'Safety extension: review_status, risk_level, assessment_method, safety_measures, incident_ref, model_ref, category',
@@ -395,12 +407,14 @@ export const EXTENSION_GROUPS: readonly ExtensionGroupEntry[] = [
  */
 export const TYPE_TO_EXTENSION_MAP: ReadonlyMap<string, string> = new Map([
   ['org.peacprotocol/access-decision', 'org.peacprotocol/access'],
+  ['org.peacprotocol/attribution-event', 'org.peacprotocol/attribution'],
   ['org.peacprotocol/compliance-check', 'org.peacprotocol/compliance'],
   ['org.peacprotocol/consent-record', 'org.peacprotocol/consent'],
   ['org.peacprotocol/identity-attestation', 'org.peacprotocol/identity'],
   ['org.peacprotocol/payment', 'org.peacprotocol/commerce'],
   ['org.peacprotocol/privacy-signal', 'org.peacprotocol/privacy'],
   ['org.peacprotocol/provenance-record', 'org.peacprotocol/provenance'],
+  ['org.peacprotocol/purpose-declaration', 'org.peacprotocol/purpose'],
   ['org.peacprotocol/safety-review', 'org.peacprotocol/safety'],
 ]);
 

--- a/packages/protocol/__tests__/verify-local-wire-02-warnings.test.ts
+++ b/packages/protocol/__tests__/verify-local-wire-02-warnings.test.ts
@@ -260,6 +260,54 @@ describe('verifyLocal(): unknown_extension_preserved warning', () => {
     }
   });
 
+  it('does not emit warning for registered attribution extension key', async () => {
+    const { privateKey, publicKey } = await generateKeypair();
+    const { jws } = await issueWire02({
+      iss: testIss,
+      kind: 'evidence',
+      type: 'org.peacprotocol/attribution-event',
+      pillars: ['attribution'],
+      extensions: {
+        'org.peacprotocol/attribution': {
+          creator_ref: 'did:web:example.com',
+        },
+      },
+      privateKey,
+      kid: testKid,
+    });
+
+    const result = await verifyLocal(jws, publicKey);
+
+    expect(result.valid).toBe(true);
+    if (result.valid && result.variant === 'wire-02') {
+      expect(result.warnings.some((w) => w.code === WARNING_UNKNOWN_EXTENSION)).toBe(false);
+    }
+  });
+
+  it('does not emit warning for registered purpose extension key', async () => {
+    const { privateKey, publicKey } = await generateKeypair();
+    const { jws } = await issueWire02({
+      iss: testIss,
+      kind: 'evidence',
+      type: 'org.peacprotocol/purpose-declaration',
+      pillars: ['purpose'],
+      extensions: {
+        'org.peacprotocol/purpose': {
+          external_purposes: ['ai_training'],
+        },
+      },
+      privateKey,
+      kid: testKid,
+    });
+
+    const result = await verifyLocal(jws, publicKey);
+
+    expect(result.valid).toBe(true);
+    if (result.valid && result.variant === 'wire-02') {
+      expect(result.warnings.some((w) => w.code === WARNING_UNKNOWN_EXTENSION)).toBe(false);
+    }
+  });
+
   it('does not emit warning for registered provenance extension key', async () => {
     const { privateKey, publicKey } = await generateKeypair();
     const { jws } = await issueWire02({

--- a/packages/schema/__tests__/wire-02-extensions-attribution-purpose.test.ts
+++ b/packages/schema/__tests__/wire-02-extensions-attribution-purpose.test.ts
@@ -1,0 +1,745 @@
+/**
+ * Wire 0.2 Extension Groups: Attribution, Purpose
+ *
+ * Covers:
+ *   - AttributionExtensionSchema: creator_ref, license_spdx, content_signal_source closed enum
+ *   - PurposeExtensionSchema: external_purposes token array, peac_purpose_mapping regex bridge
+ *   - Typed accessors: absent returns undefined, invalid throws PEACError with RFC 6901 pointer
+ *   - Wire02ClaimsSchema integration: extension validation in superRefine
+ *   - .strict() enforcement on both groups
+ *   - Shared validator integration: SpdxExpressionSchema, Sha256DigestSchema
+ *   - PURPOSE_TOKEN_REGEX bridging
+ *   - Bounds validation: maxLength, array count limits
+ *   - Registry derivation: generated constants include attribution + purpose
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, it, expect } from 'vitest';
+import {
+  // Attribution
+  AttributionExtensionSchema,
+  ContentSignalSourceSchema,
+  ATTRIBUTION_EXTENSION_KEY,
+  CONTENT_SIGNAL_SOURCES,
+  // Purpose
+  PurposeExtensionSchema,
+  PURPOSE_EXTENSION_KEY,
+  // Accessors
+  getAttributionExtension,
+  getPurposeExtension,
+  // Integration
+  Wire02ClaimsSchema,
+  EXTENSION_LIMITS,
+  // Registry derivation
+  REGISTERED_EXTENSION_GROUP_KEYS,
+  // Types
+  type Wire02Claims,
+  type PEACError,
+} from '../src/index.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function minimalEvidence(overrides?: Partial<Wire02Claims>): object {
+  return {
+    peac_version: '0.2',
+    kind: 'evidence',
+    type: 'org.peacprotocol/attribution-event',
+    iss: 'https://example.com',
+    iat: 1700000000,
+    jti: 'test-jti-ap-01',
+    ...overrides,
+  };
+}
+
+const VALID_ATTRIBUTION = {
+  creator_ref: 'did:web:example.com',
+};
+
+const VALID_ATTRIBUTION_FULL = {
+  ...VALID_ATTRIBUTION,
+  license_spdx: 'MIT',
+  obligation_type: 'attribution_required',
+  attribution_text: 'Created by Example Corp',
+  content_signal_source: 'tdmrep_json' as const,
+  content_digest: 'sha256:' + 'a'.repeat(64),
+};
+
+const VALID_PURPOSE = {
+  external_purposes: ['ai_training'],
+};
+
+const VALID_PURPOSE_FULL = {
+  ...VALID_PURPOSE,
+  external_purposes: ['ai_training', 'research'],
+  purpose_basis: 'consent',
+  purpose_limitation: true,
+  data_minimization: true,
+  compatible_purposes: ['analytics'],
+  peac_purpose_mapping: 'train',
+};
+
+// ---------------------------------------------------------------------------
+// AttributionExtensionSchema
+// ---------------------------------------------------------------------------
+
+describe('AttributionExtensionSchema', () => {
+  it('accepts minimal valid attribution extension', () => {
+    expect(AttributionExtensionSchema.safeParse(VALID_ATTRIBUTION).success).toBe(true);
+  });
+
+  it('accepts attribution with all optional fields', () => {
+    expect(AttributionExtensionSchema.safeParse(VALID_ATTRIBUTION_FULL).success).toBe(true);
+  });
+
+  // content_signal_source closed enum: exhaustive coverage
+  it('has exactly 5 content_signal_source values', () => {
+    expect(CONTENT_SIGNAL_SOURCES).toHaveLength(5);
+  });
+
+  for (const source of CONTENT_SIGNAL_SOURCES) {
+    it(`accepts content_signal_source: ${source}`, () => {
+      expect(ContentSignalSourceSchema.safeParse(source).success).toBe(true);
+    });
+  }
+
+  it('rejects unknown content_signal_source', () => {
+    expect(
+      AttributionExtensionSchema.safeParse({
+        ...VALID_ATTRIBUTION,
+        content_signal_source: 'unknown_source',
+      }).success
+    ).toBe(false);
+  });
+
+  // Required field validation
+  it('rejects missing creator_ref', () => {
+    expect(
+      AttributionExtensionSchema.safeParse({
+        license_spdx: 'MIT',
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects empty creator_ref', () => {
+    expect(
+      AttributionExtensionSchema.safeParse({
+        creator_ref: '',
+      }).success
+    ).toBe(false);
+  });
+
+  // Bounds validation
+  it('rejects creator_ref exceeding maxCreatorRefLength', () => {
+    expect(
+      AttributionExtensionSchema.safeParse({
+        creator_ref: 'x'.repeat(EXTENSION_LIMITS.maxCreatorRefLength + 1),
+      }).success
+    ).toBe(false);
+  });
+
+  it('accepts creator_ref at exactly maxCreatorRefLength', () => {
+    expect(
+      AttributionExtensionSchema.safeParse({
+        creator_ref: 'x'.repeat(EXTENSION_LIMITS.maxCreatorRefLength),
+      }).success
+    ).toBe(true);
+  });
+
+  it('rejects obligation_type exceeding bound', () => {
+    expect(
+      AttributionExtensionSchema.safeParse({
+        ...VALID_ATTRIBUTION,
+        obligation_type: 'x'.repeat(EXTENSION_LIMITS.maxObligationTypeLength + 1),
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects attribution_text exceeding maxAttributionTextLength', () => {
+    expect(
+      AttributionExtensionSchema.safeParse({
+        ...VALID_ATTRIBUTION,
+        attribution_text: 'x'.repeat(EXTENSION_LIMITS.maxAttributionTextLength + 1),
+      }).success
+    ).toBe(false);
+  });
+
+  // SPDX expression integration
+  it('accepts valid SPDX expressions', () => {
+    for (const expr of ['MIT', 'Apache-2.0', 'MIT AND Apache-2.0', 'GPL-2.0+']) {
+      expect(
+        AttributionExtensionSchema.safeParse({
+          ...VALID_ATTRIBUTION,
+          license_spdx: expr,
+        }).success
+      ).toBe(true);
+    }
+  });
+
+  it('rejects invalid SPDX expression', () => {
+    expect(
+      AttributionExtensionSchema.safeParse({
+        ...VALID_ATTRIBUTION,
+        license_spdx: '((invalid',
+      }).success
+    ).toBe(false);
+  });
+
+  // SHA-256 digest integration
+  it('accepts valid content_digest', () => {
+    expect(
+      AttributionExtensionSchema.safeParse({
+        ...VALID_ATTRIBUTION,
+        content_digest: 'sha256:' + 'b'.repeat(64),
+      }).success
+    ).toBe(true);
+  });
+
+  it('rejects content_digest with wrong prefix', () => {
+    expect(
+      AttributionExtensionSchema.safeParse({
+        ...VALID_ATTRIBUTION,
+        content_digest: 'md5:' + 'b'.repeat(32),
+      }).success
+    ).toBe(false);
+  });
+
+  // .strict() enforcement
+  it('rejects unknown fields (strict mode)', () => {
+    expect(
+      AttributionExtensionSchema.safeParse({
+        ...VALID_ATTRIBUTION,
+        unknown_field: 'should reject',
+      }).success
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PurposeExtensionSchema
+// ---------------------------------------------------------------------------
+
+describe('PurposeExtensionSchema', () => {
+  it('accepts minimal valid purpose extension', () => {
+    expect(PurposeExtensionSchema.safeParse(VALID_PURPOSE).success).toBe(true);
+  });
+
+  it('accepts purpose with all optional fields', () => {
+    expect(PurposeExtensionSchema.safeParse(VALID_PURPOSE_FULL).success).toBe(true);
+  });
+
+  // Required field validation
+  it('rejects missing external_purposes', () => {
+    expect(
+      PurposeExtensionSchema.safeParse({
+        purpose_basis: 'consent',
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects empty external_purposes array (min 1)', () => {
+    expect(
+      PurposeExtensionSchema.safeParse({
+        external_purposes: [],
+      }).success
+    ).toBe(false);
+  });
+
+  // Bounds validation
+  it('rejects external_purposes exceeding maxExternalPurposesCount', () => {
+    const purposes = Array.from(
+      { length: EXTENSION_LIMITS.maxExternalPurposesCount + 1 },
+      (_, i) => `purpose-${i}`
+    );
+    expect(PurposeExtensionSchema.safeParse({ external_purposes: purposes }).success).toBe(false);
+  });
+
+  it('accepts external_purposes at exactly maxExternalPurposesCount', () => {
+    const purposes = Array.from(
+      { length: EXTENSION_LIMITS.maxExternalPurposesCount },
+      (_, i) => `purpose-${i}`
+    );
+    expect(PurposeExtensionSchema.safeParse({ external_purposes: purposes }).success).toBe(true);
+  });
+
+  it('rejects external_purpose item exceeding maxExternalPurposeLength', () => {
+    expect(
+      PurposeExtensionSchema.safeParse({
+        external_purposes: ['x'.repeat(EXTENSION_LIMITS.maxExternalPurposeLength + 1)],
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects empty external_purpose item', () => {
+    expect(
+      PurposeExtensionSchema.safeParse({
+        external_purposes: [''],
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects purpose_basis exceeding maxPurposeBasisLength', () => {
+    expect(
+      PurposeExtensionSchema.safeParse({
+        ...VALID_PURPOSE,
+        purpose_basis: 'x'.repeat(EXTENSION_LIMITS.maxPurposeBasisLength + 1),
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects empty purpose_basis', () => {
+    expect(
+      PurposeExtensionSchema.safeParse({
+        ...VALID_PURPOSE,
+        purpose_basis: '',
+      }).success
+    ).toBe(false);
+  });
+
+  // PURPOSE_TOKEN_REGEX bridge
+  it('accepts valid peac_purpose_mapping tokens', () => {
+    for (const token of ['train', 'search', 'user_action', 'inference', 'index']) {
+      expect(
+        PurposeExtensionSchema.safeParse({
+          ...VALID_PURPOSE,
+          peac_purpose_mapping: token,
+        }).success
+      ).toBe(true);
+    }
+  });
+
+  it('accepts vendor-prefixed purpose token', () => {
+    expect(
+      PurposeExtensionSchema.safeParse({
+        ...VALID_PURPOSE,
+        peac_purpose_mapping: 'cf:ai_crawler',
+      }).success
+    ).toBe(true);
+  });
+
+  it('rejects uppercase purpose token', () => {
+    expect(
+      PurposeExtensionSchema.safeParse({
+        ...VALID_PURPOSE,
+        peac_purpose_mapping: 'TRAIN',
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects purpose token starting with digit', () => {
+    expect(
+      PurposeExtensionSchema.safeParse({
+        ...VALID_PURPOSE,
+        peac_purpose_mapping: '123abc',
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects purpose token with trailing hyphen', () => {
+    expect(
+      PurposeExtensionSchema.safeParse({
+        ...VALID_PURPOSE,
+        peac_purpose_mapping: 'train-',
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects empty peac_purpose_mapping', () => {
+    expect(
+      PurposeExtensionSchema.safeParse({
+        ...VALID_PURPOSE,
+        peac_purpose_mapping: '',
+      }).success
+    ).toBe(false);
+  });
+
+  // Boolean fields
+  it('accepts purpose_limitation true', () => {
+    expect(
+      PurposeExtensionSchema.safeParse({
+        ...VALID_PURPOSE,
+        purpose_limitation: true,
+      }).success
+    ).toBe(true);
+  });
+
+  it('accepts data_minimization false', () => {
+    expect(
+      PurposeExtensionSchema.safeParse({
+        ...VALID_PURPOSE,
+        data_minimization: false,
+      }).success
+    ).toBe(true);
+  });
+
+  it('rejects non-boolean purpose_limitation', () => {
+    expect(
+      PurposeExtensionSchema.safeParse({
+        ...VALID_PURPOSE,
+        purpose_limitation: 'yes',
+      }).success
+    ).toBe(false);
+  });
+
+  // Compatible purposes
+  it('rejects compatible_purposes exceeding maxCompatiblePurposesCount', () => {
+    const purposes = Array.from(
+      { length: EXTENSION_LIMITS.maxCompatiblePurposesCount + 1 },
+      (_, i) => `compat-${i}`
+    );
+    expect(
+      PurposeExtensionSchema.safeParse({
+        ...VALID_PURPOSE,
+        compatible_purposes: purposes,
+      }).success
+    ).toBe(false);
+  });
+
+  // .strict() enforcement
+  it('rejects unknown fields (strict mode)', () => {
+    expect(
+      PurposeExtensionSchema.safeParse({
+        ...VALID_PURPOSE,
+        unknown_field: 'should reject',
+      }).success
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Typed accessors: absent, valid, invalid
+// ---------------------------------------------------------------------------
+
+describe('Typed accessors: attribution, purpose', () => {
+  it('getAttributionExtension(): absent returns undefined', () => {
+    expect(getAttributionExtension({})).toBeUndefined();
+    expect(getAttributionExtension(undefined)).toBeUndefined();
+  });
+
+  it('getPurposeExtension(): absent returns undefined', () => {
+    expect(getPurposeExtension({})).toBeUndefined();
+    expect(getPurposeExtension(undefined)).toBeUndefined();
+  });
+
+  it('getAttributionExtension(): valid returns typed value', () => {
+    const result = getAttributionExtension({
+      [ATTRIBUTION_EXTENSION_KEY]: VALID_ATTRIBUTION_FULL,
+    });
+    expect(result).toBeDefined();
+    expect(result!.creator_ref).toBe('did:web:example.com');
+    expect(result!.license_spdx).toBe('MIT');
+    expect(result!.content_signal_source).toBe('tdmrep_json');
+  });
+
+  it('getPurposeExtension(): valid returns typed value', () => {
+    const result = getPurposeExtension({
+      [PURPOSE_EXTENSION_KEY]: VALID_PURPOSE_FULL,
+    });
+    expect(result).toBeDefined();
+    expect(result!.external_purposes).toEqual(['ai_training', 'research']);
+    expect(result!.peac_purpose_mapping).toBe('train');
+    expect(result!.purpose_limitation).toBe(true);
+  });
+
+  it('getAttributionExtension(): throws with pointer to creator_ref', () => {
+    try {
+      getAttributionExtension({
+        [ATTRIBUTION_EXTENSION_KEY]: {
+          license_spdx: 'MIT',
+        },
+      });
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      const e = err as PEACError;
+      expect(e.code).toBe('E_INVALID_ENVELOPE');
+      expect(e.pointer).toMatch(/^\/extensions\/org\.peacprotocol~1attribution/);
+    }
+  });
+
+  it('getPurposeExtension(): throws with pointer to external_purposes', () => {
+    try {
+      getPurposeExtension({
+        [PURPOSE_EXTENSION_KEY]: {
+          purpose_basis: 'consent',
+        },
+      });
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      const e = err as PEACError;
+      expect(e.code).toBe('E_INVALID_ENVELOPE');
+      expect(e.pointer).toMatch(/^\/extensions\/org\.peacprotocol~1purpose/);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wire02ClaimsSchema integration
+// ---------------------------------------------------------------------------
+
+describe('Wire02ClaimsSchema: attribution, purpose extension validation', () => {
+  it('accepts evidence with valid attribution extension', () => {
+    expect(
+      Wire02ClaimsSchema.safeParse(
+        minimalEvidence({
+          type: 'org.peacprotocol/attribution-event',
+          pillars: ['attribution'],
+          extensions: { [ATTRIBUTION_EXTENSION_KEY]: VALID_ATTRIBUTION },
+        })
+      ).success
+    ).toBe(true);
+  });
+
+  it('accepts evidence with valid purpose extension', () => {
+    expect(
+      Wire02ClaimsSchema.safeParse(
+        minimalEvidence({
+          type: 'org.peacprotocol/purpose-declaration',
+          pillars: ['purpose'],
+          extensions: { [PURPOSE_EXTENSION_KEY]: VALID_PURPOSE },
+        })
+      ).success
+    ).toBe(true);
+  });
+
+  it('rejects evidence with invalid attribution extension via superRefine', () => {
+    expect(
+      Wire02ClaimsSchema.safeParse(
+        minimalEvidence({
+          type: 'org.peacprotocol/attribution-event',
+          pillars: ['attribution'],
+          extensions: {
+            [ATTRIBUTION_EXTENSION_KEY]: { license_spdx: 'MIT' },
+          },
+        })
+      ).success
+    ).toBe(false);
+  });
+
+  it('rejects evidence with invalid purpose extension via superRefine', () => {
+    expect(
+      Wire02ClaimsSchema.safeParse(
+        minimalEvidence({
+          type: 'org.peacprotocol/purpose-declaration',
+          pillars: ['purpose'],
+          extensions: {
+            [PURPOSE_EXTENSION_KEY]: { purpose_basis: 'consent' },
+          },
+        })
+      ).success
+    ).toBe(false);
+  });
+
+  it('accepts evidence with both attribution and purpose extensions', () => {
+    expect(
+      Wire02ClaimsSchema.safeParse(
+        minimalEvidence({
+          type: 'org.peacprotocol/attribution-event',
+          pillars: ['attribution', 'purpose'],
+          extensions: {
+            [ATTRIBUTION_EXTENSION_KEY]: VALID_ATTRIBUTION,
+            [PURPOSE_EXTENSION_KEY]: VALID_PURPOSE,
+          },
+        })
+      ).success
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Extension key constants
+// ---------------------------------------------------------------------------
+
+describe('Extension key constants', () => {
+  it('ATTRIBUTION_EXTENSION_KEY is org.peacprotocol/attribution', () => {
+    expect(ATTRIBUTION_EXTENSION_KEY).toBe('org.peacprotocol/attribution');
+  });
+
+  it('PURPOSE_EXTENSION_KEY is org.peacprotocol/purpose', () => {
+    expect(PURPOSE_EXTENSION_KEY).toBe('org.peacprotocol/purpose');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Registry derivation
+// ---------------------------------------------------------------------------
+
+describe('Registry derivation: attribution + purpose keys are known', () => {
+  it('REGISTERED_EXTENSION_GROUP_KEYS contains attribution', () => {
+    expect(REGISTERED_EXTENSION_GROUP_KEYS.has(ATTRIBUTION_EXTENSION_KEY)).toBe(true);
+  });
+
+  it('REGISTERED_EXTENSION_GROUP_KEYS contains purpose', () => {
+    expect(REGISTERED_EXTENSION_GROUP_KEYS.has(PURPOSE_EXTENSION_KEY)).toBe(true);
+  });
+
+  it('REGISTERED_EXTENSION_GROUP_KEYS has exactly 12 entries', () => {
+    expect(REGISTERED_EXTENSION_GROUP_KEYS.size).toBe(12);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Recursive JSON-value rejection
+// ---------------------------------------------------------------------------
+
+describe('Wire02ClaimsSchema: rejects non-JSON values in attribution/purpose', () => {
+  it('rejects Date in attribution extension field', () => {
+    expect(
+      Wire02ClaimsSchema.safeParse(
+        minimalEvidence({
+          extensions: {
+            [ATTRIBUTION_EXTENSION_KEY]: {
+              creator_ref: new Date() as unknown as string,
+            },
+          },
+        })
+      ).success
+    ).toBe(false);
+  });
+
+  it('rejects Map in purpose extension value', () => {
+    expect(
+      Wire02ClaimsSchema.safeParse(
+        minimalEvidence({
+          type: 'org.peacprotocol/purpose-declaration',
+          pillars: ['purpose'],
+          extensions: {
+            [PURPOSE_EXTENSION_KEY]: new Map([['external_purposes', ['ai_training']]]) as unknown,
+          },
+        })
+      ).success
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Purpose token grammar enforcement
+// ---------------------------------------------------------------------------
+
+describe('PurposeExtensionSchema: machine-safe token grammar', () => {
+  it('rejects uppercase token in external_purposes', () => {
+    expect(PurposeExtensionSchema.safeParse({ external_purposes: ['AI_TRAINING'] }).success).toBe(
+      false
+    );
+  });
+
+  it('rejects token with whitespace in external_purposes', () => {
+    expect(PurposeExtensionSchema.safeParse({ external_purposes: ['ai training'] }).success).toBe(
+      false
+    );
+  });
+
+  it('rejects token with slash in external_purposes', () => {
+    expect(PurposeExtensionSchema.safeParse({ external_purposes: ['ai/training'] }).success).toBe(
+      false
+    );
+  });
+
+  it('rejects token with trailing hyphen in external_purposes', () => {
+    expect(PurposeExtensionSchema.safeParse({ external_purposes: ['ai_training-'] }).success).toBe(
+      false
+    );
+  });
+
+  it('rejects token with trailing underscore in external_purposes', () => {
+    expect(PurposeExtensionSchema.safeParse({ external_purposes: ['ai_training_'] }).success).toBe(
+      false
+    );
+  });
+
+  it('rejects token starting with digit in external_purposes', () => {
+    expect(PurposeExtensionSchema.safeParse({ external_purposes: ['123abc'] }).success).toBe(false);
+  });
+
+  it('accepts valid machine-safe tokens', () => {
+    for (const token of ['ai_training', 'analytics', 'marketing', 'cf:ai_crawler', 'a', 'a1']) {
+      expect(PurposeExtensionSchema.safeParse({ external_purposes: [token] }).success).toBe(true);
+    }
+  });
+
+  it('accepts vendor-prefixed tokens in external_purposes', () => {
+    expect(
+      PurposeExtensionSchema.safeParse({ external_purposes: ['vendor:custom-purpose'] }).success
+    ).toBe(true);
+  });
+
+  it('rejects duplicate items in external_purposes', () => {
+    expect(
+      PurposeExtensionSchema.safeParse({
+        external_purposes: ['ai_training', 'ai_training'],
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects duplicate items in compatible_purposes', () => {
+    expect(
+      PurposeExtensionSchema.safeParse({
+        external_purposes: ['ai_training'],
+        compatible_purposes: ['analytics', 'analytics'],
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects uppercase token in compatible_purposes', () => {
+    expect(
+      PurposeExtensionSchema.safeParse({
+        external_purposes: ['ai_training'],
+        compatible_purposes: ['ANALYTICS'],
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects prose in compatible_purposes', () => {
+    expect(
+      PurposeExtensionSchema.safeParse({
+        external_purposes: ['ai_training'],
+        compatible_purposes: ['for marketing use'],
+      }).success
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SPDX input-size hardening
+// ---------------------------------------------------------------------------
+
+describe('AttributionExtensionSchema: SPDX input size', () => {
+  it('rejects oversized SPDX expression (>128 chars)', () => {
+    expect(
+      AttributionExtensionSchema.safeParse({
+        ...VALID_ATTRIBUTION,
+        license_spdx: 'MIT AND ' + 'Apache-2.0 AND '.repeat(10) + 'GPL-3.0-only',
+      }).success
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Registry completion: zero null extension_groups remaining
+// ---------------------------------------------------------------------------
+
+describe('Registry completion: all receipt types have extension_group mappings', () => {
+  const registries = JSON.parse(
+    readFileSync(resolve(__dirname, '../../../specs/kernel/registries.json'), 'utf-8')
+  );
+
+  it('no receipt_types have extension_group: null', () => {
+    const nullEntries = registries.receipt_types.values.filter(
+      (e: { extension_group: string | null }) => e.extension_group === null
+    );
+    expect(nullEntries).toHaveLength(0);
+  });
+
+  it('all 10 receipt types have non-null extension_group', () => {
+    expect(registries.receipt_types.values).toHaveLength(10);
+    for (const entry of registries.receipt_types.values) {
+      expect(entry.extension_group).not.toBeNull();
+      expect(typeof entry.extension_group).toBe('string');
+    }
+  });
+
+  it('extension_groups has exactly 12 entries', () => {
+    expect(registries.extension_groups.values).toHaveLength(12);
+  });
+});

--- a/packages/schema/__tests__/wire02-extensions-ap.property.test.ts
+++ b/packages/schema/__tests__/wire02-extensions-ap.property.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Property-based tests for Attribution, Purpose extensions
+ *
+ * Uses fast-check to verify invariants across generated inputs:
+ * 1. Valid extensions always parse successfully (roundtrip)
+ * 2. Invalid enum values never parse (closed enum rejection)
+ * 3. Bounds enforcement: maxLength+1 always rejected, maxLength always accepted
+ * 4. .strict() enforcement: extra properties always rejected
+ * 5. Cross-group composition: valid extensions stay valid when combined
+ * 6. PURPOSE_TOKEN_REGEX bridging: valid tokens always accepted
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fc from 'fast-check';
+import {
+  AttributionExtensionSchema,
+  PurposeExtensionSchema,
+  CONTENT_SIGNAL_SOURCES,
+  EXTENSION_LIMITS,
+} from '../src/index.js';
+
+// ---------------------------------------------------------------------------
+// Arbitraries
+// ---------------------------------------------------------------------------
+
+/** Creator reference identifiers */
+const creatorRef = fc.constantFrom(
+  'did:web:example.com',
+  'did:key:z6Mk',
+  'https://example.com/creator',
+  'acme-corp',
+  'org-id-12345'
+);
+
+/** SPDX license expressions */
+const spdxExpression = fc.constantFrom(
+  'MIT',
+  'Apache-2.0',
+  'GPL-3.0-only',
+  'MIT AND Apache-2.0',
+  'MIT OR GPL-2.0+',
+  'LicenseRef-custom'
+);
+
+/** Obligation types */
+const obligationType = fc.constantFrom(
+  'attribution_required',
+  'share_alike',
+  'non_commercial',
+  'no_derivatives'
+);
+
+/** Content signal sources */
+const contentSignalSource = fc.constantFrom(...CONTENT_SIGNAL_SOURCES);
+
+/** External purpose tokens */
+const externalPurpose = fc.constantFrom(
+  'ai_training',
+  'analytics',
+  'marketing',
+  'service_provision',
+  'research',
+  'legal_compliance'
+);
+
+/** Valid PEAC purpose tokens (lowercase, optional vendor prefix) */
+const peacPurposeToken = fc.constantFrom('train', 'search', 'user_action', 'inference', 'index');
+
+/**
+ * Generic bounded identifier for open vocabulary fields.
+ */
+const openVocab = (min: number, max: number) =>
+  fc.stringMatching(new RegExp(`^[a-zA-Z0-9_-]{${min},${max}}$`));
+
+// ---------------------------------------------------------------------------
+// Composite arbitraries
+// ---------------------------------------------------------------------------
+
+/** Generate a valid attribution extension */
+const validAttribution = fc
+  .record({
+    creator_ref: creatorRef,
+    license_spdx: fc.option(spdxExpression, { nil: undefined }),
+    obligation_type: fc.option(obligationType, { nil: undefined }),
+    content_signal_source: fc.option(contentSignalSource, { nil: undefined }),
+  })
+  .map(({ license_spdx, obligation_type, content_signal_source, ...rest }) => ({
+    ...rest,
+    ...(license_spdx !== undefined ? { license_spdx } : {}),
+    ...(obligation_type !== undefined ? { obligation_type } : {}),
+    ...(content_signal_source !== undefined ? { content_signal_source } : {}),
+  }));
+
+/** Generate a valid purpose extension */
+const validPurpose = fc
+  .record({
+    external_purposes: fc.uniqueArray(externalPurpose, { minLength: 1, maxLength: 5 }),
+    purpose_basis: fc.option(openVocab(1, 20), { nil: undefined }),
+    purpose_limitation: fc.option(fc.boolean(), { nil: undefined }),
+    data_minimization: fc.option(fc.boolean(), { nil: undefined }),
+    peac_purpose_mapping: fc.option(peacPurposeToken, { nil: undefined }),
+  })
+  .map(
+    ({ purpose_basis, purpose_limitation, data_minimization, peac_purpose_mapping, ...rest }) => ({
+      ...rest,
+      ...(purpose_basis !== undefined ? { purpose_basis } : {}),
+      ...(purpose_limitation !== undefined ? { purpose_limitation } : {}),
+      ...(data_minimization !== undefined ? { data_minimization } : {}),
+      ...(peac_purpose_mapping !== undefined ? { peac_purpose_mapping } : {}),
+    })
+  );
+
+// ---------------------------------------------------------------------------
+// Attribution property tests
+// ---------------------------------------------------------------------------
+
+describe('AttributionExtensionSchema: property tests', () => {
+  it('valid attribution always parses', () => {
+    fc.assert(
+      fc.property(validAttribution, (attribution) => {
+        expect(AttributionExtensionSchema.safeParse(attribution).success).toBe(true);
+      }),
+      { numRuns: 100 }
+    );
+  });
+
+  it('invalid content_signal_source is always rejected', () => {
+    fc.assert(
+      fc.property(
+        openVocab(1, 20).filter((s) => !CONTENT_SIGNAL_SOURCES.includes(s as never)),
+        (badSource) => {
+          expect(
+            AttributionExtensionSchema.safeParse({
+              creator_ref: 'acme-corp',
+              content_signal_source: badSource,
+            }).success
+          ).toBe(false);
+        }
+      ),
+      { numRuns: 50 }
+    );
+  });
+
+  it('creator_ref at maxLength passes, at maxLength+1 fails', () => {
+    const max = EXTENSION_LIMITS.maxCreatorRefLength;
+    expect(AttributionExtensionSchema.safeParse({ creator_ref: 'a'.repeat(max) }).success).toBe(
+      true
+    );
+    expect(AttributionExtensionSchema.safeParse({ creator_ref: 'a'.repeat(max + 1) }).success).toBe(
+      false
+    );
+  });
+
+  it('extra properties are always rejected (.strict())', () => {
+    fc.assert(
+      fc.property(
+        validAttribution,
+        openVocab(1, 20).filter(
+          (k) =>
+            ![
+              'creator_ref',
+              'license_spdx',
+              'obligation_type',
+              'attribution_text',
+              'content_signal_source',
+              'content_digest',
+            ].includes(k)
+        ),
+        fc.string(),
+        (attribution, extraKey, extraValue) => {
+          expect(
+            AttributionExtensionSchema.safeParse({
+              ...attribution,
+              [extraKey]: extraValue,
+            }).success
+          ).toBe(false);
+        }
+      ),
+      { numRuns: 50 }
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Purpose property tests
+// ---------------------------------------------------------------------------
+
+describe('PurposeExtensionSchema: property tests', () => {
+  it('valid purpose always parses', () => {
+    fc.assert(
+      fc.property(validPurpose, (purpose) => {
+        expect(PurposeExtensionSchema.safeParse(purpose).success).toBe(true);
+      }),
+      { numRuns: 100 }
+    );
+  });
+
+  it('external_purposes must have at least 1 item', () => {
+    expect(PurposeExtensionSchema.safeParse({ external_purposes: [] }).success).toBe(false);
+  });
+
+  it('extra properties are always rejected (.strict())', () => {
+    fc.assert(
+      fc.property(
+        validPurpose,
+        openVocab(1, 20).filter(
+          (k) =>
+            ![
+              'external_purposes',
+              'purpose_basis',
+              'purpose_limitation',
+              'data_minimization',
+              'compatible_purposes',
+              'peac_purpose_mapping',
+            ].includes(k)
+        ),
+        fc.string(),
+        (purpose, extraKey, extraValue) => {
+          expect(
+            PurposeExtensionSchema.safeParse({
+              ...purpose,
+              [extraKey]: extraValue,
+            }).success
+          ).toBe(false);
+        }
+      ),
+      { numRuns: 50 }
+    );
+  });
+
+  it('valid PEAC purpose tokens always parse as peac_purpose_mapping', () => {
+    fc.assert(
+      fc.property(peacPurposeToken, (token) => {
+        expect(
+          PurposeExtensionSchema.safeParse({
+            external_purposes: ['ai_training'],
+            peac_purpose_mapping: token,
+          }).success
+        ).toBe(true);
+      }),
+      { numRuns: 50 }
+    );
+  });
+
+  it('uppercase strings are always rejected in external_purposes', () => {
+    fc.assert(
+      fc.property(
+        fc.stringMatching(/^[A-Z][A-Z0-9_-]{0,19}$/).filter((s) => s.length > 0),
+        (upperToken) => {
+          expect(
+            PurposeExtensionSchema.safeParse({ external_purposes: [upperToken] }).success
+          ).toBe(false);
+        }
+      ),
+      { numRuns: 50 }
+    );
+  });
+
+  it('tokens with spaces are always rejected in external_purposes', () => {
+    fc.assert(
+      fc.property(fc.stringMatching(/^[a-z][a-z0-9]* [a-z0-9]+$/), (spaceToken) => {
+        expect(PurposeExtensionSchema.safeParse({ external_purposes: [spaceToken] }).success).toBe(
+          false
+        );
+      }),
+      { numRuns: 50 }
+    );
+  });
+
+  it('duplicate external_purposes are always rejected', () => {
+    fc.assert(
+      fc.property(externalPurpose, (token) => {
+        expect(
+          PurposeExtensionSchema.safeParse({ external_purposes: [token, token] }).success
+        ).toBe(false);
+      }),
+      { numRuns: 50 }
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-group composition
+// ---------------------------------------------------------------------------
+
+describe('Cross-group composition: attribution + purpose', () => {
+  it('adding any valid extension to another preserves validity', () => {
+    fc.assert(
+      fc.property(validAttribution, validPurpose, (attribution, purpose) => {
+        expect(AttributionExtensionSchema.safeParse(attribution).success).toBe(true);
+        expect(PurposeExtensionSchema.safeParse(purpose).success).toBe(true);
+
+        const combined = {
+          'org.peacprotocol/attribution': attribution,
+          'org.peacprotocol/purpose': purpose,
+        };
+        expect(
+          AttributionExtensionSchema.safeParse(combined['org.peacprotocol/attribution']).success
+        ).toBe(true);
+        expect(PurposeExtensionSchema.safeParse(combined['org.peacprotocol/purpose']).success).toBe(
+          true
+        );
+      }),
+      { numRuns: 50 }
+    );
+  });
+});

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -592,6 +592,16 @@ export {
   SlsaLevelSchema,
   ProvenanceExtensionSchema,
   getProvenanceExtension,
+  // Attribution
+  ATTRIBUTION_EXTENSION_KEY,
+  CONTENT_SIGNAL_SOURCES,
+  ContentSignalSourceSchema,
+  AttributionExtensionSchema,
+  getAttributionExtension,
+  // Purpose
+  PURPOSE_EXTENSION_KEY,
+  PurposeExtensionSchema,
+  getPurposeExtension,
   // Shared validators
   Sha256DigestSchema,
   HttpsUriHintSchema,
@@ -623,6 +633,9 @@ export type {
   CustodyEntry,
   SlsaLevel,
   ProvenanceExtension,
+  ContentSignalSource,
+  AttributionExtension,
+  PurposeExtension,
 } from './wire-02-extensions';
 
 // Wire 0.2 registry constants (v0.12.0-preview.1, DD-155)

--- a/packages/schema/src/wire-02-extensions.ts
+++ b/packages/schema/src/wire-02-extensions.ts
@@ -71,6 +71,16 @@ export {
   SlsaLevelSchema,
   ProvenanceExtensionSchema,
   getProvenanceExtension,
+  // Attribution
+  ATTRIBUTION_EXTENSION_KEY,
+  CONTENT_SIGNAL_SOURCES,
+  ContentSignalSourceSchema,
+  AttributionExtensionSchema,
+  getAttributionExtension,
+  // Purpose
+  PURPOSE_EXTENSION_KEY,
+  PurposeExtensionSchema,
+  getPurposeExtension,
   // Envelope validation helper
   validateKnownExtensions,
   // Shared validators
@@ -105,4 +115,7 @@ export type {
   CustodyEntry,
   SlsaLevel,
   ProvenanceExtension,
+  ContentSignalSource,
+  AttributionExtension,
+  PurposeExtension,
 } from './wire-02-extensions/index.js';

--- a/packages/schema/src/wire-02-extensions/accessors.ts
+++ b/packages/schema/src/wire-02-extensions/accessors.ts
@@ -30,6 +30,10 @@ import { COMPLIANCE_EXTENSION_KEY, ComplianceExtensionSchema } from './complianc
 import type { ComplianceExtension } from './compliance.js';
 import { PROVENANCE_EXTENSION_KEY, ProvenanceExtensionSchema } from './provenance.js';
 import type { ProvenanceExtension } from './provenance.js';
+import { ATTRIBUTION_EXTENSION_KEY, AttributionExtensionSchema } from './attribution.js';
+import type { AttributionExtension } from './attribution.js';
+import { PURPOSE_EXTENSION_KEY, PurposeExtensionSchema } from './purpose-extension.js';
+import type { PurposeExtension } from './purpose-extension.js';
 
 // ---------------------------------------------------------------------------
 // Internal helper
@@ -143,4 +147,18 @@ export function getProvenanceExtension(
   extensions?: Record<string, unknown>
 ): ProvenanceExtension | undefined {
   return getExtension(extensions, PROVENANCE_EXTENSION_KEY, ProvenanceExtensionSchema);
+}
+
+/** @throws PEACError with RFC 6901 pointer if present but invalid */
+export function getAttributionExtension(
+  extensions?: Record<string, unknown>
+): AttributionExtension | undefined {
+  return getExtension(extensions, ATTRIBUTION_EXTENSION_KEY, AttributionExtensionSchema);
+}
+
+/** @throws PEACError with RFC 6901 pointer if present but invalid */
+export function getPurposeExtension(
+  extensions?: Record<string, unknown>
+): PurposeExtension | undefined {
+  return getExtension(extensions, PURPOSE_EXTENSION_KEY, PurposeExtensionSchema);
 }

--- a/packages/schema/src/wire-02-extensions/attribution.ts
+++ b/packages/schema/src/wire-02-extensions/attribution.ts
@@ -1,0 +1,63 @@
+/**
+ * Attribution Extension Group (org.peacprotocol/attribution)
+ *
+ * Records credit, obligations, and content signal observations.
+ *
+ * Design:
+ *   - Identifier and reference-based fields; not identity attestation
+ *   - Closed enum for content_signal_source (known observation sources)
+ *   - SPDX license expressions via parser-grade shared validator
+ *   - Observation-only semantics: records events, never enforces policy
+ */
+
+import { z } from 'zod';
+import { EXTENSION_LIMITS } from './limits.js';
+import { Sha256DigestSchema, SpdxExpressionSchema } from './shared-validators.js';
+
+export const ATTRIBUTION_EXTENSION_KEY = 'org.peacprotocol/attribution' as const;
+
+/**
+ * Content signal observation source.
+ *
+ * Closed enum: maps to the known observation sources in the
+ * content signals precedence chain.
+ */
+export const CONTENT_SIGNAL_SOURCES = [
+  'tdmrep_json',
+  'content_signal_header',
+  'content_usage_header',
+  'robots_txt',
+  'custom',
+] as const;
+export const ContentSignalSourceSchema = z.enum(CONTENT_SIGNAL_SOURCES);
+export type ContentSignalSource = z.infer<typeof ContentSignalSourceSchema>;
+
+export const AttributionExtensionSchema = z
+  .object({
+    /**
+     * Creator identifier (DID, URI, or opaque ID).
+     * Not an identity attestation; records observed attribution metadata.
+     */
+    creator_ref: z.string().min(1).max(EXTENSION_LIMITS.maxCreatorRefLength),
+
+    /** SPDX license expression (parser-grade structural subset validator). */
+    license_spdx: SpdxExpressionSchema.optional(),
+
+    /**
+     * Obligation type.
+     * Open vocabulary (e.g., attribution_required, share_alike, non_commercial).
+     */
+    obligation_type: z.string().min(1).max(EXTENSION_LIMITS.maxObligationTypeLength).optional(),
+
+    /** Required attribution text. */
+    attribution_text: z.string().min(1).max(EXTENSION_LIMITS.maxAttributionTextLength).optional(),
+
+    /** Content signal observation source (closed vocabulary). */
+    content_signal_source: ContentSignalSourceSchema.optional(),
+
+    /** SHA-256 digest of the attributed content. */
+    content_digest: Sha256DigestSchema.optional(),
+  })
+  .strict();
+
+export type AttributionExtension = z.infer<typeof AttributionExtensionSchema>;

--- a/packages/schema/src/wire-02-extensions/index.ts
+++ b/packages/schema/src/wire-02-extensions/index.ts
@@ -79,6 +79,17 @@ export {
 } from './provenance.js';
 export type { CustodyEntry, SlsaLevel, ProvenanceExtension } from './provenance.js';
 
+export {
+  ATTRIBUTION_EXTENSION_KEY,
+  CONTENT_SIGNAL_SOURCES,
+  ContentSignalSourceSchema,
+  AttributionExtensionSchema,
+} from './attribution.js';
+export type { ContentSignalSource, AttributionExtension } from './attribution.js';
+
+export { PURPOSE_EXTENSION_KEY, PurposeExtensionSchema } from './purpose-extension.js';
+export type { PurposeExtension } from './purpose-extension.js';
+
 // Typed accessors
 export {
   getCommerceExtension,
@@ -91,6 +102,8 @@ export {
   getSafetyExtension,
   getComplianceExtension,
   getProvenanceExtension,
+  getAttributionExtension,
+  getPurposeExtension,
 } from './accessors.js';
 
 // Envelope validation helper (used by Wire02ClaimsSchema.superRefine)

--- a/packages/schema/src/wire-02-extensions/purpose-extension.ts
+++ b/packages/schema/src/wire-02-extensions/purpose-extension.ts
@@ -1,0 +1,94 @@
+/**
+ * Purpose Extension Group (org.peacprotocol/purpose)
+ *
+ * Records external/legal/business purpose declarations as observations.
+ * Explicitly separated from PEAC operational purpose tokens
+ * (CanonicalPurpose in purpose.ts).
+ *
+ * Design:
+ *   - external_purposes: token-based array (machine-safe, bounded, unique)
+ *   - peac_purpose_mapping: optional bridge to PEAC operational tokens
+ *     via PURPOSE_TOKEN_REGEX
+ *   - No prose-heavy fields at schema layer
+ *   - Observation-only semantics: records events, never enforces policy
+ */
+
+import { z } from 'zod';
+import { EXTENSION_LIMITS } from './limits.js';
+import { PURPOSE_TOKEN_REGEX, MAX_PURPOSE_TOKEN_LENGTH } from '../purpose.js';
+
+export const PURPOSE_EXTENSION_KEY = 'org.peacprotocol/purpose' as const;
+
+/**
+ * Machine-safe token schema for purpose label arrays.
+ *
+ * Reuses PURPOSE_TOKEN_REGEX from purpose.ts for the lexical grammar
+ * (lowercase alphanumeric, underscores, hyphens, optional vendor prefix).
+ * Semantically independent from PEAC operational CanonicalPurpose tokens.
+ */
+const MachineSafePurposeTokenSchema = z
+  .string()
+  .min(1)
+  .max(EXTENSION_LIMITS.maxExternalPurposeLength)
+  .regex(PURPOSE_TOKEN_REGEX, 'must be a machine-safe lowercase token');
+
+/**
+ * Check that all items in a string array are unique.
+ */
+function hasUniqueItems(items: string[]): boolean {
+  return new Set(items).size === items.length;
+}
+
+export const PurposeExtensionSchema = z
+  .object({
+    /**
+     * External/legal/business purpose labels.
+     * Machine-safe tokens: lowercase alphanumeric with underscores, hyphens,
+     * and optional vendor prefix (e.g., ai_training, analytics, marketing).
+     * Not PEAC operational tokens; use peac_purpose_mapping for bridging.
+     * Items must be unique.
+     */
+    external_purposes: z
+      .array(MachineSafePurposeTokenSchema)
+      .min(1)
+      .max(EXTENSION_LIMITS.maxExternalPurposesCount)
+      .refine(hasUniqueItems, { message: 'external_purposes must contain unique items' }),
+
+    /**
+     * Legal or policy basis for the declared purposes.
+     * Open vocabulary (e.g., consent, legitimate_interest, contract).
+     */
+    purpose_basis: z.string().min(1).max(EXTENSION_LIMITS.maxPurposeBasisLength).optional(),
+
+    /** Whether purpose limitation applies. */
+    purpose_limitation: z.boolean().optional(),
+
+    /** Whether data minimization was applied. */
+    data_minimization: z.boolean().optional(),
+
+    /**
+     * Compatible purposes for secondary use.
+     * Same machine-safe token grammar as external_purposes.
+     * Items must be unique.
+     */
+    compatible_purposes: z
+      .array(MachineSafePurposeTokenSchema)
+      .max(EXTENSION_LIMITS.maxCompatiblePurposesCount)
+      .refine(hasUniqueItems, { message: 'compatible_purposes must contain unique items' })
+      .optional(),
+
+    /**
+     * Explicit mapping to a PEAC operational CanonicalPurpose token.
+     * Validated against PURPOSE_TOKEN_REGEX from purpose.ts.
+     * Bridges external purpose vocabulary to operational tokens.
+     */
+    peac_purpose_mapping: z
+      .string()
+      .min(1)
+      .max(MAX_PURPOSE_TOKEN_LENGTH)
+      .regex(PURPOSE_TOKEN_REGEX, 'must be a valid PEAC purpose token')
+      .optional(),
+  })
+  .strict();
+
+export type PurposeExtension = z.infer<typeof PurposeExtensionSchema>;

--- a/packages/schema/src/wire-02-extensions/schema-map.ts
+++ b/packages/schema/src/wire-02-extensions/schema-map.ts
@@ -20,6 +20,8 @@ import { PRIVACY_EXTENSION_KEY, PrivacyExtensionSchema } from './privacy.js';
 import { SAFETY_EXTENSION_KEY, SafetyExtensionSchema } from './safety.js';
 import { COMPLIANCE_EXTENSION_KEY, ComplianceExtensionSchema } from './compliance.js';
 import { PROVENANCE_EXTENSION_KEY, ProvenanceExtensionSchema } from './provenance.js';
+import { ATTRIBUTION_EXTENSION_KEY, AttributionExtensionSchema } from './attribution.js';
+import { PURPOSE_EXTENSION_KEY, PurposeExtensionSchema } from './purpose-extension.js';
 
 /** Map from known extension key to its Zod schema */
 export const EXTENSION_SCHEMA_MAP = new Map<string, z.ZodTypeAny>();
@@ -33,3 +35,5 @@ EXTENSION_SCHEMA_MAP.set(PRIVACY_EXTENSION_KEY, PrivacyExtensionSchema);
 EXTENSION_SCHEMA_MAP.set(SAFETY_EXTENSION_KEY, SafetyExtensionSchema);
 EXTENSION_SCHEMA_MAP.set(COMPLIANCE_EXTENSION_KEY, ComplianceExtensionSchema);
 EXTENSION_SCHEMA_MAP.set(PROVENANCE_EXTENSION_KEY, ProvenanceExtensionSchema);
+EXTENSION_SCHEMA_MAP.set(ATTRIBUTION_EXTENSION_KEY, AttributionExtensionSchema);
+EXTENSION_SCHEMA_MAP.set(PURPOSE_EXTENSION_KEY, PurposeExtensionSchema);

--- a/specs/conformance/fixtures/inventory.json
+++ b/specs/conformance/fixtures/inventory.json
@@ -1,12 +1,12 @@
 {
   "$schema": "https://www.peacprotocol.org/schemas/conformance/inventory.schema.json",
-  "generated_at": "2026-03-15T06:59:00.663Z",
+  "generated_at": "2026-03-15T09:03:30.472Z",
   "version": "0.12.1",
   "schema_version": "0.12.1",
-  "total_fixtures": 657,
-  "total_with_requirements": 212,
+  "total_fixtures": 676,
+  "total_with_requirements": 231,
   "total_unmapped": 445,
-  "wire02_requirement_links": 510,
+  "wire02_requirement_links": 541,
   "carrier_requirement_links": 11,
   "entries": [
     {
@@ -3014,6 +3014,76 @@
     {
       "directory": "wire-02/extensions",
       "file": "conformance.json",
+      "fixture_name": "attribution-content-signal-header-valid",
+      "description": "Valid attribution with content_signal_header source",
+      "primary_requirement_id": "WIRE02-EXT-057",
+      "requirement_ids": ["WIRE02-EXT-055", "WIRE02-EXT-057"],
+      "status": "positive",
+      "has_requirements": true
+    },
+    {
+      "directory": "wire-02/extensions",
+      "file": "conformance.json",
+      "fixture_name": "attribution-content-usage-header-valid",
+      "description": "Valid attribution with content_usage_header source",
+      "primary_requirement_id": "WIRE02-EXT-057",
+      "requirement_ids": ["WIRE02-EXT-055", "WIRE02-EXT-057"],
+      "status": "positive",
+      "has_requirements": true
+    },
+    {
+      "directory": "wire-02/extensions",
+      "file": "conformance.json",
+      "fixture_name": "attribution-custom-source-valid",
+      "description": "Valid attribution with custom content signal source",
+      "primary_requirement_id": "WIRE02-EXT-057",
+      "requirement_ids": ["WIRE02-EXT-055", "WIRE02-EXT-057"],
+      "status": "positive",
+      "has_requirements": true
+    },
+    {
+      "directory": "wire-02/extensions",
+      "file": "conformance.json",
+      "fixture_name": "attribution-extension-all-fields-valid",
+      "description": "Valid attribution extension with all optional fields present",
+      "primary_requirement_id": "WIRE02-EXT-055",
+      "requirement_ids": ["WIRE02-EXT-055", "WIRE02-EXT-056", "WIRE02-EXT-057", "WIRE02-EXT-058"],
+      "status": "positive",
+      "has_requirements": true
+    },
+    {
+      "directory": "wire-02/extensions",
+      "file": "conformance.json",
+      "fixture_name": "attribution-extension-valid",
+      "description": "Valid attribution extension with required fields",
+      "primary_requirement_id": "WIRE02-EXT-055",
+      "requirement_ids": ["WIRE02-EXT-055"],
+      "status": "positive",
+      "has_requirements": true
+    },
+    {
+      "directory": "wire-02/extensions",
+      "file": "conformance.json",
+      "fixture_name": "attribution-robots-txt-valid",
+      "description": "Valid attribution with robots_txt source",
+      "primary_requirement_id": "WIRE02-EXT-057",
+      "requirement_ids": ["WIRE02-EXT-055", "WIRE02-EXT-057"],
+      "status": "positive",
+      "has_requirements": true
+    },
+    {
+      "directory": "wire-02/extensions",
+      "file": "conformance.json",
+      "fixture_name": "attribution-tdmrep-json-valid",
+      "description": "Valid attribution with tdmrep_json content signal source",
+      "primary_requirement_id": "WIRE02-EXT-057",
+      "requirement_ids": ["WIRE02-EXT-055", "WIRE02-EXT-057"],
+      "status": "positive",
+      "has_requirements": true
+    },
+    {
+      "directory": "wire-02/extensions",
+      "file": "conformance.json",
       "fixture_name": "commerce-extension-valid",
       "description": "Valid commerce extension with all required fields",
       "primary_requirement_id": "WIRE02-EXT-006",
@@ -3200,7 +3270,13 @@
       "fixture_name": "provenance-extension-all-fields-valid",
       "description": "Valid provenance extension with custody chain and SLSA metadata",
       "primary_requirement_id": "WIRE02-EXT-049",
-      "requirement_ids": ["WIRE02-EXT-049", "WIRE02-EXT-050", "WIRE02-EXT-051", "WIRE02-EXT-052"],
+      "requirement_ids": [
+        "WIRE02-EXT-049",
+        "WIRE02-EXT-050",
+        "WIRE02-EXT-051",
+        "WIRE02-EXT-052",
+        "WIRE02-EXT-054"
+      ],
       "status": "positive",
       "has_requirements": true
     },
@@ -3232,6 +3308,56 @@
       "primary_requirement_id": "WIRE02-EXT-052",
       "requirement_ids": ["WIRE02-EXT-049", "WIRE02-EXT-052"],
       "status": "boundary",
+      "has_requirements": true
+    },
+    {
+      "directory": "wire-02/extensions",
+      "file": "conformance.json",
+      "fixture_name": "purpose-extension-all-fields-valid",
+      "description": "Valid purpose extension with all optional fields and purpose mapping",
+      "primary_requirement_id": "WIRE02-EXT-061",
+      "requirement_ids": ["WIRE02-EXT-061", "WIRE02-EXT-062", "WIRE02-EXT-063", "WIRE02-EXT-066"],
+      "status": "positive",
+      "has_requirements": true
+    },
+    {
+      "directory": "wire-02/extensions",
+      "file": "conformance.json",
+      "fixture_name": "purpose-extension-valid",
+      "description": "Valid purpose extension with required fields",
+      "primary_requirement_id": "WIRE02-EXT-061",
+      "requirement_ids": ["WIRE02-EXT-061"],
+      "status": "positive",
+      "has_requirements": true
+    },
+    {
+      "directory": "wire-02/extensions",
+      "file": "conformance.json",
+      "fixture_name": "reject-attribution-extra-field",
+      "description": "Unknown field in attribution extension rejected by .strict()",
+      "primary_requirement_id": "WIRE02-EXT-059",
+      "requirement_ids": ["WIRE02-EXT-059"],
+      "status": "negative",
+      "has_requirements": true
+    },
+    {
+      "directory": "wire-02/extensions",
+      "file": "conformance.json",
+      "fixture_name": "reject-attribution-invalid-signal-source",
+      "description": "Invalid content_signal_source value is rejected (closed enum)",
+      "primary_requirement_id": "WIRE02-EXT-057",
+      "requirement_ids": ["WIRE02-EXT-057"],
+      "status": "negative",
+      "has_requirements": true
+    },
+    {
+      "directory": "wire-02/extensions",
+      "file": "conformance.json",
+      "fixture_name": "reject-attribution-missing-creator-ref",
+      "description": "Missing required creator_ref field is rejected",
+      "primary_requirement_id": "WIRE02-EXT-055",
+      "requirement_ids": ["WIRE02-EXT-055"],
+      "status": "negative",
       "has_requirements": true
     },
     {
@@ -3441,6 +3567,76 @@
       "description": "Non-integer SLSA level is rejected",
       "primary_requirement_id": "WIRE02-EXT-052",
       "requirement_ids": ["WIRE02-EXT-052"],
+      "status": "negative",
+      "has_requirements": true
+    },
+    {
+      "directory": "wire-02/extensions",
+      "file": "conformance.json",
+      "fixture_name": "reject-purpose-duplicate-tokens",
+      "description": "Duplicate tokens in external_purposes rejected",
+      "primary_requirement_id": "WIRE02-EXT-061",
+      "requirement_ids": ["WIRE02-EXT-061"],
+      "status": "negative",
+      "has_requirements": true
+    },
+    {
+      "directory": "wire-02/extensions",
+      "file": "conformance.json",
+      "fixture_name": "reject-purpose-empty-external-purposes",
+      "description": "Empty external_purposes array is rejected (min 1)",
+      "primary_requirement_id": "WIRE02-EXT-061",
+      "requirement_ids": ["WIRE02-EXT-061"],
+      "status": "negative",
+      "has_requirements": true
+    },
+    {
+      "directory": "wire-02/extensions",
+      "file": "conformance.json",
+      "fixture_name": "reject-purpose-extra-field",
+      "description": "Unknown field in purpose extension rejected by .strict()",
+      "primary_requirement_id": "WIRE02-EXT-064",
+      "requirement_ids": ["WIRE02-EXT-064"],
+      "status": "negative",
+      "has_requirements": true
+    },
+    {
+      "directory": "wire-02/extensions",
+      "file": "conformance.json",
+      "fixture_name": "reject-purpose-invalid-peac-mapping",
+      "description": "Invalid peac_purpose_mapping token is rejected",
+      "primary_requirement_id": "WIRE02-EXT-066",
+      "requirement_ids": ["WIRE02-EXT-066"],
+      "status": "negative",
+      "has_requirements": true
+    },
+    {
+      "directory": "wire-02/extensions",
+      "file": "conformance.json",
+      "fixture_name": "reject-purpose-missing-external-purposes",
+      "description": "Missing required external_purposes field is rejected",
+      "primary_requirement_id": "WIRE02-EXT-061",
+      "requirement_ids": ["WIRE02-EXT-061"],
+      "status": "negative",
+      "has_requirements": true
+    },
+    {
+      "directory": "wire-02/extensions",
+      "file": "conformance.json",
+      "fixture_name": "reject-purpose-uppercase-token",
+      "description": "Uppercase token in external_purposes rejected by machine-safe grammar",
+      "primary_requirement_id": "WIRE02-EXT-065",
+      "requirement_ids": ["WIRE02-EXT-065"],
+      "status": "negative",
+      "has_requirements": true
+    },
+    {
+      "directory": "wire-02/extensions",
+      "file": "conformance.json",
+      "fixture_name": "reject-purpose-whitespace-token",
+      "description": "Whitespace-containing token in external_purposes rejected",
+      "primary_requirement_id": "WIRE02-EXT-065",
+      "requirement_ids": ["WIRE02-EXT-065"],
       "status": "negative",
       "has_requirements": true
     },

--- a/specs/conformance/fixtures/wire-02/extensions/conformance.json
+++ b/specs/conformance/fixtures/wire-02/extensions/conformance.json
@@ -1398,7 +1398,13 @@
       "description": "Valid provenance extension with custody chain and SLSA metadata",
       "type": "full-pipeline",
       "primary_requirement_id": "WIRE02-EXT-049",
-      "requirement_ids": ["WIRE02-EXT-049", "WIRE02-EXT-050", "WIRE02-EXT-051", "WIRE02-EXT-052"],
+      "requirement_ids": [
+        "WIRE02-EXT-049",
+        "WIRE02-EXT-050",
+        "WIRE02-EXT-051",
+        "WIRE02-EXT-052",
+        "WIRE02-EXT-054"
+      ],
       "status": "positive",
       "input": {
         "claims": {
@@ -1528,6 +1534,500 @@
         "valid": false,
         "error_code": "E_INVALID_EXTENSION_FORMAT"
       }
+    },
+    {
+      "name": "attribution-extension-valid",
+      "description": "Valid attribution extension with required fields",
+      "type": "full-pipeline",
+      "primary_requirement_id": "WIRE02-EXT-055",
+      "requirement_ids": ["WIRE02-EXT-055"],
+      "status": "positive",
+      "input": {
+        "claims": {
+          "peac_version": "0.2",
+          "kind": "evidence",
+          "type": "org.peacprotocol/attribution-event",
+          "iss": "https://api.example.com",
+          "iat": 1709500000,
+          "jti": "ext-attribution-001",
+          "pillars": ["attribution"],
+          "extensions": {
+            "org.peacprotocol/attribution": {
+              "creator_ref": "did:web:example.com"
+            }
+          }
+        }
+      },
+      "expected": { "valid": true }
+    },
+    {
+      "name": "attribution-extension-all-fields-valid",
+      "description": "Valid attribution extension with all optional fields present",
+      "type": "full-pipeline",
+      "primary_requirement_id": "WIRE02-EXT-055",
+      "requirement_ids": ["WIRE02-EXT-055", "WIRE02-EXT-056", "WIRE02-EXT-057", "WIRE02-EXT-058"],
+      "status": "positive",
+      "input": {
+        "claims": {
+          "peac_version": "0.2",
+          "kind": "evidence",
+          "type": "org.peacprotocol/attribution-event",
+          "iss": "https://api.example.com",
+          "iat": 1709500000,
+          "jti": "ext-attribution-002",
+          "pillars": ["attribution"],
+          "extensions": {
+            "org.peacprotocol/attribution": {
+              "creator_ref": "did:web:example.com",
+              "license_spdx": "MIT",
+              "obligation_type": "attribution_required",
+              "attribution_text": "Created by Example Corp",
+              "content_signal_source": "tdmrep_json",
+              "content_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            }
+          }
+        }
+      },
+      "expected": { "valid": true }
+    },
+    {
+      "name": "attribution-tdmrep-json-valid",
+      "description": "Valid attribution with tdmrep_json content signal source",
+      "type": "full-pipeline",
+      "primary_requirement_id": "WIRE02-EXT-057",
+      "requirement_ids": ["WIRE02-EXT-055", "WIRE02-EXT-057"],
+      "status": "positive",
+      "input": {
+        "claims": {
+          "peac_version": "0.2",
+          "kind": "evidence",
+          "type": "org.peacprotocol/attribution-event",
+          "iss": "https://api.example.com",
+          "iat": 1709500000,
+          "jti": "ext-attribution-010",
+          "pillars": ["attribution"],
+          "extensions": {
+            "org.peacprotocol/attribution": {
+              "creator_ref": "acme-corp",
+              "content_signal_source": "tdmrep_json"
+            }
+          }
+        }
+      },
+      "expected": { "valid": true }
+    },
+    {
+      "name": "attribution-content-signal-header-valid",
+      "description": "Valid attribution with content_signal_header source",
+      "type": "full-pipeline",
+      "primary_requirement_id": "WIRE02-EXT-057",
+      "requirement_ids": ["WIRE02-EXT-055", "WIRE02-EXT-057"],
+      "status": "positive",
+      "input": {
+        "claims": {
+          "peac_version": "0.2",
+          "kind": "evidence",
+          "type": "org.peacprotocol/attribution-event",
+          "iss": "https://api.example.com",
+          "iat": 1709500000,
+          "jti": "ext-attribution-011",
+          "pillars": ["attribution"],
+          "extensions": {
+            "org.peacprotocol/attribution": {
+              "creator_ref": "acme-corp",
+              "content_signal_source": "content_signal_header"
+            }
+          }
+        }
+      },
+      "expected": { "valid": true }
+    },
+    {
+      "name": "attribution-content-usage-header-valid",
+      "description": "Valid attribution with content_usage_header source",
+      "type": "full-pipeline",
+      "primary_requirement_id": "WIRE02-EXT-057",
+      "requirement_ids": ["WIRE02-EXT-055", "WIRE02-EXT-057"],
+      "status": "positive",
+      "input": {
+        "claims": {
+          "peac_version": "0.2",
+          "kind": "evidence",
+          "type": "org.peacprotocol/attribution-event",
+          "iss": "https://api.example.com",
+          "iat": 1709500000,
+          "jti": "ext-attribution-012",
+          "pillars": ["attribution"],
+          "extensions": {
+            "org.peacprotocol/attribution": {
+              "creator_ref": "acme-corp",
+              "content_signal_source": "content_usage_header"
+            }
+          }
+        }
+      },
+      "expected": { "valid": true }
+    },
+    {
+      "name": "attribution-robots-txt-valid",
+      "description": "Valid attribution with robots_txt source",
+      "type": "full-pipeline",
+      "primary_requirement_id": "WIRE02-EXT-057",
+      "requirement_ids": ["WIRE02-EXT-055", "WIRE02-EXT-057"],
+      "status": "positive",
+      "input": {
+        "claims": {
+          "peac_version": "0.2",
+          "kind": "evidence",
+          "type": "org.peacprotocol/attribution-event",
+          "iss": "https://api.example.com",
+          "iat": 1709500000,
+          "jti": "ext-attribution-013",
+          "pillars": ["attribution"],
+          "extensions": {
+            "org.peacprotocol/attribution": {
+              "creator_ref": "acme-corp",
+              "content_signal_source": "robots_txt"
+            }
+          }
+        }
+      },
+      "expected": { "valid": true }
+    },
+    {
+      "name": "attribution-custom-source-valid",
+      "description": "Valid attribution with custom content signal source",
+      "type": "full-pipeline",
+      "primary_requirement_id": "WIRE02-EXT-057",
+      "requirement_ids": ["WIRE02-EXT-055", "WIRE02-EXT-057"],
+      "status": "positive",
+      "input": {
+        "claims": {
+          "peac_version": "0.2",
+          "kind": "evidence",
+          "type": "org.peacprotocol/attribution-event",
+          "iss": "https://api.example.com",
+          "iat": 1709500000,
+          "jti": "ext-attribution-014",
+          "pillars": ["attribution"],
+          "extensions": {
+            "org.peacprotocol/attribution": {
+              "creator_ref": "acme-corp",
+              "content_signal_source": "custom"
+            }
+          }
+        }
+      },
+      "expected": { "valid": true }
+    },
+    {
+      "name": "reject-attribution-missing-creator-ref",
+      "description": "Missing required creator_ref field is rejected",
+      "type": "full-pipeline",
+      "primary_requirement_id": "WIRE02-EXT-055",
+      "requirement_ids": ["WIRE02-EXT-055"],
+      "status": "negative",
+      "input": {
+        "claims": {
+          "peac_version": "0.2",
+          "kind": "evidence",
+          "type": "org.peacprotocol/attribution-event",
+          "iss": "https://api.example.com",
+          "iat": 1709500000,
+          "jti": "ext-attribution-003",
+          "pillars": ["attribution"],
+          "extensions": {
+            "org.peacprotocol/attribution": {
+              "license_spdx": "MIT"
+            }
+          }
+        }
+      },
+      "expected": { "valid": false, "error_code": "E_INVALID_EXTENSION_FORMAT" }
+    },
+    {
+      "name": "reject-attribution-invalid-signal-source",
+      "description": "Invalid content_signal_source value is rejected (closed enum)",
+      "type": "full-pipeline",
+      "primary_requirement_id": "WIRE02-EXT-057",
+      "requirement_ids": ["WIRE02-EXT-057"],
+      "status": "negative",
+      "input": {
+        "claims": {
+          "peac_version": "0.2",
+          "kind": "evidence",
+          "type": "org.peacprotocol/attribution-event",
+          "iss": "https://api.example.com",
+          "iat": 1709500000,
+          "jti": "ext-attribution-004",
+          "pillars": ["attribution"],
+          "extensions": {
+            "org.peacprotocol/attribution": {
+              "creator_ref": "acme-corp",
+              "content_signal_source": "unknown_source"
+            }
+          }
+        }
+      },
+      "expected": { "valid": false, "error_code": "E_INVALID_EXTENSION_FORMAT" }
+    },
+    {
+      "name": "reject-attribution-extra-field",
+      "description": "Unknown field in attribution extension rejected by .strict()",
+      "type": "full-pipeline",
+      "primary_requirement_id": "WIRE02-EXT-059",
+      "requirement_ids": ["WIRE02-EXT-059"],
+      "status": "negative",
+      "input": {
+        "claims": {
+          "peac_version": "0.2",
+          "kind": "evidence",
+          "type": "org.peacprotocol/attribution-event",
+          "iss": "https://api.example.com",
+          "iat": 1709500000,
+          "jti": "ext-attribution-005",
+          "pillars": ["attribution"],
+          "extensions": {
+            "org.peacprotocol/attribution": {
+              "creator_ref": "acme-corp",
+              "unknown_field": "should reject"
+            }
+          }
+        }
+      },
+      "expected": { "valid": false, "error_code": "E_INVALID_EXTENSION_FORMAT" }
+    },
+    {
+      "name": "purpose-extension-valid",
+      "description": "Valid purpose extension with required fields",
+      "type": "full-pipeline",
+      "primary_requirement_id": "WIRE02-EXT-061",
+      "requirement_ids": ["WIRE02-EXT-061"],
+      "status": "positive",
+      "input": {
+        "claims": {
+          "peac_version": "0.2",
+          "kind": "evidence",
+          "type": "org.peacprotocol/purpose-declaration",
+          "iss": "https://api.example.com",
+          "iat": 1709500000,
+          "jti": "ext-purpose-001",
+          "pillars": ["purpose"],
+          "extensions": {
+            "org.peacprotocol/purpose": {
+              "external_purposes": ["ai_training"]
+            }
+          }
+        }
+      },
+      "expected": { "valid": true }
+    },
+    {
+      "name": "purpose-extension-all-fields-valid",
+      "description": "Valid purpose extension with all optional fields and purpose mapping",
+      "type": "full-pipeline",
+      "primary_requirement_id": "WIRE02-EXT-061",
+      "requirement_ids": ["WIRE02-EXT-061", "WIRE02-EXT-062", "WIRE02-EXT-063", "WIRE02-EXT-066"],
+      "status": "positive",
+      "input": {
+        "claims": {
+          "peac_version": "0.2",
+          "kind": "evidence",
+          "type": "org.peacprotocol/purpose-declaration",
+          "iss": "https://api.example.com",
+          "iat": 1709500000,
+          "jti": "ext-purpose-002",
+          "pillars": ["purpose"],
+          "extensions": {
+            "org.peacprotocol/purpose": {
+              "external_purposes": ["ai_training", "research"],
+              "purpose_basis": "consent",
+              "purpose_limitation": true,
+              "data_minimization": true,
+              "compatible_purposes": ["analytics"],
+              "peac_purpose_mapping": "train"
+            }
+          }
+        }
+      },
+      "expected": { "valid": true }
+    },
+    {
+      "name": "reject-purpose-missing-external-purposes",
+      "description": "Missing required external_purposes field is rejected",
+      "type": "full-pipeline",
+      "primary_requirement_id": "WIRE02-EXT-061",
+      "requirement_ids": ["WIRE02-EXT-061"],
+      "status": "negative",
+      "input": {
+        "claims": {
+          "peac_version": "0.2",
+          "kind": "evidence",
+          "type": "org.peacprotocol/purpose-declaration",
+          "iss": "https://api.example.com",
+          "iat": 1709500000,
+          "jti": "ext-purpose-003",
+          "pillars": ["purpose"],
+          "extensions": {
+            "org.peacprotocol/purpose": {
+              "purpose_basis": "consent"
+            }
+          }
+        }
+      },
+      "expected": { "valid": false, "error_code": "E_INVALID_EXTENSION_FORMAT" }
+    },
+    {
+      "name": "reject-purpose-empty-external-purposes",
+      "description": "Empty external_purposes array is rejected (min 1)",
+      "type": "full-pipeline",
+      "primary_requirement_id": "WIRE02-EXT-061",
+      "requirement_ids": ["WIRE02-EXT-061"],
+      "status": "negative",
+      "input": {
+        "claims": {
+          "peac_version": "0.2",
+          "kind": "evidence",
+          "type": "org.peacprotocol/purpose-declaration",
+          "iss": "https://api.example.com",
+          "iat": 1709500000,
+          "jti": "ext-purpose-004",
+          "pillars": ["purpose"],
+          "extensions": {
+            "org.peacprotocol/purpose": {
+              "external_purposes": []
+            }
+          }
+        }
+      },
+      "expected": { "valid": false, "error_code": "E_INVALID_EXTENSION_FORMAT" }
+    },
+    {
+      "name": "reject-purpose-invalid-peac-mapping",
+      "description": "Invalid peac_purpose_mapping token is rejected",
+      "type": "full-pipeline",
+      "primary_requirement_id": "WIRE02-EXT-066",
+      "requirement_ids": ["WIRE02-EXT-066"],
+      "status": "negative",
+      "input": {
+        "claims": {
+          "peac_version": "0.2",
+          "kind": "evidence",
+          "type": "org.peacprotocol/purpose-declaration",
+          "iss": "https://api.example.com",
+          "iat": 1709500000,
+          "jti": "ext-purpose-005",
+          "pillars": ["purpose"],
+          "extensions": {
+            "org.peacprotocol/purpose": {
+              "external_purposes": ["ai_training"],
+              "peac_purpose_mapping": "INVALID-Token"
+            }
+          }
+        }
+      },
+      "expected": { "valid": false, "error_code": "E_INVALID_EXTENSION_FORMAT" }
+    },
+    {
+      "name": "reject-purpose-extra-field",
+      "description": "Unknown field in purpose extension rejected by .strict()",
+      "type": "full-pipeline",
+      "primary_requirement_id": "WIRE02-EXT-064",
+      "requirement_ids": ["WIRE02-EXT-064"],
+      "status": "negative",
+      "input": {
+        "claims": {
+          "peac_version": "0.2",
+          "kind": "evidence",
+          "type": "org.peacprotocol/purpose-declaration",
+          "iss": "https://api.example.com",
+          "iat": 1709500000,
+          "jti": "ext-purpose-006",
+          "pillars": ["purpose"],
+          "extensions": {
+            "org.peacprotocol/purpose": {
+              "external_purposes": ["analytics"],
+              "unknown_field": "should reject"
+            }
+          }
+        }
+      },
+      "expected": { "valid": false, "error_code": "E_INVALID_EXTENSION_FORMAT" }
+    },
+    {
+      "name": "reject-purpose-uppercase-token",
+      "description": "Uppercase token in external_purposes rejected by machine-safe grammar",
+      "type": "full-pipeline",
+      "primary_requirement_id": "WIRE02-EXT-065",
+      "requirement_ids": ["WIRE02-EXT-065"],
+      "status": "negative",
+      "input": {
+        "claims": {
+          "peac_version": "0.2",
+          "kind": "evidence",
+          "type": "org.peacprotocol/purpose-declaration",
+          "iss": "https://api.example.com",
+          "iat": 1709500000,
+          "jti": "ext-purpose-010",
+          "pillars": ["purpose"],
+          "extensions": {
+            "org.peacprotocol/purpose": {
+              "external_purposes": ["AI_TRAINING"]
+            }
+          }
+        }
+      },
+      "expected": { "valid": false, "error_code": "E_INVALID_EXTENSION_FORMAT" }
+    },
+    {
+      "name": "reject-purpose-whitespace-token",
+      "description": "Whitespace-containing token in external_purposes rejected",
+      "type": "full-pipeline",
+      "primary_requirement_id": "WIRE02-EXT-065",
+      "requirement_ids": ["WIRE02-EXT-065"],
+      "status": "negative",
+      "input": {
+        "claims": {
+          "peac_version": "0.2",
+          "kind": "evidence",
+          "type": "org.peacprotocol/purpose-declaration",
+          "iss": "https://api.example.com",
+          "iat": 1709500000,
+          "jti": "ext-purpose-011",
+          "pillars": ["purpose"],
+          "extensions": {
+            "org.peacprotocol/purpose": {
+              "external_purposes": ["ai training"]
+            }
+          }
+        }
+      },
+      "expected": { "valid": false, "error_code": "E_INVALID_EXTENSION_FORMAT" }
+    },
+    {
+      "name": "reject-purpose-duplicate-tokens",
+      "description": "Duplicate tokens in external_purposes rejected",
+      "type": "full-pipeline",
+      "primary_requirement_id": "WIRE02-EXT-061",
+      "requirement_ids": ["WIRE02-EXT-061"],
+      "status": "negative",
+      "input": {
+        "claims": {
+          "peac_version": "0.2",
+          "kind": "evidence",
+          "type": "org.peacprotocol/purpose-declaration",
+          "iss": "https://api.example.com",
+          "iat": 1709500000,
+          "jti": "ext-purpose-012",
+          "pillars": ["purpose"],
+          "extensions": {
+            "org.peacprotocol/purpose": {
+              "external_purposes": ["ai_training", "ai_training"]
+            }
+          }
+        }
+      },
+      "expected": { "valid": false, "error_code": "E_INVALID_EXTENSION_FORMAT" }
     }
   ]
 }

--- a/specs/conformance/requirement-ids.json
+++ b/specs/conformance/requirement-ids.json
@@ -1346,6 +1346,136 @@
           "enforcement_class": "hard_fail",
           "introduced_in": "0.12.2",
           "last_reviewed_in": "0.12.2"
+        },
+        {
+          "id": "WIRE02-EXT-054",
+          "keyword": "MUST",
+          "summary": "Provenance extension: source_uri and build_provenance_uri are HTTPS locator hints only",
+          "source_fragment": "`source_uri` and `build_provenance_uri` HTTPS URI hint optional: locator hints only; callers MUST NOT auto-fetch.",
+          "source_fragment_hash": "sha256:369e48a0cbe003e4290b8817948023d341744cc3445ef5e0b5f8ab8eed06f68c",
+          "enforcement_class": "hard_fail",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
+        },
+        {
+          "id": "WIRE02-EXT-055",
+          "keyword": "REQUIRED",
+          "summary": "Attribution extension: creator_ref is REQUIRED",
+          "source_fragment": "`creator_ref` string REQUIRED: identifies the creator.",
+          "source_fragment_hash": "sha256:97a506548e347b92f202d916486f02f081581f73b7229f22d8729ac163cd6018",
+          "enforcement_class": "hard_fail",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
+        },
+        {
+          "id": "WIRE02-EXT-056",
+          "keyword": "SHOULD",
+          "summary": "Attribution extension: license_spdx uses parser-grade SPDX validator",
+          "source_fragment": "`license_spdx` SPDX expression optional: uses the parser-grade SPDX license expression validator.",
+          "source_fragment_hash": "sha256:f897ef7cc16f279befa9d50e2ab61608cae47987a83f1d58ad397c26b1322c08",
+          "enforcement_class": "advisory",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
+        },
+        {
+          "id": "WIRE02-EXT-057",
+          "keyword": "MUST",
+          "summary": "Attribution extension: content_signal_source is closed enum",
+          "source_fragment": "`content_signal_source` enum optional: tdmrep_json, content_signal_header, content_usage_header, robots_txt, custom.",
+          "source_fragment_hash": "sha256:9eb9c06f5aa56fb2ec8867e4947fe4956c996a700abd68ff197b5e8636ce50f6",
+          "enforcement_class": "hard_fail",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
+        },
+        {
+          "id": "WIRE02-EXT-058",
+          "keyword": "SHOULD",
+          "summary": "Attribution extension: content_digest uses typed SHA-256 digest validation",
+          "source_fragment": "`content_digest` SHA-256 digest optional: uses `Sha256DigestSchema` for typed digest validation.",
+          "source_fragment_hash": "sha256:f9df2fb27b768f7990151d341035a40494d3f42f9a7ccfaaf62d8955d5a06636",
+          "enforcement_class": "advisory",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
+        },
+        {
+          "id": "WIRE02-EXT-059",
+          "keyword": "MUST",
+          "summary": "Attribution extension: .strict() rejects unknown properties",
+          "source_fragment": "`.strict()` rejects unknown properties: the attribution extension uses `.strict()` mode; unrecognized fields are rejected.",
+          "source_fragment_hash": "sha256:47003ad9870adb66488f4a3f28327ae249487ff2b91493cc970fd5999a484757",
+          "enforcement_class": "hard_fail",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
+        },
+        {
+          "id": "WIRE02-EXT-060",
+          "keyword": "SHOULD",
+          "summary": "Attribution extension: records observed metadata, not identity attestation (design guidance)",
+          "source_fragment": "Not an identity attestation; records observed attribution metadata.",
+          "source_fragment_hash": "sha256:f2ed1b90e528aceb625c676ba9908b997b7f433ed921d9b580a8e5b859c6c2c9",
+          "enforcement_class": "advisory",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
+        },
+        {
+          "id": "WIRE02-EXT-061",
+          "keyword": "REQUIRED",
+          "summary": "Purpose extension: external_purposes is REQUIRED, min 1, max 32 items",
+          "source_fragment": "`external_purposes` string[] REQUIRED min 1 max 32 items: external/legal/business purpose labels.",
+          "source_fragment_hash": "sha256:d11d9ae832701052b15c6ef52a73b3d48589b26cdf80209c83e16b24ee6d54dc",
+          "enforcement_class": "hard_fail",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
+        },
+        {
+          "id": "WIRE02-EXT-062",
+          "keyword": "SHOULD",
+          "summary": "Purpose extension: purpose_basis is open vocabulary",
+          "source_fragment": "`purpose_basis` string optional: legal or policy basis for the declared purposes.",
+          "source_fragment_hash": "sha256:4d53de5af04b137171e9cedb767934d1cf8bd98206c1951bbd9f225e31b2b727",
+          "enforcement_class": "advisory",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
+        },
+        {
+          "id": "WIRE02-EXT-063",
+          "keyword": "SHOULD",
+          "summary": "Purpose extension: peac_purpose_mapping bridges to operational tokens",
+          "source_fragment": "`peac_purpose_mapping` string optional: explicit bridge to a PEAC operational CanonicalPurpose token.",
+          "source_fragment_hash": "sha256:82831a0e370e06ea44d5b13c3d87bc9c8a98ed0cbdaf3900a091e006bc70be5e",
+          "enforcement_class": "advisory",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
+        },
+        {
+          "id": "WIRE02-EXT-064",
+          "keyword": "MUST",
+          "summary": "Purpose extension: .strict() rejects unknown properties",
+          "source_fragment": "`.strict()` rejects unknown properties: the purpose extension uses `.strict()` mode; unrecognized fields are rejected.",
+          "source_fragment_hash": "sha256:371bb62d235b518b0148847fc7b77a04af8a5c5853ee92a7bc36da63e6afd86a",
+          "enforcement_class": "hard_fail",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
+        },
+        {
+          "id": "WIRE02-EXT-065",
+          "keyword": "MUST",
+          "summary": "Purpose extension: external_purposes and compatible_purposes enforce machine-safe token grammar and uniqueness",
+          "source_fragment": "Each item MUST match the machine-safe token grammar and items MUST be unique.",
+          "source_fragment_hash": "sha256:4c0eaebcdbfa11fb123d581db002ef228de34c92b047ef7602c464097fa328c4",
+          "enforcement_class": "hard_fail",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
+        },
+        {
+          "id": "WIRE02-EXT-066",
+          "keyword": "MUST",
+          "summary": "Purpose extension: peac_purpose_mapping validated against PURPOSE_TOKEN_REGEX",
+          "source_fragment": "Validated against PURPOSE_TOKEN_REGEX.",
+          "source_fragment_hash": "sha256:85cc89fb485a60a1c6e8f8423d51ac25f3c9ed34cf34e8805616f99604217cf3",
+          "enforcement_class": "hard_fail",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         }
       ]
     },

--- a/specs/kernel/registries.json
+++ b/specs/kernel/registries.json
@@ -286,14 +286,14 @@
         "id": "org.peacprotocol/attribution-event",
         "pillar": "attribution",
         "description": "Content or action attribution evidence",
-        "extension_group": null,
+        "extension_group": "org.peacprotocol/attribution",
         "status": "informational"
       },
       {
         "id": "org.peacprotocol/purpose-declaration",
         "pillar": "purpose",
         "description": "Purpose declaration or limitation evidence",
-        "extension_group": null,
+        "extension_group": "org.peacprotocol/purpose",
         "status": "informational"
       }
     ]
@@ -349,6 +349,16 @@
       {
         "id": "org.peacprotocol/provenance",
         "description": "Provenance extension: source_type, source_ref, source_uri, build_provenance_uri, verification_method, custody_chain, slsa",
+        "status": "informational"
+      },
+      {
+        "id": "org.peacprotocol/attribution",
+        "description": "Attribution extension: creator_ref, license_spdx, obligation_type, attribution_text, content_signal_source, content_digest",
+        "status": "informational"
+      },
+      {
+        "id": "org.peacprotocol/purpose",
+        "description": "Purpose extension: external_purposes, purpose_basis, purpose_limitation, data_minimization, compatible_purposes, peac_purpose_mapping",
         "status": "informational"
       }
     ]


### PR DESCRIPTION
## Summary

Add two typed Wire 0.2 extension groups:

- `org.peacprotocol/attribution`
- `org.peacprotocol/purpose`

This completes the typed extension-group surface for the current Wire 0.2
receipt-type registry.

## Scope

- add attribution extension group with:
  - required `creator_ref`
  - optional SPDX license expression
  - optional obligation and attribution text fields
  - closed `content_signal_source` enum
  - optional typed SHA-256 content digest

- add purpose extension group with:
  - required `external_purposes`
  - machine-safe token grammar for purpose arrays
  - duplicate rejection for `external_purposes` and `compatible_purposes`
  - optional PEAC purpose bridge via `peac_purpose_mapping`

- update:
  - schema map
  - typed accessors
  - package barrels
  - registries and generated constants
  - Wire 0.2 spec sections 12.15 and 12.16
  - conformance fixtures and requirement registry
  - protocol warning-path tests for known extension keys

## Notes

- attribution remains observational metadata and does not act as identity attestation
- purpose remains token-based and machine-safe at schema layer
- no release changes
- no type-to-extension enforcement in this PR

## Validation

- build: clean
- lint: clean
- typecheck: clean
- test: 6252 passing
- format: clean
- guard: clean
- codegen drift: clean