### PR TITLE
feat: experimental commerce evidence bundle

### DIFF
--- a/packages/audit/src/commerce-bundle-types.ts
+++ b/packages/audit/src/commerce-bundle-types.ts
@@ -1,0 +1,92 @@
+/**
+ * Commerce evidence bundle types (experimental, DD-192).
+ *
+ * Cross-ecosystem commerce evidence correlation without aggregating
+ * or asserting settlement totals. Non-aggregating by default.
+ *
+ * Promotion gate (must be met before removing -experimental suffix):
+ * - At least 2 independent producers
+ * - At least 1 independent verifier path
+ * - Documented in a versioned spec
+ */
+
+/** Bundle format version */
+export const COMMERCE_BUNDLE_VERSION = 'peac.commerce-bundle/0.1-experimental' as const;
+
+/** Source discriminant for protocol-specific evidence */
+export interface ProtocolEvidence {
+  /** Protocol source identifier */
+  source: string;
+  /** Timestamp of the evidence capture */
+  captured_at: string;
+  /** Protocol-specific evidence data */
+  data: Record<string, unknown>;
+}
+
+/** Timeline entry for chronological event tracking */
+export interface TimelineEntry {
+  /** Timestamp of the event */
+  timestamp: string;
+  /** Protocol source */
+  source: string;
+  /** Event description */
+  event: string;
+  /** Optional metadata */
+  metadata?: Record<string, unknown>;
+}
+
+/** Individual observed amount (non-aggregated) */
+export interface ObservedAmount {
+  /** Protocol source that reported this amount */
+  source: string;
+  /** Amount in minor units (string for arbitrary precision) */
+  amount: string;
+  /** Currency code */
+  currency: string;
+  /** Semantic stage if known (e.g., "authorization", "settlement") */
+  semantic_stage?: string;
+}
+
+/** Commerce summary: observation-set, NOT aggregation */
+export interface CommerceSummary {
+  /** Individual observed amounts from each source (not rolled up) */
+  observed_amounts: ObservedAmount[];
+  /** Currencies observed across all sources */
+  currencies_observed: string[];
+  /** Payment rails observed */
+  rails_observed: string[];
+  /** Count of protocol evidence snapshots */
+  evidence_count: number;
+}
+
+/** Commerce evidence bundle */
+export interface CommerceEvidenceBundle {
+  /** Format version (includes -experimental suffix) */
+  version: typeof COMMERCE_BUNDLE_VERSION;
+  /** Cross-system transaction correlation ID */
+  transaction_ref: string;
+  /** Payment rails observed in this transaction */
+  rails_observed: string[];
+  /** Protocol-specific evidence snapshots */
+  protocol_evidence: ProtocolEvidence[];
+  /** Chronological event sequence */
+  timeline: TimelineEntry[];
+  /** Associated PEAC receipt references (receipt_ref hashes) */
+  receipts: string[];
+  /** Non-aggregating observation summary */
+  summary: CommerceSummary;
+  /** Bundle creation timestamp */
+  created_at: string;
+}
+
+/** Options for creating a commerce evidence bundle */
+export interface CreateCommerceBundleOptions {
+  /** Cross-system transaction correlation ID */
+  transaction_ref: string;
+  /** Optional initial protocol evidence */
+  evidence?: ProtocolEvidence[];
+  /** Optional initial timeline entries */
+  timeline?: TimelineEntry[];
+  /** Optional initial receipt references */
+  receipts?: string[];
+}

--- a/packages/audit/src/commerce-bundle.ts
+++ b/packages/audit/src/commerce-bundle.ts
@@ -1,0 +1,175 @@
+/**
+ * Commerce evidence bundle (experimental, DD-192).
+ *
+ * Cross-ecosystem commerce evidence correlation. Correlates receipts
+ * across payment rails without aggregating or asserting settlement totals.
+ *
+ * Summary is non-aggregating by default: observed_amounts lists each
+ * source's observation independently. A canonical total may only be
+ * derived when same currency, same semantic stage, and an explicit
+ * authoritative-winner rule is documented and tested.
+ */
+
+import type {
+  CommerceEvidenceBundle,
+  CommerceSummary,
+  CreateCommerceBundleOptions,
+  ObservedAmount,
+  ProtocolEvidence,
+  TimelineEntry,
+} from './commerce-bundle-types.js';
+import { COMMERCE_BUNDLE_VERSION } from './commerce-bundle-types.js';
+
+/**
+ * Create a new commerce evidence bundle.
+ */
+export function createCommerceEvidenceBundle(
+  options: CreateCommerceBundleOptions
+): CommerceEvidenceBundle {
+  const evidence = options.evidence ?? [];
+  const timeline = options.timeline ?? [];
+  const receipts = options.receipts ?? [];
+
+  const bundle: CommerceEvidenceBundle = {
+    version: COMMERCE_BUNDLE_VERSION,
+    transaction_ref: options.transaction_ref,
+    rails_observed: extractRails(evidence),
+    protocol_evidence: evidence,
+    timeline: sortTimeline(timeline),
+    receipts,
+    summary: computeCommerceSummary(evidence),
+    created_at: new Date().toISOString(),
+  };
+
+  return bundle;
+}
+
+/**
+ * Add protocol evidence to an existing bundle.
+ * Returns a new bundle (immutable pattern).
+ */
+export function addProtocolEvidence(
+  bundle: CommerceEvidenceBundle,
+  evidence: ProtocolEvidence
+): CommerceEvidenceBundle {
+  const newEvidence = [...bundle.protocol_evidence, evidence];
+  return {
+    ...bundle,
+    protocol_evidence: newEvidence,
+    rails_observed: extractRails(newEvidence),
+    summary: computeCommerceSummary(newEvidence),
+  };
+}
+
+/**
+ * Add a timeline entry to an existing bundle.
+ * Returns a new bundle with sorted timeline.
+ */
+export function addTimelineEntry(
+  bundle: CommerceEvidenceBundle,
+  entry: TimelineEntry
+): CommerceEvidenceBundle {
+  return {
+    ...bundle,
+    timeline: sortTimeline([...bundle.timeline, entry]),
+  };
+}
+
+/**
+ * Add a receipt reference to an existing bundle.
+ */
+export function addReceiptRef(
+  bundle: CommerceEvidenceBundle,
+  receiptRef: string
+): CommerceEvidenceBundle {
+  return {
+    ...bundle,
+    receipts: [...bundle.receipts, receiptRef],
+  };
+}
+
+/**
+ * Compute a non-aggregating commerce summary from protocol evidence.
+ *
+ * Lists each source's observed amounts independently. Does NOT compute
+ * a rolled-up transaction total. A canonical total requires same currency,
+ * same semantic stage, and an explicit authoritative-winner rule.
+ */
+export function computeCommerceSummary(evidence: ProtocolEvidence[]): CommerceSummary {
+  const observedAmounts: ObservedAmount[] = [];
+  const currencies = new Set<string>();
+  const rails = new Set<string>();
+
+  for (const ev of evidence) {
+    const data = ev.data;
+
+    // Extract amount/currency if present in evidence data
+    const amount =
+      typeof data.amount_minor === 'string'
+        ? data.amount_minor
+        : typeof data.amount === 'string'
+          ? data.amount
+          : typeof data.amount === 'number'
+            ? String(data.amount)
+            : undefined;
+
+    const currency = typeof data.currency === 'string' ? data.currency : undefined;
+    const rail = typeof data.payment_rail === 'string' ? data.payment_rail : undefined;
+    const stage =
+      typeof data.commerce_event === 'string'
+        ? data.commerce_event
+        : typeof data.semantic_stage === 'string'
+          ? data.semantic_stage
+          : undefined;
+
+    if (amount && currency) {
+      observedAmounts.push({
+        source: ev.source,
+        amount,
+        currency: currency.toUpperCase(),
+        semantic_stage: stage,
+      });
+      currencies.add(currency.toUpperCase());
+    }
+
+    if (rail) rails.add(rail);
+  }
+
+  return {
+    observed_amounts: observedAmounts,
+    currencies_observed: [...currencies].sort(),
+    rails_observed: [...rails].sort(),
+    evidence_count: evidence.length,
+  };
+}
+
+/**
+ * Serialize a commerce bundle to deterministic JSON (sorted keys).
+ */
+export function serializeCommerceBundle(bundle: CommerceEvidenceBundle): string {
+  return JSON.stringify(bundle, Object.keys(bundle).sort(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function extractRails(evidence: ProtocolEvidence[]): string[] {
+  const rails = new Set<string>();
+  for (const ev of evidence) {
+    if (typeof ev.data.payment_rail === 'string') {
+      rails.add(ev.data.payment_rail);
+    }
+    // Also check source as a fallback rail indicator
+    if (ev.source && !ev.source.includes('/')) {
+      rails.add(ev.source);
+    }
+  }
+  return [...rails].sort();
+}
+
+function sortTimeline(entries: TimelineEntry[]): TimelineEntry[] {
+  return [...entries].sort(
+    (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+  );
+}

--- a/packages/audit/src/index.ts
+++ b/packages/audit/src/index.ts
@@ -144,3 +144,24 @@ export {
 
 // Verification report (v0.9.30+)
 export { verifyBundle, serializeReport, formatReportText } from './verification-report.js';
+
+// Commerce evidence bundle (experimental, DD-192, v0.12.4+)
+export type {
+  CommerceEvidenceBundle,
+  CommerceSummary,
+  CreateCommerceBundleOptions,
+  ProtocolEvidence,
+  TimelineEntry,
+  ObservedAmount,
+} from './commerce-bundle-types.js';
+
+export { COMMERCE_BUNDLE_VERSION } from './commerce-bundle-types.js';
+
+export {
+  createCommerceEvidenceBundle,
+  addProtocolEvidence,
+  addTimelineEntry,
+  addReceiptRef,
+  computeCommerceSummary,
+  serializeCommerceBundle,
+} from './commerce-bundle.js';

--- a/packages/audit/tests/commerce-bundle.test.ts
+++ b/packages/audit/tests/commerce-bundle.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Tests for experimental commerce evidence bundle (DD-192).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  createCommerceEvidenceBundle,
+  addProtocolEvidence,
+  addTimelineEntry,
+  addReceiptRef,
+  computeCommerceSummary,
+  serializeCommerceBundle,
+  COMMERCE_BUNDLE_VERSION,
+} from '../src/index.js';
+import type { ProtocolEvidence, TimelineEntry } from '../src/index.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeEvidence(source: string, overrides?: Record<string, unknown>): ProtocolEvidence {
+  return {
+    source,
+    captured_at: '2025-01-15T12:00:00Z',
+    data: {
+      payment_rail: source,
+      amount_minor: '1000',
+      currency: 'USD',
+      ...overrides,
+    },
+  };
+}
+
+function makeTimeline(source: string, event: string, ts?: string): TimelineEntry {
+  return {
+    timestamp: ts ?? '2025-01-15T12:00:00Z',
+    source,
+    event,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// createCommerceEvidenceBundle
+// ---------------------------------------------------------------------------
+
+describe('createCommerceEvidenceBundle', () => {
+  it('should create a bundle with version and transaction_ref', () => {
+    const bundle = createCommerceEvidenceBundle({
+      transaction_ref: 'txn_abc123',
+    });
+
+    expect(bundle.version).toBe(COMMERCE_BUNDLE_VERSION);
+    expect(bundle.version).toContain('-experimental');
+    expect(bundle.transaction_ref).toBe('txn_abc123');
+    expect(bundle.created_at).toBeTruthy();
+  });
+
+  it('should create empty bundle when no evidence provided', () => {
+    const bundle = createCommerceEvidenceBundle({
+      transaction_ref: 'txn_empty',
+    });
+
+    expect(bundle.protocol_evidence).toEqual([]);
+    expect(bundle.timeline).toEqual([]);
+    expect(bundle.receipts).toEqual([]);
+    expect(bundle.rails_observed).toEqual([]);
+    expect(bundle.summary.evidence_count).toBe(0);
+  });
+
+  it('should accept initial evidence', () => {
+    const bundle = createCommerceEvidenceBundle({
+      transaction_ref: 'txn_123',
+      evidence: [makeEvidence('stripe'), makeEvidence('paymentauth')],
+    });
+
+    expect(bundle.protocol_evidence).toHaveLength(2);
+    expect(bundle.rails_observed).toContain('stripe');
+    expect(bundle.rails_observed).toContain('paymentauth');
+  });
+
+  it('should sort initial timeline entries', () => {
+    const bundle = createCommerceEvidenceBundle({
+      transaction_ref: 'txn_123',
+      timeline: [
+        makeTimeline('stripe', 'settled', '2025-01-15T13:00:00Z'),
+        makeTimeline('paymentauth', 'challenged', '2025-01-15T12:00:00Z'),
+      ],
+    });
+
+    expect(bundle.timeline[0].source).toBe('paymentauth');
+    expect(bundle.timeline[1].source).toBe('stripe');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addProtocolEvidence
+// ---------------------------------------------------------------------------
+
+describe('addProtocolEvidence', () => {
+  it('should add evidence immutably', () => {
+    const bundle = createCommerceEvidenceBundle({ transaction_ref: 'txn_1' });
+    const updated = addProtocolEvidence(bundle, makeEvidence('stripe'));
+
+    expect(bundle.protocol_evidence).toHaveLength(0);
+    expect(updated.protocol_evidence).toHaveLength(1);
+    expect(updated.rails_observed).toContain('stripe');
+  });
+
+  it('should update summary when evidence added', () => {
+    const bundle = createCommerceEvidenceBundle({ transaction_ref: 'txn_1' });
+    const updated = addProtocolEvidence(bundle, makeEvidence('stripe'));
+
+    expect(updated.summary.evidence_count).toBe(1);
+    expect(updated.summary.observed_amounts).toHaveLength(1);
+    expect(updated.summary.observed_amounts[0].source).toBe('stripe');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addTimelineEntry / addReceiptRef
+// ---------------------------------------------------------------------------
+
+describe('addTimelineEntry', () => {
+  it('should add and sort timeline entries', () => {
+    let bundle = createCommerceEvidenceBundle({ transaction_ref: 'txn_1' });
+    bundle = addTimelineEntry(bundle, makeTimeline('stripe', 'settled', '2025-01-15T13:00:00Z'));
+    bundle = addTimelineEntry(bundle, makeTimeline('acp', 'created', '2025-01-15T12:00:00Z'));
+
+    expect(bundle.timeline).toHaveLength(2);
+    expect(bundle.timeline[0].source).toBe('acp');
+    expect(bundle.timeline[1].source).toBe('stripe');
+  });
+});
+
+describe('addReceiptRef', () => {
+  it('should add receipt reference', () => {
+    const bundle = createCommerceEvidenceBundle({ transaction_ref: 'txn_1' });
+    const updated = addReceiptRef(bundle, 'sha256:abc123');
+
+    expect(updated.receipts).toContain('sha256:abc123');
+    expect(bundle.receipts).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeCommerceSummary (non-aggregating)
+// ---------------------------------------------------------------------------
+
+describe('computeCommerceSummary', () => {
+  it('should list observed amounts per source (not rolled up)', () => {
+    const evidence = [
+      makeEvidence('stripe', {
+        amount_minor: '1000',
+        currency: 'USD',
+        commerce_event: 'settlement',
+      }),
+      makeEvidence('paymentauth', { amount_minor: '500', currency: 'USD' }),
+    ];
+
+    const summary = computeCommerceSummary(evidence);
+
+    expect(summary.observed_amounts).toHaveLength(2);
+    expect(summary.observed_amounts[0]).toEqual({
+      source: 'stripe',
+      amount: '1000',
+      currency: 'USD',
+      semantic_stage: 'settlement',
+    });
+    expect(summary.observed_amounts[1]).toEqual({
+      source: 'paymentauth',
+      amount: '500',
+      currency: 'USD',
+      semantic_stage: undefined,
+    });
+  });
+
+  it('should NOT compute a rolled-up total', () => {
+    const evidence = [
+      makeEvidence('stripe', { amount_minor: '1000', currency: 'USD' }),
+      makeEvidence('x402', { amount_minor: '2000', currency: 'USD' }),
+    ];
+
+    const summary = computeCommerceSummary(evidence);
+
+    // No total field; only individual observations
+    expect(summary.observed_amounts).toHaveLength(2);
+    expect((summary as Record<string, unknown>).total).toBeUndefined();
+  });
+
+  it('should track currencies observed', () => {
+    const evidence = [
+      makeEvidence('stripe', { amount_minor: '1000', currency: 'usd' }),
+      makeEvidence('x402', { amount_minor: '500', currency: 'eur' }),
+    ];
+
+    const summary = computeCommerceSummary(evidence);
+
+    expect(summary.currencies_observed).toEqual(['EUR', 'USD']);
+  });
+
+  it('should track rails observed', () => {
+    const evidence = [
+      makeEvidence('stripe', { payment_rail: 'stripe' }),
+      makeEvidence('paymentauth', { payment_rail: 'paymentauth' }),
+    ];
+
+    const summary = computeCommerceSummary(evidence);
+
+    expect(summary.rails_observed).toContain('stripe');
+    expect(summary.rails_observed).toContain('paymentauth');
+  });
+
+  it('should handle empty evidence', () => {
+    const summary = computeCommerceSummary([]);
+
+    expect(summary.observed_amounts).toEqual([]);
+    expect(summary.currencies_observed).toEqual([]);
+    expect(summary.rails_observed).toEqual([]);
+    expect(summary.evidence_count).toBe(0);
+  });
+
+  it('should skip evidence without amount/currency', () => {
+    const evidence = [
+      makeEvidence('acp', { payment_rail: 'acp' }), // no amount_minor or currency
+    ];
+
+    // Override the default fixture data
+    evidence[0].data = { payment_rail: 'acp' };
+
+    const summary = computeCommerceSummary(evidence);
+
+    expect(summary.observed_amounts).toEqual([]);
+    expect(summary.rails_observed).toContain('acp');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// serializeCommerceBundle
+// ---------------------------------------------------------------------------
+
+describe('serializeCommerceBundle', () => {
+  it('should produce deterministic JSON with sorted keys', () => {
+    const bundle = createCommerceEvidenceBundle({
+      transaction_ref: 'txn_det',
+      evidence: [makeEvidence('stripe')],
+    });
+
+    const json1 = serializeCommerceBundle(bundle);
+    const json2 = serializeCommerceBundle(bundle);
+
+    expect(json1).toBe(json2);
+  });
+
+  it('should be valid JSON', () => {
+    const bundle = createCommerceEvidenceBundle({
+      transaction_ref: 'txn_valid',
+      evidence: [makeEvidence('stripe')],
+      receipts: ['sha256:abc'],
+    });
+
+    const json = serializeCommerceBundle(bundle);
+    const parsed = JSON.parse(json);
+
+    expect(parsed.version).toBe(COMMERCE_BUNDLE_VERSION);
+    expect(parsed.transaction_ref).toBe('txn_valid');
+  });
+});


### PR DESCRIPTION
## Summary

Experimental cross-ecosystem commerce evidence bundle in `@peac/audit` (DD-192). Correlates receipts across payment rails without aggregating or asserting settlement totals.

## Semantic Boundary

Summary is **non-aggregating by default**: `observed_amounts` lists each source's observation independently. No rolled-up transaction total. A canonical total may only be derived when: same currency, same semantic stage, and an explicit authoritative-winner rule is documented and tested.

## Changes

- `src/commerce-bundle-types.ts`: types for bundle, evidence, timeline, summary, observed amounts
- `src/commerce-bundle.ts`: create, add evidence/timeline/receipts, compute summary, serialize
- `src/index.ts`: barrel exports
- `tests/commerce-bundle.test.ts`: 22 tests covering creation, immutability, summary non-aggregation, serialization

## Version

`peac.commerce-bundle/0.1-experimental`

## Validation

- 144 tests passing across 7 test files (22 new)
- 85/85 monorepo build targets
- Prettier, lint, and forbidden-strings clean