### PR TITLE
fix: harden commerce bundle serialization and determinism

### DIFF
--- a/packages/audit/src/commerce-bundle-types.ts
+++ b/packages/audit/src/commerce-bundle-types.ts
@@ -89,4 +89,6 @@ export interface CreateCommerceBundleOptions {
   timeline?: TimelineEntry[];
   /** Optional initial receipt references */
   receipts?: string[];
+  /** Optional creation timestamp (for deterministic output; defaults to now) */
+  created_at?: string;
 }

--- a/packages/audit/src/commerce-bundle.ts
+++ b/packages/audit/src/commerce-bundle.ts
@@ -38,7 +38,7 @@ export function createCommerceEvidenceBundle(
     timeline: sortTimeline(timeline),
     receipts,
     summary: computeCommerceSummary(evidence),
-    created_at: new Date().toISOString(),
+    created_at: options.created_at ?? new Date().toISOString(),
   };
 
   return bundle;
@@ -144,25 +144,46 @@ export function computeCommerceSummary(evidence: ProtocolEvidence[]): CommerceSu
 }
 
 /**
- * Serialize a commerce bundle to deterministic JSON (sorted keys).
+ * Serialize a commerce bundle to deterministic JSON.
+ *
+ * Uses recursive key sorting so nested objects (protocol evidence,
+ * timeline metadata, summary) are also serialized deterministically.
+ * Arrays are preserved in-order. No nested fields are omitted.
  */
 export function serializeCommerceBundle(bundle: CommerceEvidenceBundle): string {
-  return JSON.stringify(bundle, Object.keys(bundle).sort(), 2);
+  return JSON.stringify(stableSort(bundle), null, 2);
+}
+
+/**
+ * Recursively sort object keys for deterministic serialization.
+ * Arrays preserved in-order; primitives pass through unchanged.
+ */
+function stableSort(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(stableSort);
+
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+    sorted[key] = stableSort((value as Record<string, unknown>)[key]);
+  }
+  return sorted;
 }
 
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Extract payment rails from evidence.
+ * Only uses explicit payment_rail from evidence data.
+ * Does NOT infer rails from source names to avoid semantic drift.
+ */
 function extractRails(evidence: ProtocolEvidence[]): string[] {
   const rails = new Set<string>();
   for (const ev of evidence) {
     if (typeof ev.data.payment_rail === 'string') {
       rails.add(ev.data.payment_rail);
-    }
-    // Also check source as a fallback rail indicator
-    if (ev.source && !ev.source.includes('/')) {
-      rails.add(ev.source);
     }
   }
   return [...rails].sort();

--- a/packages/audit/tests/commerce-bundle.test.ts
+++ b/packages/audit/tests/commerce-bundle.test.ts
@@ -47,12 +47,22 @@ describe('createCommerceEvidenceBundle', () => {
   it('should create a bundle with version and transaction_ref', () => {
     const bundle = createCommerceEvidenceBundle({
       transaction_ref: 'txn_abc123',
+      created_at: '2025-06-01T12:00:00Z',
     });
 
     expect(bundle.version).toBe(COMMERCE_BUNDLE_VERSION);
     expect(bundle.version).toContain('-experimental');
     expect(bundle.transaction_ref).toBe('txn_abc123');
+    expect(bundle.created_at).toBe('2025-06-01T12:00:00Z');
+  });
+
+  it('should default created_at to current time when not provided', () => {
+    const bundle = createCommerceEvidenceBundle({
+      transaction_ref: 'txn_default_time',
+    });
+
     expect(bundle.created_at).toBeTruthy();
+    expect(new Date(bundle.created_at).getTime()).toBeGreaterThan(0);
   });
 
   it('should create empty bundle when no evidence provided', () => {
@@ -263,5 +273,85 @@ describe('serializeCommerceBundle', () => {
 
     expect(parsed.version).toBe(COMMERCE_BUNDLE_VERSION);
     expect(parsed.transaction_ref).toBe('txn_valid');
+  });
+
+  it('should recursively sort nested object keys', () => {
+    const bundle = createCommerceEvidenceBundle({
+      transaction_ref: 'txn_nested',
+      created_at: '2025-06-01T12:00:00Z',
+      evidence: [
+        {
+          source: 'stripe',
+          captured_at: '2025-06-01T12:00:00Z',
+          data: {
+            zebra_field: 'last',
+            alpha_field: 'first',
+            nested: { zz_inner: 'z', aa_inner: 'a' },
+            payment_rail: 'stripe',
+            amount_minor: '100',
+            currency: 'USD',
+          },
+        },
+      ],
+    });
+
+    const json = serializeCommerceBundle(bundle);
+    const parsed = JSON.parse(json);
+
+    // Top-level keys sorted
+    const topKeys = Object.keys(parsed);
+    expect(topKeys).toEqual([...topKeys].sort());
+
+    // Nested evidence data keys sorted
+    const evidenceData = parsed.protocol_evidence[0].data;
+    const dataKeys = Object.keys(evidenceData);
+    expect(dataKeys).toEqual([...dataKeys].sort());
+
+    // Deeply nested keys sorted
+    const nestedKeys = Object.keys(evidenceData.nested);
+    expect(nestedKeys).toEqual(['aa_inner', 'zz_inner']);
+
+    // No nested fields dropped
+    expect(evidenceData.zebra_field).toBe('last');
+    expect(evidenceData.alpha_field).toBe('first');
+    expect(evidenceData.nested.aa_inner).toBe('a');
+    expect(evidenceData.nested.zz_inner).toBe('z');
+  });
+
+  it('should preserve arrays in order (not sort array elements)', () => {
+    const bundle = createCommerceEvidenceBundle({
+      transaction_ref: 'txn_array',
+      created_at: '2025-06-01T12:00:00Z',
+      receipts: ['sha256:ccc', 'sha256:aaa', 'sha256:bbb'],
+    });
+
+    const json = serializeCommerceBundle(bundle);
+    const parsed = JSON.parse(json);
+
+    // Array order preserved (not alphabetically sorted)
+    expect(parsed.receipts).toEqual(['sha256:ccc', 'sha256:aaa', 'sha256:bbb']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractRails: explicit payment_rail only
+// ---------------------------------------------------------------------------
+
+describe('extractRails behavior', () => {
+  it('should only use explicit payment_rail, not infer from source', () => {
+    const bundle = createCommerceEvidenceBundle({
+      transaction_ref: 'txn_rails',
+      created_at: '2025-06-01T12:00:00Z',
+      evidence: [
+        {
+          source: 'some-arbitrary-source',
+          captured_at: '2025-06-01T12:00:00Z',
+          data: { amount_minor: '100', currency: 'USD' },
+        },
+      ],
+    });
+
+    // No payment_rail in data, so rails_observed should be empty
+    expect(bundle.rails_observed).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Surgical hardening of the experimental commerce evidence bundle (DD-192).

## Changes

1. **Recursive stable serializer**: replace top-level-only `JSON.stringify` replacer with `stableSort()` that recursively sorts object keys. No nested fields dropped. Arrays preserved in-order.
2. **Injectable `created_at`**: `CreateCommerceBundleOptions` now accepts optional `created_at` for deterministic output; defaults to `new Date().toISOString()` when omitted.
3. **Explicit rails only**: `extractRails()` only uses explicit `payment_rail` from evidence data; does not infer rails from arbitrary source names.
4. **Tests**: nested key sorting, array order preservation, injectable timestamp, explicit-rails-only behavior.

## Validation

- 148 audit tests passing (was 144, +4 new)
- Prettier clean