### PR TITLE
docs: add profile documents

### DIFF
--- a/docs/profiles/README.md
+++ b/docs/profiles/README.md
@@ -9,7 +9,8 @@ enforces field structure; `verifyLocal()` enforces protocol behavior including
 type-to-extension enforcement. Profiles document recommended usage patterns on
 top of those layers.
 
-See `reference/PROFILE_RULES.md` for the architectural boundary between profiles and schemas.
+Profiles constrain existing schema fields; they never add new wire format fields.
+See `docs/specs/WIRE-0.2.md` section 12 for the normative extension group specification.
 
 ## Available Profiles
 
@@ -20,6 +21,8 @@ regulatory, operational, or evidence workflow.
 
 | Profile                       | Extension Group                | Since   | Status |
 | ----------------------------- | ------------------------------ | ------- | ------ |
+| [Access](access.md)           | `org.peacprotocol/access`      | v0.12.2 | Draft  |
+| [Identity](identity.md)       | `org.peacprotocol/identity`    | v0.12.2 | Draft  |
 | [Consent](consent.md)         | `org.peacprotocol/consent`     | v0.12.2 | Draft  |
 | [Privacy](privacy.md)         | `org.peacprotocol/privacy`     | v0.12.2 | Draft  |
 | [Safety](safety.md)           | `org.peacprotocol/safety`      | v0.12.2 | Draft  |
@@ -79,7 +82,7 @@ receipts for a specific integration. Requires a backing package.
 3. **Package / Function**: the backing `@peac/rails-*` or `@peac/adapter-*` package
 4. **Mapping**: input/output field mapping tables
 5. **Validation rules**: numbered, testable invariants
-6. **Conformance vectors**: link to `specs/conformance/fixtures/<category>/`
+6. **Conformance vectors**: link to fixtures in `specs/conformance/fixtures/` under the relevant category
 7. **Quick demo**: a runnable command a stranger can execute in under 5 minutes
 8. **Example**: inline code showing the happy path
 

--- a/docs/profiles/access.md
+++ b/docs/profiles/access.md
@@ -1,0 +1,223 @@
+# Access Profile
+
+**Status:** Draft
+**Since:** v0.12.2
+**Extension Group:** `org.peacprotocol/access`
+**Receipt Type:** `org.peacprotocol/access-decision`
+
+## Abstract
+
+The Access profile documents how to use the `org.peacprotocol/access`
+extension group to record access control decisions as evidence receipts.
+It covers resource identification, action classification, and
+three-state decision outcomes (allow, deny, review). All three fields
+in the access extension group are schema-required, so this profile does
+not tighten any fields beyond what the schema already mandates.
+
+## When to use
+
+- Recording that an API gateway, MCP server, or service mesh evaluated
+  an access request and reached a decision (allow, deny, or deferred
+  for review)
+- Producing machine-verifiable evidence that a specific resource was
+  accessed (or denied) for a specific action at a specific time
+- Creating auditable access decision logs that can be verified by third
+  parties independently of the system that made the decision
+
+## Required / Recommended / Prohibited fields
+
+All fields below belong to the `org.peacprotocol/access` extension group.
+
+| Field      | Schema Status | Profile Status | Rationale                                              |
+| ---------- | ------------- | -------------- | ------------------------------------------------------ |
+| `resource` | REQUIRED      | REQUIRED       | Identifies the resource being accessed                 |
+| `action`   | REQUIRED      | REQUIRED       | Identifies the action performed on the resource        |
+| `decision` | REQUIRED      | REQUIRED       | Records the access control outcome (allow/deny/review) |
+
+All fields are schema-required. This profile does not tighten any
+optional fields to REQUIRED status.
+
+## Minimal valid receipt
+
+The smallest receipt body that satisfies this profile. The `extensions`
+object carries the `org.peacprotocol/access` group with the three
+required fields.
+
+```json
+{
+  "iss": "https://gateway.example.com",
+  "aud": "https://consumer.example.com",
+  "kind": "evidence",
+  "type": "org.peacprotocol/access-decision",
+  "pillars": ["access"],
+  "extensions": {
+    "org.peacprotocol/access": {
+      "resource": "https://api.example.com/inference/v1",
+      "action": "execute",
+      "decision": "allow"
+    }
+  }
+}
+```
+
+## Companion profiles
+
+- **Identity** (recommended, not enforced): when the access decision
+  depends on a verified identity attestation, pairing an identity
+  receipt with an access receipt provides a complete evidence chain
+  from identity proof to access outcome
+- **Compliance** (recommended for audit workflows): when access
+  decisions are subject to regulatory audit, a companion compliance
+  receipt records the framework and audit reference
+
+Companion profiles are recommendations for common workflows, not
+enforced dependencies. Receipts are valid without companion profiles.
+
+## Regulatory context
+
+The access extension group supports evidence relevant to:
+
+- SOC 2 Type II: access control evidence for CC6.1 (logical and
+  physical access controls)
+- ISO 27001: access control evidence for Annex A.9 (access control)
+- NIST SP 800-53: access control evidence for AC (Access Control)
+  family
+
+This profile can help document access decisions for audit purposes.
+PEAC is evidence infrastructure; these mappings do not themselves
+constitute compliance.
+
+## Conformance examples
+
+### Valid: access-decision with allow outcome
+
+```json
+{
+  "iss": "https://gateway.example.com",
+  "kind": "evidence",
+  "type": "org.peacprotocol/access-decision",
+  "pillars": ["access"],
+  "extensions": {
+    "org.peacprotocol/access": {
+      "resource": "https://api.example.com/data/users",
+      "action": "read",
+      "decision": "allow"
+    }
+  }
+}
+```
+
+This receipt satisfies the profile: all three required fields are
+present and the decision is one of the three valid values.
+
+### Invalid: missing decision field
+
+```json
+{
+  "iss": "https://gateway.example.com",
+  "kind": "evidence",
+  "type": "org.peacprotocol/access-decision",
+  "pillars": ["access"],
+  "extensions": {
+    "org.peacprotocol/access": {
+      "resource": "https://api.example.com/data/users",
+      "action": "read"
+    }
+  }
+}
+```
+
+This receipt fails schema validation (not just profile validation):
+`decision` is schema-required. The access extension group has no
+optional fields, so schema validation and profile validation are
+equivalent for this group.
+
+### Companion: access + identity
+
+```json
+{
+  "iss": "https://gateway.example.com",
+  "kind": "evidence",
+  "type": "org.peacprotocol/access-decision",
+  "pillars": ["access"],
+  "extensions": {
+    "org.peacprotocol/access": {
+      "resource": "https://api.example.com/inference/v1",
+      "action": "execute",
+      "decision": "allow"
+    },
+    "org.peacprotocol/identity": {
+      "proof_ref": "did:key:z6Mkf5rGMoatrSj1f4CyvuHBeXJELe9RPdzo2PKGNCKVtZxP"
+    }
+  }
+}
+```
+
+This receipt pairs access evidence with an identity proof reference,
+providing a complete evidence chain from identity to access outcome.
+
+## Quick demo
+
+```typescript
+import { generateKeypair } from '@peac/crypto';
+import { issue, verifyLocal } from '@peac/protocol';
+
+const { privateKey, publicKey } = await generateKeypair();
+
+const { jws } = await issue({
+  iss: 'https://gateway.example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/access-decision',
+  pillars: ['access'],
+  extensions: {
+    'org.peacprotocol/access': {
+      resource: 'https://api.example.com/inference/v1',
+      action: 'execute',
+      decision: 'allow',
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+
+const result = await verifyLocal(jws, publicKey, {
+  issuer: 'https://gateway.example.com',
+  strictness: 'strict',
+});
+
+console.log(result.valid); // true
+console.log(result.claims.type); // 'org.peacprotocol/access-decision'
+```
+
+## Cross-references
+
+- Wire 0.2 spec: section 12.5 (`org.peacprotocol/access` extension group) in `docs/specs/WIRE-0.2.md`
+- Registered receipt type: `org.peacprotocol/access-decision` in `specs/kernel/registries.json`
+- Type-to-extension enforcement: section 12.17 in `docs/specs/WIRE-0.2.md`
+
+## Non-goals / not guaranteed
+
+- This profile does not introduce new schema fields. All fields referenced
+  exist in the `org.peacprotocol/access` extension group schema
+- This profile does not by itself establish legal compliance with any regulation.
+  PEAC is evidence infrastructure; legal compliance depends on organizational
+  controls, processes, and legal interpretation beyond the scope of this protocol
+- Verifier enforcement is only what the protocol specification defines.
+  Profile-level field requirements (such as REQUIRED fields marked OPTIONAL
+  in the schema) are documentary guidance, not runtime-enforced constraints
+- Companion profile recommendations are suggestions for common workflows,
+  not enforced dependencies. Receipts are valid without companion profiles
+
+## Notes / caveats
+
+- The `decision` field uses a closed vocabulary of three values:
+  `allow`, `deny`, `review`. The `review` value represents a deferred
+  decision where a human or downstream system must make the final call
+- The `resource` field accepts URIs or opaque identifiers up to 2048
+  characters. Organizations should use consistent resource naming
+  conventions for interoperability
+- The `action` field is an open vocabulary string. Common values include
+  `read`, `write`, `execute`, `delete`, `list`, but any string up to
+  256 characters is valid
+- Access decisions are observations: recording an access decision does
+  not constitute granting or revoking access

--- a/docs/profiles/attribution.md
+++ b/docs/profiles/attribution.md
@@ -1,0 +1,232 @@
+# Attribution Profile
+
+**Status:** Draft
+**Since:** v0.12.2
+**Extension Group:** `org.peacprotocol/attribution`
+**Receipt Type:** `org.peacprotocol/attribution-event`
+
+## Abstract
+
+The Attribution profile documents how to use the `org.peacprotocol/attribution`
+extension group to record credit, licensing, and content signal observations
+as evidence receipts. It covers creator identification, SPDX license
+expressions, obligation types, content signal sources, and content digests.
+This profile does not tighten any schema-optional fields beyond recommending
+`license_spdx` and `content_digest` for content licensing and origin
+evidence workflows.
+
+## When to use
+
+- Recording that content has a specific creator and license, with evidence
+  suitable for content licensing workflows and creator credit obligations
+- Producing machine-verifiable attribution evidence that documents SPDX
+  license expressions, content signal observations, and obligation types
+- Creating auditable attribution records that link content digests to
+  creator identifiers and license terms
+
+## Required / Recommended / Prohibited fields
+
+All fields below belong to the `org.peacprotocol/attribution` extension group.
+
+| Field                   | Schema Status | Profile Status | Rationale                                                         |
+| ----------------------- | ------------- | -------------- | ----------------------------------------------------------------- |
+| `creator_ref`           | REQUIRED      | REQUIRED       | Schema-required; identifies the creator (DID, URI, or opaque ID)  |
+| `license_spdx`          | OPTIONAL      | RECOMMENDED    | Supports evidence of content licensing terms                      |
+| `content_digest`        | OPTIONAL      | RECOMMENDED    | Supports evidence of which content is attributed (SHA-256 digest) |
+| `obligation_type`       | OPTIONAL      | OPTIONAL       | Records obligation type (attribution_required, share_alike)       |
+| `attribution_text`      | OPTIONAL      | OPTIONAL       | Required attribution text for display                             |
+| `content_signal_source` | OPTIONAL      | OPTIONAL       | Content signal observation source (closed vocabulary)             |
+
+## Minimal valid receipt
+
+The smallest receipt body that satisfies this profile. Only the
+schema-required `creator_ref` field is needed.
+
+```json
+{
+  "iss": "https://example.com",
+  "iat": 1710460800,
+  "peac_version": "0.2",
+  "kind": "evidence",
+  "type": "org.peacprotocol/attribution-event",
+  "pillars": ["attribution"],
+  "extensions": {
+    "org.peacprotocol/attribution": {
+      "creator_ref": "did:example:creator123"
+    }
+  }
+}
+```
+
+## Companion profiles
+
+The following combinations are recommended for common workflows. Companion
+profiles are recommendations, not enforced dependencies. Receipts are valid
+without companion profiles.
+
+| Companion                   | Workflow                                                       |
+| --------------------------- | -------------------------------------------------------------- |
+| [Provenance](provenance.md) | Content origin tracking alongside creator credit and licensing |
+
+## Regulatory context
+
+This profile supports evidence relevant to content attribution and licensing
+workflows. PEAC is evidence infrastructure; legal compliance depends on
+organizational controls, processes, and legal interpretation beyond the
+scope of this protocol.
+
+| Regulation / Standard         | Relevance                                                                    |
+| ----------------------------- | ---------------------------------------------------------------------------- |
+| SPDX 3.0.1                    | Maps naturally to Software Package Data Exchange license expression concepts |
+| C2PA                          | Complementary to Coalition for Content Provenance and Authenticity concepts  |
+| Content licensing obligations | Supports evidence relevant to creator credit and license attribution         |
+
+## Conformance examples
+
+### Minimal valid issue
+
+```typescript
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/attribution-event',
+  pillars: ['attribution'],
+  extensions: {
+    'org.peacprotocol/attribution': {
+      creator_ref: 'did:example:creator123',
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+```
+
+### Verify
+
+```typescript
+const result = await verifyLocal(jws, publicKey, {
+  issuer: 'https://example.com',
+  strictness: 'strict',
+});
+
+console.log(result.valid); // true
+console.log(result.claims.type); // 'org.peacprotocol/attribution-event'
+```
+
+### Invalid example: empty creator_ref
+
+The following receipt is schema-invalid because `creator_ref` is
+REQUIRED and must be a non-empty string.
+
+```typescript
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/attribution-event',
+  pillars: ['attribution'],
+  extensions: {
+    'org.peacprotocol/attribution': {
+      creator_ref: '', // schema-invalid: must be non-empty
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+// Throws: schema validation error
+```
+
+### Companion example: attribution with provenance
+
+```typescript
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/attribution-event',
+  pillars: ['attribution', 'provenance'],
+  extensions: {
+    'org.peacprotocol/attribution': {
+      creator_ref: 'did:example:photographer',
+      license_spdx: 'CC-BY-4.0',
+      obligation_type: 'attribution_required',
+      attribution_text: 'Photo by Example Photographer',
+      content_digest: 'sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+    },
+    'org.peacprotocol/provenance': {
+      source_type: 'original',
+      source_uri: 'https://example.com/photos/sunset-2026',
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+```
+
+## Quick demo
+
+```typescript
+import { generateKeypair } from '@peac/crypto';
+import { issue, verifyLocal } from '@peac/protocol';
+
+const { privateKey, publicKey } = await generateKeypair();
+
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/attribution-event',
+  pillars: ['attribution'],
+  extensions: {
+    'org.peacprotocol/attribution': {
+      creator_ref: 'did:example:creator123',
+      license_spdx: 'MIT',
+      content_digest: 'sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+
+const result = await verifyLocal(jws, publicKey, {
+  issuer: 'https://example.com',
+  strictness: 'strict',
+});
+
+console.log(result.valid); // true
+console.log(result.claims.type); // 'org.peacprotocol/attribution-event'
+```
+
+## Non-goals / not guaranteed
+
+- This profile does not introduce new schema fields. All fields referenced
+  exist in the `org.peacprotocol/attribution` extension group schema
+- This profile does not by itself establish legal compliance with any regulation.
+  PEAC is evidence infrastructure; legal compliance depends on organizational
+  controls, processes, and legal interpretation beyond the scope of this protocol
+- Verifier enforcement is only what the protocol specification defines.
+  Profile-level field requirements (such as REQUIRED fields marked OPTIONAL
+  in the schema) are documentary guidance, not runtime-enforced constraints
+- Companion profile recommendations are suggestions for common workflows,
+  not enforced dependencies. Receipts are valid without companion profiles
+
+## Cross-references
+
+- Wire 0.2 spec: section 12.15 (`org.peacprotocol/attribution` extension group) in `docs/specs/WIRE-0.2.md`
+- Registered receipt type: `org.peacprotocol/attribution-event` in `specs/kernel/registries.json`
+- Type-to-extension enforcement: section 12.17 in `docs/specs/WIRE-0.2.md`
+
+## Notes / caveats
+
+- The `creator_ref` field is not an identity attestation: it records
+  observed attribution metadata. Identity verification belongs to the
+  Identity extension group
+- The `license_spdx` field uses a structural subset of the SPDX license
+  expression grammar. Complex expressions may be truncated by the parser;
+  use the simplest valid expression
+- The `content_signal_source` field uses a closed vocabulary of five
+  values: `tdmrep_json`, `content_signal_header`, `content_usage_header`,
+  `robots_txt`, `custom`. These map to the content signals precedence
+  chain
+- The `content_digest` field accepts SHA-256 digests in
+  `sha256:<hex>` format, providing a tamper-evident link to the
+  attributed content without embedding it
+- Attribution events are observations: recording an attribution event
+  does not constitute a binding license grant or obligation

--- a/docs/profiles/compliance.md
+++ b/docs/profiles/compliance.md
@@ -1,0 +1,248 @@
+# Compliance Profile
+
+**Status:** Draft
+**Since:** v0.12.2
+**Extension Group:** `org.peacprotocol/compliance`
+**Receipt Type:** `org.peacprotocol/compliance-check`
+
+## Abstract
+
+The Compliance profile documents how to use the `org.peacprotocol/compliance`
+extension group to record regulatory compliance check evidence as receipts.
+It covers framework identification, compliance status determination, audit
+provenance, and assessor identity. The profile tightens two schema-optional
+fields (`audit_ref` and `auditor`) to REQUIRED status so that receipts
+produced under this profile carry evidence of audit provenance and assessor
+identity.
+
+## When to use
+
+- Recording that a compliance check occurred against a specific regulatory
+  framework, with evidence of the framework evaluated, the observed outcome,
+  and who performed the assessment
+- Producing machine-verifiable compliance check evidence for audit trails
+  across SOC 2 Type II, ISO 27001, EU AI Act, or other regulatory frameworks
+- Creating auditable compliance assessment records that include assessor
+  identity and audit reference, suitable for feeding into governance workflows
+
+## Required / Recommended / Prohibited fields
+
+All fields below belong to the `org.peacprotocol/compliance` extension group.
+
+| Field               | Schema Status | Profile Status | Rationale                                               |
+| ------------------- | ------------- | -------------- | ------------------------------------------------------- |
+| `framework`         | REQUIRED      | REQUIRED       | Schema-required; identifies the regulatory framework    |
+| `compliance_status` | REQUIRED      | REQUIRED       | Schema-required; records the observed compliance state  |
+| `audit_ref`         | OPTIONAL      | REQUIRED       | Supports evidence of audit provenance                   |
+| `auditor`           | OPTIONAL      | REQUIRED       | Supports evidence of assessor identity                  |
+| `audit_date`        | OPTIONAL      | RECOMMENDED    | Records when the compliance check was performed         |
+| `scope`             | OPTIONAL      | RECOMMENDED    | Documents the scope of the compliance check             |
+| `validity_period`   | OPTIONAL      | OPTIONAL       | How long this finding remains valid (ISO 8601 duration) |
+| `evidence_ref`      | OPTIONAL      | OPTIONAL       | SHA-256 digest of supporting evidence document          |
+
+## Minimal valid receipt
+
+The smallest receipt body that satisfies this profile. The `extensions`
+object carries the `org.peacprotocol/compliance` group with the four
+profile-required fields.
+
+```json
+{
+  "iss": "https://example.com",
+  "iat": 1710460800,
+  "peac_version": "0.2",
+  "kind": "evidence",
+  "type": "org.peacprotocol/compliance-check",
+  "pillars": ["compliance"],
+  "extensions": {
+    "org.peacprotocol/compliance": {
+      "framework": "soc2-type2",
+      "compliance_status": "compliant",
+      "audit_ref": "RPT-2026-0042",
+      "auditor": "Acme Audit Corp"
+    }
+  }
+}
+```
+
+## Companion profiles
+
+The following combinations are recommended for common workflows. Companion
+profiles are recommendations, not enforced dependencies. Receipts are valid
+without companion profiles.
+
+| Companion           | Workflow                                                                    |
+| ------------------- | --------------------------------------------------------------------------- |
+| [Safety](safety.md) | EU AI Act Art 9 risk management alongside Art 28 deployer compliance checks |
+
+Compliance can also be used standalone for frameworks such as SOC 2 Type II
+or ISO 27001 where audit reference and framework identification are the
+primary evidence needs.
+
+## Regulatory context
+
+This profile supports evidence relevant to compliance assessment and audit
+workflows. PEAC is evidence infrastructure; legal compliance depends on
+organizational controls, processes, and legal interpretation beyond the
+scope of this protocol.
+
+| Regulation / Standard | Relevance                                                                  |
+| --------------------- | -------------------------------------------------------------------------- |
+| SOC 2 Type II         | Supports evidence relevant to service organization control audit workflows |
+| ISO 27001             | Can help document information security management system audit evidence    |
+| EU AI Act Art 28      | Supports evidence relevant to deployer obligation workflows                |
+| ISO 19011:2018        | Maps naturally to auditing management system concepts                      |
+
+## Conformance examples
+
+### Minimal valid issue
+
+```typescript
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/compliance-check',
+  pillars: ['compliance'],
+  extensions: {
+    'org.peacprotocol/compliance': {
+      framework: 'soc2-type2',
+      compliance_status: 'compliant',
+      audit_ref: 'RPT-2026-0042',
+      auditor: 'Acme Audit Corp',
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+```
+
+### Verify
+
+```typescript
+const result = await verifyLocal(jws, publicKey, {
+  issuer: 'https://example.com',
+  strictness: 'strict',
+});
+
+console.log(result.valid); // true
+console.log(result.claims.type); // 'org.peacprotocol/compliance-check'
+```
+
+### Invalid example: missing profile-required fields
+
+The following receipt is schema-valid (because `audit_ref` and `auditor`
+are OPTIONAL at the schema level) but does not satisfy this profile
+because it omits both.
+
+```typescript
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/compliance-check',
+  pillars: ['compliance'],
+  extensions: {
+    'org.peacprotocol/compliance': {
+      framework: 'iso-27001',
+      compliance_status: 'compliant',
+      // audit_ref omitted: schema-valid but does not satisfy this profile
+      // auditor omitted: schema-valid but does not satisfy this profile
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+```
+
+### Companion example: compliance with safety
+
+```typescript
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/compliance-check',
+  pillars: ['compliance', 'safety'],
+  extensions: {
+    'org.peacprotocol/compliance': {
+      framework: 'eu-ai-act',
+      compliance_status: 'under_review',
+      audit_ref: 'AIA-2026-DEPLOY-001',
+      auditor: 'Internal Risk Team',
+      scope: 'High-risk AI system deployment',
+    },
+    'org.peacprotocol/safety': {
+      review_status: 'reviewed',
+      risk_level: 'high',
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+```
+
+## Quick demo
+
+```typescript
+import { generateKeypair } from '@peac/crypto';
+import { issue, verifyLocal } from '@peac/protocol';
+
+const { privateKey, publicKey } = await generateKeypair();
+
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/compliance-check',
+  pillars: ['compliance'],
+  extensions: {
+    'org.peacprotocol/compliance': {
+      framework: 'soc2-type2',
+      compliance_status: 'compliant',
+      audit_ref: 'RPT-2026-0042',
+      auditor: 'Acme Audit Corp',
+      audit_date: '2026-03-15',
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+
+const result = await verifyLocal(jws, publicKey, {
+  issuer: 'https://example.com',
+  strictness: 'strict',
+});
+
+console.log(result.valid); // true
+console.log(result.claims.type); // 'org.peacprotocol/compliance-check'
+```
+
+## Non-goals / not guaranteed
+
+- This profile does not introduce new schema fields. All fields referenced
+  exist in the `org.peacprotocol/compliance` extension group schema
+- This profile does not by itself establish legal compliance with any regulation.
+  PEAC is evidence infrastructure; legal compliance depends on organizational
+  controls, processes, and legal interpretation beyond the scope of this protocol
+- Verifier enforcement is only what the protocol specification defines.
+  Profile-level field requirements (such as REQUIRED fields marked OPTIONAL
+  in the schema) are documentary guidance, not runtime-enforced constraints
+- Companion profile recommendations are suggestions for common workflows,
+  not enforced dependencies. Receipts are valid without companion profiles
+
+## Cross-references
+
+- Wire 0.2 spec: section 12.13 (`org.peacprotocol/compliance` extension group) in `docs/specs/WIRE-0.2.md`
+- Registered receipt type: `org.peacprotocol/compliance-check` in `specs/kernel/registries.json`
+- Type-to-extension enforcement: section 12.17 in `docs/specs/WIRE-0.2.md`
+
+## Notes / caveats
+
+- The `compliance_status` field uses a closed vocabulary of five states:
+  `compliant`, `non_compliant`, `partial`, `under_review`, `exempt`.
+  These map to ISO 19011 audit conclusion categories
+- Compliance checks are observations: recording a compliance check does
+  not constitute certification or legal compliance
+- The `framework` field uses an open vocabulary. Preferred grammar is
+  lowercase slugs with hyphens (e.g., `eu-ai-act`, `soc2-type2`,
+  `iso-27001`, `nist-ai-rmf`, `gdpr`, `hipaa`)
+- The `evidence_ref` field accepts a SHA-256 digest of supporting
+  evidence documents, providing a tamper-evident link to external
+  audit artifacts without embedding them in the receipt

--- a/docs/profiles/consent.md
+++ b/docs/profiles/consent.md
@@ -1,0 +1,244 @@
+# Consent Profile
+
+**Status:** Draft
+**Since:** v0.12.2
+**Extension Group:** `org.peacprotocol/consent`
+**Receipt Type:** `org.peacprotocol/consent-record`
+
+## Abstract
+
+The Consent profile documents how to use the `org.peacprotocol/consent`
+extension group to record consent collection and withdrawal events as
+evidence receipts. It covers consent lifecycle states, legal basis
+identification, data category scoping, and jurisdiction tagging. The
+profile tightens two schema-optional fields (`data_categories` and
+`jurisdiction`) to REQUIRED status so that receipts produced under this
+profile carry evidence of what data categories consent covers and which
+jurisdiction applies.
+
+## When to use
+
+- Recording that a data subject granted or withdrew consent for specific
+  data processing categories, with evidence of legal basis and jurisdiction
+- Producing machine-verifiable consent evidence that can feed into
+  privacy-engineering workflows or data-subject access requests
+- Creating auditable consent lifecycle records across jurisdictions that
+  require different legal bases (explicit consent, opt-out, legitimate
+  interest)
+
+## Required / Recommended / Prohibited fields
+
+All fields below belong to the `org.peacprotocol/consent` extension group.
+
+| Field              | Schema Status | Profile Status | Rationale                                                        |
+| ------------------ | ------------- | -------------- | ---------------------------------------------------------------- |
+| `consent_basis`    | REQUIRED      | REQUIRED       | Schema-required; identifies the legal basis for consent          |
+| `consent_status`   | REQUIRED      | REQUIRED       | Schema-required; records the consent lifecycle state             |
+| `data_categories`  | OPTIONAL      | REQUIRED       | Supports evidence of what data categories consent covers         |
+| `jurisdiction`     | OPTIONAL      | REQUIRED       | Supports evidence of which jurisdiction's law applies            |
+| `retention_period` | OPTIONAL      | RECOMMENDED    | Supports evidence of data retention commitments                  |
+| `consent_method`   | OPTIONAL      | RECOMMENDED    | Records how consent was collected (click-through, double opt-in) |
+| `withdrawal_uri`   | OPTIONAL      | OPTIONAL       | Locator hint for consent withdrawal; callers MUST NOT auto-fetch |
+| `scope`            | OPTIONAL      | OPTIONAL       | Free-text scope description                                      |
+
+## Minimal valid receipt
+
+The smallest receipt body that satisfies this profile. The `extensions`
+object carries the `org.peacprotocol/consent` group with the four
+profile-required fields.
+
+```json
+{
+  "iss": "https://example.com",
+  "iat": 1710460800,
+  "peac_version": "0.2",
+  "kind": "evidence",
+  "type": "org.peacprotocol/consent-record",
+  "pillars": ["consent"],
+  "extensions": {
+    "org.peacprotocol/consent": {
+      "consent_basis": "explicit",
+      "consent_status": "granted",
+      "data_categories": ["personal"],
+      "jurisdiction": "EU"
+    }
+  }
+}
+```
+
+## Companion profiles
+
+The following combinations are recommended for common workflows. Companion
+profiles are recommendations, not enforced dependencies. Receipts are valid
+without companion profiles.
+
+| Companion             | Workflow                                                               |
+| --------------------- | ---------------------------------------------------------------------- |
+| [Purpose](purpose.md) | GDPR Art 5(1)(b) purpose limitation alongside Art 6-7 consent evidence |
+| [Privacy](privacy.md) | GDPR Art 13-14 data handling disclosure alongside consent evidence     |
+
+## Regulatory context
+
+This profile supports evidence relevant to consent-related regulatory
+workflows. PEAC is evidence infrastructure; legal compliance depends on
+organizational controls, processes, and legal interpretation beyond the
+scope of this protocol.
+
+| Regulation / Standard | Relevance                                                                      |
+| --------------------- | ------------------------------------------------------------------------------ |
+| GDPR Art 6-7          | Supports evidence relevant to legal basis for processing and consent workflows |
+| CCPA Sec 1798.120     | Can help document opt-out consent events                                       |
+| LGPD Art 8            | Supports evidence relevant to consent collection in Brazilian data protection  |
+| ISO/IEC 29184:2020    | Maps naturally to online privacy notice and consent concepts                   |
+
+## Conformance examples
+
+### Minimal valid issue
+
+```typescript
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/consent-record',
+  pillars: ['consent'],
+  extensions: {
+    'org.peacprotocol/consent': {
+      consent_basis: 'explicit',
+      consent_status: 'granted',
+      data_categories: ['personal'],
+      jurisdiction: 'EU',
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+```
+
+### Verify
+
+```typescript
+const result = await verifyLocal(jws, publicKey, {
+  issuer: 'https://example.com',
+  strictness: 'strict',
+});
+
+console.log(result.valid); // true
+console.log(result.claims.type); // 'org.peacprotocol/consent-record'
+```
+
+### Invalid example: missing profile-required field
+
+The following receipt is schema-valid (both `data_categories` and
+`jurisdiction` are OPTIONAL at the schema level) but does not satisfy
+this profile because it omits `jurisdiction`.
+
+```typescript
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/consent-record',
+  pillars: ['consent'],
+  extensions: {
+    'org.peacprotocol/consent': {
+      consent_basis: 'explicit',
+      consent_status: 'granted',
+      data_categories: ['personal'],
+      // jurisdiction omitted: schema-valid but does not satisfy this profile
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+```
+
+### Companion example: consent with purpose
+
+```typescript
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/consent-record',
+  pillars: ['consent', 'purpose'],
+  extensions: {
+    'org.peacprotocol/consent': {
+      consent_basis: 'explicit',
+      consent_status: 'granted',
+      data_categories: ['personal', 'biometric'],
+      jurisdiction: 'EU',
+    },
+    'org.peacprotocol/purpose': {
+      external_purposes: ['identity_verification'],
+      purpose_basis: 'consent',
+      purpose_limitation: true,
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+```
+
+## Quick demo
+
+```typescript
+import { generateKeypair } from '@peac/crypto';
+import { issue, verifyLocal } from '@peac/protocol';
+
+const { privateKey, publicKey } = await generateKeypair();
+
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/consent-record',
+  pillars: ['consent'],
+  extensions: {
+    'org.peacprotocol/consent': {
+      consent_basis: 'explicit',
+      consent_status: 'granted',
+      data_categories: ['personal'],
+      jurisdiction: 'EU',
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+
+const result = await verifyLocal(jws, publicKey, {
+  issuer: 'https://example.com',
+  strictness: 'strict',
+});
+
+console.log(result.valid); // true
+console.log(result.claims.type); // 'org.peacprotocol/consent-record'
+```
+
+## Non-goals / not guaranteed
+
+- This profile does not introduce new schema fields. All fields referenced
+  exist in the `org.peacprotocol/consent` extension group schema
+- This profile does not by itself establish legal compliance with any regulation.
+  PEAC is evidence infrastructure; legal compliance depends on organizational
+  controls, processes, and legal interpretation beyond the scope of this protocol
+- Verifier enforcement is only what the protocol specification defines.
+  Profile-level field requirements (such as REQUIRED fields marked OPTIONAL
+  in the schema) are documentary guidance, not runtime-enforced constraints
+- Companion profile recommendations are suggestions for common workflows,
+  not enforced dependencies. Receipts are valid without companion profiles
+
+## Cross-references
+
+- Wire 0.2 spec: section 12.10 (`org.peacprotocol/consent` extension group) in `docs/specs/WIRE-0.2.md`
+- Registered receipt type: `org.peacprotocol/consent-record` in `specs/kernel/registries.json`
+- Type-to-extension enforcement: section 12.17 in `docs/specs/WIRE-0.2.md`
+
+## Notes / caveats
+
+- The `consent_status` field uses a closed vocabulary of four states:
+  `granted`, `withdrawn`, `denied`, `expired`. These cover the universal
+  consent lifecycle; jurisdiction-specific semantics are carried by
+  `consent_basis` (open vocabulary)
+- The `withdrawal_uri` field is a locator hint only. Callers MUST NOT
+  auto-fetch this URI; it exists for human-readable reference
+- Consent events are observations: recording a consent event does not
+  constitute obtaining or verifying consent
+- The `data_categories` field uses an open vocabulary. Organizations should
+  establish consistent category naming conventions for interoperability

--- a/docs/profiles/identity.md
+++ b/docs/profiles/identity.md
@@ -1,0 +1,252 @@
+# Identity Profile
+
+**Status:** Draft
+**Since:** v0.12.2
+**Extension Group:** `org.peacprotocol/identity`
+**Receipt Type:** `org.peacprotocol/identity-attestation`
+
+## Abstract
+
+The Identity profile documents how to use the `org.peacprotocol/identity`
+extension group to record identity verification or attestation evidence
+as receipts. The identity extension group is deliberately minimal: a
+single optional `proof_ref` field that carries an opaque reference to
+the identity proof mechanism. The top-level `actor` field (outside the
+extension) is the canonical location for actor binding; the identity
+extension group provides supplementary proof metadata when needed.
+
+## When to use
+
+- Recording that an identity attestation was verified for an agent,
+  service, or user at a specific point in time
+- Linking a receipt to an external identity proof mechanism (DID, SPIFFE,
+  x509 certificate chain, EAT passport) via an opaque reference
+- Creating auditable identity evidence that feeds into access control
+  or compliance workflows alongside companion profiles
+
+## Required / Recommended / Prohibited fields
+
+All fields below belong to the `org.peacprotocol/identity` extension group.
+
+| Field       | Schema Status | Profile Status | Rationale                                               |
+| ----------- | ------------- | -------------- | ------------------------------------------------------- |
+| `proof_ref` | OPTIONAL      | RECOMMENDED    | Links to external identity proof for audit traceability |
+
+The identity extension group has no schema-required fields. The
+extension group itself must be present for receipts with type
+`org.peacprotocol/identity-attestation` (enforced by type-to-extension
+enforcement in strict mode), but `proof_ref` is the only field and it
+is optional at both schema and profile level.
+
+## Minimal valid receipt
+
+The smallest receipt body that satisfies this profile. The `extensions`
+object carries the `org.peacprotocol/identity` group. Since `proof_ref`
+is optional, an empty extension object is valid.
+
+```json
+{
+  "iss": "https://idp.example.com",
+  "aud": "https://consumer.example.com",
+  "kind": "evidence",
+  "type": "org.peacprotocol/identity-attestation",
+  "pillars": ["identity"],
+  "extensions": {
+    "org.peacprotocol/identity": {}
+  }
+}
+```
+
+With the recommended `proof_ref`:
+
+```json
+{
+  "iss": "https://idp.example.com",
+  "aud": "https://consumer.example.com",
+  "kind": "evidence",
+  "type": "org.peacprotocol/identity-attestation",
+  "pillars": ["identity"],
+  "extensions": {
+    "org.peacprotocol/identity": {
+      "proof_ref": "did:key:z6Mkf5rGMoatrSj1f4CyvuHBeXJELe9RPdzo2PKGNCKVtZxP"
+    }
+  }
+}
+```
+
+## Companion profiles
+
+- **Access** (recommended, not enforced): when an identity attestation
+  leads to an access decision, pairing identity evidence with an access
+  receipt provides a complete chain from identity proof to access outcome
+- **Compliance** (recommended for regulated workflows): when identity
+  verification is subject to regulatory requirements (KYC, AML), a
+  companion compliance receipt records the framework and verification status
+
+Companion profiles are recommendations for common workflows, not
+enforced dependencies. Receipts are valid without companion profiles.
+
+## Regulatory context
+
+The identity extension group supports evidence relevant to:
+
+- NIST SP 800-63 (Digital Identity Guidelines): identity proofing and
+  authentication assurance levels
+- eIDAS 2.0 (EU Digital Identity Framework): identity attestation
+  evidence for European digital identity wallets
+- NIST AI 600-1 (Agent Identity): agent identity binding evidence for
+  AI systems acting on behalf of users or operators
+
+This profile can help document identity attestation events for audit
+purposes. PEAC is evidence infrastructure; these mappings do not
+themselves constitute compliance.
+
+## Conformance examples
+
+### Valid: identity attestation with DID proof reference
+
+```json
+{
+  "iss": "https://idp.example.com",
+  "kind": "evidence",
+  "type": "org.peacprotocol/identity-attestation",
+  "pillars": ["identity"],
+  "extensions": {
+    "org.peacprotocol/identity": {
+      "proof_ref": "did:key:z6Mkf5rGMoatrSj1f4CyvuHBeXJELe9RPdzo2PKGNCKVtZxP"
+    }
+  }
+}
+```
+
+This receipt satisfies the profile: the identity extension group is
+present and `proof_ref` provides a DID reference for audit traceability.
+
+### Valid: minimal identity attestation without proof_ref
+
+```json
+{
+  "iss": "https://idp.example.com",
+  "kind": "evidence",
+  "type": "org.peacprotocol/identity-attestation",
+  "pillars": ["identity"],
+  "extensions": {
+    "org.peacprotocol/identity": {}
+  }
+}
+```
+
+This receipt is valid at both schema and profile level. The empty
+extension object satisfies type-to-extension enforcement (the group
+is present). The `proof_ref` field is RECOMMENDED but not REQUIRED.
+
+### Invalid: identity-attestation type without extension group
+
+```json
+{
+  "iss": "https://idp.example.com",
+  "kind": "evidence",
+  "type": "org.peacprotocol/identity-attestation",
+  "pillars": ["identity"]
+}
+```
+
+This receipt fails strict-mode verification with
+`E_EXTENSION_GROUP_REQUIRED`: the registered type
+`org.peacprotocol/identity-attestation` requires the
+`org.peacprotocol/identity` extension group to be present.
+
+### Companion: identity + access
+
+```json
+{
+  "iss": "https://gateway.example.com",
+  "kind": "evidence",
+  "type": "org.peacprotocol/access-decision",
+  "pillars": ["access"],
+  "extensions": {
+    "org.peacprotocol/access": {
+      "resource": "https://api.example.com/inference/v1",
+      "action": "execute",
+      "decision": "allow"
+    },
+    "org.peacprotocol/identity": {
+      "proof_ref": "did:key:z6Mkf5rGMoatrSj1f4CyvuHBeXJELe9RPdzo2PKGNCKVtZxP"
+    }
+  }
+}
+```
+
+This receipt pairs access evidence with identity proof metadata. The
+primary type is `access-decision` with the required access extension;
+the identity extension provides supplementary proof context.
+
+## Quick demo
+
+```typescript
+import { generateKeypair } from '@peac/crypto';
+import { issue, verifyLocal } from '@peac/protocol';
+
+const { privateKey, publicKey } = await generateKeypair();
+
+const { jws } = await issue({
+  iss: 'https://idp.example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/identity-attestation',
+  pillars: ['identity'],
+  extensions: {
+    'org.peacprotocol/identity': {
+      proof_ref: 'did:key:z6Mkf5rGMoatrSj1f4CyvuHBeXJELe9RPdzo2PKGNCKVtZxP',
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+
+const result = await verifyLocal(jws, publicKey, {
+  issuer: 'https://idp.example.com',
+  strictness: 'strict',
+});
+
+console.log(result.valid); // true
+console.log(result.claims.type); // 'org.peacprotocol/identity-attestation'
+```
+
+## Cross-references
+
+- Wire 0.2 spec: section 12.6 (`org.peacprotocol/identity` extension group) in `docs/specs/WIRE-0.2.md`
+- Registered receipt type: `org.peacprotocol/identity-attestation` in `specs/kernel/registries.json`
+- Type-to-extension enforcement: section 12.17 in `docs/specs/WIRE-0.2.md`
+- Agent Identity specification: `docs/specs/AGENT-IDENTITY.md`
+- Actor Binding (Wire 0.1): `docs/specs/AGENT-IDENTITY-PROFILE.md`
+
+## Non-goals / not guaranteed
+
+- This profile does not introduce new schema fields. All fields referenced
+  exist in the `org.peacprotocol/identity` extension group schema
+- This profile does not by itself establish legal compliance with any regulation.
+  PEAC is evidence infrastructure; legal compliance depends on organizational
+  controls, processes, and legal interpretation beyond the scope of this protocol
+- Verifier enforcement is only what the protocol specification defines.
+  Profile-level field requirements (such as REQUIRED fields marked OPTIONAL
+  in the schema) are documentary guidance, not runtime-enforced constraints
+- Companion profile recommendations are suggestions for common workflows,
+  not enforced dependencies. Receipts are valid without companion profiles
+- The identity extension group does NOT perform identity verification.
+  It records that a verification event occurred and optionally references
+  the proof mechanism. Actual identity verification is performed by
+  external systems
+
+## Notes / caveats
+
+- The `proof_ref` field is an opaque string up to 256 characters. It can
+  carry DIDs, SPIFFE IDs, certificate fingerprints, or any other identifier
+  meaningful to the verifier. No format validation is performed beyond
+  length bounds
+- The top-level `actor` claim (outside extensions) is the canonical location
+  for actor binding. The identity extension supplements it with proof
+  metadata; it does not replace or duplicate actor binding
+- DID document resolution is not performed at the schema or protocol layer.
+  DID resolution belongs in Layer 4 adapters (such as `@peac/adapter-did`)
+- Identity attestation events are observations: recording an attestation
+  does not constitute verifying or establishing identity

--- a/docs/profiles/privacy.md
+++ b/docs/profiles/privacy.md
@@ -1,0 +1,231 @@
+# Privacy Profile
+
+**Status:** Draft
+**Since:** v0.12.2
+**Extension Group:** `org.peacprotocol/privacy`
+**Receipt Type:** `org.peacprotocol/privacy-signal`
+
+## Abstract
+
+The Privacy profile documents how to use the `org.peacprotocol/privacy`
+extension group to record data classification and handling observations
+as evidence receipts. It covers data classification levels, processing
+basis identification, retention semantics, recipient scoping, and
+cross-border transfer mechanisms. This profile does not tighten any
+schema-optional fields beyond recommending `processing_basis` and
+`retention_period` for regulatory evidence workflows.
+
+## When to use
+
+- Recording the data classification level and processing basis for a
+  data handling event, with evidence suitable for GDPR Art 13-14
+  information disclosure workflows
+- Producing machine-verifiable privacy signal evidence that documents
+  data handling practices including retention, anonymization, and
+  cross-border transfers
+- Creating auditable records of data classification decisions and
+  recipient scope determinations
+
+## Required / Recommended / Prohibited fields
+
+All fields below belong to the `org.peacprotocol/privacy` extension group.
+
+| Field                   | Schema Status | Profile Status | Rationale                                                                |
+| ----------------------- | ------------- | -------------- | ------------------------------------------------------------------------ |
+| `data_classification`   | REQUIRED      | REQUIRED       | Schema-required; classifies the sensitivity level of data handled        |
+| `processing_basis`      | OPTIONAL      | RECOMMENDED    | Supports evidence of legal basis for processing                          |
+| `retention_period`      | OPTIONAL      | RECOMMENDED    | Supports evidence of data retention commitments (ISO 8601 duration)      |
+| `retention_mode`        | OPTIONAL      | OPTIONAL       | Non-duration retention semantics (time_bound, indefinite, session_only)  |
+| `recipient_scope`       | OPTIONAL      | OPTIONAL       | Data recipient classification (internal, processor, third_party, public) |
+| `anonymization_method`  | OPTIONAL      | OPTIONAL       | Records anonymization or pseudonymization technique applied              |
+| `data_subject_category` | OPTIONAL      | OPTIONAL       | Data subject classification (customer, employee, minor)                  |
+| `transfer_mechanism`    | OPTIONAL      | OPTIONAL       | Cross-border data transfer mechanism (adequacy_decision, scc, bcr)       |
+
+## Minimal valid receipt
+
+The smallest receipt body that satisfies this profile. Only the
+schema-required `data_classification` field is needed.
+
+```json
+{
+  "iss": "https://example.com",
+  "iat": 1710460800,
+  "peac_version": "0.2",
+  "kind": "evidence",
+  "type": "org.peacprotocol/privacy-signal",
+  "pillars": ["privacy"],
+  "extensions": {
+    "org.peacprotocol/privacy": {
+      "data_classification": "confidential"
+    }
+  }
+}
+```
+
+## Companion profiles
+
+The following combinations are recommended for common workflows. Companion
+profiles are recommendations, not enforced dependencies. Receipts are valid
+without companion profiles.
+
+| Companion             | Workflow                                                              |
+| --------------------- | --------------------------------------------------------------------- |
+| [Consent](consent.md) | GDPR Art 7 consent evidence alongside Art 13-14 data handling signals |
+
+## Regulatory context
+
+This profile supports evidence relevant to data handling and privacy
+workflows. PEAC is evidence infrastructure; legal compliance depends on
+organizational controls, processes, and legal interpretation beyond the
+scope of this protocol.
+
+| Regulation / Standard | Relevance                                                             |
+| --------------------- | --------------------------------------------------------------------- |
+| GDPR Art 13-14        | Supports evidence relevant to information disclosure to data subjects |
+| ISO/IEC 27701:2019    | Maps naturally to privacy information management concepts             |
+
+## Conformance examples
+
+### Minimal valid issue
+
+```typescript
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/privacy-signal',
+  pillars: ['privacy'],
+  extensions: {
+    'org.peacprotocol/privacy': {
+      data_classification: 'confidential',
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+```
+
+### Verify
+
+```typescript
+const result = await verifyLocal(jws, publicKey, {
+  issuer: 'https://example.com',
+  strictness: 'strict',
+});
+
+console.log(result.valid); // true
+console.log(result.claims.type); // 'org.peacprotocol/privacy-signal'
+```
+
+### Invalid example: empty data_classification
+
+The following receipt is schema-invalid because `data_classification`
+is REQUIRED and must be a non-empty string.
+
+```typescript
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/privacy-signal',
+  pillars: ['privacy'],
+  extensions: {
+    'org.peacprotocol/privacy': {
+      data_classification: '', // schema-invalid: must be non-empty
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+// Throws: schema validation error
+```
+
+### Companion example: privacy with consent
+
+```typescript
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/privacy-signal',
+  pillars: ['privacy', 'consent'],
+  extensions: {
+    'org.peacprotocol/privacy': {
+      data_classification: 'pii',
+      processing_basis: 'consent',
+      retention_period: 'P365D',
+      retention_mode: 'time_bound',
+      recipient_scope: 'processor',
+    },
+    'org.peacprotocol/consent': {
+      consent_basis: 'explicit',
+      consent_status: 'granted',
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+```
+
+## Quick demo
+
+```typescript
+import { generateKeypair } from '@peac/crypto';
+import { issue, verifyLocal } from '@peac/protocol';
+
+const { privateKey, publicKey } = await generateKeypair();
+
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/privacy-signal',
+  pillars: ['privacy'],
+  extensions: {
+    'org.peacprotocol/privacy': {
+      data_classification: 'confidential',
+      processing_basis: 'legitimate_interest',
+      retention_period: 'P90D',
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+
+const result = await verifyLocal(jws, publicKey, {
+  issuer: 'https://example.com',
+  strictness: 'strict',
+});
+
+console.log(result.valid); // true
+console.log(result.claims.type); // 'org.peacprotocol/privacy-signal'
+```
+
+## Non-goals / not guaranteed
+
+- This profile does not introduce new schema fields. All fields referenced
+  exist in the `org.peacprotocol/privacy` extension group schema
+- This profile does not by itself establish legal compliance with any regulation.
+  PEAC is evidence infrastructure; legal compliance depends on organizational
+  controls, processes, and legal interpretation beyond the scope of this protocol
+- Verifier enforcement is only what the protocol specification defines.
+  Profile-level field requirements (such as REQUIRED fields marked OPTIONAL
+  in the schema) are documentary guidance, not runtime-enforced constraints
+- Companion profile recommendations are suggestions for common workflows,
+  not enforced dependencies. Receipts are valid without companion profiles
+
+## Cross-references
+
+- Wire 0.2 spec: section 12.11 (`org.peacprotocol/privacy` extension group) in `docs/specs/WIRE-0.2.md`
+- Registered receipt type: `org.peacprotocol/privacy-signal` in `specs/kernel/registries.json`
+- Type-to-extension enforcement: section 12.17 in `docs/specs/WIRE-0.2.md`
+
+## Notes / caveats
+
+- The `retention_mode` and `retention_period` fields are separate by design:
+  `retention_period` carries ISO 8601 duration grammar; `retention_mode`
+  carries non-duration retention semantics. When `retention_mode` is
+  `time_bound`, `retention_period` SHOULD also be present
+- The `recipient_scope` field uses a closed vocabulary of four values:
+  `internal`, `processor`, `third_party`, `public`. These align with
+  GDPR Art 13-14 disclosure categories
+- Privacy signals are observations: recording a data classification event
+  does not constitute a binding privacy commitment
+- The `anonymization_method` field uses an open vocabulary. Organizations
+  should document their specific anonymization technique mappings

--- a/docs/profiles/provenance.md
+++ b/docs/profiles/provenance.md
@@ -1,0 +1,243 @@
+# Provenance Profile
+
+**Status:** Draft
+**Since:** v0.12.2
+**Extension Group:** `org.peacprotocol/provenance`
+**Receipt Type:** `org.peacprotocol/provenance-record`
+
+## Abstract
+
+The Provenance profile documents how to use the `org.peacprotocol/provenance`
+extension group to record origin tracking and chain of custody observations
+as evidence receipts. It covers source type classification, source references,
+verification methods, custody chain entries, and SLSA-aligned build provenance
+metadata. This profile does not tighten any schema-optional fields beyond
+recommending `source_uri` and `verification_method` for content origin
+evidence workflows.
+
+## When to use
+
+- Recording the origin and derivation type of a data artifact or content
+  asset, with evidence suitable for AI-generated content transparency
+  workflows
+- Producing machine-verifiable provenance evidence that documents the
+  chain of custody from source to current holder, including custodian
+  actions and timestamps
+- Creating auditable provenance records aligned with supply chain
+  integrity standards such as SLSA for software artifacts
+
+## Required / Recommended / Prohibited fields
+
+All fields below belong to the `org.peacprotocol/provenance` extension group.
+
+| Field                  | Schema Status | Profile Status | Rationale                                                           |
+| ---------------------- | ------------- | -------------- | ------------------------------------------------------------------- |
+| `source_type`          | REQUIRED      | REQUIRED       | Schema-required; classifies the derivation type                     |
+| `source_uri`           | OPTIONAL      | RECOMMENDED    | Supports evidence of origin location (locator hint; no auto-fetch)  |
+| `verification_method`  | OPTIONAL      | RECOMMENDED    | Records how provenance was verified                                 |
+| `source_ref`           | OPTIONAL      | OPTIONAL       | Opaque source reference identifier (commit hash, artifact ID)       |
+| `build_provenance_uri` | OPTIONAL      | OPTIONAL       | HTTPS URI hint for build provenance metadata; no auto-fetch         |
+| `custody_chain`        | OPTIONAL      | OPTIONAL       | Ordered custody chain entries with custodian, action, and timestamp |
+| `slsa`                 | OPTIONAL      | OPTIONAL       | SLSA-aligned provenance metadata (track, level, version)            |
+
+## Minimal valid receipt
+
+The smallest receipt body that satisfies this profile. Only the
+schema-required `source_type` field is needed.
+
+```json
+{
+  "iss": "https://example.com",
+  "iat": 1710460800,
+  "peac_version": "0.2",
+  "kind": "evidence",
+  "type": "org.peacprotocol/provenance-record",
+  "pillars": ["provenance"],
+  "extensions": {
+    "org.peacprotocol/provenance": {
+      "source_type": "original"
+    }
+  }
+}
+```
+
+## Companion profiles
+
+The following combinations are recommended for common workflows. Companion
+profiles are recommendations, not enforced dependencies. Receipts are valid
+without companion profiles.
+
+| Companion                     | Workflow                                                       |
+| ----------------------------- | -------------------------------------------------------------- |
+| [Attribution](attribution.md) | Content origin tracking alongside creator credit and licensing |
+
+## Regulatory context
+
+This profile supports evidence relevant to content provenance and
+transparency workflows. PEAC is evidence infrastructure; legal compliance
+depends on organizational controls, processes, and legal interpretation
+beyond the scope of this protocol.
+
+| Regulation / Standard | Relevance                                                                         |
+| --------------------- | --------------------------------------------------------------------------------- |
+| EU AI Act Art 50      | Supports evidence relevant to AI-generated content transparency obligations       |
+| W3C PROV-DM           | Maps naturally to W3C Provenance Data Model concepts                              |
+| SLSA v1.2             | Supports evidence relevant to Supply-chain Levels for Software Artifacts tracking |
+
+## Conformance examples
+
+### Minimal valid issue
+
+```typescript
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/provenance-record',
+  pillars: ['provenance'],
+  extensions: {
+    'org.peacprotocol/provenance': {
+      source_type: 'original',
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+```
+
+### Verify
+
+```typescript
+const result = await verifyLocal(jws, publicKey, {
+  issuer: 'https://example.com',
+  strictness: 'strict',
+});
+
+console.log(result.valid); // true
+console.log(result.claims.type); // 'org.peacprotocol/provenance-record'
+```
+
+### Invalid example: empty source_type
+
+The following receipt is schema-invalid because `source_type` is
+REQUIRED and must be a non-empty string.
+
+```typescript
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/provenance-record',
+  pillars: ['provenance'],
+  extensions: {
+    'org.peacprotocol/provenance': {
+      source_type: '', // schema-invalid: must be non-empty
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+// Throws: schema validation error
+```
+
+### Companion example: provenance with attribution
+
+```typescript
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/provenance-record',
+  pillars: ['provenance', 'attribution'],
+  extensions: {
+    'org.peacprotocol/provenance': {
+      source_type: 'derived',
+      source_uri: 'https://example.com/datasets/v2',
+      verification_method: 'hash_chain',
+      custody_chain: [
+        {
+          custodian: 'DataSource Inc',
+          action: 'released',
+          timestamp: '2026-03-01T10:00:00Z',
+        },
+        {
+          custodian: 'ML Team',
+          action: 'transformed',
+          timestamp: '2026-03-10T14:30:00Z',
+        },
+      ],
+    },
+    'org.peacprotocol/attribution': {
+      creator_ref: 'did:example:datasource',
+      license_spdx: 'Apache-2.0',
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+```
+
+## Quick demo
+
+```typescript
+import { generateKeypair } from '@peac/crypto';
+import { issue, verifyLocal } from '@peac/protocol';
+
+const { privateKey, publicKey } = await generateKeypair();
+
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/provenance-record',
+  pillars: ['provenance'],
+  extensions: {
+    'org.peacprotocol/provenance': {
+      source_type: 'original',
+      source_uri: 'https://example.com/artifact/abc123',
+      verification_method: 'signature_check',
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+
+const result = await verifyLocal(jws, publicKey, {
+  issuer: 'https://example.com',
+  strictness: 'strict',
+});
+
+console.log(result.valid); // true
+console.log(result.claims.type); // 'org.peacprotocol/provenance-record'
+```
+
+## Non-goals / not guaranteed
+
+- This profile does not introduce new schema fields. All fields referenced
+  exist in the `org.peacprotocol/provenance` extension group schema
+- This profile does not by itself establish legal compliance with any regulation.
+  PEAC is evidence infrastructure; legal compliance depends on organizational
+  controls, processes, and legal interpretation beyond the scope of this protocol
+- Verifier enforcement is only what the protocol specification defines.
+  Profile-level field requirements (such as REQUIRED fields marked OPTIONAL
+  in the schema) are documentary guidance, not runtime-enforced constraints
+- Companion profile recommendations are suggestions for common workflows,
+  not enforced dependencies. Receipts are valid without companion profiles
+
+## Cross-references
+
+- Wire 0.2 spec: section 12.14 (`org.peacprotocol/provenance` extension group) in `docs/specs/WIRE-0.2.md`
+- Registered receipt type: `org.peacprotocol/provenance-record` in `specs/kernel/registries.json`
+- Type-to-extension enforcement: section 12.17 in `docs/specs/WIRE-0.2.md`
+
+## Notes / caveats
+
+- The `source_type` field uses an open vocabulary. Common values include
+  `original`, `derived`, `curated`, `synthetic`, `aggregated`, `transformed`
+- URI fields (`source_uri`, `build_provenance_uri`) are locator hints only.
+  Callers MUST NOT auto-fetch these URIs; they exist for human-readable
+  reference or explicit out-of-band resolution
+- The `custody_chain` array is ordered: entries represent sequential custody
+  events. Each entry includes a `custodian`, `action`, and `timestamp`
+  (RFC 3339 with seconds)
+- The `slsa` field records SLSA-aligned metadata using a track-based model
+  (track, level, version). It does not certify SLSA compliance; it records
+  observed SLSA-relevant metadata
+- Provenance records are observations: recording provenance does not
+  constitute a guarantee of origin or chain of custody integrity

--- a/docs/profiles/purpose.md
+++ b/docs/profiles/purpose.md
@@ -1,0 +1,236 @@
+# Purpose Profile
+
+**Status:** Draft
+**Since:** v0.12.2
+**Extension Group:** `org.peacprotocol/purpose`
+**Receipt Type:** `org.peacprotocol/purpose-declaration`
+
+## Abstract
+
+The Purpose profile documents how to use the `org.peacprotocol/purpose`
+extension group to record external, legal, or business purpose declarations
+as evidence receipts. It covers purpose labeling, purpose basis
+identification, purpose limitation, data minimization, and bridging to
+PEAC operational purpose tokens. This profile does not tighten any
+schema-optional fields beyond recommending `purpose_basis` and
+`purpose_limitation` for regulatory evidence workflows. The Purpose
+extension carries external compliance-level purpose declarations, not
+PEAC operational purpose tokens; the optional `peac_purpose_mapping`
+field bridges between the two vocabularies.
+
+## When to use
+
+- Recording the declared purpose(s) of a data processing activity, with
+  evidence suitable for GDPR Art 5(1)(b) purpose limitation workflows
+- Producing machine-verifiable purpose declaration evidence that documents
+  which external purposes apply to a processing operation and whether
+  purpose limitation was asserted
+- Creating auditable purpose records that bridge external purpose
+  vocabularies to PEAC operational tokens via the
+  `peac_purpose_mapping` field
+
+## Required / Recommended / Prohibited fields
+
+All fields below belong to the `org.peacprotocol/purpose` extension group.
+
+| Field                  | Schema Status | Profile Status | Rationale                                                                      |
+| ---------------------- | ------------- | -------------- | ------------------------------------------------------------------------------ |
+| `external_purposes`    | REQUIRED      | REQUIRED       | Schema-required; declares external/legal/business purpose labels               |
+| `purpose_basis`        | OPTIONAL      | RECOMMENDED    | Supports evidence of legal or policy basis for the declared purposes           |
+| `purpose_limitation`   | OPTIONAL      | RECOMMENDED    | Supports evidence of whether purpose limitation applies                        |
+| `data_minimization`    | OPTIONAL      | OPTIONAL       | Records whether data minimization was applied                                  |
+| `compatible_purposes`  | OPTIONAL      | OPTIONAL       | Lists compatible purposes for secondary use                                    |
+| `peac_purpose_mapping` | OPTIONAL      | OPTIONAL       | Bridges external purpose vocabulary to PEAC operational CanonicalPurpose token |
+
+## Minimal valid receipt
+
+The smallest receipt body that satisfies this profile. Only the
+schema-required `external_purposes` field is needed.
+
+```json
+{
+  "iss": "https://example.com",
+  "iat": 1710460800,
+  "peac_version": "0.2",
+  "kind": "evidence",
+  "type": "org.peacprotocol/purpose-declaration",
+  "pillars": ["purpose"],
+  "extensions": {
+    "org.peacprotocol/purpose": {
+      "external_purposes": ["analytics"]
+    }
+  }
+}
+```
+
+## Companion profiles
+
+The following combinations are recommended for common workflows. Companion
+profiles are recommendations, not enforced dependencies. Receipts are valid
+without companion profiles.
+
+| Companion             | Workflow                                                               |
+| --------------------- | ---------------------------------------------------------------------- |
+| [Consent](consent.md) | GDPR Art 6-7 consent evidence alongside Art 5(1)(b) purpose limitation |
+
+## Regulatory context
+
+This profile supports evidence relevant to purpose declaration and
+limitation workflows. PEAC is evidence infrastructure; legal compliance
+depends on organizational controls, processes, and legal interpretation
+beyond the scope of this protocol.
+
+| Regulation / Standard | Relevance                                                            |
+| --------------------- | -------------------------------------------------------------------- |
+| GDPR Art 5(1)(b)      | Supports evidence relevant to purpose limitation principle workflows |
+| W3C DPV               | Maps naturally to Data Privacy Vocabulary purpose concepts           |
+
+## Conformance examples
+
+### Minimal valid issue
+
+```typescript
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/purpose-declaration',
+  pillars: ['purpose'],
+  extensions: {
+    'org.peacprotocol/purpose': {
+      external_purposes: ['analytics'],
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+```
+
+### Verify
+
+```typescript
+const result = await verifyLocal(jws, publicKey, {
+  issuer: 'https://example.com',
+  strictness: 'strict',
+});
+
+console.log(result.valid); // true
+console.log(result.claims.type); // 'org.peacprotocol/purpose-declaration'
+```
+
+### Invalid example: empty external_purposes array
+
+The following receipt is schema-invalid because `external_purposes`
+requires at least one item.
+
+```typescript
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/purpose-declaration',
+  pillars: ['purpose'],
+  extensions: {
+    'org.peacprotocol/purpose': {
+      external_purposes: [], // schema-invalid: min 1 item required
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+// Throws: schema validation error
+```
+
+### Companion example: purpose with consent
+
+```typescript
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/purpose-declaration',
+  pillars: ['purpose', 'consent'],
+  extensions: {
+    'org.peacprotocol/purpose': {
+      external_purposes: ['ai_training', 'model_evaluation'],
+      purpose_basis: 'consent',
+      purpose_limitation: true,
+      data_minimization: true,
+    },
+    'org.peacprotocol/consent': {
+      consent_basis: 'explicit',
+      consent_status: 'granted',
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+```
+
+## Quick demo
+
+```typescript
+import { generateKeypair } from '@peac/crypto';
+import { issue, verifyLocal } from '@peac/protocol';
+
+const { privateKey, publicKey } = await generateKeypair();
+
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/purpose-declaration',
+  pillars: ['purpose'],
+  extensions: {
+    'org.peacprotocol/purpose': {
+      external_purposes: ['analytics', 'reporting'],
+      purpose_basis: 'legitimate_interest',
+      purpose_limitation: true,
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+
+const result = await verifyLocal(jws, publicKey, {
+  issuer: 'https://example.com',
+  strictness: 'strict',
+});
+
+console.log(result.valid); // true
+console.log(result.claims.type); // 'org.peacprotocol/purpose-declaration'
+```
+
+## Non-goals / not guaranteed
+
+- This profile does not introduce new schema fields. All fields referenced
+  exist in the `org.peacprotocol/purpose` extension group schema
+- This profile does not by itself establish legal compliance with any regulation.
+  PEAC is evidence infrastructure; legal compliance depends on organizational
+  controls, processes, and legal interpretation beyond the scope of this protocol
+- Verifier enforcement is only what the protocol specification defines.
+  Profile-level field requirements (such as REQUIRED fields marked OPTIONAL
+  in the schema) are documentary guidance, not runtime-enforced constraints
+- Companion profile recommendations are suggestions for common workflows,
+  not enforced dependencies. Receipts are valid without companion profiles
+
+## Cross-references
+
+- Wire 0.2 spec: section 12.16 (`org.peacprotocol/purpose` extension group) in `docs/specs/WIRE-0.2.md`
+- Registered receipt type: `org.peacprotocol/purpose-declaration` in `specs/kernel/registries.json`
+- Type-to-extension enforcement: section 12.17 in `docs/specs/WIRE-0.2.md`
+
+## Notes / caveats
+
+- The `external_purposes` field carries external, legal, or business
+  purpose labels, not PEAC operational purpose tokens. Use the
+  `peac_purpose_mapping` field to bridge external purposes to PEAC
+  operational CanonicalPurpose tokens
+- Purpose tokens use machine-safe lowercase grammar: alphanumeric
+  characters, underscores, and hyphens (e.g., `ai_training`, `analytics`,
+  `marketing`). Items in `external_purposes` must be unique
+- The `compatible_purposes` field lists purposes that are compatible for
+  secondary use. These use the same machine-safe token grammar as
+  `external_purposes` and must also be unique
+- Purpose declarations are observations: recording a purpose declaration
+  does not constitute a binding commitment to limit processing
+- The distinction between `external_purposes` and PEAC operational tokens
+  is intentional. External purposes are compliance-level declarations;
+  PEAC operational tokens (`CanonicalPurpose`) are protocol-level routing
+  semantics

--- a/docs/profiles/safety.md
+++ b/docs/profiles/safety.md
@@ -1,0 +1,234 @@
+# Safety Profile
+
+**Status:** Draft
+**Since:** v0.12.2
+**Extension Group:** `org.peacprotocol/safety`
+**Receipt Type:** `org.peacprotocol/safety-review`
+
+## Abstract
+
+The Safety profile documents how to use the `org.peacprotocol/safety`
+extension group to record safety assessment evidence as receipts. It
+covers review status lifecycle, risk classification, assessment methods,
+and safety measures. The profile tightens one schema-optional field
+(`risk_level`) to REQUIRED status so that receipts produced under this
+profile carry evidence of risk classification, which supports evidence
+relevant to EU AI Act Art 9 risk classification workflows.
+
+## When to use
+
+- Recording that a safety review occurred for an AI system or content,
+  with evidence of the review outcome and risk classification
+- Producing machine-verifiable safety assessment evidence that documents
+  risk level, assessment method, and safety measures applied
+- Creating auditable safety review records that can feed into risk
+  management workflows across regulatory frameworks
+
+## Required / Recommended / Prohibited fields
+
+All fields below belong to the `org.peacprotocol/safety` extension group.
+
+| Field               | Schema Status | Profile Status | Rationale                                                                   |
+| ------------------- | ------------- | -------------- | --------------------------------------------------------------------------- |
+| `review_status`     | REQUIRED      | REQUIRED       | Schema-required; records the safety assessment lifecycle state              |
+| `risk_level`        | OPTIONAL      | REQUIRED       | Supports evidence relevant to EU AI Act Art 9 risk classification workflows |
+| `assessment_method` | OPTIONAL      | RECOMMENDED    | Records how the safety assessment was performed                             |
+| `safety_measures`   | OPTIONAL      | RECOMMENDED    | Documents safety measures applied                                           |
+| `incident_ref`      | OPTIONAL      | OPTIONAL       | Opaque reference to incident report                                         |
+| `model_ref`         | OPTIONAL      | OPTIONAL       | Opaque reference to AI model version                                        |
+| `category`          | OPTIONAL      | OPTIONAL       | Safety category (content_safety, bias, hallucination, toxicity)             |
+
+## Minimal valid receipt
+
+The smallest receipt body that satisfies this profile. The `extensions`
+object carries the `org.peacprotocol/safety` group with the two
+profile-required fields.
+
+```json
+{
+  "iss": "https://example.com",
+  "iat": 1710460800,
+  "peac_version": "0.2",
+  "kind": "evidence",
+  "type": "org.peacprotocol/safety-review",
+  "pillars": ["safety"],
+  "extensions": {
+    "org.peacprotocol/safety": {
+      "review_status": "reviewed",
+      "risk_level": "limited"
+    }
+  }
+}
+```
+
+## Companion profiles
+
+The following combinations are recommended for common workflows. Companion
+profiles are recommendations, not enforced dependencies. Receipts are valid
+without companion profiles.
+
+| Companion                   | Workflow                                                              |
+| --------------------------- | --------------------------------------------------------------------- |
+| [Compliance](compliance.md) | EU AI Act Art 9 risk management alongside Art 28 deployer obligations |
+
+## Regulatory context
+
+This profile supports evidence relevant to safety assessment and risk
+management workflows. PEAC is evidence infrastructure; legal compliance
+depends on organizational controls, processes, and legal interpretation
+beyond the scope of this protocol.
+
+| Regulation / Standard | Relevance                                                                          |
+| --------------------- | ---------------------------------------------------------------------------------- |
+| EU AI Act Art 9       | Supports evidence relevant to risk management system workflows                     |
+| EU AI Act Art 14      | Can help document human oversight measures                                         |
+| EU AI Act Art 15      | Supports evidence relevant to accuracy, robustness, and cybersecurity requirements |
+| ISO/IEC 23894:2023    | Maps naturally to AI risk management concepts                                      |
+
+## Conformance examples
+
+### Minimal valid issue
+
+```typescript
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/safety-review',
+  pillars: ['safety'],
+  extensions: {
+    'org.peacprotocol/safety': {
+      review_status: 'reviewed',
+      risk_level: 'limited',
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+```
+
+### Verify
+
+```typescript
+const result = await verifyLocal(jws, publicKey, {
+  issuer: 'https://example.com',
+  strictness: 'strict',
+});
+
+console.log(result.valid); // true
+console.log(result.claims.type); // 'org.peacprotocol/safety-review'
+```
+
+### Invalid example: missing profile-required field
+
+The following receipt is schema-valid (because `risk_level` is OPTIONAL
+at the schema level) but does not satisfy this profile because it omits
+`risk_level`.
+
+```typescript
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/safety-review',
+  pillars: ['safety'],
+  extensions: {
+    'org.peacprotocol/safety': {
+      review_status: 'reviewed',
+      // risk_level omitted: schema-valid but does not satisfy this profile
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+```
+
+### Companion example: safety with compliance
+
+```typescript
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/safety-review',
+  pillars: ['safety', 'compliance'],
+  extensions: {
+    'org.peacprotocol/safety': {
+      review_status: 'reviewed',
+      risk_level: 'high',
+      assessment_method: 'human_review',
+      safety_measures: ['content_filter', 'rate_limiting'],
+    },
+    'org.peacprotocol/compliance': {
+      framework: 'eu-ai-act',
+      compliance_status: 'under_review',
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+```
+
+## Quick demo
+
+```typescript
+import { generateKeypair } from '@peac/crypto';
+import { issue, verifyLocal } from '@peac/protocol';
+
+const { privateKey, publicKey } = await generateKeypair();
+
+const { jws } = await issue({
+  iss: 'https://example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/safety-review',
+  pillars: ['safety'],
+  extensions: {
+    'org.peacprotocol/safety': {
+      review_status: 'reviewed',
+      risk_level: 'limited',
+      assessment_method: 'automated_scan',
+      category: 'content_safety',
+    },
+  },
+  privateKey,
+  kid: 'key-2026-03',
+});
+
+const result = await verifyLocal(jws, publicKey, {
+  issuer: 'https://example.com',
+  strictness: 'strict',
+});
+
+console.log(result.valid); // true
+console.log(result.claims.type); // 'org.peacprotocol/safety-review'
+```
+
+## Non-goals / not guaranteed
+
+- This profile does not introduce new schema fields. All fields referenced
+  exist in the `org.peacprotocol/safety` extension group schema
+- This profile does not by itself establish legal compliance with any regulation.
+  PEAC is evidence infrastructure; legal compliance depends on organizational
+  controls, processes, and legal interpretation beyond the scope of this protocol
+- Verifier enforcement is only what the protocol specification defines.
+  Profile-level field requirements (such as REQUIRED fields marked OPTIONAL
+  in the schema) are documentary guidance, not runtime-enforced constraints
+- Companion profile recommendations are suggestions for common workflows,
+  not enforced dependencies. Receipts are valid without companion profiles
+
+## Cross-references
+
+- Wire 0.2 spec: section 12.12 (`org.peacprotocol/safety` extension group) in `docs/specs/WIRE-0.2.md`
+- Registered receipt type: `org.peacprotocol/safety-review` in `specs/kernel/registries.json`
+- Type-to-extension enforcement: section 12.17 in `docs/specs/WIRE-0.2.md`
+
+## Notes / caveats
+
+- The `risk_level` field uses a closed vocabulary of four tiers:
+  `unacceptable`, `high`, `limited`, `minimal`. These converge across
+  EU AI Act Art 6, NIST AI RMF, and ISO 23894 risk classification
+- The `review_status` field uses a closed vocabulary of four states:
+  `reviewed`, `pending`, `flagged`, `not_applicable`. These cover the
+  universal safety assessment lifecycle
+- Safety reviews are observations: recording a safety review does not
+  constitute safety certification or approval
+- The `safety_measures` field is an array of open vocabulary strings.
+  Organizations should establish consistent measure naming conventions
+  for interoperability


### PR DESCRIPTION
## Summary

Add 9 documentary usage profiles for pillar extension groups, completing
coverage for all pillars with first-party receipt types: access, identity,
consent, privacy, safety, compliance, provenance, attribution, purpose.

## Scope

- 9 pillar-profile documents in `docs/profiles/`
- Each follows the mandatory pillar-profile template with all 10 sections
- Schema-vs-profile field tables distinguishing schema and profile constraints
- Mandatory Non-goals section in every profile
- Strict-mode-valid quick demos using real registered types and mapped extensions
- Cross-references to Wire 0.2 spec sections and registered receipt types
- Companion-profile guidance marked as recommendations, not enforced
- Standards references: ISO/IEC 29184, ISO/IEC 27701, ISO/IEC 23894, ISO 19011,
  W3C PROV-DM, SLSA v1.2, SPDX 3.0.1, C2PA, W3C DPV, NIST SP 800-53/800-63
- Neutral regulatory wording throughout
- Updated profile README index and adapter-profile template placeholder
- No local-only references in any public profile doc

Generic commerce pillar profile deferred: the existing stripe-x402 adapter
profile provides commerce coverage. A generic commerce pillar profile can
follow in v0.12.3 if demand materializes.

Profiles are documentation overlays, not runtime-enforced constraints.

## Validation

- format: clean
- guard: clean, including:
  - doc-truth profile naming parity (9 pillars vs registries.json)
  - doc-truth stale extension-group count detection
  - fail-closed Trojan Source scan (`find-invisible-unicode.mjs`): all tracked
    `.ts`, `.md`, `.json`, `.yaml` files scanned for invisible/bidirectional
    Unicode. GitHub's diff-page bidi warning is a cosmetic renderer artifact;
    the repo proves cleanliness via deterministic guard
- pre-commit: clean
- commit-msg: clean