### PR TITLE
release: sync workspace packages, manifests, and docs for v0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.2] - 2026-03-16
+
+### Profile-Defined Types and Extension Groups
+
+Completes the 12-group typed extension surface for Wire 0.2 interaction records,
+adds type-to-extension enforcement at verification time, ships 9 pillar usage
+profiles, and introduces shared protocol-grade validators.
+
+### Added
+
+- **7 new extension groups** (#519, #520, #521): consent, compliance, privacy, safety, provenance, attribution, purpose
+- **Shared validator helpers** (#518): SHA-256 digest, HTTPS URI hint (SSRF-hardened), ISO 8601 duration (parser-grade), ISO 8601 date, SPDX 3.0.1 license expression parser
+- **Type-to-extension enforcement** (#522): strict mode requires mapped extension group for registered types; interop mode downgrades to warnings
+- **Byte-budget controls** (#518): per-group 64 KB, total 256 KB, per-array 32 KB limits with browser-safe UTF-8 measurement
+- **9 pillar usage profiles** (#525): access, identity, consent, privacy, safety, compliance, provenance, attribution, purpose
+- **Commerce event field** (#526): 6-value closed enum (observational metadata only)
+- **ProofMethodSchema deprecation** (#526): transport-binding alias preserved through v0.12.x; remove-not-before v0.13.0
+- **AST no-network audit** (#527): static analysis confirming `@peac/schema` has zero I/O call sites
+- **API contract extraction** (#527): extracted API surface artifacts at `contracts/api/`
+- **Extension regression benchmarks** (#528): strict-mode enforcement benchmarks and byte-budget boundary coverage
+- **Registry codegen** (#518): `registries.generated.ts` from `registries.json` with deterministic output
+- **Subject record terminology** (#518): `SubjectRecord` canonical; `SubjectProfile` kept as deprecated alias
+
+### Changed
+
+- Extension groups: 12 total (was 5); all 10 receipt types now have non-null `extension_group`
+- Warning codes: 6 total (was 4): added `extension_group_missing`, `extension_group_mismatch`
+- Error codes: 4 new (`E_EXTENSION_SIZE_EXCEEDED`, `E_EXTENSION_NON_JSON_VALUE`, `E_EXTENSION_GROUP_REQUIRED`, `E_EXTENSION_GROUP_MISMATCH`)
+- Node CI matrix: Node 24 (canonical) + Node 22 (compat) + Node 25 (forward-compat)
+
+### Deferred
+
+- `@peac/adapter-did` (DID resolution): v0.12.3
+- Wire 0.2 adoption across A2A/ACP/UCP mappings: v0.12.3
+- Commerce events vocabulary expansion: v0.12.3+
+- Profile capability signaling: v0.12.3+
+
 ## [0.12.1] - 2026-03-13
 
 ### x402 Upstream Wire Sync

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ See [packages/cli/README.md](packages/cli/README.md) for the full command refere
 
 ## Versioning
 
-- **Current stable:** Interaction Record format (`interaction-record+jwt`, v0.12.1+)
+- **Current stable:** Interaction Record format (`interaction-record+jwt`, v0.12.2+)
 - **Legacy:** Wire 0.1 (`peac-receipt/0.1`) is frozen; `verifyLocal()` returns `E_UNSUPPORTED_WIRE_VERSION`
 
 See [docs/specs/VERSIONING.md](docs/specs/VERSIONING.md) for the full versioning doctrine.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-api",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "PEAC Protocol API server with OpenAPI 3.1, RFC 9457 Problem Details, and content negotiation",
   "type": "module",
   "main": "dist/index.js",

--- a/apps/bridge/package.json
+++ b/apps/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-bridge",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "PEAC Protocol Bridge - Local development sidecar",
   "type": "module",
   "main": "dist/server.js",

--- a/apps/sandbox-issuer/package.json
+++ b/apps/sandbox-issuer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-sandbox-issuer",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "PEAC Protocol Sandbox Issuer - Test receipt issuance for development",
   "type": "module",
   "main": "dist/node.js",

--- a/apps/verifier/package.json
+++ b/apps/verifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-verifier",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "PEAC Protocol Browser Verifier - Client-side receipt verification",
   "type": "module",
   "private": true,

--- a/docs/releases/current.json
+++ b/docs/releases/current.json
@@ -1,8 +1,8 @@
 {
   "description": "PEAC release manifest: CI-enforceable source of truth for release state",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "wire_format_version": "0.2",
   "dist_tag": "latest",
   "registries_version": "0.5.0",
-  "errors_version": "0.12.1"
+  "errors_version": "0.12.2"
 }

--- a/docs/specs/CONFORMANCE-MATRIX.md
+++ b/docs/specs/CONFORMANCE-MATRIX.md
@@ -1,7 +1,7 @@
 # PEAC Conformance Matrix
 
 > **Generated**: Do not edit manually. Source: `node scripts/conformance/generate-matrix.mjs`
-> **Version**: 0.12.1
+> **Version**: 0.12.2
 
 ## Wire 0.2 Protocol Requirements
 

--- a/docs/specs/WIRE-0.2.md
+++ b/docs/specs/WIRE-0.2.md
@@ -2,7 +2,7 @@
 
 **Status**: NORMATIVE
 
-**Version**: 0.12.0
+**Version**: 0.12.2
 
 **Wire Format**: `interaction-record+jwt`
 
@@ -1418,5 +1418,6 @@ Centralized bounds for Wire 0.2 extension fields, defined in `EXTENSION_LIMITS`:
 
 ## Version History
 
-- **0.12.0-preview.2** (pending release): Sections 18-20 added: Identifier Stack and Token Confusion (4-layer identifier table, dispatch rules, typ acceptance form matching, token confusion prevention per RFC 8725, provisional media type, peac_version formalization, version disambiguation), Verifier Validation Algorithm (13-step normative procedure with 10a/10b jti split, RFC 9068-style strict profile, error code mapping table), Replay Prevention (issuer-MUST jti uniqueness, verifier-SHOULD conditional replay detection, cache guidance, no-expiration rationale). RFC 9068 added to standards references. Conformance fixture for jti boundary length.
+- **0.12.2**: Twelve typed extension groups with per-group schemas. Type-to-extension enforcement in strict mode. Shared protocol-grade validators (SHA-256, HTTPS URI, ISO 8601, SPDX 3.0.1). Byte-budget controls for extensions. Nine pillar usage profiles. Commerce event field (6-value observational enum). ProofMethodSchema deprecated. 6 warning codes (was 4). SubjectRecord terminology.
+- **0.12.0-preview.2**: Sections 18-20 added: Identifier Stack and Token Confusion (4-layer identifier table, dispatch rules, typ acceptance form matching, token confusion prevention per RFC 8725, provisional media type, peac_version formalization, version disambiguation), Verifier Validation Algorithm (13-step normative procedure with 10a/10b jti split, RFC 9068-style strict profile, error code mapping table), Replay Prevention (issuer-MUST jti uniqueness, verifier-SHOULD conditional replay detection, cache guidance, no-expiration rationale). RFC 9068 added to standards references. Conformance fixture for jti boundary length.
 - **0.12.0-preview.1**: Initial Wire 0.2 specification (NORMATIVE PREVIEW). Two structural kinds, open semantic type, 10-pillar taxonomy, canonical issuer form, JOSE hardening, policy binding (JCS + SHA-256, three-state), 5 typed extension groups, RFC 9457 challenge body, 4 warning codes, dual-stack compatibility, strictness profiles.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/monorepo",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "description": "PEAC Protocol - Cryptographic receipts for agentic commerce",
   "repository": {

--- a/packages/access/package.json
+++ b/packages/access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/access",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "description": "PEAC access pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/adapters/core/package.json
+++ b/packages/adapters/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-core",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Shared utilities for PEAC payment rail adapters",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/eat/package.json
+++ b/packages/adapters/eat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-eat",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "EAT (Entity Attestation Token, RFC 9711) passport decoder and PEAC claim mapper",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/openai-compatible/package.json
+++ b/packages/adapters/openai-compatible/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-openai-compatible",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "OpenAI-compatible chat completion adapter for PEAC interaction evidence (hash-first)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/openclaw/package.json
+++ b/packages/adapters/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-openclaw",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "OpenClaw adapter for PEAC interaction evidence capture",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/daydreams/package.json
+++ b/packages/adapters/x402/daydreams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402-daydreams",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Daydreams AI inference event normalizer for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/fluora/package.json
+++ b/packages/adapters/x402/fluora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402-fluora",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Fluora MCP marketplace event normalizer for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/package.json
+++ b/packages/adapters/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "x402 offer/receipt verification, term-matching, and PEAC record mapping",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/pinata/package.json
+++ b/packages/adapters/x402/pinata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402-pinata",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Pinata private IPFS objects event normalizer for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/aipref/package.json
+++ b/packages/aipref/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/pref",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "AIPREF resolver with robots.txt bridge",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/attribution/package.json
+++ b/packages/attribution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/attribution",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "PEAC attribution attestation - content derivation and usage proofs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/audit",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Audit logging and case bundle generation for PEAC protocol disputes",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/capture/core/package.json
+++ b/packages/capture/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/capture-core",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Runtime-neutral capture pipeline for PEAC interaction evidence",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/capture/node/package.json
+++ b/packages/capture/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/capture-node",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Node.js durable storage for PEAC capture pipeline (filesystem spool store and dedupe index)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/cli",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "PEAC protocol command-line tools",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/compliance/package.json
+++ b/packages/compliance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/compliance",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "description": "PEAC compliance pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/conformance-harness/package.json
+++ b/packages/conformance-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/conformance-harness",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "description": "Conformance test harness for PEAC protocol fixtures",
   "main": "dist/index.cjs",

--- a/packages/consent/package.json
+++ b/packages/consent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/consent",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "description": "PEAC consent pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/contracts",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "PEAC canonical error codes and verification mode contracts",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/control/package.json
+++ b/packages/control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/control",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "PEAC Protocol Control - control engine interfaces and validation",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/core",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "DEPRECATED - Use @peac/kernel, @peac/schema, @peac/crypto, @peac/protocol instead",
   "type": "module",
   "homepage": "https://www.peacprotocol.org",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/crypto",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Ed25519 JWS signing and verification for PEAC protocol",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/disc",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "PEAC discovery with ≤20 lines enforcement",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/http-signatures/package.json
+++ b/packages/http-signatures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/http-signatures",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "RFC 9421 HTTP Message Signatures parsing and verification",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/intelligence/package.json
+++ b/packages/intelligence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/intelligence",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "description": "PEAC intelligence pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/jwks-cache/package.json
+++ b/packages/jwks-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/jwks-cache",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Edge-safe JWKS fetch and cache with SSRF protection",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/kernel",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "PEAC protocol kernel - normative constants, errors, and registries",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/kernel/src/error-categories.generated.ts
+++ b/packages/kernel/src/error-categories.generated.ts
@@ -3,7 +3,7 @@
  *
  * AUTO-GENERATED from specs/kernel/errors.json
  * DO NOT EDIT MANUALLY - run: npx tsx scripts/codegen-errors.ts
- * Spec version: 0.12.1
+ * Spec version: 0.12.2
  */
 
 /**

--- a/packages/kernel/src/errors.generated.ts
+++ b/packages/kernel/src/errors.generated.ts
@@ -3,7 +3,7 @@
  *
  * AUTO-GENERATED from specs/kernel/errors.json
  * DO NOT EDIT MANUALLY - run: npx tsx scripts/codegen-errors.ts
- * Spec version: 0.12.1
+ * Spec version: 0.12.2
  */
 
 import type { ErrorDefinition } from './types.js';

--- a/packages/mappings/a2a/package.json
+++ b/packages/mappings/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-a2a",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Agent-to-Agent Protocol (A2A) integration for PEAC",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/mappings/acp/package.json
+++ b/packages/mappings/acp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-acp",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Agentic Commerce Protocol (ACP) integration for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/aipref/package.json
+++ b/packages/mappings/aipref/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-aipref",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "IETF AIPREF vocabulary mapping for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/content-signals/package.json
+++ b/packages/mappings/content-signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-content-signals",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Content use policy signal parsing for PEAC (robots.txt, tdmrep.json, Content-Usage)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/mappings/mcp/package.json
+++ b/packages/mappings/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-mcp",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Model Context Protocol (MCP) integration for PEAC",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/mappings/rsl/package.json
+++ b/packages/mappings/rsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-rsl",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "RSL (Robots Specification Layer) mapping for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/tap/package.json
+++ b/packages/mappings/tap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-tap",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Visa Trusted Agent Protocol mapping to PEAC control evidence",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mappings/ucp/package.json
+++ b/packages/mappings/ucp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-ucp",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Google Universal Commerce Protocol (UCP) mapping to PEAC receipts and dispute evidence",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp-server/manifest.json
+++ b/packages/mcp-server/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "peac-mcp-server",
   "display_name": "PEAC Protocol",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Verify, inspect, decode, issue, and bundle PEAC receipts. Portable, offline-verifiable evidence for AI agent interactions.",
   "long_description": "PEAC Protocol provides cryptographically signed, offline-verifiable receipts that record what happened during automated interactions. Each receipt is a compact JWS (JSON Web Signature) using Ed25519 signatures. This MCP server exposes 5 tools for receipt operations: verify (signature + claims), inspect (metadata without verification), decode (raw JWS structure), issue (sign new receipts), and create_bundle (portable evidence directories).",
   "author": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mcp-server",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "PEAC receipt operations as MCP tools (verify, inspect, decode, issue, bundle)",
   "mcpName": "io.github.peacprotocol/peac",
   "main": "dist/index.cjs",

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "subfolder": "packages/mcp-server"
   },
-  "version": "0.12.1",
+  "version": "0.12.2",
   "websiteUrl": "https://www.peacprotocol.org",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@peac/mcp-server",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "transport": {
         "type": "stdio"
       }

--- a/packages/middleware-core/package.json
+++ b/packages/middleware-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/middleware-core",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Framework-agnostic middleware primitives for PEAC receipt issuance",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/middleware-express/package.json
+++ b/packages/middleware-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/middleware-express",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Express.js middleware for automatic PEAC receipt issuance",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/net/node/package.json
+++ b/packages/net/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/net-node",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "SSRF-safe network utilities for PEAC Protocol with DNS resolution pinning (Node.js only)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/pay402/package.json
+++ b/packages/pay402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/pay402",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Generic HTTP 402 adapter with multi-rail payment negotiation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/policy-kit/package.json
+++ b/packages/policy-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/policy-kit",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "PEAC Policy Kit - deterministic policy evaluation for CAL semantics",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/privacy/package.json
+++ b/packages/privacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/privacy",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "description": "Privacy pillar for PEAC protocol - k-anonymity, privacy-preserving hashing, data protection",
   "main": "dist/index.js",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/protocol",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "PEAC protocol implementation - receipt issuance and verification",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/provenance/package.json
+++ b/packages/provenance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/provenance",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "description": "Provenance pillar for PEAC protocol - content provenance, C2PA integration, and chain-of-custody",
   "main": "dist/index.js",

--- a/packages/rails/card/package.json
+++ b/packages/rails/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-card",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Card payment rail adapter for PEAC protocol (Flowglad, Stripe Billing, Lago)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rails/razorpay/package.json
+++ b/packages/rails/razorpay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-razorpay",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "description": "Razorpay payment rail adapter for PEAC protocol (UPI, cards, netbanking)",
   "main": "dist/index.js",

--- a/packages/rails/stripe/package.json
+++ b/packages/rails/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-stripe",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Stripe payment rail adapter for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rails/x402/package.json
+++ b/packages/rails/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-x402",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "x402 payment rail adapter for PEAC protocol",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/receipts/package.json
+++ b/packages/receipts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/receipts",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "PEAC Protocol receipt builders, parsers, and validators with CBOR support",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/schema",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "PEAC Protocol JSON schemas, OpenAPI specs, and TypeScript types",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/sdk",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "PEAC client SDK with discover/verify functions",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/server",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "PEAC verification server with DoS protection and rate limiting",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry-otel/package.json
+++ b/packages/telemetry-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/telemetry-otel",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "OpenTelemetry adapter for PEAC telemetry",
   "keywords": [
     "peac",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/telemetry",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Telemetry interfaces and no-op implementation for PEAC protocol",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/transport/grpc/package.json
+++ b/packages/transport/grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-grpc",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "description": "PEAC gRPC transport layer with HTTP StatusCode parity",
   "type": "module",

--- a/packages/transport/http/package.json
+++ b/packages/transport/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-http",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "description": "PEAC HTTP transport layer - headers, middleware, DPoP L3/L4",
   "type": "module",

--- a/packages/transport/ws/package.json
+++ b/packages/transport/ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-ws",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "description": "PEAC WebSocket transport layer (placeholder for v0.9.17+)",
   "type": "module",

--- a/packages/worker-core/package.json
+++ b/packages/worker-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-core",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Runtime-neutral TAP verification handler for edge workers",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/worker-shared/package.json
+++ b/packages/worker-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-shared",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "description": "Shared runtime-neutral TAP verification logic for edge worker surfaces",
   "type": "module",

--- a/scripts/conformance/build-registry.mjs
+++ b/scripts/conformance/build-registry.mjs
@@ -21,7 +21,7 @@ function hash(fragment) {
   return 'sha256:' + createHash('sha256').update(fragment, 'utf-8').digest('hex');
 }
 
-const VERSION = '0.12.1';
+const VERSION = '0.12.2';
 
 // Section slug mapping (markdown anchor format)
 const SECTION_ANCHORS = {

--- a/scripts/publish-manifest.json
+++ b/scripts/publish-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Single source of truth for PEAC Protocol npm publish order",
-  "version": "0.12.1",
-  "lastUpdated": "2026-03-13",
+  "version": "0.12.2",
+  "lastUpdated": "2026-03-16",
   "totalPackages": 28,
   "packages": [
     "@peac/kernel",

--- a/specs/conformance/erc8004-mapping/vector-wrapper.json
+++ b/specs/conformance/erc8004-mapping/vector-wrapper.json
@@ -2,7 +2,7 @@
   "$schema": "../common/conformance-vector.schema.json",
   "name": "erc8004-feedback-hash-wrapper",
   "description": "ERC-8004 feedbackHash computation from Pattern B wrapper file via JCS canonicalization",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "input": {
     "file": "golden-wrapper.json",
     "description": "ERC-8004 wrapper file referencing a PEAC receipt (Pattern B integration)"

--- a/specs/conformance/erc8004-mapping/vector.json
+++ b/specs/conformance/erc8004-mapping/vector.json
@@ -2,7 +2,7 @@
   "$schema": "../common/conformance-vector.schema.json",
   "name": "erc8004-feedback-hash",
   "description": "ERC-8004 feedbackHash computation from PEAC receipt via JCS canonicalization",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "input": {
     "file": "golden-receipt.json",
     "description": "PEAC receipt in peac-receipt/0.1 wire format"

--- a/specs/conformance/fixtures/agent-identity/edge-cases.json
+++ b/specs/conformance/fixtures/agent-identity/edge-cases.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Edge case AgentIdentityAttestation golden vectors (v0.9.25+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "unicode-agent-id",
@@ -245,5 +245,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/agent-identity/invalid-actor-binding.json
+++ b/specs/conformance/fixtures/agent-identity/invalid-actor-binding.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Invalid ActorBinding fixtures (DD-142, DD-143, DD-144, v0.11.3+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "invalid-origin-with-path",
@@ -187,5 +187,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/agent-identity/invalid.json
+++ b/specs/conformance/fixtures/agent-identity/invalid.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Invalid AgentIdentityAttestation golden vectors (v0.9.25+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "missing-agent-id",
@@ -234,5 +234,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/agent-identity/valid-actor-binding.json
+++ b/specs/conformance/fixtures/agent-identity/valid-actor-binding.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Valid ActorBinding fixtures: one per proof_type (DD-142, DD-143, v0.11.3+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "ed25519-cert-chain",
@@ -116,5 +116,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/agent-identity/valid.json
+++ b/specs/conformance/fixtures/agent-identity/valid.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Valid AgentIdentityAttestation golden vectors (v0.9.25+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "operator-bot",
@@ -200,5 +200,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/attribution/edge-cases.json
+++ b/specs/conformance/fixtures/attribution/edge-cases.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Edge case AttributionAttestation golden vectors (v0.9.26+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "max-sources",
@@ -429,5 +429,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/attribution/invalid.json
+++ b/specs/conformance/fixtures/attribution/invalid.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Invalid AttributionAttestation golden vectors (v0.9.26+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "missing-sources",
@@ -479,5 +479,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/attribution/valid.json
+++ b/specs/conformance/fixtures/attribution/valid.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Valid AttributionAttestation golden vectors (v0.9.26+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "single-source-rag",
@@ -438,5 +438,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/bundle/determinism.json
+++ b/specs/conformance/fixtures/bundle/determinism.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Determinism tests for DisputeBundle verification reports (v0.9.30+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Tests that verification reports are deterministic across implementations",
   "rules": {
     "content_hash": {
@@ -105,5 +105,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/bundle/invalid.json
+++ b/specs/conformance/fixtures/bundle/invalid.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Invalid DisputeBundle golden vectors (v0.9.30+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "missing-manifest",
@@ -214,5 +214,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/bundle/valid.json
+++ b/specs/conformance/fixtures/bundle/valid.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Valid DisputeBundle golden vectors (v0.9.30+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Specification of valid bundle manifest structure and verification semantics",
   "fixtures": [
     {
@@ -174,5 +174,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/bundle/vectors/manifest.json
+++ b/specs/conformance/fixtures/bundle/vectors/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "PEAC Dispute Bundle conformance vectors",
   "vectors": [
     {

--- a/specs/conformance/fixtures/carrier-boundary/conformance.json
+++ b/specs/conformance/fixtures/carrier-boundary/conformance.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Transport Boundary conformance vectors (CARRIER-* namespace, DD-124 through DD-131)",
-  "version": "0.12.1",
-  "schema_version": "0.12.1",
+  "version": "0.12.2",
+  "schema_version": "0.12.2",
   "fixtures": [
     {
       "name": "mcp-embed-under-limit",

--- a/specs/conformance/fixtures/content-usage/edge-cases.json
+++ b/specs/conformance/fixtures/content-usage/edge-cases.json
@@ -1,7 +1,7 @@
 {
   "description": "Edge case Content-Usage header parsing fixtures (RFC 9651 value type handling)",
-  "version": "0.12.1",
-  "schema_version": "0.12.1",
+  "version": "0.12.2",
+  "schema_version": "0.12.2",
   "fixture_count": 8,
   "fixtures": [
     {

--- a/specs/conformance/fixtures/content-usage/valid.json
+++ b/specs/conformance/fixtures/content-usage/valid.json
@@ -1,7 +1,7 @@
 {
   "description": "Valid Content-Usage header parsing fixtures (AIPREF vocab-03, RFC 9651)",
-  "version": "0.12.1",
-  "schema_version": "0.12.1",
+  "version": "0.12.2",
+  "schema_version": "0.12.2",
   "fixture_count": 8,
   "fixtures": [
     {

--- a/specs/conformance/fixtures/discovery/issuer-config.json
+++ b/specs/conformance/fixtures/discovery/issuer-config.json
@@ -1,6 +1,6 @@
 {
   "$comment": "PEAC issuer configuration conformance vectors (v0.10.0+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "spec": "docs/specs/PEAC-ISSUER.md",
   "format": "peac-issuer/0.1",
   "location": "/.well-known/peac-issuer.json",
@@ -261,5 +261,5 @@
       }
     ]
   },
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/discovery/policy-manifest.json
+++ b/specs/conformance/fixtures/discovery/policy-manifest.json
@@ -1,6 +1,6 @@
 {
   "$comment": "PEAC policy manifest conformance vectors (v0.10.0+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "spec": "docs/specs/PEAC-TXT.md",
   "format": "peac-policy/0.1",
   "location": "/.well-known/peac.txt",
@@ -232,5 +232,5 @@
       }
     ]
   },
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/dispute/edge-cases.json
+++ b/specs/conformance/fixtures/dispute/edge-cases.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Edge case DisputeAttestation golden vectors (v0.9.27+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "max-grounds",
@@ -684,5 +684,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/dispute/invalid.json
+++ b/specs/conformance/fixtures/dispute/invalid.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Invalid DisputeAttestation golden vectors (v0.9.27+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "missing-type",
@@ -722,5 +722,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/dispute/valid.json
+++ b/specs/conformance/fixtures/dispute/valid.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Valid DisputeAttestation golden vectors (v0.9.27+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "minimal-filed",
@@ -491,5 +491,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/errors/next-action-hints.json
+++ b/specs/conformance/fixtures/errors/next-action-hints.json
@@ -1,7 +1,7 @@
 {
   "$comment": "AUTO-GENERATED hint table (DD-132, DD-133). These are best-effort guidance hints, not normative protocol promises. Servers MAY change mappings between minor versions without breaking the protocol. Agents SHOULD NOT build hard dependencies on specific next_action values for specific error codes.",
-  "version": "0.12.1",
-  "schema_version": "0.12.1",
+  "version": "0.12.2",
+  "schema_version": "0.12.2",
   "source_file": "specs/kernel/errors.json",
   "hints": {
     "E_INVALID_SIGNATURE": {

--- a/specs/conformance/fixtures/fingerprint-ref/golden-vectors.json
+++ b/specs/conformance/fixtures/fingerprint-ref/golden-vectors.json
@@ -1,7 +1,7 @@
 {
   "$comment": "FingerprintRef round-trip golden vectors (v0.11.3+, DD-146)",
-  "version": "0.12.1",
-  "schema_version": "0.12.1",
+  "version": "0.12.2",
+  "schema_version": "0.12.2",
   "vectors": [
     {
       "name": "sha256-empty-input",

--- a/specs/conformance/fixtures/interaction/edge-cases.json
+++ b/specs/conformance/fixtures/interaction/edge-cases.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.peacprotocol.org/schemas/conformance/interaction-fixtures.schema.json",
   "$comment": "Edge cases and warnings for InteractionEvidenceV01 (v0.10.7+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "unregistered-kind-warns",
@@ -561,5 +561,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/interaction/invalid.json
+++ b/specs/conformance/fixtures/interaction/invalid.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.peacprotocol.org/schemas/conformance/interaction-fixtures.schema.json",
   "$comment": "Invalid InteractionEvidenceV01 vectors with expected error codes (v0.10.7+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "not-an-object",
@@ -739,5 +739,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/interaction/rfc9421-proof.json
+++ b/specs/conformance/fixtures/interaction/rfc9421-proof.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.peacprotocol.org/schemas/conformance/interaction-fixtures.schema.json",
   "$comment": "RFC 9421 proof capture extension vectors (v0.10.12+). All vectors are valid InteractionEvidenceV01 with the org.peacprotocol/rfc9421-proof@0.1 extension.",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "rfc9421-verified-signature",
@@ -231,5 +231,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/interaction/valid.json
+++ b/specs/conformance/fixtures/interaction/valid.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.peacprotocol.org/schemas/conformance/interaction-fixtures.schema.json",
   "$comment": "Valid InteractionEvidenceV01 golden vectors (v0.10.7+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "minimal-tool-call",
@@ -515,5 +515,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/inventory.json
+++ b/specs/conformance/fixtures/inventory.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://www.peacprotocol.org/schemas/conformance/inventory.schema.json",
-  "generated_at": "2026-03-15T16:42:45.655Z",
-  "version": "0.12.1",
-  "schema_version": "0.12.1",
+  "generated_at": "2026-03-16T08:34:31.691Z",
+  "version": "0.12.2",
+  "schema_version": "0.12.2",
   "total_fixtures": 688,
   "total_with_requirements": 243,
   "total_unmapped": 445,

--- a/specs/conformance/fixtures/issue/invalid.json
+++ b/specs/conformance/fixtures/issue/invalid.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Invalid Issue() input golden vectors for cross-language conformance (v0.9.29+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "runner_contract": {
     "input_format": "untyped JSON values passed to Issue()",
     "float_handling": "runner decodes amt as any/interface{}, Issue() validates integer constraint",
@@ -185,5 +185,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/issue/valid.json
+++ b/specs/conformance/fixtures/issue/valid.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Valid Issue() input golden vectors for cross-language conformance (v0.9.29+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "runner_contract": {
     "input_format": "untyped JSON values passed to Issue()",
     "assertion_mode": "invariant-based (subset checking, not exact equality)",
@@ -177,5 +177,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/key-rotation/key-rotation.json
+++ b/specs/conformance/fixtures/key-rotation/key-rotation.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Key Rotation Lifecycle conformance fixtures (DD-148, v0.11.3+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "normal-rotation",
@@ -182,5 +182,5 @@
     "$comment": "RFC 5280 CRLReason subset relevant to receipt signing keys",
     "values": ["key_compromise", "superseded", "cessation_of_operation", "privilege_withdrawn"]
   },
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/manifest.json
+++ b/specs/conformance/fixtures/manifest.json
@@ -81,82 +81,82 @@
   "purpose": {
     "normalization.json": {
       "description": "Purpose header normalization golden vectors (v0.9.24+)",
-      "version": "0.12.1"
+      "version": "0.12.2"
     },
     "validation.json": {
       "description": "Purpose token validation golden vectors (v0.9.24+)",
-      "version": "0.12.1"
+      "version": "0.12.2"
     },
     "reason.json": {
       "description": "Purpose reason derivation golden vectors (v0.9.24+)",
-      "version": "0.12.1"
+      "version": "0.12.2"
     }
   },
   "agent-identity": {
     "valid.json": {
       "description": "Valid AgentIdentityAttestation golden vectors (v0.9.25+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 9
     },
     "invalid.json": {
       "description": "Invalid AgentIdentityAttestation golden vectors (v0.9.25+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 12
     },
     "edge-cases.json": {
       "description": "Edge case AgentIdentityAttestation golden vectors (v0.9.25+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 10
     },
     "valid-actor-binding.json": {
       "description": "Valid ActorBinding conformance fixtures (DD-142, DD-143, v0.11.3+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 8
     },
     "invalid-actor-binding.json": {
       "description": "Invalid ActorBinding conformance fixtures (DD-142, DD-144, v0.11.3+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 8
     }
   },
   "obligations": {
     "valid.json": {
       "description": "Valid obligations extension golden vectors (v0.9.26+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 4
     },
     "invalid.json": {
       "description": "Invalid obligations extension golden vectors (v0.9.26+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 6
     }
   },
   "dispute": {
     "valid.json": {
       "description": "Valid DisputeAttestation golden vectors (v0.9.27+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 15
     },
     "invalid.json": {
       "description": "Invalid DisputeAttestation golden vectors (v0.9.27+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 25
     },
     "edge-cases.json": {
       "description": "Edge case DisputeAttestation golden vectors including runtime tests (v0.9.27+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 22
     }
   },
   "issue": {
     "valid.json": {
       "description": "Valid Issue() input golden vectors with invariant-based assertions (v0.9.29+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 7
     },
     "invalid.json": {
       "description": "Invalid Issue() input golden vectors (v0.9.29+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 10,
       "note": "Evidence non-finite/depth tests are language-specific unit tests, not cross-language fixtures"
     }
@@ -164,43 +164,43 @@
   "policy": {
     "evaluation.json": {
       "description": "Policy evaluation golden vectors with first-match-wins semantics (v0.9.29+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 12
     },
     "validation.json": {
       "description": "Policy document validation golden vectors including empty-rules-valid case (v0.9.29+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 11,
       "valid_count": 4,
       "invalid_count": 7
     },
     "enforcement.json": {
       "description": "Policy enforcement HTTP mapping golden vectors using locked API (v0.9.29+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 6
     }
   },
   "bundle": {
     "valid.json": {
       "description": "Valid DisputeBundle manifest golden vectors (v0.9.30+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 2
     },
     "invalid.json": {
       "description": "Invalid DisputeBundle golden vectors with error codes (v0.9.30+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 12
     },
     "determinism.json": {
       "description": "Determinism tests for cross-language parity of report_hash (v0.9.30+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 5
     }
   },
   "discovery": {
     "issuer-config.json": {
       "description": "PEAC issuer configuration parsing and validation vectors (v0.10.0+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "format": "peac-issuer/0.1",
       "location": "/.well-known/peac-issuer.json",
       "valid_count": 4,
@@ -208,7 +208,7 @@
     },
     "policy-manifest.json": {
       "description": "PEAC policy manifest parsing and validation vectors (v0.10.0+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "format": "peac-policy/0.1",
       "location": "/.well-known/peac.txt",
       "valid_count": 9,
@@ -218,127 +218,127 @@
   "workflow": {
     "valid.json": {
       "description": "Valid WorkflowContext and WorkflowSummaryAttestation golden vectors (v0.10.2+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 12
     },
     "invalid.json": {
       "description": "Invalid WorkflowContext and WorkflowSummaryAttestation vectors (v0.10.2+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 14
     },
     "edge-cases.json": {
       "description": "Edge case workflow correlation vectors including limits testing (v0.10.2+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 11
     }
   },
   "interaction": {
     "valid.json": {
       "description": "Valid InteractionEvidenceV01 golden vectors (v0.10.7+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 16
     },
     "invalid.json": {
       "description": "Invalid InteractionEvidenceV01 vectors with expected error codes (v0.10.7+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 36
     },
     "edge-cases.json": {
       "description": "Edge case InteractionEvidenceV01 vectors with warnings (v0.10.7+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 22
     },
     "rfc9421-proof.json": {
       "description": "RFC 9421 proof capture extension vectors with org.peacprotocol/rfc9421-proof@0.1 extension",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 5
     }
   },
   "attribution": {
     "valid.json": {
       "description": "Valid AttributionAttestation golden vectors (v0.9.26+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 16
     },
     "invalid.json": {
       "description": "Invalid AttributionAttestation golden vectors (v0.9.26+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 21
     },
     "edge-cases.json": {
       "description": "Edge case AttributionAttestation golden vectors (v0.9.26+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 16
     }
   },
   "verifier": {
     "policy-binding.json": {
       "description": "Policy binding conformance fixtures (DD-49, v0.10.10+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 8
     },
     "security-limits.json": {
       "description": "Security limits conformance fixtures (v0.10.8+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 10
     },
     "ssrf-protection.json": {
       "description": "SSRF protection conformance fixtures (v0.10.8+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 12
     },
     "transport-profiles.json": {
       "description": "Transport profile conformance fixtures (v0.10.8+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 10
     },
     "trust-pinning.json": {
       "description": "Trust pinning conformance fixtures (v0.10.8+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 11
     },
     "verification-report.json": {
       "description": "Verification report conformance fixtures (v0.10.8+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 9
     }
   },
   "parse": {
     "valid-commerce-receipt.json": {
       "description": "Valid commerce receipt for parseReceiptClaims (v0.10.9+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "expected_variant": "commerce"
     },
     "valid-attestation-receipt.json": {
       "description": "Valid attestation receipt for parseReceiptClaims (v0.10.9+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "expected_variant": "attestation"
     },
     "invalid-partial-commerce-amt-only.json": {
       "description": "Has amt but missing payment -- must fail as E_PARSE_COMMERCE_INVALID",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "expected_error": "E_PARSE_COMMERCE_INVALID"
     },
     "invalid-commerce-wrong-types.json": {
       "description": "Commerce receipt with amt as string -- must fail as E_PARSE_COMMERCE_INVALID",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "expected_error": "E_PARSE_COMMERCE_INVALID"
     },
     "edge-attestation-with-accidental-amt.json": {
       "description": "Attestation-shaped but has amt key -- classified as commerce, fails as E_PARSE_COMMERCE_INVALID",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "expected_error": "E_PARSE_COMMERCE_INVALID"
     },
     "edge-unknown-top-level-keys.json": {
       "description": "Extra keys beyond schema -- rejected by strict schemas",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "expected_error": "E_PARSE_ATTESTATION_INVALID"
     }
   },
   "errors": {
     "next-action-hints.json": {
       "description": "Agent recovery next_action hint table (DD-132, DD-133); best-effort guidance, not normative",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 146,
       "expected_valid": true
     }
@@ -346,194 +346,194 @@
   "content-usage": {
     "valid.json": {
       "description": "Valid Content-Usage header parsing fixtures (AIPREF vocab-03, RFC 9651)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 8
     },
     "edge-cases.json": {
       "description": "Edge case Content-Usage header parsing fixtures (RFC 9651 value type handling)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 8
     }
   },
   "treaty": {
     "treaty.json": {
       "description": "Treaty extension conformance fixtures (DD-147, v0.11.3+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 5
     }
   },
   "fingerprint-ref": {
     "golden-vectors.json": {
       "description": "FingerprintRef round-trip conversion golden vectors (DD-146, v0.11.3+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 4
     }
   },
   "zero-trust": {
     "credential-event.json": {
       "description": "Credential event extension conformance fixtures (DD-145, v0.11.3+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 6
     },
     "tool-registry.json": {
       "description": "Tool registry extension conformance fixtures (DD-145, v0.11.3+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 6
     },
     "control-action.json": {
       "description": "Control action extension conformance fixtures (DD-145, v0.11.3+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 6
     }
   },
   "key-rotation": {
     "key-rotation.json": {
       "description": "Key rotation lifecycle conformance fixtures (DD-148, v0.11.3+)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 6
     }
   },
   "carrier": {
     "valid-minimal.json": {
       "description": "Minimal carrier with only receipt_ref",
-      "version": "0.12.1"
+      "version": "0.12.2"
     },
     "valid-full.json": {
       "description": "Full carrier with all optional fields",
-      "version": "0.12.1"
+      "version": "0.12.2"
     },
     "valid-embed-no-optional.json": {
       "description": "Embed carrier with receipt_jws but no other optional fields",
-      "version": "0.12.1"
+      "version": "0.12.2"
     },
     "valid-http-reference.json": {
       "description": "HTTP reference-only carrier within 8KB header limit",
-      "version": "0.12.1"
+      "version": "0.12.2"
     },
     "valid-with-redaction.json": {
       "description": "Carrier with redaction metadata",
-      "version": "0.12.1"
+      "version": "0.12.2"
     },
     "invalid-receipt-ref.json": {
       "description": "Carrier with malformed receipt_ref",
-      "version": "0.12.1"
+      "version": "0.12.2"
     },
     "invalid-jws-format.json": {
       "description": "Carrier with invalid receipt_jws format",
-      "version": "0.12.1"
+      "version": "0.12.2"
     },
     "invalid-oversize.json": {
       "description": "Carrier exceeding transport max_size",
-      "version": "0.12.1"
+      "version": "0.12.2"
     },
     "valid-with-receipt-url.json": {
       "description": "Valid carrier with receipt_url locator hint (DD-135)",
-      "version": "0.12.1"
+      "version": "0.12.2"
     },
     "invalid-receipt-url-http.json": {
       "description": "Invalid carrier: receipt_url uses HTTP instead of HTTPS (DD-135)",
-      "version": "0.12.1"
+      "version": "0.12.2"
     },
     "invalid-receipt-url-credentials.json": {
       "description": "Invalid carrier: receipt_url contains credentials (DD-135)",
-      "version": "0.12.1"
+      "version": "0.12.2"
     },
     "invalid-receipt-url-too-long.json": {
       "description": "Invalid carrier: receipt_url exceeds 2048 character limit (DD-135)",
-      "version": "0.12.1"
+      "version": "0.12.2"
     }
   },
   "wire-02": {
     "valid.json": {
       "description": "Wire 0.2 valid receipt golden vectors (DD-156)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 28
     },
     "invalid.json": {
       "description": "Wire 0.2 invalid receipt rejection vectors (DD-156)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 27
     },
     "warnings.json": {
       "description": "Wire 0.2 warning emission vectors (DD-155)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 4
     },
     "replay-prevention/boundary-jti-length.json": {
       "description": "Wire 0.2 replay prevention: jti at maximum length boundary",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 1
     },
     "kinds/conformance.json": {
       "description": "Wire 0.2 kind semantics conformance vectors (Section 5, DD-164)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 6
     },
     "types/conformance.json": {
       "description": "Wire 0.2 type grammar conformance vectors (Section 6, DD-164)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 12
     },
     "pillars/conformance.json": {
       "description": "Wire 0.2 pillar taxonomy conformance vectors (Section 7, DD-164)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 7
     },
     "issuers/conformance.json": {
       "description": "Wire 0.2 issuer canonical form conformance vectors (Section 8, DD-164)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 10
     },
     "occurred-at/conformance.json": {
       "description": "Wire 0.2 occurred-at semantics conformance vectors (Section 9, DD-164)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 6
     },
     "jose/conformance.json": {
       "description": "Wire 0.2 JWS header constraints conformance vectors (Section 10, DD-164)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 13
     },
     "policy-binding/conformance.json": {
       "description": "Wire 0.2 policy binding conformance vectors (Section 11, DD-164)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 6
     },
     "extensions/conformance.json": {
       "description": "Wire 0.2 extension groups conformance vectors (Section 12, DD-164)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 13
     },
     "identifier-stack/conformance.json": {
       "description": "Wire 0.2 identifier stack conformance vectors (Section 18, DD-164)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 5
     },
     "validation/conformance.json": {
       "description": "Wire 0.2 validation algorithm conformance vectors (Section 19, DD-164)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 9
     },
     "replay/conformance.json": {
       "description": "Wire 0.2 replay prevention conformance vectors (Section 20, DD-164)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 6
     },
     "challenge.json": {
       "description": "Wire 0.2 challenge body conformance vectors (Section 13, DD-158)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 5
     },
     "dual-stack.json": {
       "description": "Wire 0.2 dual-stack compatibility conformance vectors (Section 15, DD-158)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 4
     }
   },
   "carrier-boundary": {
     "conformance.json": {
       "description": "Transport boundary conformance vectors (CARRIER-* namespace, DD-124 through DD-131)",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "fixture_count": 11
     }
   }

--- a/specs/conformance/fixtures/policy/enforcement.json
+++ b/specs/conformance/fixtures/policy/enforcement.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Policy enforcement HTTP mapping golden vectors for cross-language conformance (v0.9.29+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "runner_contract": {
     "api_shape": "EnforceDecision(decision Decision, receiptVerified bool) (int, http.Header)",
     "402_semantics": "Only when decision=review AND receiptVerified=false",
@@ -88,5 +88,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/policy/evaluation.json
+++ b/specs/conformance/fixtures/policy/evaluation.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Policy evaluation golden vectors for cross-language conformance (v0.9.29+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "runner_contract": {
     "semantics": "first-match-wins",
     "empty_rules": "valid, falls back to defaults.decision",
@@ -259,5 +259,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/policy/validation.json
+++ b/specs/conformance/fixtures/policy/validation.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Policy document validation golden vectors for cross-language conformance (v0.9.29+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "runner_contract": {
     "parsing": "strict",
     "unknown_fields": "reject",
@@ -222,5 +222,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/purpose/normalization.json
+++ b/specs/conformance/fixtures/purpose/normalization.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../schema.json",
   "description": "Purpose header normalization golden vectors (v0.9.24+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "vectors": [
     {
       "id": "single-canonical",
@@ -134,5 +134,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/purpose/reason.json
+++ b/specs/conformance/fixtures/purpose/reason.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../schema.json",
   "description": "Purpose reason derivation golden vectors (v0.9.24+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "vectors": [
     {
       "id": "undeclared-default",
@@ -101,5 +101,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/purpose/validation.json
+++ b/specs/conformance/fixtures/purpose/validation.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../schema.json",
   "description": "Purpose token validation golden vectors (v0.9.24+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "vectors": [
     {
       "id": "invalid-leading-digit",
@@ -125,5 +125,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/stripe-crypto/manifest.json
+++ b/specs/conformance/fixtures/stripe-crypto/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../manifest.schema.json",
   "name": "stripe-crypto-payment",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Conformance vectors for @peac/rails-stripe fromCryptoPaymentIntent()",
   "profile": "stripe-x402-machine-payment/0.1",
   "categories": {

--- a/specs/conformance/fixtures/treaty/treaty.json
+++ b/specs/conformance/fixtures/treaty/treaty.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Treaty extension conformance fixtures (v0.11.3+, DD-147)",
-  "version": "0.12.1",
-  "schema_version": "0.12.1",
+  "version": "0.12.2",
+  "schema_version": "0.12.2",
   "valid": [
     {
       "name": "valid-informational",

--- a/specs/conformance/fixtures/verifier/policy-binding.json
+++ b/specs/conformance/fixtures/verifier/policy-binding.json
@@ -1,6 +1,6 @@
 {
   "description": "Policy binding conformance fixtures (DD-49)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "design_decision": "DD-49",
   "deferred_convention": "Test cases with 'deferred_until' and 'executable: false' describe future Wire 0.2 behavior. They are non-executable placeholders -- input values use angle-bracket pseudocode (e.g. '<base64url of SHA-256>'). They become executable when the deferred_until version ships.",
   "test_cases": [
@@ -169,5 +169,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/verifier/security-limits.json
+++ b/specs/conformance/fixtures/verifier/security-limits.json
@@ -1,6 +1,6 @@
 {
   "description": "Security limits conformance fixtures per VERIFIER-SECURITY-MODEL.md",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "limits": {
     "max_receipt_bytes": 262144,
     "max_jwks_bytes": 65536,
@@ -139,5 +139,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/verifier/ssrf-protection.json
+++ b/specs/conformance/fixtures/verifier/ssrf-protection.json
@@ -1,6 +1,6 @@
 {
   "description": "SSRF protection conformance fixtures per VERIFIER-SECURITY-MODEL.md",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "test_cases": [
     {
       "id": "https-required",
@@ -169,5 +169,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/verifier/transport-profiles.json
+++ b/specs/conformance/fixtures/verifier/transport-profiles.json
@@ -1,6 +1,6 @@
 {
   "description": "Transport profile conformance fixtures per TRANSPORT-PROFILES.md",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "test_cases": [
     {
       "id": "header-valid",
@@ -168,5 +168,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/verifier/trust-pinning.json
+++ b/specs/conformance/fixtures/verifier/trust-pinning.json
@@ -1,6 +1,6 @@
 {
   "description": "Trust pinning conformance fixtures per TRUST-PINNING-POLICY.md",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "test_cases": [
     {
       "id": "issuer-in-allowlist",
@@ -211,5 +211,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/verifier/verification-report.json
+++ b/specs/conformance/fixtures/verifier/verification-report.json
@@ -1,6 +1,6 @@
 {
   "description": "Verification report conformance fixtures per VERIFICATION-REPORT-FORMAT.md",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "report_version": "peac-verification-report/0.1",
   "test_cases": [
     {
@@ -298,5 +298,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/wire-02/challenge.json
+++ b/specs/conformance/fixtures/wire-02/challenge.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Wire 0.2 challenge body conformance vectors (v0.12.0 stable, sections 13, DD-158)",
-  "schema_version": "0.12.1",
-  "version": "0.12.1",
+  "schema_version": "0.12.2",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "challenge-with-problem-type-required",

--- a/specs/conformance/fixtures/wire-02/dual-stack.json
+++ b/specs/conformance/fixtures/wire-02/dual-stack.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Wire 0.2 dual-stack compatibility vectors (v0.12.0 stable, section 15, DD-158)",
-  "schema_version": "0.12.1",
-  "version": "0.12.1",
+  "schema_version": "0.12.2",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "wire02-typ-coherent",

--- a/specs/conformance/fixtures/wire-02/identifier-stack/conformance.json
+++ b/specs/conformance/fixtures/wire-02/identifier-stack/conformance.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Wire 0.2 Identifier Stack and Token Confusion conformance vectors (Section 18)",
-  "version": "0.12.1",
-  "schema_version": "0.12.1",
+  "version": "0.12.2",
+  "schema_version": "0.12.2",
   "fixtures": [
     {
       "name": "compact-typ-valid",

--- a/specs/conformance/fixtures/wire-02/invalid.json
+++ b/specs/conformance/fixtures/wire-02/invalid.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Wire 0.2 invalid receipt rejection vectors (v0.12.0-preview.1, DD-156)",
-  "schema_version": "0.12.1",
-  "version": "0.12.1",
+  "schema_version": "0.12.2",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "reject-jwk",

--- a/specs/conformance/fixtures/wire-02/issuers/conformance.json
+++ b/specs/conformance/fixtures/wire-02/issuers/conformance.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Wire 0.2 Issuer Canonical Form conformance vectors (Section 8, DD-156)",
-  "version": "0.12.1",
-  "schema_version": "0.12.1",
+  "version": "0.12.2",
+  "schema_version": "0.12.2",
   "fixtures": [
     {
       "name": "https-issuer-valid",

--- a/specs/conformance/fixtures/wire-02/jose/conformance.json
+++ b/specs/conformance/fixtures/wire-02/jose/conformance.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Wire 0.2 JWS Header Constraints conformance vectors (Section 10, DD-156)",
-  "version": "0.12.1",
-  "schema_version": "0.12.1",
+  "version": "0.12.2",
+  "schema_version": "0.12.2",
   "fixtures": [
     {
       "name": "eddsa-alg-valid",

--- a/specs/conformance/fixtures/wire-02/kinds/conformance.json
+++ b/specs/conformance/fixtures/wire-02/kinds/conformance.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Wire 0.2 Kind Semantics conformance vectors (Section 5, DD-156)",
-  "version": "0.12.1",
-  "schema_version": "0.12.1",
+  "version": "0.12.2",
+  "schema_version": "0.12.2",
   "fixtures": [
     {
       "name": "evidence-kind-valid",

--- a/specs/conformance/fixtures/wire-02/occurred-at/conformance.json
+++ b/specs/conformance/fixtures/wire-02/occurred-at/conformance.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Wire 0.2 Occurred-at Semantics conformance vectors (Section 9, DD-156)",
-  "version": "0.12.1",
-  "schema_version": "0.12.1",
+  "version": "0.12.2",
+  "schema_version": "0.12.2",
   "fixtures": [
     {
       "name": "occurred-at-valid-utc",

--- a/specs/conformance/fixtures/wire-02/pillars/conformance.json
+++ b/specs/conformance/fixtures/wire-02/pillars/conformance.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Wire 0.2 Pillar Taxonomy conformance vectors (Section 7, DD-156)",
-  "version": "0.12.1",
-  "schema_version": "0.12.1",
+  "version": "0.12.2",
+  "schema_version": "0.12.2",
   "fixtures": [
     {
       "name": "single-pillar-valid",

--- a/specs/conformance/fixtures/wire-02/policy-binding/conformance.json
+++ b/specs/conformance/fixtures/wire-02/policy-binding/conformance.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Wire 0.2 Policy Binding conformance vectors (Section 11, DD-49/DD-156)",
-  "version": "0.12.1",
-  "schema_version": "0.12.1",
+  "version": "0.12.2",
+  "schema_version": "0.12.2",
   "fixtures": [
     {
       "name": "policy-binding-verified",

--- a/specs/conformance/fixtures/wire-02/replay-prevention/boundary-jti-length.json
+++ b/specs/conformance/fixtures/wire-02/replay-prevention/boundary-jti-length.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Wire 0.2 replay prevention: jti at maximum length boundary",
-  "schema_version": "0.12.1",
-  "version": "0.12.1",
+  "schema_version": "0.12.2",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "jti-at-max-length-256",

--- a/specs/conformance/fixtures/wire-02/replay/conformance.json
+++ b/specs/conformance/fixtures/wire-02/replay/conformance.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Wire 0.2 Replay Prevention conformance vectors (Section 20)",
-  "version": "0.12.1",
-  "schema_version": "0.12.1",
+  "version": "0.12.2",
+  "schema_version": "0.12.2",
   "fixtures": [
     {
       "name": "jti-present-valid",

--- a/specs/conformance/fixtures/wire-02/types/conformance.json
+++ b/specs/conformance/fixtures/wire-02/types/conformance.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Wire 0.2 Type Grammar conformance vectors (Section 6, DD-156)",
-  "version": "0.12.1",
-  "schema_version": "0.12.1",
+  "version": "0.12.2",
+  "schema_version": "0.12.2",
   "fixtures": [
     {
       "name": "reverse-dns-valid",

--- a/specs/conformance/fixtures/wire-02/valid.json
+++ b/specs/conformance/fixtures/wire-02/valid.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Wire 0.2 valid receipt golden vectors (v0.12.0-preview.1, DD-156)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "evidence-commerce-minimal",
@@ -1042,5 +1042,5 @@
       "_audit_note": "Backfilled by scripts/conformance/backfill-existing-fixtures.mjs"
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/wire-02/validation/conformance.json
+++ b/specs/conformance/fixtures/wire-02/validation/conformance.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Wire 0.2 Verifier Validation Algorithm conformance vectors (Section 19)",
-  "version": "0.12.1",
-  "schema_version": "0.12.1",
+  "version": "0.12.2",
+  "schema_version": "0.12.2",
   "fixtures": [
     {
       "name": "full-validation-pass",

--- a/specs/conformance/fixtures/wire-02/warnings.json
+++ b/specs/conformance/fixtures/wire-02/warnings.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Wire 0.2 warning emission vectors (v0.12.0-preview.1, DD-155)",
-  "schema_version": "0.12.1",
-  "version": "0.12.1",
+  "schema_version": "0.12.2",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "unknown-type-preserved",

--- a/specs/conformance/fixtures/workflow/edge-cases.json
+++ b/specs/conformance/fixtures/workflow/edge-cases.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.peacprotocol.org/schemas/conformance/workflow-fixtures.schema.json",
   "$comment": "Edge case WorkflowContext and WorkflowSummaryAttestation vectors (v0.10.2+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "max-parents-allowed",
@@ -357,5 +357,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/workflow/invalid.json
+++ b/specs/conformance/fixtures/workflow/invalid.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.peacprotocol.org/schemas/conformance/workflow-fixtures.schema.json",
   "$comment": "Invalid WorkflowContext and WorkflowSummaryAttestation vectors (v0.10.2+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "invalid-workflow-id-format",
@@ -446,5 +446,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/workflow/valid.json
+++ b/specs/conformance/fixtures/workflow/valid.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.peacprotocol.org/schemas/conformance/workflow-fixtures.schema.json",
   "$comment": "Valid WorkflowContext and WorkflowSummaryAttestation golden vectors (v0.10.2+)",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "fixtures": [
     {
       "name": "minimal-root-step",
@@ -274,5 +274,5 @@
       }
     }
   ],
-  "schema_version": "0.12.1"
+  "schema_version": "0.12.2"
 }

--- a/specs/conformance/fixtures/x402/manifest.json
+++ b/specs/conformance/fixtures/x402/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../manifest.schema.json",
   "name": "x402-adapter",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Conformance vectors for @peac/adapter-x402 verification and record mapping (v0.12.1 upstream sync)",
   "profile": "peac-x402-offer-receipt/0.2",
   "fixture_kinds": ["offer_verification", "receipt_verification", "consistency_verification"],

--- a/specs/conformance/fixtures/zero-trust/control-action.json
+++ b/specs/conformance/fixtures/zero-trust/control-action.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Control Action extension conformance fixtures (v0.11.3+, DD-145)",
-  "version": "0.12.1",
-  "schema_version": "0.12.1",
+  "version": "0.12.2",
+  "schema_version": "0.12.2",
   "valid": [
     {
       "name": "grant-on-policy",

--- a/specs/conformance/fixtures/zero-trust/credential-event.json
+++ b/specs/conformance/fixtures/zero-trust/credential-event.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Credential Event extension conformance fixtures (v0.11.3+, DD-145)",
-  "version": "0.12.1",
-  "schema_version": "0.12.1",
+  "version": "0.12.2",
+  "schema_version": "0.12.2",
   "valid": [
     {
       "name": "issued-credential",

--- a/specs/conformance/fixtures/zero-trust/tool-registry.json
+++ b/specs/conformance/fixtures/zero-trust/tool-registry.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Tool Registry extension conformance fixtures (v0.11.3+, DD-145)",
-  "version": "0.12.1",
-  "schema_version": "0.12.1",
+  "version": "0.12.2",
+  "schema_version": "0.12.2",
   "valid": [
     {
       "name": "https-registry",

--- a/specs/conformance/requirement-ids.json
+++ b/specs/conformance/requirement-ids.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://www.peacprotocol.org/schemas/conformance/requirement-registry.schema.json",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "spec_file": "docs/specs/WIRE-0.2.md",
   "sections": [
     {
@@ -15,8 +15,8 @@
           "source_fragment": "Issuers MUST emit this form",
           "source_fragment_hash": "sha256:0ad5b045ab78f4e9109ba8037bc1f1279ceac8a58fe748136751984969ffbbef",
           "enforcement_class": "issuance",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-MEDIA-002",
@@ -25,8 +25,8 @@
           "source_fragment": "Verifiers MUST accept; normalized to compact form",
           "source_fragment_hash": "sha256:2192ce1ab3f1ba59c7488f2aff9fba90fd7c08e68c7bc636ada4606da7d049a7",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -36,8 +36,8 @@
           "source_fragment": "The full media type form `application/interaction-record+jwt` is accepted by verifiers and MUST be normalized to the compact form `interaction-record+jwt` before returning the decoded header.",
           "source_fragment_hash": "sha256:536c2b007a3b8591d4bff457718ff298d28fa896762b1392affa342a07d29ae1",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -47,8 +47,8 @@
           "source_fragment": "Issuers MUST NOT emit the full media type form.",
           "source_fragment_hash": "sha256:c5251f9b638b45a73e848b71c5121e797cd7dd4f5fa43720d0aa47ec10f1f117",
           "enforcement_class": "issuance",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-MEDIA-005",
@@ -57,8 +57,8 @@
           "source_fragment": "Verifiers MUST enforce coherence between the JWS `typ` header and the `peac_version` payload claim",
           "source_fragment_hash": "sha256:b00235eb16c6c6a0db81c566721b4d1271c741923e2f69b30a880c11ea380652",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_WIRE_VERSION_MISMATCH"
         },
         {
@@ -68,8 +68,8 @@
           "source_fragment": "**Strict** (default): `typ` MUST be present and MUST match `interaction-record+jwt`",
           "source_fragment_hash": "sha256:feea1d7debb179f57fa31ebcb0853a4bbf1118989b05b69bcbcd187e6a101d12",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -79,8 +79,8 @@
           "source_fragment": "`typ` MUST be present and MUST match `interaction-record+jwt` (or its full media type form)",
           "source_fragment_hash": "sha256:5f3a5b55d3012cef50a6cc2699a13ed3e7c1c4d827d2e7da7d292ccdde202a62",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         }
       ]
@@ -97,8 +97,8 @@
           "source_fragment": "unknown top-level fields MUST be rejected",
           "source_fragment_hash": "sha256:0a219ef551e19ac56debd23c4e58fb3585a277c6b8105a879d34dea9f25c947c",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -108,8 +108,8 @@
           "source_fragment": "`peac_version`     | `\"0.2\"` (literal)             | REQUIRED",
           "source_fragment_hash": "sha256:7bdfc7c71a0079dd9be6c98c8291a9ffa977cca29b6b8838a60878b51c107b92",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_MISSING_REQUIRED_CLAIM"
         },
         {
@@ -119,8 +119,8 @@
           "source_fragment": "`kind`             | `\"evidence\"` or `\"challenge\"` | REQUIRED",
           "source_fragment_hash": "sha256:6eb7afd03f82e66ffa5dd05154f3d0228d33c328943720a06108d3a9cac74d8e",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_MISSING_REQUIRED_CLAIM"
         },
         {
@@ -130,8 +130,8 @@
           "source_fragment": "`type`             | string                        | REQUIRED",
           "source_fragment_hash": "sha256:04573792998fc65838c8c6fc9aef4666f58911e5cff321bac00e0aec0b668902",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_MISSING_REQUIRED_CLAIM"
         },
         {
@@ -141,8 +141,8 @@
           "source_fragment": "`iss`              | string                        | REQUIRED",
           "source_fragment_hash": "sha256:3b33b4c628f84218b3f3e8dd580a836a3c24100c33180a7d894dad1042631694",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_MISSING_REQUIRED_CLAIM"
         },
         {
@@ -152,8 +152,8 @@
           "source_fragment": "`iat`              | integer                       | REQUIRED",
           "source_fragment_hash": "sha256:3e51ea5e7d687be0295340ff1a9dd984de20e63a61df2a585950bd783b2ec310",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_MISSING_REQUIRED_CLAIM"
         },
         {
@@ -163,8 +163,8 @@
           "source_fragment": "`jti`              | string (1 to 256 chars)       | REQUIRED",
           "source_fragment_hash": "sha256:f3da034768ff8233af700a8b83e1313bbca770d99cc6c9dafd17ea9f8d647016",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_MISSING_REQUIRED_CLAIM"
         },
         {
@@ -174,8 +174,8 @@
           "source_fragment": "`sub`              | string                        | OPTIONAL",
           "source_fragment_hash": "sha256:368037b5dd9d9d45debe0a28810244010f647c080e2a87cef3976872e8b70110",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-ENV-009",
@@ -184,8 +184,8 @@
           "source_fragment": "`pillars`          | array of EvidencePillar       | OPTIONAL",
           "source_fragment_hash": "sha256:3c1fb8b3d1405472cdc66d347203e9949eb7706e07a0d903dac2cfb45b5d6bf8",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-ENV-010",
@@ -194,8 +194,8 @@
           "source_fragment": "`actor`            | ActorBinding                  | OPTIONAL",
           "source_fragment_hash": "sha256:82aadd69066785dd8f44acf578fc2686a1eb5359e96065c46d848ed587871ba7",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-ENV-011",
@@ -204,8 +204,8 @@
           "source_fragment": "`policy`           | PolicyBlock                   | OPTIONAL",
           "source_fragment_hash": "sha256:93901a0cd62d30b95f49a9d0eb0d6d3d78f49abc35917291f9e42fa29014fa2d",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-ENV-012",
@@ -214,8 +214,8 @@
           "source_fragment": "`representation`   | RepresentationFields          | OPTIONAL",
           "source_fragment_hash": "sha256:6c21b884daef697f596d1265e5f0999ebf30c663d83827b4f67e7669c4910f00",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-ENV-013",
@@ -224,8 +224,8 @@
           "source_fragment": "`occurred_at`      | string (ISO 8601 / RFC 3339)  | OPTIONAL",
           "source_fragment_hash": "sha256:09c416e1f615c62bb03424221e6e49fdb76bff6dcd054246b39be359b1bbc0dc",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-ENV-014",
@@ -234,8 +234,8 @@
           "source_fragment": "`purpose_declared` | string                        | OPTIONAL",
           "source_fragment_hash": "sha256:6eaa35ce74a62fb8287bc7bac0555baadf18e1c1539561f8e65410c88376b37d",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-ENV-015",
@@ -244,8 +244,8 @@
           "source_fragment": "`extensions`       | `Record<string, unknown>`     | OPTIONAL",
           "source_fragment_hash": "sha256:357a034ff5acf71dcf7e5e8fe4f9fdaf855c6bf05daa76a6e38b3e4ed2581b3a",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-ENV-016",
@@ -254,8 +254,8 @@
           "source_fragment": "Every Wire 0.2 receipt MUST include `peac_version`, `kind`, `type`, `iss`, `iat`, and `jti`.",
           "source_fragment_hash": "sha256:0b6a7094c1677c40ed1ba6e0062d68e7292dcd6676cc994fbc78f6ff1b667acd",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_MISSING_REQUIRED_CLAIM"
         },
         {
@@ -265,8 +265,8 @@
           "source_fragment": "`digest`  | string       | REQUIRED",
           "source_fragment_hash": "sha256:f7fadd5e4ff154c09df1e7c997f3803c05e6cef1636627d589ec4004c8a9f359",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -276,8 +276,8 @@
           "source_fragment": "`uri`     | string (URL) | OPTIONAL",
           "source_fragment_hash": "sha256:7d3200d8cbdda3ad2ae9ead49df440e01aee4693ba47544472aad9b246887ccb",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-ENV-019",
@@ -286,8 +286,8 @@
           "source_fragment": "`version` | string       | OPTIONAL",
           "source_fragment_hash": "sha256:847a8b8d08050a0821bac204dc0bbf29a2231edce770275418c00b91a99a2983",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-ENV-020",
@@ -296,8 +296,8 @@
           "source_fragment": "MUST start with `https://`",
           "source_fragment_hash": "sha256:b00cc865588cf7afea2762339afffbe7f4d1c2b3e6c6d4111e36e236a86d7c82",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -307,8 +307,8 @@
           "source_fragment": "Implementations MUST NOT trigger automatic fetch on encountering this URL (DD-55: no implicit network I/O).",
           "source_fragment_hash": "sha256:b9b373c3855d77993558e4f640698b8787d0e60280fadd1dde24a15960d15489",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-ENV-022",
@@ -317,8 +317,8 @@
           "source_fragment": "`content_hash`   | string  | OPTIONAL",
           "source_fragment_hash": "sha256:ffc021c0e538456d445d8e0fd7907844f984bd3b2412383fdeb4571b818c2ce2",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-ENV-023",
@@ -327,8 +327,8 @@
           "source_fragment": "`content_type`   | string  | OPTIONAL",
           "source_fragment_hash": "sha256:8f93a5c91e507880fcc45133dfa7e96bff9c4f8c510111b1f8c3c6874093fb08",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-ENV-024",
@@ -337,8 +337,8 @@
           "source_fragment": "`content_length` | integer | OPTIONAL",
           "source_fragment_hash": "sha256:63efd3cc5bed5ce343e37a669cc8180be7fe1c50120e344dd4530ade9e75cfb2",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-ENV-025",
@@ -347,8 +347,8 @@
           "source_fragment": "`id`          | string       | REQUIRED",
           "source_fragment_hash": "sha256:7af6f0226cae75167152cdf21cde68c2404c4426144560742442a95657425fa8",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -358,8 +358,8 @@
           "source_fragment": "`proof_type`  | string       | REQUIRED",
           "source_fragment_hash": "sha256:d5411eee9d574e04dee5f6e9aedb0b0180b61b166072ae80872f18da4e4a365b",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -369,8 +369,8 @@
           "source_fragment": "`origin`      | string (URL) | REQUIRED",
           "source_fragment_hash": "sha256:86b8b2cc2bdf87a2a388173218f0d12c91b64d6798610263e0cdcf6af59f226e",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         }
       ]
@@ -387,8 +387,8 @@
           "source_fragment": "Implementations MUST preserve unrecognized but well-formed values.",
           "source_fragment_hash": "sha256:d5fcf9d57516607b494f8bd3c95ce1ddfe19e3d6e0b8d250ccc863843945c30c",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -398,8 +398,8 @@
           "source_fragment": "The `pillars` array MUST be sorted in ascending lexicographic order with no duplicates.",
           "source_fragment_hash": "sha256:df1dc0586b45fe1fe15460c398be50de688f5e41581c36d568d49dd69e0c48e4",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_PILLARS_NOT_SORTED"
         }
       ]
@@ -416,8 +416,8 @@
           "source_fragment": "The `occurred_at` field MUST NOT appear on challenge receipts. Its presence produces `E_OCCURRED_AT_ON_CHALLENGE`.",
           "source_fragment_hash": "sha256:0c9326365380c0f36b9dbfb09cdc93fee3b912350e093ca74646b8e9297c6d01",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_OCCURRED_AT_ON_CHALLENGE"
         },
         {
@@ -427,8 +427,8 @@
           "source_fragment": "Challenges SHOULD include the challenge extension group (Section 13) with a `challenge_type` and an RFC 9457 `problem` body.",
           "source_fragment_hash": "sha256:5932bba9c1814ecb065c9d21064f3cb22737da09cc45c0ef7e878f632a4ed11e",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-KIND-003",
@@ -437,8 +437,8 @@
           "source_fragment": "A single `type` MAY appear with either kind.",
           "source_fragment_hash": "sha256:3419f8b63d75f9019a180b672532ecc9c75f5cbf783c2dda671bcad4428a727d",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         }
       ]
     },
@@ -454,8 +454,8 @@
           "source_fragment": "MUST contain at least one dot",
           "source_fragment_hash": "sha256:76c4e2721d93d12ee6f41526c906ec4b87f0288ded040b6135890fe9057a8d47",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -465,8 +465,8 @@
           "source_fragment": "MUST match /^[a-zA-Z0-9][a-zA-Z0-9.-]*$/",
           "source_fragment_hash": "sha256:791b7ed1eb8a412789e76442c9f37863918e9e151b0eff64644a282e4cd9917c",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -476,8 +476,8 @@
           "source_fragment": "MUST be non-empty",
           "source_fragment_hash": "sha256:527c9881eabc05d1d7e6260f1a1b8664ebe0d6d40fd4088eebf1dff57daf3b3c",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -487,8 +487,8 @@
           "source_fragment": "MUST match /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/",
           "source_fragment_hash": "sha256:bf6b1041585078132fc5c48276049653c2b301bd459438fb8e7a7feab4d1e78b",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -498,8 +498,8 @@
           "source_fragment": "MUST start with an alphanumeric character. MUST contain at least one dot",
           "source_fragment_hash": "sha256:397207842eeab8e97d7cf1b12b08bb5aecad68f329df64948541b1ad6cb37375",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -509,8 +509,8 @@
           "source_fragment": "MUST start with an alphanumeric character. Underscores are permitted",
           "source_fragment_hash": "sha256:e40d853063da5b3e4419a41096ee14abe7c0914d68adb9d7d5e6188a04ae7a52",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -520,8 +520,8 @@
           "source_fragment": "Reverse-DNS `type` values SHOULD be lowercase ASCII.",
           "source_fragment_hash": "sha256:f509acdb0fc7873553b33fc2146ef92ef1e68947699affd6d429f552b515c822",
           "enforcement_class": "warning_only",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "warning_code": "type_casing"
         },
         {
@@ -531,8 +531,8 @@
           "source_fragment": "Verifiers MAY emit a warning when a reverse-DNS form `type` contains uppercase characters.",
           "source_fragment_hash": "sha256:82f3f63095402c90f7253a7b44800a15443cd8b746fcf0b46d54111a5489e0ed",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         }
       ]
     },
@@ -548,8 +548,8 @@
           "source_fragment": "Unknown values MUST be rejected.",
           "source_fragment_hash": "sha256:8c52f393b3c95e4454171c4e23e5be62de76cd7bd5bf31d8ec15f37c78d32b3f",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -559,8 +559,8 @@
           "source_fragment": "When present, the array MUST contain at least one element.",
           "source_fragment_hash": "sha256:e162bdea04ccd79484ed4fb48f2165473212dce60525430aa4b68bbd260f50f0",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -570,8 +570,8 @@
           "source_fragment": "Values MUST be in ascending lexicographic order. Implementations MUST verify that each element is strictly greater than the preceding element.",
           "source_fragment_hash": "sha256:86f1129e192559d435a3a5a8370255aa8965646ea999041d5fb9b70727bd6bb3",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_PILLARS_NOT_SORTED"
         },
         {
@@ -581,8 +581,8 @@
           "source_fragment": "Duplicate values MUST be rejected.",
           "source_fragment_hash": "sha256:b7c4d9c9ae2146ab351623faced439570bac1f7f98521b9b5579c293f4e120c2",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_PILLARS_NOT_SORTED"
         },
         {
@@ -592,8 +592,8 @@
           "source_fragment": "A receipt MAY have a type that does not directly correspond to any single pillar",
           "source_fragment_hash": "sha256:a56684bbc8a9ff7a9bfa42261f273539d268b5477f3d6635c7bec6be19959005",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-PILLAR-006",
@@ -602,8 +602,8 @@
           "source_fragment": "MAY have multiple pillars for a single type",
           "source_fragment_hash": "sha256:04d1aa09ef34f8a86458ad894f71768f3af04849c95174a90415f13c7eddddbc",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         }
       ]
     },
@@ -619,8 +619,8 @@
           "source_fragment": "Scheme MUST be lowercase `https`.",
           "source_fragment_hash": "sha256:340af1900036f5018284f6a081f4dc3a36e211d166a762191023180ee44b22d7",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_ISS_NOT_CANONICAL"
         },
         {
@@ -630,8 +630,8 @@
           "source_fragment": "Host MUST be lowercase ASCII. Raw Unicode hostnames are rejected; punycode (`xn--` labels) is accepted.",
           "source_fragment_hash": "sha256:1c9b58031d3b52cce215f86f64bec955fd14c32c7e5d74b05220b431192b2542",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_ISS_NOT_CANONICAL"
         },
         {
@@ -641,8 +641,8 @@
           "source_fragment": "The default port 443 MUST NOT appear explicitly (`:443` is rejected).",
           "source_fragment_hash": "sha256:3fae3e5b2c05757490af983cbe35e0f6160b7f75b74ee1500f3cf2be0b79d341",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_ISS_NOT_CANONICAL"
         },
         {
@@ -652,8 +652,8 @@
           "source_fragment": "iss MUST equal the reconstructed origin exactly",
           "source_fragment_hash": "sha256:c25ef0d3c0299bf0f76e958e401ed2d599885b7d9d09de11537da46b8235361d",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_ISS_NOT_CANONICAL"
         },
         {
@@ -663,8 +663,8 @@
           "source_fragment": "Method: lowercase letters and digits only (`[a-z0-9]+`).",
           "source_fragment_hash": "sha256:58fedf785aee680dd1324e3a9db760e0aa065cdc231520306e2911dfa2aeee63",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_ISS_NOT_CANONICAL"
         },
         {
@@ -674,8 +674,8 @@
           "source_fragment": "Method-specific-id: non-empty, MUST NOT contain `/`, `?`, or `#`.",
           "source_fragment_hash": "sha256:51c1ff570c935c7f8caaf500bc17d030d7ad7be72f353afe7f210b55b352ee4e",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_ISS_NOT_CANONICAL"
         },
         {
@@ -685,8 +685,8 @@
           "source_fragment": "All schemes other than `https` and `did` produce `E_ISS_NOT_CANONICAL`.",
           "source_fragment_hash": "sha256:ca4f7e9f5736e15df7917a6edb6966b1d8146d70375f77e40046330a81fb7371",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_ISS_NOT_CANONICAL"
         },
         {
@@ -696,8 +696,8 @@
           "source_fragment": "callers MUST always provide the `publicKey: Uint8Array` parameter directly.",
           "source_fragment_hash": "sha256:3436a530fe006ecff1bf43c79a68c1e040d107240271776d47662981b1bfe93c",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         }
       ]
     },
@@ -713,8 +713,8 @@
           "source_fragment": "The value MUST be a valid ISO 8601 / RFC 3339 datetime string with a timezone offset.",
           "source_fragment_hash": "sha256:df73c9e7fca543026e966859413423de0442bd96c8ed261b15f43bd5ae021b42",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         }
       ]
@@ -731,8 +731,8 @@
           "source_fragment": "Ed25519 only (RFC 8032); all other algorithms MUST be rejected",
           "source_fragment_hash": "sha256:02add0106196163c312ea724c73b8a398b70e16c846a31998383155df9ebfc8e",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -742,8 +742,8 @@
           "source_fragment": "REQUIRED; identifies the signing key in the issuer JWKS",
           "source_fragment_hash": "sha256:b01833bfb4f89976769b4795b7f3c70ceda6ecbeef7f97a1b6bec82dc3567574",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_JWS_MISSING_KID"
         },
         {
@@ -753,8 +753,8 @@
           "source_fragment": "Presence of any of the following MUST cause a hard error:",
           "source_fragment_hash": "sha256:e82c8ed352530ef59384ee45ddff7bb287ce4ad2fb9665312e36e8259db5adf3",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_JWS_EMBEDDED_KEY"
         },
         {
@@ -764,8 +764,8 @@
           "source_fragment": "`crit`                | `E_JWS_CRIT_REJECTED`",
           "source_fragment_hash": "sha256:0f2c91b9be324183d7aafcf21b012b2f08f2657b9b74e63ab0e2825bd2f181ec",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_JWS_CRIT_REJECTED"
         },
         {
@@ -775,8 +775,8 @@
           "source_fragment": "`b64` (value `false`) | `E_JWS_B64_REJECTED`",
           "source_fragment_hash": "sha256:624cf60abbefea8de74cf653a1ef02edf889c0c038140d8ff8847143230d2b10",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_JWS_B64_REJECTED"
         },
         {
@@ -786,8 +786,8 @@
           "source_fragment": "`zip`                 | `E_JWS_ZIP_REJECTED`",
           "source_fragment_hash": "sha256:0f0bf8574d920ff36ed3109b49c75595078687eccdca3543b5ba3683bee24f6c",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_JWS_ZIP_REJECTED"
         },
         {
@@ -797,8 +797,8 @@
           "source_fragment": "`kid` MUST be present and non-empty. Absent or empty `kid` produces `E_JWS_MISSING_KID`.",
           "source_fragment_hash": "sha256:23e75820922e5b31ecfb9de61623529017fb72e27752185e52a0a80ab277f28d",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_JWS_MISSING_KID"
         },
         {
@@ -808,8 +808,8 @@
           "source_fragment": "`kid` MUST NOT exceed 256 characters (DoS safety).",
           "source_fragment_hash": "sha256:0a2329aa89c09f8af6403f20ea63645a1f1d5de6a1f708f8540bcc1c54dcf42c",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_JWS_MISSING_KID"
         },
         {
@@ -819,8 +819,8 @@
           "source_fragment": "The total JWS compact serialization MUST NOT exceed 262,144 bytes (256 KB).",
           "source_fragment_hash": "sha256:558f335146dd4be605f9581b69c18e275ea5812034503e4da4d59d8435180527",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         }
       ]
@@ -837,8 +837,8 @@
           "source_fragment": "The option value MUST match the format `sha256:<64 lowercase hex>` or it is rejected with `E_INVALID_FORMAT`.",
           "source_fragment_hash": "sha256:8f97e7abf39967076fc9e9dc85f2b59d85db134c90dea3a8e36f32a8864716ea",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -848,8 +848,8 @@
           "source_fragment": "The `policy.uri` field MUST be an `https://` URL.",
           "source_fragment_hash": "sha256:861ad1d8e8729d7ff1e5840f90440935e51724249bd86643763a50fc0f44700d",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -859,8 +859,8 @@
           "source_fragment": "Implementations MUST NOT auto-fetch the policy document based on this URI",
           "source_fragment_hash": "sha256:4e5d22e97c5488174832969f3fd8ea56357488f0028ad7c99699ddac2739bde4",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         }
       ]
     },
@@ -876,8 +876,8 @@
           "source_fragment": "Extension keys MUST conform to the grammar: `<domain>/<segment>`.",
           "source_fragment_hash": "sha256:6059e4a23465efe86be0170f488cd7bbb6b973fa1a3e56ba147609d1ce4023bf",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_KEY"
         },
         {
@@ -887,8 +887,8 @@
           "source_fragment": "At least one dot (single-label domains are rejected).",
           "source_fragment_hash": "sha256:f6d1ef132993d981e99022245e0d295b21b18c4e9513521abd2a6740c42d9a87",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_KEY"
         },
         {
@@ -898,8 +898,8 @@
           "source_fragment": "MUST NOT exceed 63 characters",
           "source_fragment_hash": "sha256:7b1caa3cff16e013a5b9ede5e158d7b623430b36ccafdbe415446822164682d6",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_KEY"
         },
         {
@@ -909,8 +909,8 @@
           "source_fragment": "The segment MUST be non-empty.",
           "source_fragment_hash": "sha256:e0d5a69e348a4b316aea039d986d7bd08e7605a4b0f80b2370f905e9c49c2a9e",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_KEY"
         },
         {
@@ -920,8 +920,8 @@
           "source_fragment": "Matches `[a-z0-9][a-z0-9_-]*` (lowercase only).",
           "source_fragment_hash": "sha256:37dda7eeb76fd63c660ec12322002e352f8f422f633ce6ea98d4e88baa9ce698",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_KEY"
         },
         {
@@ -931,8 +931,8 @@
           "source_fragment": "`payment_rail` | string                                                                                    | REQUIRED | 128",
           "source_fragment_hash": "sha256:3b508ee815139f34dca10d8cd2d4f64a48bbd546654d56267f228322bb79cfa6",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -942,8 +942,8 @@
           "source_fragment": "`amount_minor` | string                                                                                    | REQUIRED | 64",
           "source_fragment_hash": "sha256:9aa4a38a7a2b5426e8760e107f2e063f719921d57b07e012122eca76f1827d41",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -953,8 +953,8 @@
           "source_fragment": "`currency`     | string                                                                                    | REQUIRED | 16",
           "source_fragment_hash": "sha256:2ef4df7bacdd47eb333023b0b03802107195d6b1aa270e88047e224e7325786b",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -964,8 +964,8 @@
           "source_fragment": "The `amount_minor` field MUST be a base-10 integer string.",
           "source_fragment_hash": "sha256:60d7724ef11256b4581a89df925ebf7053dd181bd58d69e63af99c44c702a8d1",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -975,8 +975,8 @@
           "source_fragment": "Issuers SHOULD use a distinct receipt `type`",
           "source_fragment_hash": "sha256:3bfc0a15f74f0a378f2e93041895f67ebad51cd15f57265bcf90821b88c2f3c9",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-EXT-011",
@@ -985,8 +985,8 @@
           "source_fragment": "`resource` | string                             | REQUIRED",
           "source_fragment_hash": "sha256:973a53405252385d13f9245cbebaccc8d01c99d007d7fcb09038a7cd07a81b9c",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -996,8 +996,8 @@
           "source_fragment": "`action`   | string                             | REQUIRED",
           "source_fragment_hash": "sha256:c7ba9eff8c89184e97601edd690d45c431a43d584834d3c8b27e45f74fb6b840",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1007,8 +1007,8 @@
           "source_fragment": "`decision` | `\"allow\"`, `\"deny\"`, or `\"review\"` | REQUIRED",
           "source_fragment_hash": "sha256:bef10f106f2bac40c8141b22dda5bb136abd20498637ce2dd068ddc8ce503f94",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1018,8 +1018,8 @@
           "source_fragment": "`trace_id` MUST match `/^[0-9a-f]{32}$/` (exactly 32 lowercase hex characters).",
           "source_fragment_hash": "sha256:4fe34442550458f59fada0230ed5e6db557d1addbe027a4415ed530b506a722f",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1029,8 +1029,8 @@
           "source_fragment": "`span_id` MUST match `/^[0-9a-f]{16}$/` (exactly 16 lowercase hex characters).",
           "source_fragment_hash": "sha256:b3c1e979b846dfcd3c6a31537274ef7a007917397abe3c126eb799819014563f",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1040,8 +1040,8 @@
           "source_fragment": "MUST be preserved (not silently dropped).",
           "source_fragment_hash": "sha256:069778ce9d7309fcd0c5bc56292cffa09146e9c1958084db5eea737e6c7fe1fc",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1051,8 +1051,8 @@
           "source_fragment": "MUST trigger an `unknown_extension_preserved` warning at the protocol layer",
           "source_fragment_hash": "sha256:7218b5a436c7bbde6657707d94d0ce89c320fd83fda5e243418138f331ffeb78",
           "enforcement_class": "warning_only",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "warning_code": "unknown_extension_preserved"
         },
         {
@@ -1062,8 +1062,8 @@
           "source_fragment": "MUST NOT cause a validation error.",
           "source_fragment_hash": "sha256:7df9acd0d60c081513e8caa9c952e64e310407fca9496a4f840fa6571fb281a5",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1073,8 +1073,8 @@
           "source_fragment": "`consent_basis` string REQUIRED: identifies the legal basis for consent.",
           "source_fragment_hash": "sha256:09cea66f777b829db5404215c7020f251a2e18ac3791e0265969860d8ec6295a",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1084,8 +1084,8 @@
           "source_fragment": "`consent_status` enum REQUIRED: granted, withdrawn, denied, expired.",
           "source_fragment_hash": "sha256:0e8149e310a1aec19d7ee48c683afce8c76860d844f6a483eefa096733990a0e",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1095,8 +1095,8 @@
           "source_fragment": "`data_categories` string[] optional: data categories covered by the consent record.",
           "source_fragment_hash": "sha256:9ac85070d70f8d9becb39c1314ac94009de20c705d08df722bb8cc94b30e1033",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-EXT-022",
@@ -1105,8 +1105,8 @@
           "source_fragment": "`retention_period` Iso8601DurationSchema optional: uses the parser-grade ISO 8601 duration validator.",
           "source_fragment_hash": "sha256:8179de2cbe6b1146a51c7fe8ef40b948b1500d81b8ca3dcbb35b34020e69b973",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-EXT-024",
@@ -1115,8 +1115,8 @@
           "source_fragment": "`.strict()` rejects unknown properties: the consent extension uses `.strict()` mode; unrecognized fields are rejected.",
           "source_fragment_hash": "sha256:31c6461e793edbc660beaa25967694a0d8dc7888496da38352c0e99042006b0f",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1126,8 +1126,8 @@
           "source_fragment": "`data_classification` string REQUIRED: identifies the classification level of the data.",
           "source_fragment_hash": "sha256:3bb849ef447715eb5110fa541847aa2dd380243e6293100a5a2a25fcf34396bb",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1137,8 +1137,8 @@
           "source_fragment": "`processing_basis` string optional: legal basis for data processing.",
           "source_fragment_hash": "sha256:66d47d95bf463063ff7eaf1365426ee0758cb94a4e5993f646664a31b926a02b",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-EXT-033",
@@ -1147,8 +1147,8 @@
           "source_fragment": "`retention_mode` enum optional: time_bound, indefinite, session_only.",
           "source_fragment_hash": "sha256:3cbf29cbc11839404cab2d998b3048e60576fa01f67912c68cf25ad70ab246be",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1158,8 +1158,8 @@
           "source_fragment": "`recipient_scope` enum optional: internal, processor, third_party, public.",
           "source_fragment_hash": "sha256:e6d3ca15130c834f7fe34fa81a01914e4f8625d7cb9c7fd753edb6f3c1ab6de8",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1169,8 +1169,8 @@
           "source_fragment": "`anonymization_method` string optional: method applied for de-identification.",
           "source_fragment_hash": "sha256:5d9df644e04721e6d15151ecc58ae9382985fbde9a80657662fd1026565c7b27",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-EXT-036",
@@ -1179,8 +1179,8 @@
           "source_fragment": "`transfer_mechanism` string optional: cross-border data transfer mechanism.",
           "source_fragment_hash": "sha256:85075e07e7bab318149b81ad9393e984054dc15006cf1f8457f2b6da3f911648",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-EXT-037",
@@ -1189,8 +1189,8 @@
           "source_fragment": "`review_status` enum REQUIRED: reviewed, pending, flagged, not_applicable.",
           "source_fragment_hash": "sha256:bbb4ea179df8a616d537805b0f5dab41eb5e952484a4210a6695112e8a5daedf",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1200,8 +1200,8 @@
           "source_fragment": "`risk_level` enum optional: unacceptable, high, limited, minimal.",
           "source_fragment_hash": "sha256:81e8c421221f1011ccf56f564f9d333314fa94705325d4ea18d094f1de2166e8",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1211,8 +1211,8 @@
           "source_fragment": "`assessment_method` string optional: describes the review methodology used.",
           "source_fragment_hash": "sha256:d4b463389daa264e05b666424eccc181b855a239564d4dd40f6d7c79bf8e945e",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-EXT-040",
@@ -1221,8 +1221,8 @@
           "source_fragment": "`safety_measures` string[] optional max 32 items: safety measures applied.",
           "source_fragment_hash": "sha256:a5bb4c064c702ae509f68a3732389d4cd4298962cb4b89978366ffa2f4d53106",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-EXT-041",
@@ -1231,8 +1231,8 @@
           "source_fragment": "`incident_ref` string optional: reference to an incident report.",
           "source_fragment_hash": "sha256:40afb5bd14bfeeb154224a5d68bc85904875d9549f5b9355363301e47a7a73a1",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-EXT-042",
@@ -1241,8 +1241,8 @@
           "source_fragment": "`model_ref` string optional: identifies the AI model under review.",
           "source_fragment_hash": "sha256:ab7c36421d23ee44cb93c1286466a8471d54678307175ff1dc532c7b2bbd917f",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-EXT-043",
@@ -1251,8 +1251,8 @@
           "source_fragment": "`framework` string REQUIRED: identifies the regulatory or standards framework evaluated.",
           "source_fragment_hash": "sha256:84a1e8f85d718faae95fff55d60b823fe507b09e2e9812699e5cf9ef51718997",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1262,8 +1262,8 @@
           "source_fragment": "`compliance_status` enum REQUIRED: compliant, non_compliant, partial, under_review, exempt.",
           "source_fragment_hash": "sha256:9ef31d79e0a23985bf608a81be4b609ffcb6aa8a53b48ace54e19a7b6ad6612d",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1273,8 +1273,8 @@
           "source_fragment": "`audit_date` ISO 8601 date optional: structural date validation (YYYY-MM-DD).",
           "source_fragment_hash": "sha256:493767e96d33aca475e6d6745e30087f76a774dbd84c07df8d5919a5259137ce",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-EXT-046",
@@ -1283,8 +1283,8 @@
           "source_fragment": "`validity_period` ISO 8601 duration optional: uses the parser-grade ISO 8601 duration validator.",
           "source_fragment_hash": "sha256:7e24cb7558329bf4fddb184bfc7c6c4b80a92759aa19f1e799a7ca16ee99aa92",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-EXT-047",
@@ -1293,8 +1293,8 @@
           "source_fragment": "`evidence_ref` SHA-256 digest optional: uses `Sha256DigestSchema` for typed digest validation.",
           "source_fragment_hash": "sha256:8e2d1ecc65139b8cb02d4824511714220bff8fde072a3848d163201249e704e6",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-EXT-048",
@@ -1303,8 +1303,8 @@
           "source_fragment": "`.strict()` rejects unknown properties: the compliance extension uses `.strict()` mode; unrecognized fields are rejected.",
           "source_fragment_hash": "sha256:122f818833eeb49b4977c5f3e76e68f9a03a079e16404b56f180dadbf1a350c9",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1314,8 +1314,8 @@
           "source_fragment": "`source_type` string REQUIRED: identifies the derivation type.",
           "source_fragment_hash": "sha256:311e9b372eb9f8fe50cf91784fe1e345870a95771918ad6895e2d9303cca5f3b",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1325,8 +1325,8 @@
           "source_fragment": "`source_ref` string optional: opaque source reference identifier.",
           "source_fragment_hash": "sha256:7130696c116901b704490060724bb144fb692416f7f16c371ec7dab8cd0d67b9",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-EXT-051",
@@ -1335,8 +1335,8 @@
           "source_fragment": "`custody_chain` CustodyEntry[] optional max 16 items: ordered chain of custody events.",
           "source_fragment_hash": "sha256:663e68e061ff0ee03650b86702694c298439ee9fc2e7654ef8acae1c0943490b",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-EXT-052",
@@ -1345,8 +1345,8 @@
           "source_fragment": "`slsa` SlsaLevel optional: structured SLSA-aligned metadata.",
           "source_fragment_hash": "sha256:1aecd99b250f6194ef512c5a699e31ae26e2d5a454ee9918e72d4340e847e288",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-EXT-053",
@@ -1355,8 +1355,8 @@
           "source_fragment": "`.strict()` rejects unknown properties: the provenance extension and all nested schemas use `.strict()` mode.",
           "source_fragment_hash": "sha256:32aec8d80ca7ce4426709dd18089bfb2d2df6cac0a883de2f932be4cc8c08352",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1366,8 +1366,8 @@
           "source_fragment": "`source_uri` and `build_provenance_uri` HTTPS URI hint optional: locator hints only; callers MUST NOT auto-fetch.",
           "source_fragment_hash": "sha256:369e48a0cbe003e4290b8817948023d341744cc3445ef5e0b5f8ab8eed06f68c",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-EXT-055",
@@ -1376,8 +1376,8 @@
           "source_fragment": "`creator_ref` string REQUIRED: identifies the creator.",
           "source_fragment_hash": "sha256:97a506548e347b92f202d916486f02f081581f73b7229f22d8729ac163cd6018",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1387,8 +1387,8 @@
           "source_fragment": "`license_spdx` SPDX expression optional: uses the parser-grade SPDX license expression validator.",
           "source_fragment_hash": "sha256:f897ef7cc16f279befa9d50e2ab61608cae47987a83f1d58ad397c26b1322c08",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-EXT-057",
@@ -1397,8 +1397,8 @@
           "source_fragment": "`content_signal_source` enum optional: tdmrep_json, content_signal_header, content_usage_header, robots_txt, custom.",
           "source_fragment_hash": "sha256:9eb9c06f5aa56fb2ec8867e4947fe4956c996a700abd68ff197b5e8636ce50f6",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1408,8 +1408,8 @@
           "source_fragment": "`content_digest` SHA-256 digest optional: uses `Sha256DigestSchema` for typed digest validation.",
           "source_fragment_hash": "sha256:f9df2fb27b768f7990151d341035a40494d3f42f9a7ccfaaf62d8955d5a06636",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-EXT-059",
@@ -1418,8 +1418,8 @@
           "source_fragment": "`.strict()` rejects unknown properties: the attribution extension uses `.strict()` mode; unrecognized fields are rejected.",
           "source_fragment_hash": "sha256:47003ad9870adb66488f4a3f28327ae249487ff2b91493cc970fd5999a484757",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1429,8 +1429,8 @@
           "source_fragment": "Not an identity attestation; records observed attribution metadata.",
           "source_fragment_hash": "sha256:f2ed1b90e528aceb625c676ba9908b997b7f433ed921d9b580a8e5b859c6c2c9",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-EXT-061",
@@ -1439,8 +1439,8 @@
           "source_fragment": "`external_purposes` string[] REQUIRED min 1 max 32 items: external/legal/business purpose labels.",
           "source_fragment_hash": "sha256:d11d9ae832701052b15c6ef52a73b3d48589b26cdf80209c83e16b24ee6d54dc",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1450,8 +1450,8 @@
           "source_fragment": "`compatible_purposes` string[] optional max 32 items: each item MUST match the machine-safe lowercase token grammar and items MUST be unique within the array.",
           "source_fragment_hash": "sha256:e7bc1dc712ff834e1bc20f285e8a203baff09363440d716573c15447a71c019d",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-EXT-063",
@@ -1460,8 +1460,8 @@
           "source_fragment": "`purpose_basis` string optional: legal or policy basis for the declared purposes.",
           "source_fragment_hash": "sha256:4d53de5af04b137171e9cedb767934d1cf8bd98206c1951bbd9f225e31b2b727",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-EXT-064",
@@ -1470,8 +1470,8 @@
           "source_fragment": "`.strict()` rejects unknown properties: the purpose extension uses `.strict()` mode; unrecognized fields are rejected.",
           "source_fragment_hash": "sha256:371bb62d235b518b0148847fc7b77a04af8a5c5853ee92a7bc36da63e6afd86a",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1481,8 +1481,8 @@
           "source_fragment": "Each item MUST match the machine-safe token grammar and items MUST be unique.",
           "source_fragment_hash": "sha256:4c0eaebcdbfa11fb123d581db002ef228de34c92b047ef7602c464097fa328c4",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1492,8 +1492,8 @@
           "source_fragment": "`peac_purpose_mapping` string optional: explicit bridge to a PEAC operational CanonicalPurpose token.",
           "source_fragment_hash": "sha256:82831a0e370e06ea44d5b13c3d87bc9c8a98ed0cbdaf3900a091e006bc70be5e",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-EXT-071",
@@ -1502,8 +1502,8 @@
           "source_fragment": "items MUST be unique within the array.",
           "source_fragment_hash": "sha256:dbcd6e3c158bfd4782f83f90d01a642a15c9d5f8c4c92d0d1fb79788d5242f7b",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1513,8 +1513,8 @@
           "source_fragment": "the expected extension group MUST be present in the extensions record in strict verification mode.",
           "source_fragment_hash": "sha256:003a2a08d3a25910733772e67d31234b1fcf65440bbb1077be8c5f79c8adac63",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT",
           "warning_code": "extension_group_missing"
         },
@@ -1525,8 +1525,8 @@
           "source_fragment": "In interop mode, its absence is a warning.",
           "source_fragment_hash": "sha256:003d4dde216ce42def198af46128132ef770cd831acf18b756055e87f3b66350",
           "enforcement_class": "warning_only",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "warning_code": "extension_group_missing"
         },
         {
@@ -1536,8 +1536,8 @@
           "source_fragment": "verifiers MUST report a mismatch in strict mode.",
           "source_fragment_hash": "sha256:871e93601acd89d873cc654906cf656628e4baf02fd2ac62e69a49c31e8a8190",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT",
           "warning_code": "extension_group_mismatch"
         },
@@ -1548,8 +1548,8 @@
           "source_fragment": "Custom or unmapped types are not subject to this check.",
           "source_fragment_hash": "sha256:fe8dd908e5178fb09f2e215c491f1278eae9dbfa70a2e5dc2ae7017679b5eded",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         }
       ]
     },
@@ -1565,8 +1565,8 @@
           "source_fragment": "`status`   | integer      | REQUIRED",
           "source_fragment_hash": "sha256:b4218e7ac57b5bf9763b94b4cbc7edcd1e360cf1162d9c083e6c3d29d9ad70d4",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1576,8 +1576,8 @@
           "source_fragment": "`type`     | string (URL) | REQUIRED",
           "source_fragment_hash": "sha256:336fe7122380cfb8ee818e73689d3a9f676b9a135dc07246969ffcee570861f0",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1587,8 +1587,8 @@
           "source_fragment": "`title`    | string       | OPTIONAL",
           "source_fragment_hash": "sha256:0fdb18e80464e208d1e2bd5151107bb006e4d64a7fbda704d8e647dd5f275768",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-CHAL-004",
@@ -1597,8 +1597,8 @@
           "source_fragment": "`detail`   | string       | OPTIONAL",
           "source_fragment_hash": "sha256:3d2883122fa49b9184bb9d9556f984fd3cfbd6edde0bd91ed606e35c334d1f69",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-CHAL-005",
@@ -1607,8 +1607,8 @@
           "source_fragment": "`instance` | string       | OPTIONAL",
           "source_fragment_hash": "sha256:c91561a806f53774e3288522c42a21211f2af4e043dff9d66bccaa0dc7cdbe4a",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-CHAL-006",
@@ -1617,8 +1617,8 @@
           "source_fragment": "`resource`     | string                    | OPTIONAL",
           "source_fragment_hash": "sha256:8ec538f2f5c8884e2a91e5cfd0276438d1a7b5832a8aa99cb8e749a13e68efab",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-CHAL-007",
@@ -1627,8 +1627,8 @@
           "source_fragment": "`action`       | string                    | OPTIONAL",
           "source_fragment_hash": "sha256:4cd10b5a9f3e5524e6f5bec0b44bbd5df2d03415afc905ba00fa78ed3147800b",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         }
       ]
     },
@@ -1644,8 +1644,8 @@
           "source_fragment": "`code`    | string | REQUIRED | Stable warning code identifier",
           "source_fragment_hash": "sha256:aeae61c3e1f194cf11323fafd2810f55704efde214f3d7c2895911d4851100ae",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1655,8 +1655,8 @@
           "source_fragment": "`message` | string | REQUIRED | Human-readable description",
           "source_fragment_hash": "sha256:4ce4086f3c8535c97df31bdb2619e257c8349eeab809b32cd9c6ffee8226c01a",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1666,8 +1666,8 @@
           "source_fragment": "MUST NOT be used for conformance testing",
           "source_fragment_hash": "sha256:da9dc2e53c59e715f0c547855d47f703c8a27d41d9de01b2bfa62a13eb341792",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-WARN-004",
@@ -1676,8 +1676,8 @@
           "source_fragment": "New warning codes MAY be added in future versions.",
           "source_fragment_hash": "sha256:0abcd88cb76eec7c1920c54a8b350da9c165499ba7d77dea426811d852460e5a",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-WARN-005",
@@ -1686,8 +1686,8 @@
           "source_fragment": "Existing warning codes MUST NOT be removed or renamed.",
           "source_fragment_hash": "sha256:a20c727a06711424cf334d4735243ff0646b3c9da8613fe76369144eb60ece23",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-WARN-006",
@@ -1696,8 +1696,8 @@
           "source_fragment": "Consumers MUST tolerate unknown warning codes gracefully.",
           "source_fragment_hash": "sha256:533c1b7fd85aeed77615120ec8ab044c2d2f742d0cfdf302e3194045ba3b2cf9",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-WARN-007",
@@ -1706,8 +1706,8 @@
           "source_fragment": "Warnings MUST be sorted by `(pointer ascending, code ascending)`.",
           "source_fragment_hash": "sha256:09e1408513af162bf1c74da14026aa9195460703a39d6b2889080f705a248215",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1717,8 +1717,8 @@
           "source_fragment": "Conformance implementations MUST assert on `code` and `pointer` fields only.",
           "source_fragment_hash": "sha256:049af55e0fc391c97d96e42c7e44fc9675fde9145a696fd279e0ec74b9f3c9ac",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-WARN-009",
@@ -1727,8 +1727,8 @@
           "source_fragment": "The `message` field is implementation-defined and MUST NOT be used for conformance testing.",
           "source_fragment_hash": "sha256:168e30636fc4164b370eae96e9570de0f11cf64457f5cd35ed4a2107af978cc8",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         }
       ]
     },
@@ -1744,8 +1744,8 @@
           "source_fragment": "implementations MUST verify coherence between the JWS `typ` and the payload `peac_version` field",
           "source_fragment_hash": "sha256:21ef041cd2efe1ca1429cddbf3043f1c4b302b05586285af26b5de63d72ae21f",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_WIRE_VERSION_MISMATCH"
         },
         {
@@ -1755,8 +1755,8 @@
           "source_fragment": "Wire 0.1 route: payload MUST NOT contain `peac_version: \"0.2\"`.",
           "source_fragment_hash": "sha256:b45a1c576245f248194b3ce73626b45523725356900db2a5c87e03a5f63f54f0",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_WIRE_VERSION_MISMATCH"
         },
         {
@@ -1766,8 +1766,8 @@
           "source_fragment": "Wire 0.2 route: payload MUST contain `peac_version: \"0.2\"`.",
           "source_fragment_hash": "sha256:7131653b896b21b5c8805bec85fc1a2cdc940de336c16a31dfe98ea4b98f34cd",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_WIRE_VERSION_MISMATCH"
         }
       ]
@@ -1784,8 +1784,8 @@
           "source_fragment": "JWS `typ` MUST be present.",
           "source_fragment_hash": "sha256:5106f5d60d9724a46f15f75d921552e6e0f2fe0358b4cbda541d107e1b90df6d",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1795,8 +1795,8 @@
           "source_fragment": "`typ` MUST be a recognized value",
           "source_fragment_hash": "sha256:a73c3888ee9f366fdf3d620e23336b4e804bf6755a223267343b0d6e1beef229",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1806,8 +1806,8 @@
           "source_fragment": "Production deployments SHOULD use strict mode.",
           "source_fragment_hash": "sha256:2ce27e3de73b934a758c88791dacb2726042377fa19dfcb253f0b3fb98c0964d",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         }
       ]
     },
@@ -1823,8 +1823,8 @@
           "source_fragment": "Compact form: `interaction-record+jwt` (canonical; issuers MUST emit this form)",
           "source_fragment_hash": "sha256:66b3df3e98ef9e64b3479b15dbe8ba55de1e91d01a931cee8b0c5ee1ac27b5fa",
           "enforcement_class": "issuance",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-IDENT-002",
@@ -1833,8 +1833,8 @@
           "source_fragment": "Media-type form: `application/interaction-record+jwt` (verifiers MUST accept)",
           "source_fragment_hash": "sha256:0d694b4d700e7214b23c88b889d9f0cb47badf2cde00470cc04515ac54a9f69f",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1844,8 +1844,8 @@
           "source_fragment": "Implementations MUST NOT perform content-type parameter parsing",
           "source_fragment_hash": "sha256:79a9b6f7133f4ed3a663776297d1072b174115329d47ebffcde917ea063745a6",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1855,8 +1855,8 @@
           "source_fragment": "The `typ` header and `peac_version` payload claim MUST agree.",
           "source_fragment_hash": "sha256:c459e15f3358ed1350da5e97be4206679a06689aed5dbd988deaec86fb233528",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_WIRE_VERSION_MISMATCH"
         },
         {
@@ -1866,8 +1866,8 @@
           "source_fragment": "Production deployments SHOULD use strict mode, which rejects missing `typ`.",
           "source_fragment_hash": "sha256:ce03eb555707e7b685b512790116727b730bcbba9ac8220308cfeb701ff5ab20",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-IDENT-006",
@@ -1876,8 +1876,8 @@
           "source_fragment": "Future implementations MAY relax this to process unknown minor versions with a warning",
           "source_fragment_hash": "sha256:444f26b04d129b0690a5e2fc9674c470e655e45e0dae0497d89aa7728cd9e66f",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-IDENT-007",
@@ -1886,8 +1886,8 @@
           "source_fragment": "Multiple package versions MAY implement the same wire format version.",
           "source_fragment_hash": "sha256:b96a8e527c40171cb1d81ee42cce33e854ae56ba37aa1c66db9bf0a90c15b497",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         }
       ]
     },
@@ -1903,8 +1903,8 @@
           "source_fragment": "Implementations MUST perform steps in the order specified.",
           "source_fragment_hash": "sha256:4128f7475c53d98a4e70cac0671afc8a247bb7d0ec1b3798f66f60c3c661a9b8",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1914,8 +1914,8 @@
           "source_fragment": "A step that produces a hard error MUST terminate validation immediately",
           "source_fragment_hash": "sha256:1d89cea8c8aa48ad9023d83847f3f73ea95b63949aaf2d90c2c11afc3da7c74e",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1925,8 +1925,8 @@
           "source_fragment": "the verifier MUST NOT continue to subsequent steps.",
           "source_fragment_hash": "sha256:1e88d48481f5bc56e8231cdf4abc77fb1842aa24a31235c1a741bba223bc8271",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1936,8 +1936,8 @@
           "source_fragment": "`jws`          | string     | REQUIRED",
           "source_fragment_hash": "sha256:e91cc74e34001e7eea4cb856b9ff1aa6fa8973759561339aef88b0d983d76a30",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1947,8 +1947,8 @@
           "source_fragment": "`publicKey`    | Uint8Array | REQUIRED",
           "source_fragment_hash": "sha256:bb3957aeaab5c3d3acb727ca1df11272d2e8c190786fe3b6d57c683bad55173c",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1958,8 +1958,8 @@
           "source_fragment": "The `alg` header parameter MUST be `EdDSA`.",
           "source_fragment_hash": "sha256:a9a566b439e97cd88451d44f3c2cf0ae54e377b595daf3b548218c0c398137ab",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1969,8 +1969,8 @@
           "source_fragment": "Kernel constraints are structural limits (field lengths, array sizes) enforced before schema parsing. Failure is fail-closed: return `E_CONSTRAINT_VIOLATION`.",
           "source_fragment_hash": "sha256:154b58e4f819d531f2e3ea87fb4a29e9c518407f07625328d820374d7e20b563",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_CONSTRAINT_VIOLATION"
         },
         {
@@ -1980,8 +1980,8 @@
           "source_fragment": "`iat` MUST NOT exceed `now + maxClockSkew`.",
           "source_fragment_hash": "sha256:07dec89d4303bb400bb8d20b5185c70755e217e255dd530fb107cdda1408cfd1",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_NOT_YET_VALID"
         },
         {
@@ -1991,8 +1991,8 @@
           "source_fragment": "The `jti` claim is REQUIRED (enforced by schema validation in Step 4).",
           "source_fragment_hash": "sha256:5494a3e5cde868771a2f1061c7394739dff025ab45c9b5ac6a42f49067529cad",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_MISSING_REQUIRED_CLAIM"
         },
         {
@@ -2002,8 +2002,8 @@
           "source_fragment": "Verifiers that maintain a replay cache SHOULD reject duplicate `jti`",
           "source_fragment_hash": "sha256:ae1e18480bea50183b3c9407bb7ba5d2264fc03a2bbbb4ba6d91a2c536953a97",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-VALID-011",
@@ -2012,8 +2012,8 @@
           "source_fragment": "Verifiers without a replay cache MAY skip this step",
           "source_fragment_hash": "sha256:9193f11f66a913d2032a76e80cdfd063863a8a803bde92c629d18b19d9dd91d1",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-VALID-012",
@@ -2022,8 +2022,8 @@
           "source_fragment": "implementations SHOULD map these to HTTP 400 Bad Request",
           "source_fragment_hash": "sha256:0b01c93a0a54fcdcb2d5f1d293a568b7f40233d53c6fad7dfb51ed57552fd7e5",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         }
       ]
     },
@@ -2039,8 +2039,8 @@
           "source_fragment": "The `jti` claim is REQUIRED on all Wire 0.2 receipts.",
           "source_fragment_hash": "sha256:460780907183f76a99ef33f4a22f6c3e81c94dbb02afb3cd91cbf9202bba9ba2",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_MISSING_REQUIRED_CLAIM"
         },
         {
@@ -2050,8 +2050,8 @@
           "source_fragment": "Issuers MUST ensure `jti` uniqueness across all receipts they produce.",
           "source_fragment_hash": "sha256:39a87e0be4d2b781f4888a8b30d69ec44a56dda023f22ef24599c53c63d6eb9b",
           "enforcement_class": "issuance",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-REPLAY-003",
@@ -2060,8 +2060,8 @@
           "source_fragment": "The `jti` value MUST be a non-empty string of 1 to 256 characters.",
           "source_fragment_hash": "sha256:1203bf2bc4c86cd5b41cd8ee3985f2654464f314fcf697cc889b8d578a495c90",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_MISSING_REQUIRED_CLAIM"
         },
         {
@@ -2071,8 +2071,8 @@
           "source_fragment": "Implementations SHOULD use at least 128 bits of entropy",
           "source_fragment_hash": "sha256:72a3f6caea40dfa3ede2d547c652e206824ee5172b34fb3e630ab2fec1267663",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-REPLAY-005",
@@ -2081,8 +2081,8 @@
           "source_fragment": "Verifiers that maintain a replay cache SHOULD reject duplicate `jti` from the same `iss`",
           "source_fragment_hash": "sha256:25f08ecd322bde687e84eae8066045c8a7be4c01d95dda79973bc2007b63a3b1",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-REPLAY-006",
@@ -2091,8 +2091,8 @@
           "source_fragment": "Verifiers without a replay cache (stateless deployments, edge functions, serverless) MAY skip replay detection.",
           "source_fragment_hash": "sha256:d9673740aa9379ad1afaafb490dfb31b976b32fb737baad7fd92c3ba41e9865a",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-REPLAY-007",
@@ -2101,8 +2101,8 @@
           "source_fragment": "Use `iat`-based expiry.",
           "source_fragment_hash": "sha256:0e012acf04d5dfb402653c296f4b8f6b88a3b9add432952abfb10006b85c31ca",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-REPLAY-008",
@@ -2111,8 +2111,8 @@
           "source_fragment": "A RECOMMENDED window is 2x `OCCURRED_AT_TOLERANCE_SECONDS` (600 seconds).",
           "source_fragment_hash": "sha256:0e48a4e3a328cdf6b91bc9cca1f544f447e8091e594c9df2690d8273400e89e3",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-REPLAY-009",
@@ -2121,8 +2121,8 @@
           "source_fragment": "Caches SHOULD be scoped per `iss`",
           "source_fragment_hash": "sha256:fa37f432cdec2c3e57e684d9b9fd170e7bad898a2d11fa18b94b5870f6655d72",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-REPLAY-010",
@@ -2131,8 +2131,8 @@
           "source_fragment": "Implementations MAY use bloom filters or probabilistic data structures",
           "source_fragment_hash": "sha256:9f49f49451d5a5b0feb62354f4737c44d041aa1dfa007d1fb86f708b50d41fa9",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-REPLAY-011",
@@ -2141,8 +2141,8 @@
           "source_fragment": "The `aud` claim is OPTIONAL in Wire 0.2.",
           "source_fragment_hash": "sha256:f4954bc439f94c9203e5eb67291f9e4a55b87ae3e3d924c4d78e311668ff5249",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-REPLAY-012",
@@ -2151,8 +2151,8 @@
           "source_fragment": "Verifiers that check `aud` SHOULD reject receipts not addressed to them.",
           "source_fragment_hash": "sha256:21689600c2bb21482e756b96ebb569b450e355b25156c70847e0a48bd55119be",
           "enforcement_class": "advisory",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1"
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2"
         },
         {
           "id": "WIRE02-REPLAY-013",
@@ -2161,8 +2161,8 @@
           "source_fragment": "Each receipt in an evidence bundle MUST have a unique `jti`.",
           "source_fragment_hash": "sha256:36cbe5e5b9a462edadfc673c9f3df0ea4a61d4608cf1392bdd7025bebb3f1d57",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.12.1",
-          "last_reviewed_in": "0.12.1",
+          "introduced_in": "0.12.2",
+          "last_reviewed_in": "0.12.2",
           "error_code": "E_MISSING_REQUIRED_CLAIM"
         }
       ]

--- a/specs/conformance/test-mappings.json
+++ b/specs/conformance/test-mappings.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Protocol-level test mappings for requirements not provable by fixtures alone",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "mappings": [
     {
       "requirement_id": "WIRE02-VALID-001",

--- a/specs/kernel/error-categories.json
+++ b/specs/kernel/error-categories.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.peacprotocol.org/schemas/kernel/error-categories.schema.json",
   "$comment": "AUTO-GENERATED from specs/kernel/errors.json - DO NOT EDIT MANUALLY",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "source_file": "specs/kernel/errors.json",
   "categories": [
     "attribution",

--- a/specs/kernel/errors.json
+++ b/specs/kernel/errors.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "PEAC error codes - normative source of truth",
   "errors": [
     {

--- a/surfaces/analytics/package.json
+++ b/surfaces/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/analytics",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "description": "Analytics surface for PEAC Protocol - metrics API with k-anonymity protection",
   "type": "module",

--- a/surfaces/nextjs/middleware/package.json
+++ b/surfaces/nextjs/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/middleware-nextjs",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "description": "PEAC TAP verifier and 402 access gate for Next.js Edge Runtime",
   "type": "module",

--- a/surfaces/workers/akamai/package.json
+++ b/surfaces/workers/akamai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-akamai",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "description": "PEAC receipt verification worker for Akamai EdgeWorkers",
   "type": "module",

--- a/surfaces/workers/cloudflare/package.json
+++ b/surfaces/workers/cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-cloudflare",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "description": "PEAC receipt verification worker for Cloudflare Workers",
   "type": "module",

--- a/surfaces/workers/fastly/package.json
+++ b/surfaces/workers/fastly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-fastly",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "description": "PEAC receipt verification worker for Fastly Compute",
   "type": "module",

--- a/tests/conformance/attribution.spec.ts
+++ b/tests/conformance/attribution.spec.ts
@@ -105,7 +105,7 @@ describe('Attribution Conformance', () => {
   describe('Valid Fixtures', () => {
     it('should have fixtures to test', () => {
       expect(validFixtures.fixtures.length).toBeGreaterThan(0);
-      expect(validFixtures.version).toBe('0.12.1');
+      expect(validFixtures.version).toBe('0.12.2');
     });
 
     // We'll use a loop to generate tests for each fixture
@@ -224,7 +224,7 @@ describe('Attribution Conformance', () => {
   describe('Invalid Fixtures', () => {
     it('should have fixtures to test', () => {
       expect(invalidFixtures.fixtures.length).toBeGreaterThan(0);
-      expect(invalidFixtures.version).toBe('0.12.1');
+      expect(invalidFixtures.version).toBe('0.12.2');
     });
 
     describe('Schema Validation', () => {
@@ -277,7 +277,7 @@ describe('Attribution Conformance', () => {
   describe('Edge Case Fixtures', () => {
     it('should have fixtures to test', () => {
       expect(edgeCaseFixtures.fixtures.length).toBeGreaterThan(0);
-      expect(edgeCaseFixtures.version).toBe('0.12.1');
+      expect(edgeCaseFixtures.version).toBe('0.12.2');
     });
 
     describe('Schema Validation', () => {
@@ -365,9 +365,9 @@ describe('Attribution Conformance', () => {
 
   describe('Cross-Language Parity', () => {
     it('should have consistent fixture version across all files', () => {
-      expect(validFixtures.version).toBe('0.12.1');
-      expect(invalidFixtures.version).toBe('0.12.1');
-      expect(edgeCaseFixtures.version).toBe('0.12.1');
+      expect(validFixtures.version).toBe('0.12.2');
+      expect(invalidFixtures.version).toBe('0.12.2');
+      expect(edgeCaseFixtures.version).toBe('0.12.2');
     });
 
     it('should have comprehensive fixture coverage', () => {

--- a/tests/conformance/x402.spec.ts
+++ b/tests/conformance/x402.spec.ts
@@ -301,7 +301,7 @@ describe('x402 Adapter Conformance', () => {
   describe('Manifest Integrity', () => {
     it('should have valid manifest structure', () => {
       expect(manifest.name).toBe('x402-adapter');
-      expect(manifest.version).toBe('0.12.1');
+      expect(manifest.version).toBe('0.12.2');
       expect(manifest.profile).toBe('peac-x402-offer-receipt/0.2');
       expect(manifest.categories.valid.vectors.length).toBeGreaterThan(0);
       expect(manifest.categories.invalid.vectors.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

Version bump to 0.12.2 across all publishable packages, CHANGELOG entry, release manifest, and public doc updates.

## Scope

- Version bump to 0.12.2 across 68 publishable packages (via `bump-version.mjs`)
- CHANGELOG entry for v0.12.2
- `docs/releases/current.json` updated
- `docs/specs/WIRE-0.2.md` version header and version history entry
- `README.md` stable version reference
- Conformance fixture manifests and test version assertions aligned to 0.12.2

## Validation

- Build: 84/84 targets
- Tests: 6428/6428 (249 files)
- Lint, typecheck, format: clean
- Version sync: all 68 packages at 0.12.2