### PR TITLE
fix: resolve flatted prototype pollution (GHSA-rf6f-7fwh-wjgh)

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
       "zod": "^4.3.6",
       "rollup": ">=4.59.0",
       "express-rate-limit": ">=8.2.2",
-      "flatted": ">=3.4.1"
+      "flatted": "3.4.2"
     },
     "overridesComments": {
       "minimatch": "Cross-major pin: typescript-estree requires ^9.0.4 but 9.x has no patch for GHSA-3ppc-4f35-3m26. minimatch 10.x is API-compatible (same globbing interface). Drops Node 18 (fine: repo baseline is >=22.0.0). Lint verified clean.",
@@ -116,7 +116,7 @@
       "zod": "Workspace-wide Zod 4 enforcement: prevents mixed Zod 3/4 which causes runtime TypeError (incompatible internal _parse API). All workspace packages must use Zod 4.",
       "rollup": "Override vulnerable 4.53.2 to >=4.59.0 (fixes GHSA-mw96-cpmx-2vgc path traversal). Dev-only via vitest/vite/tsup.",
       "express-rate-limit": "Override 8.2.1 to >=8.2.2 (fixes GHSA-46wh-pxpv-q5gq IPv4-mapped IPv6 bypass). Prod dep via @modelcontextprotocol/sdk.",
-      "flatted": "Override 3.3.3 to >=3.4.1 (fixes GHSA-25h7-pfq9-p65f unbounded recursion DoS in parse()). Dev-only via eslint -> file-entry-cache -> flat-cache."
+      "flatted": "Override to >=3.4.2 (fixes GHSA-25h7-pfq9-p65f unbounded recursion DoS + GHSA-rf6f-7fwh-wjgh prototype pollution via parse()). Dev-only via eslint -> file-entry-cache -> flat-cache."
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   zod: ^4.3.6
   rollup: '>=4.59.0'
   express-rate-limit: '>=8.2.2'
-  flatted: '>=3.4.1'
+  flatted: 3.4.2
 
 importers:
 
@@ -2515,8 +2515,8 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
-  /@emnapi/core@1.9.0:
-    resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
+  /@emnapi/core@1.9.1:
+    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
     requiresBuild: true
     dependencies:
       '@emnapi/wasi-threads': 1.2.0
@@ -2524,8 +2524,8 @@ packages:
     dev: true
     optional: true
 
-  /@emnapi/runtime@1.9.0:
-    resolution: {integrity: sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==}
+  /@emnapi/runtime@1.9.1:
+    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
     requiresBuild: true
     dependencies:
       tslib: 2.8.1
@@ -3938,7 +3938,7 @@ packages:
     cpu: [wasm32]
     requiresBuild: true
     dependencies:
-      '@emnapi/runtime': 1.9.0
+      '@emnapi/runtime': 1.9.1
     dev: true
     optional: true
 
@@ -3948,7 +3948,7 @@ packages:
     cpu: [wasm32]
     requiresBuild: true
     dependencies:
-      '@emnapi/runtime': 1.9.0
+      '@emnapi/runtime': 1.9.1
     dev: true
     optional: true
 
@@ -4530,8 +4530,8 @@ packages:
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
     requiresBuild: true
     dependencies:
-      '@emnapi/core': 1.9.0
-      '@emnapi/runtime': 1.9.0
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
       '@tybys/wasm-util': 0.10.1
     dev: true
     optional: true
@@ -4540,8 +4540,8 @@ packages:
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
     requiresBuild: true
     dependencies:
-      '@emnapi/core': 1.9.0
-      '@emnapi/runtime': 1.9.0
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
       '@tybys/wasm-util': 0.10.1
     dev: true
     optional: true
@@ -7437,12 +7437,12 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
     dependencies:
-      flatted: 3.4.1
+      flatted: 3.4.2
       keyv: 4.5.4
     dev: true
 
-  /flatted@3.4.1:
-    resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
+  /flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
     dev: true
 
   /for-each@0.3.5:

--- a/security/audit-allowlist.json
+++ b/security/audit-allowlist.json
@@ -19,7 +19,8 @@
       ],
       "verified_by": "pnpm audit --prod shows no MODERATE; pnpm why esbuild confirms wrangler-only path",
       "owner": "jithinraj",
-      "added_at": "2026-02-19"
+      "added_at": "2026-02-19",
+      "reviewed_at": "2026-03-24"
     },
     {
       "advisory_id": "GHSA-g9mf-h72j-4rw9",
@@ -34,7 +35,8 @@
       "dependency_chain": ["wrangler@3.114.17", "miniflare", "undici@5.29.0"],
       "verified_by": "pnpm audit --prod shows no MODERATE; pnpm why undici confirms wrangler-only path",
       "owner": "jithinraj",
-      "added_at": "2026-02-19"
+      "added_at": "2026-02-19",
+      "reviewed_at": "2026-03-24"
     },
     {
       "advisory_id": "GHSA-2g4f-4pwh-qvx6",
@@ -49,7 +51,8 @@
       "dependency_chain": ["eslint@10.0.1", "ajv@6.12.6"],
       "verified_by": "pnpm audit --prod shows no MODERATE; direct ajv bumped to 8.18.0; remaining is eslint transitive",
       "owner": "jithinraj",
-      "added_at": "2026-02-19"
+      "added_at": "2026-02-19",
+      "reviewed_at": "2026-03-24"
     },
     {
       "advisory_id": "GHSA-7r86-cg39-jmmj",


### PR DESCRIPTION
## Summary

Resolve flatted prototype pollution vulnerability (GHSA-rf6f-7fwh-wjgh, HIGH) and renew stale audit allowlist entries.

## Changes

- Pin flatted pnpm override to exact `3.4.2` (was `>=3.4.1`); fixes prototype pollution via `parse()` in flatted
- Renew `reviewed_at` on 3 oldest allowlist entries (esbuild CSRF, undici decompression bomb, ajv ReDoS)
- All affected entries are dev-only (eslint, wrangler) with no production exposure

## Validation

- `AUDIT_STRICT=1 node scripts/audit-gate.mjs` passes: 0 high, 4 moderate (all allowed)
- Build and lint clean