### PR TITLE
docs: sync and add profile template

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ const { jws } = await issue({
   kind: 'evidence',
   type: 'org.peacprotocol/access-decision',
   pillars: ['access'],
+  extensions: {
+    'org.peacprotocol/access': {
+      resource: 'https://api.example.com/inference/v1',
+      action: 'execute',
+      decision: 'allow',
+    },
+  },
   privateKey,
   kid: 'key-2026-03',
 });

--- a/docs/README_LONG.md
+++ b/docs/README_LONG.md
@@ -56,7 +56,7 @@ const { jws } = await issue({
       payment_rail: 'x402',
       amount_minor: '100000',
       currency: 'USD',
-      settlement_ref: 'tx_abc123',
+      reference: 'tx_abc123',
     },
   },
   privateKey,
@@ -81,6 +81,13 @@ app.get('/data', async (req, res) => {
     kind: 'evidence',
     type: 'org.peacprotocol/access-decision',
     pillars: ['access'],
+    extensions: {
+      'org.peacprotocol/access': {
+        resource: '/data',
+        action: 'read',
+        decision: 'allow',
+      },
+    },
     privateKey,
     kid: 'key-2026-01',
   });
@@ -223,7 +230,7 @@ See [docs/specs/PEAC-ISSUER.md](specs/PEAC-ISSUER.md).
 - Two structural kinds: `evidence` and `challenge`
 - Open semantic `type` (reverse-DNS or absolute URI)
 - Multi-valued `pillars` from 10-value closed taxonomy
-- 5 typed extension groups: commerce, access, challenge, identity, correlation
+- 12 typed extension groups with type-to-extension enforcement
 - Policy binding: JCS (RFC 8785) + SHA-256 digest comparison
 - JOSE hardening: embedded keys rejected, `kid` required
 

--- a/docs/profiles/README.md
+++ b/docs/profiles/README.md
@@ -1,27 +1,118 @@
 # PEAC Profiles
 
-Profiles are document overlays that describe how to use PEAC with specific payment rails,
-identity systems, or workflow patterns. A profile does NOT add new schema fields: it
-constrains and maps existing PEAC structures for a specific integration.
+Profiles are documentation overlays that describe how to use PEAC for specific
+use cases, regulatory contexts, or integration patterns. A profile does NOT add
+new schema fields: it constrains and documents existing PEAC structures.
+
+Profiles are documentary, not runtime-enforced. Schema validation (`@peac/schema`)
+enforces field structure; `verifyLocal()` enforces protocol behavior including
+type-to-extension enforcement. Profiles document recommended usage patterns on
+top of those layers.
 
 See `reference/PROFILE_RULES.md` for the architectural boundary between profiles and schemas.
 
 ## Available Profiles
 
+### Pillar Profiles
+
+Pillar profiles document how to use a specific PEAC extension group for a
+regulatory, operational, or evidence workflow.
+
+| Profile                       | Extension Group                | Since   | Status |
+| ----------------------------- | ------------------------------ | ------- | ------ |
+| [Consent](consent.md)         | `org.peacprotocol/consent`     | v0.12.2 | Draft  |
+| [Privacy](privacy.md)         | `org.peacprotocol/privacy`     | v0.12.2 | Draft  |
+| [Safety](safety.md)           | `org.peacprotocol/safety`      | v0.12.2 | Draft  |
+| [Compliance](compliance.md)   | `org.peacprotocol/compliance`  | v0.12.2 | Draft  |
+| [Provenance](provenance.md)   | `org.peacprotocol/provenance`  | v0.12.2 | Draft  |
+| [Attribution](attribution.md) | `org.peacprotocol/attribution` | v0.12.2 | Draft  |
+| [Purpose](purpose.md)         | `org.peacprotocol/purpose`     | v0.12.2 | Draft  |
+
+### Adapter Profiles
+
+Adapter profiles document how to normalize external protocol artifacts into
+PEAC receipts for a specific integration.
+
 | Profile                                                         | Package              | Since    | Status |
 | --------------------------------------------------------------- | -------------------- | -------- | ------ |
 | [Stripe x402 Machine Payments](stripe-x402-machine-payments.md) | `@peac/rails-stripe` | v0.10.11 | Draft  |
 
-## Creating a New Profile
+## Profile Templates
 
-A profile document should include:
+PEAC uses two profile templates. Choose the one that matches your use case.
+
+### Pillar Profile Template
+
+For profiles that document how to use a PEAC extension group for a specific
+evidence or regulatory workflow. No backing package required.
+
+1. **Abstract**: one-paragraph description of the profile and its purpose
+2. **When to use**: scenarios where this profile applies
+3. **Required / Recommended / Prohibited fields**: which fields from the
+   extension group are REQUIRED, RECOMMENDED, or PROHIBITED for this profile,
+   using RFC 2119 keywords
+4. **Minimal valid receipt**: the smallest receipt that satisfies this profile
+5. **Companion profiles**: recommended combinations with other profiles
+6. **Regulatory context**: specific regulations or standards this profile
+   supports evidence for, using neutral wording ("supports evidence relevant
+   to", "can help document"; never "required for compliance")
+7. **Conformance examples**: documentary examples in a standardized pattern:
+   - Minimal valid issue example
+   - Verify example
+   - Invalid example (violates a profile constraint, with explanation)
+   - Companion-profile example where relevant (two profiles combined)
+8. **Quick demo**: a runnable TypeScript snippet (issue + verify) a stranger
+   can execute in under 5 minutes
+9. **Non-goals / not guaranteed**: must state plainly that the profile:
+   - does not create new schema fields
+   - does not by itself establish legal compliance
+   - does not imply verifier enforcement beyond what the protocol spec defines
+10. **Notes / caveats**: limitations, future directions, or scope boundaries
+
+### Adapter Profile Template
+
+For profiles that document how to normalize external protocol data into PEAC
+receipts for a specific integration. Requires a backing package.
 
 1. **Abstract**: one-paragraph description
-2. **Use Case**: the scenario this profile targets
-3. **Mapping**: input/output field mapping tables
-4. **Validation Rules**: numbered, testable invariants
-5. **Conformance Vectors**: link to `specs/conformance/fixtures/<category>/`
-6. **Quick Demo**: a runnable command a stranger can execute in under 5 minutes
-7. **Example**: inline code showing the happy path
+2. **Use case**: the scenario this profile targets
+3. **Package / Function**: the backing `@peac/rails-*` or `@peac/adapter-*` package
+4. **Mapping**: input/output field mapping tables
+5. **Validation rules**: numbered, testable invariants
+6. **Conformance vectors**: link to `specs/conformance/fixtures/<category>/`
+7. **Quick demo**: a runnable command a stranger can execute in under 5 minutes
+8. **Example**: inline code showing the happy path
+
+## Regulatory Wording Rules
+
+Profile documents that reference regulations or standards must use neutral,
+evidence-oriented language:
+
+- "supports evidence relevant to [Article X] workflows"
+- "can help document [requirement Y]"
+- "maps naturally to [standard Z] concepts"
+
+Do NOT use language that implies direct compliance or legal sufficiency:
+
+- ~~"required for [Article X] compliance"~~
+- ~~"ensures GDPR conformance"~~
+- ~~"satisfies [regulation] requirements"~~
+
+PEAC is evidence and interoperability infrastructure. Extension groups and
+profiles support workflows relevant to regulatory requirements; they do not
+themselves constitute compliance artifacts.
+
+## Companion Profile Guidance
+
+Certain profiles are natural companions for common regulatory workflows:
+
+| Workflow                  | Recommended Profiles     | Context                                              |
+| ------------------------- | ------------------------ | ---------------------------------------------------- |
+| GDPR evidence             | Consent + Purpose        | Art 6-7 legal basis + Art 5(1)(b) purpose limitation |
+| GDPR data handling        | Privacy + Consent        | Art 13-14 disclosure + Art 7 consent                 |
+| EU AI Act risk management | Safety + Compliance      | Art 9 risk management + Art 28 deployer obligations  |
+| AI-generated content      | Provenance + Attribution | Art 50 transparency + content origin                 |
+| SOC 2 / ISO 27001 audit   | Compliance               | Standalone; audit reference + framework              |
+| Content licensing         | Attribution + Provenance | SPDX license + origin tracking                       |
 
 Profiles live in `docs/profiles/` and are linked from this index.

--- a/docs/specs/WIRE-0.2.md
+++ b/docs/specs/WIRE-0.2.md
@@ -623,7 +623,7 @@ Output: boolean (true if valid extension key grammar)
 
 ### 12.3 Core Extension Groups
 
-Eight core extension groups have typed schemas in `@peac/schema`. All use `.strict()` mode (unknown keys within a group are rejected).
+Twelve core extension groups have typed schemas in `@peac/schema`. All use `.strict()` mode (unknown keys within a group are rejected). Registered first-party receipt types with a mapped extension group are enforced in `verifyLocal()`: strict mode requires the mapped group; interop mode downgrades absence or mismatch to warnings (see section 12.17).
 
 | Key                            | Group       | Section |
 | ------------------------------ | ----------- | ------- |
@@ -635,6 +635,10 @@ Eight core extension groups have typed schemas in `@peac/schema`. All use `.stri
 | `org.peacprotocol/consent`     | Consent     | 12.10   |
 | `org.peacprotocol/privacy`     | Privacy     | 12.11   |
 | `org.peacprotocol/safety`      | Safety      | 12.12   |
+| `org.peacprotocol/compliance`  | Compliance  | 12.13   |
+| `org.peacprotocol/provenance`  | Provenance  | 12.14   |
+| `org.peacprotocol/attribution` | Attribution | 12.15   |
+| `org.peacprotocol/purpose`     | Purpose     | 12.16   |
 
 ### 12.4 Commerce Extension
 

--- a/scripts/guard.sh
+++ b/scripts/guard.sh
@@ -568,4 +568,55 @@ else
   echo "SKIP: validate-doc-examples.mjs not found"
 fi
 
+# == doc-truth: stale extension-group counts ==
+# Prevents public docs from claiming a stale extension-group count.
+# Excludes version-history sections (historically accurate references).
+echo "== doc-truth: stale extension-group counts =="
+_doc_stale=0
+_stale_5=$(git grep -n 'Five typed extension group\|5 typed extension group' -- 'docs/**' 'README.md' ':!node_modules' 2>/dev/null | grep -vi 'version history\|changelog\|preview\.1\|preview\.2' || true)
+if [ -n "$_stale_5" ]; then
+  echo "FAIL: public docs still say '5 typed extension groups'"
+  echo "$_stale_5"
+  _doc_stale=1
+fi
+_stale_8=$(git grep -n 'Eight core extension group\|8 core extension group' -- 'docs/**' 'README.md' ':!node_modules' 2>/dev/null | grep -vi 'version history\|changelog\|preview\.1\|preview\.2' || true)
+if [ -n "$_stale_8" ]; then
+  echo "FAIL: public docs still say '8 core extension groups'"
+  echo "$_stale_8"
+  _doc_stale=1
+fi
+if [ "$_doc_stale" = 1 ]; then
+  bad=1
+else
+  echo "OK"
+fi
+
+# == doc-truth: profile naming vs registry parity ==
+# Ensures profile filenames in docs/profiles/README.md match pillar names in registries.json.
+echo "== doc-truth: profile naming parity =="
+_naming_ok=1
+if [ -f specs/kernel/registries.json ] && [ -f docs/profiles/README.md ]; then
+  # Extract pillar names from registry receipt_types that have extension_groups
+  _pillars=$(node -e "
+    const r = require('./specs/kernel/registries.json');
+    const skip = new Set(['commerce','access','identity']); // adapter profiles, not pillar profiles
+    r.receipt_types.values
+      .filter(v => v.extension_group && !skip.has(v.pillar))
+      .forEach(v => console.log(v.pillar));
+  " 2>/dev/null || true)
+  for _p in $_pillars; do
+    if ! grep -qi "(${_p}.md)" docs/profiles/README.md 2>/dev/null; then
+      echo "FAIL: pillar '$_p' has no matching profile link (${_p}.md) in docs/profiles/README.md"
+      _naming_ok=0
+    fi
+  done
+  if [ "$_naming_ok" = 0 ]; then
+    bad=1
+  else
+    echo "OK"
+  fi
+else
+  echo "SKIP: registries.json or profiles/README.md not found"
+fi
+
 exit $bad


### PR DESCRIPTION
## Summary

Fix public doc-truth drift introduced by type-to-extension enforcement (#522)
and the 7 new extension groups (#519-#521). Prerequisite for PR 6 (usage
profiles) and PR 9 (commerce events).

## Scope

- README quick-start: add required `org.peacprotocol/access` extension for
  `access-decision` type (strict-mode `verifyLocal()` requires it since #522)
- README_LONG Express example: same fix, plus correct invalid `settlement_ref`
  to `reference` (commerce `.strict()` rejects unknown keys)
- WIRE-0.2.md section 12.3: "Eight" to "Twelve" extension groups with 4
  missing table entries and enforcement cross-reference
- docs/profiles/README.md: two-class template system (pillar + adapter),
  mandatory Non-goals section, schema-vs-profile field tables, strict-mode
  demo requirement, companion-profile guidance, regulatory wording rules
- docs/README_LONG.md: "5 typed extension groups" to "12"
- scripts/guard.sh: doc-truth CI guards (stale count detection, profile-naming
  parity check against registries.json)

## Validation

- build: clean
- lint: clean
- typecheck: clean
- test: 6334 passing (244 files)
- format: clean
- guard: clean (including new doc-truth checks)