### PR TITLE
feat: A2A v1.0 transition normalizer and AIPREF version pin

### DIFF
--- a/packages/mappings/a2a/src/discovery.ts
+++ b/packages/mappings/a2a/src/discovery.ts
@@ -12,6 +12,7 @@ import { PEAC_RECEIPT_HEADER } from '@peac/kernel';
 
 import type { A2AAgentCard, AgentCardPeacExtension } from './types';
 import { PEAC_EXTENSION_URI } from './types';
+import { normalizeAgentCard } from './normalizers';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -185,8 +186,12 @@ export async function discoverAgentCard(
 
       const card = JSON.parse(text) as A2AAgentCard;
 
-      // Basic validation: must have name and url
-      if (typeof card.name !== 'string' || typeof card.url !== 'string') {
+      // Dual-version validation (DD-186): accept v0.3.0 (url) or v1.0.0 (supportedInterfaces)
+      if (typeof card.name !== 'string') {
+        continue;
+      }
+      const normalized = normalizeAgentCard(card);
+      if (!normalized) {
         continue;
       }
 

--- a/packages/mappings/a2a/src/index.ts
+++ b/packages/mappings/a2a/src/index.ts
@@ -2,8 +2,8 @@
  * @peac/mappings-a2a
  *
  * Agent-to-Agent Protocol (A2A) integration for PEAC.
- * Maps PEAC evidence carriers to A2A metadata (TaskStatus, Message, Artifact)
- * per A2A spec v0.3.0.
+ * Maps PEAC evidence carriers to A2A metadata (TaskStatus, Message, Artifact).
+ * Supports both A2A v0.3.0 and v1.0.0 (DD-186 dual-version transition).
  */
 
 // Types
@@ -11,6 +11,7 @@ export type {
   AgentCardExtension,
   AgentCardPeacExtension,
   A2AAgentCard,
+  A2ASupportedInterface,
   A2AMetadata,
   A2ATaskStatusLike,
   A2AMessageLike,
@@ -18,7 +19,24 @@ export type {
   A2APeacPayload,
 } from './types';
 
-export { PEAC_EXTENSION_URI, A2A_MAX_CARRIER_SIZE } from './types';
+export {
+  PEAC_EXTENSION_URI,
+  A2A_MAX_CARRIER_SIZE,
+  A2A_V1_TASK_STATE,
+  A2A_V1_MESSAGE_ROLE,
+  TASK_STATE_V03_TO_V1,
+} from './types';
+
+// Normalizers (DD-186: v0.3.0 + v1.0.0 dual-version)
+export type { NormalizedAgentCard } from './normalizers';
+
+export {
+  isV1AgentCard,
+  normalizeAgentCard,
+  selectBestInterface,
+  normalizeTaskState,
+  _resetDeprecationWarning,
+} from './normalizers';
 
 // Attach
 export {

--- a/packages/mappings/a2a/src/normalizers.ts
+++ b/packages/mappings/a2a/src/normalizers.ts
@@ -1,0 +1,135 @@
+/**
+ * A2A v1.0.0 transition normalizers (DD-186).
+ *
+ * Accept both v0.3.0 and v1.0.0 Agent Card, TaskState, and Part shapes.
+ * v0.3.0 inputs emit a deprecation warning. v0.3.0 removal at v0.13.0.
+ */
+
+import type { A2AAgentCard, A2ASupportedInterface } from './types';
+import { TASK_STATE_V03_TO_V1 } from './types';
+
+// ---------------------------------------------------------------------------
+// Deprecation warning (fires once per process)
+// ---------------------------------------------------------------------------
+
+let v03DeprecationWarned = false;
+
+function warnV03Deprecated(context: string): void {
+  if (!v03DeprecationWarned) {
+    v03DeprecationWarned = true;
+    process.emitWarning(
+      `A2A v0.3.0 ${context} detected. Migrate to v1.0.0. ` +
+        'v0.3.0 support will be removed in @peac/mappings-a2a v0.13.0.',
+      'DeprecationWarning'
+    );
+  }
+}
+
+/** Reset deprecation warning state (for testing only) */
+export function _resetDeprecationWarning(): void {
+  v03DeprecationWarned = false;
+}
+
+// ---------------------------------------------------------------------------
+// Agent Card normalizer
+// ---------------------------------------------------------------------------
+
+/** Normalized Agent Card with a resolved URL regardless of version */
+export interface NormalizedAgentCard {
+  name: string;
+  url: string;
+  version: '0.3.0' | '1.0.0';
+  supportedInterfaces: A2ASupportedInterface[];
+  original: A2AAgentCard;
+}
+
+/**
+ * Detect whether an Agent Card uses v1.0.0 structure.
+ *
+ * v1.0.0 cards have `supportedInterfaces[]` instead of top-level `url`.
+ */
+export function isV1AgentCard(card: A2AAgentCard): boolean {
+  return (
+    Array.isArray(card.supportedInterfaces) &&
+    card.supportedInterfaces.length > 0 &&
+    typeof card.supportedInterfaces[0]?.url === 'string'
+  );
+}
+
+/**
+ * Normalize an A2A Agent Card from either v0.3.0 or v1.0.0 format.
+ *
+ * Returns a consistent shape with a resolved URL. v0.3.0 cards emit
+ * a deprecation warning on first encounter.
+ *
+ * Returns null if the card has neither a valid `url` nor valid
+ * `supportedInterfaces[0].url`.
+ */
+export function normalizeAgentCard(card: A2AAgentCard): NormalizedAgentCard | null {
+  if (isV1AgentCard(card)) {
+    const iface = card.supportedInterfaces![0]!;
+    return {
+      name: card.name,
+      url: iface.url,
+      version: '1.0.0',
+      supportedInterfaces: card.supportedInterfaces!,
+      original: card,
+    };
+  }
+
+  if (typeof card.url === 'string') {
+    warnV03Deprecated('Agent Card (top-level url)');
+    return {
+      name: card.name,
+      url: card.url,
+      version: '0.3.0',
+      supportedInterfaces: [
+        {
+          url: card.url,
+          protocolBinding: 'http+json',
+          protocolVersion: '0.3.0',
+        },
+      ],
+      original: card,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Select the best interface from a v1.0.0 Agent Card.
+ *
+ * Prefers the interface with the highest protocolVersion, then the first
+ * entry as tiebreaker.
+ */
+export function selectBestInterface(
+  interfaces: A2ASupportedInterface[]
+): A2ASupportedInterface | null {
+  if (interfaces.length === 0) return null;
+  return [...interfaces].sort((a, b) =>
+    b.protocolVersion.localeCompare(a.protocolVersion, undefined, { numeric: true })
+  )[0]!;
+}
+
+// ---------------------------------------------------------------------------
+// TaskState normalizer
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a task state string from v0.3.0 or v1.0.0 format.
+ *
+ * v0.3.0 uses kebab-case (e.g., "working"), v1.0.0 uses prefixed
+ * SCREAMING_SNAKE_CASE (e.g., "TASK_STATE_WORKING").
+ *
+ * Returns the v1.0.0 canonical form. Unrecognized values pass through
+ * unchanged.
+ */
+export function normalizeTaskState(state: string): string {
+  const v1 = TASK_STATE_V03_TO_V1[state];
+  if (v1) {
+    warnV03Deprecated('TaskState value');
+    return v1;
+  }
+  return state;
+}

--- a/packages/mappings/a2a/src/types.ts
+++ b/packages/mappings/a2a/src/types.ts
@@ -1,9 +1,12 @@
 /**
- * Minimal A2A types from spec v0.3.0.
+ * A2A types supporting both v0.3.0 and v1.0.0.
  *
  * These types are defined locally rather than importing @a2a-js/sdk,
  * which brings protobuf + gRPC + express peer dependencies that are
  * not needed for evidence placement.
+ *
+ * v1.0.0 transition (DD-186): dual-version acceptance with v0.3.0
+ * deprecated via process.emitWarning(). v0.3.0 removal at v0.13.0.
  */
 
 import type { CarrierFormat, PeacEvidenceCarrier, CarrierMeta } from '@peac/kernel';
@@ -19,7 +22,7 @@ export const PEAC_EXTENSION_URI = 'https://www.peacprotocol.org/ext/traceability
 export const A2A_MAX_CARRIER_SIZE = 65_536;
 
 // ---------------------------------------------------------------------------
-// A2A Agent Card types (v0.3.0)
+// A2A Agent Card types (v0.3.0 + v1.0.0)
 // ---------------------------------------------------------------------------
 
 /** A2A extension entry in capabilities.extensions[] */
@@ -42,12 +45,28 @@ export interface AgentCardPeacExtension {
   };
 }
 
-/** Minimal A2A Agent Card shape (v0.3.0) */
+/** A2A v1.0.0 supported interface entry */
+export interface A2ASupportedInterface {
+  url: string;
+  protocolBinding: string;
+  protocolVersion: string;
+}
+
+/**
+ * Minimal A2A Agent Card shape (v0.3.0 + v1.0.0).
+ *
+ * v0.3.0 cards have top-level `url`. v1.0.0 cards replace it with
+ * `supportedInterfaces[]`. Both shapes are accepted; v0.3.0 emits
+ * a deprecation warning. v0.3.0 support removal at v0.13.0.
+ */
 export interface A2AAgentCard {
   name: string;
-  url: string;
+  /** @deprecated v0.3.0 field. Use supportedInterfaces[0].url in v1.0.0. */
+  url?: string;
+  supportedInterfaces?: A2ASupportedInterface[];
   capabilities?: {
     extensions?: AgentCardExtension[];
+    extendedAgentCard?: boolean;
     [key: string]: unknown;
   };
   [key: string]: unknown;
@@ -82,6 +101,40 @@ export interface A2AArtifactLike {
   metadata?: A2AMetadata;
   [key: string]: unknown;
 }
+
+// ---------------------------------------------------------------------------
+// A2A v1.0.0 enum constants (reference values)
+// ---------------------------------------------------------------------------
+
+/** A2A v1.0.0 TaskState values (SCREAMING_SNAKE_CASE with type prefix) */
+export const A2A_V1_TASK_STATE = {
+  SUBMITTED: 'TASK_STATE_SUBMITTED',
+  WORKING: 'TASK_STATE_WORKING',
+  COMPLETED: 'TASK_STATE_COMPLETED',
+  FAILED: 'TASK_STATE_FAILED',
+  CANCELED: 'TASK_STATE_CANCELED',
+  REJECTED: 'TASK_STATE_REJECTED',
+  INPUT_REQUIRED: 'TASK_STATE_INPUT_REQUIRED',
+  AUTH_REQUIRED: 'TASK_STATE_AUTH_REQUIRED',
+} as const;
+
+/** A2A v1.0.0 MessageRole values */
+export const A2A_V1_MESSAGE_ROLE = {
+  USER: 'ROLE_USER',
+  AGENT: 'ROLE_AGENT',
+} as const;
+
+/** Map from v0.3.0 kebab-case task states to v1.0.0 prefixed form */
+export const TASK_STATE_V03_TO_V1: Record<string, string> = {
+  submitted: A2A_V1_TASK_STATE.SUBMITTED,
+  working: A2A_V1_TASK_STATE.WORKING,
+  completed: A2A_V1_TASK_STATE.COMPLETED,
+  failed: A2A_V1_TASK_STATE.FAILED,
+  canceled: A2A_V1_TASK_STATE.CANCELED,
+  rejected: A2A_V1_TASK_STATE.REJECTED,
+  'input-required': A2A_V1_TASK_STATE.INPUT_REQUIRED,
+  'auth-required': A2A_V1_TASK_STATE.AUTH_REQUIRED,
+};
 
 // ---------------------------------------------------------------------------
 // Carrier payload type

--- a/packages/mappings/a2a/tests/normalizers.test.ts
+++ b/packages/mappings/a2a/tests/normalizers.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  isV1AgentCard,
+  normalizeAgentCard,
+  selectBestInterface,
+  normalizeTaskState,
+  _resetDeprecationWarning,
+  A2A_V1_TASK_STATE,
+  type A2AAgentCard,
+  type A2ASupportedInterface,
+} from '../src/index';
+
+describe('isV1AgentCard', () => {
+  it('returns true for v1.0.0 card with supportedInterfaces', () => {
+    const card: A2AAgentCard = {
+      name: 'Test Agent',
+      supportedInterfaces: [
+        { url: 'https://agent.example.com', protocolBinding: 'http+json', protocolVersion: '1.0' },
+      ],
+    };
+    expect(isV1AgentCard(card)).toBe(true);
+  });
+
+  it('returns false for v0.3.0 card with top-level url', () => {
+    const card: A2AAgentCard = {
+      name: 'Test Agent',
+      url: 'https://agent.example.com',
+    };
+    expect(isV1AgentCard(card)).toBe(false);
+  });
+
+  it('returns false for card with empty supportedInterfaces', () => {
+    const card: A2AAgentCard = {
+      name: 'Test Agent',
+      supportedInterfaces: [],
+    };
+    expect(isV1AgentCard(card)).toBe(false);
+  });
+});
+
+describe('normalizeAgentCard', () => {
+  beforeEach(() => {
+    _resetDeprecationWarning();
+  });
+
+  it('normalizes v1.0.0 card with supportedInterfaces', () => {
+    const card: A2AAgentCard = {
+      name: 'V1 Agent',
+      supportedInterfaces: [
+        { url: 'https://v1.example.com', protocolBinding: 'http+json', protocolVersion: '1.0' },
+      ],
+    };
+    const result = normalizeAgentCard(card);
+    expect(result).not.toBeNull();
+    expect(result!.version).toBe('1.0.0');
+    expect(result!.url).toBe('https://v1.example.com');
+    expect(result!.name).toBe('V1 Agent');
+    expect(result!.original).toBe(card);
+  });
+
+  it('normalizes v0.3.0 card with top-level url', () => {
+    const card: A2AAgentCard = {
+      name: 'Legacy Agent',
+      url: 'https://legacy.example.com',
+    };
+    const result = normalizeAgentCard(card);
+    expect(result).not.toBeNull();
+    expect(result!.version).toBe('0.3.0');
+    expect(result!.url).toBe('https://legacy.example.com');
+    expect(result!.supportedInterfaces).toHaveLength(1);
+    expect(result!.supportedInterfaces[0]!.protocolVersion).toBe('0.3.0');
+  });
+
+  it('returns null for card with neither url nor supportedInterfaces', () => {
+    const card: A2AAgentCard = { name: 'Broken Agent' };
+    expect(normalizeAgentCard(card)).toBeNull();
+  });
+
+  it('prefers supportedInterfaces over url when both present', () => {
+    const card: A2AAgentCard = {
+      name: 'Both Agent',
+      url: 'https://old.example.com',
+      supportedInterfaces: [
+        { url: 'https://new.example.com', protocolBinding: 'http+json', protocolVersion: '1.0' },
+      ],
+    };
+    const result = normalizeAgentCard(card);
+    expect(result!.version).toBe('1.0.0');
+    expect(result!.url).toBe('https://new.example.com');
+  });
+
+  it('normalizes v1.0.0 card with multiple interfaces', () => {
+    const card: A2AAgentCard = {
+      name: 'Multi Agent',
+      supportedInterfaces: [
+        { url: 'https://http.example.com', protocolBinding: 'http+json', protocolVersion: '1.0' },
+        { url: 'https://grpc.example.com', protocolBinding: 'grpc+proto', protocolVersion: '1.0' },
+      ],
+    };
+    const result = normalizeAgentCard(card);
+    expect(result!.supportedInterfaces).toHaveLength(2);
+    expect(result!.url).toBe('https://http.example.com');
+  });
+
+  it('preserves capabilities and extensions from original card', () => {
+    const card: A2AAgentCard = {
+      name: 'Ext Agent',
+      supportedInterfaces: [
+        { url: 'https://agent.example.com', protocolBinding: 'http+json', protocolVersion: '1.0' },
+      ],
+      capabilities: {
+        extendedAgentCard: true,
+        extensions: [{ uri: 'org.peacprotocol', description: 'PEAC', required: false }],
+      },
+    };
+    const result = normalizeAgentCard(card);
+    expect(result!.original.capabilities?.extendedAgentCard).toBe(true);
+  });
+});
+
+describe('selectBestInterface', () => {
+  it('selects highest protocol version', () => {
+    const interfaces: A2ASupportedInterface[] = [
+      { url: 'https://a.example.com', protocolBinding: 'http+json', protocolVersion: '0.3' },
+      { url: 'https://b.example.com', protocolBinding: 'http+json', protocolVersion: '1.0' },
+    ];
+    const best = selectBestInterface(interfaces);
+    expect(best!.url).toBe('https://b.example.com');
+  });
+
+  it('returns null for empty array', () => {
+    expect(selectBestInterface([])).toBeNull();
+  });
+
+  it('returns single interface', () => {
+    const interfaces: A2ASupportedInterface[] = [
+      { url: 'https://only.example.com', protocolBinding: 'http+json', protocolVersion: '1.0' },
+    ];
+    expect(selectBestInterface(interfaces)!.url).toBe('https://only.example.com');
+  });
+});
+
+describe('normalizeTaskState', () => {
+  beforeEach(() => {
+    _resetDeprecationWarning();
+  });
+
+  it('converts v0.3.0 kebab-case to v1.0.0 prefixed form', () => {
+    expect(normalizeTaskState('submitted')).toBe(A2A_V1_TASK_STATE.SUBMITTED);
+    expect(normalizeTaskState('working')).toBe(A2A_V1_TASK_STATE.WORKING);
+    expect(normalizeTaskState('completed')).toBe(A2A_V1_TASK_STATE.COMPLETED);
+    expect(normalizeTaskState('failed')).toBe(A2A_V1_TASK_STATE.FAILED);
+    expect(normalizeTaskState('canceled')).toBe(A2A_V1_TASK_STATE.CANCELED);
+    expect(normalizeTaskState('rejected')).toBe(A2A_V1_TASK_STATE.REJECTED);
+    expect(normalizeTaskState('input-required')).toBe(A2A_V1_TASK_STATE.INPUT_REQUIRED);
+    expect(normalizeTaskState('auth-required')).toBe(A2A_V1_TASK_STATE.AUTH_REQUIRED);
+  });
+
+  it('passes through v1.0.0 values unchanged', () => {
+    expect(normalizeTaskState('TASK_STATE_WORKING')).toBe('TASK_STATE_WORKING');
+    expect(normalizeTaskState('TASK_STATE_COMPLETED')).toBe('TASK_STATE_COMPLETED');
+  });
+
+  it('passes through unknown values unchanged', () => {
+    expect(normalizeTaskState('custom-state')).toBe('custom-state');
+  });
+});

--- a/packages/mappings/aipref/src/index.ts
+++ b/packages/mappings/aipref/src/index.ts
@@ -9,6 +9,16 @@
  */
 
 import type { CanonicalPurpose, PurposeToken } from '@peac/schema';
+
+// ---------------------------------------------------------------------------
+// AIPREF version constants (DD-189)
+// ---------------------------------------------------------------------------
+
+/** Pinned AIPREF vocabulary draft version */
+export const AIPREF_VOCAB_VERSION = 'draft-ietf-aipref-vocab-05' as const;
+
+/** Pinned AIPREF attach draft version */
+export const AIPREF_ATTACH_VERSION = 'draft-ietf-aipref-attach-04' as const;
 import type {
   AiprefKey,
   AiprefKnownKey,


### PR DESCRIPTION
## Summary

Add A2A v1.0.0 dual-version transition support and AIPREF version constants.

## Changes

### A2A v1.0.0 Transition Normalizer (DD-186)

- Add `normalizeAgentCard()`: accepts both v0.3.0 (top-level `url`) and v1.0.0 (`supportedInterfaces[]`), returns a consistent `NormalizedAgentCard` shape
- Add `isV1AgentCard()`: detects card version by shape
- Add `selectBestInterface()`: picks highest `protocolVersion` from v1.0.0 cards
- Add `normalizeTaskState()`: maps v0.3.0 kebab-case (e.g., `working`) to v1.0.0 prefixed form (e.g., `TASK_STATE_WORKING`)
- Add v1.0.0 enum reference constants: `A2A_V1_TASK_STATE`, `A2A_V1_MESSAGE_ROLE`, `TASK_STATE_V03_TO_V1`
- Add `A2ASupportedInterface` type for v1.0.0 Agent Card interface entries
- Update `A2AAgentCard` type: `url` is now optional (deprecated), `supportedInterfaces` added
- Update `discoverAgentCard()`: dual-version validation via normalizer
- v0.3.0 inputs emit `DeprecationWarning` via `process.emitWarning()` (once per process)
- v0.3.0 removal not before v0.13.0

### AIPREF Version Pin (DD-189)

- Export `AIPREF_VOCAB_VERSION = 'draft-ietf-aipref-vocab-05'`
- Export `AIPREF_ATTACH_VERSION = 'draft-ietf-aipref-attach-04'`

### MCP SDK

- `~1.27.0` already resolves to 1.27.1 via tilde constraint; no explicit package.json change needed

## What is not in this PR

- No UCP or ACP semantic changes (deferred to v0.12.4)
- No new protocol surface in kernel/schema/crypto/protocol layers
- Layer 4 only

## Validation

- 6443 tests passing (250 files), up from 6428 (+15 normalizer tests)
- 84 build targets clean
- guard.sh all checks pass
- Prettier format clean