### PR TITLE
chore(release): v0.12.4 commerce evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes to PEAC Protocol will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.4] - 2026-03-25
+
+### Theme: Commerce Evidence + Integration Depth
+
+PEAC as the neutral portable evidence layer across paymentauth/MPP, ACP, x402, Stripe SPT, and UCP.
+
+### Added
+
+- `@peac/mappings-paymentauth` (DD-191): new Layer 4 package for HTTP Payment authentication scheme envelope parsing, evidence mapping, and carrier adapter
+- `paymentauth` payment rail registration (DD-190): informational registry entry for `draft-ryan-httpauth-payment`
+- x402 v2 dual-header read compatibility (DD-193): PEAC-Receipt > PAYMENT-RESPONSE (v2) > X-PAYMENT-RESPONSE (v1)
+- ACP session lifecycle evidence (DD-188): session states produce access evidence; commerce evidence only from explicit payment artifacts with `observed_payment_state`
+- Stripe SPT delegated payment evidence: delegation-specific vocabulary (`delegated_payment_granted/presented/deactivated`); `fromStripePaymentIntentObservation()` for commerce events
+- UCP order-vs-payment semantic separation (DD-187): `UcpPaymentState`, `payment_state_source` marker for derived vs explicit
+- Experimental commerce evidence bundle (DD-192) in `@peac/audit`: non-aggregating cross-ecosystem correlation
+- Commerce pillar profile (`docs/profiles/commerce.md`)
+- Commerce evidence boundary spec (`docs/specs/COMMERCE-EVIDENCE.md`)
+- Commerce semantics spec (`docs/specs/COMMERCE-SEMANTICS.md`): canonical vocabulary for observed vs derived payment state, delegation vs finality, carrier vs upstream artifacts
+- Integration kits: paymentauth, ACP, x402 (populated from placeholders)
+- 6 runnable commerce examples with deterministic output
+- `pnpm verify:examples-commerce` smoke target
+- 21 cross-package commerce boundary conformance tests
+- Shared Stripe metadata sanitization helper (`metadata.ts`)
+
+### Fixed
+
+- flatted prototype pollution (GHSA-rf6f-7fwh-wjgh): pin to 3.4.2
+- Dynamic error category derivation from generated file (no more hardcoded list)
+- Recursive stable serialization for commerce bundles
+- Injectable `created_at` for deterministic bundle output
+
+### Changed
+
+- MCP server version constant updated from 0.11.2 to 0.12.4
+- 91 build targets (was 84)
+- 6664 tests (was 6443)
+- 361 conformance tests (was 340)
+- 29 packages in publish manifest (was 28)
+
+### Deferred
+
+- `@peac/adapter-did`: deferred to v0.12.5
+- x402 V2 full adapter rewrite: deferred to v0.12.5
+- Go/Python SDK: deferred to v0.12.5 (gated on external signal)
+- A2A v1.0 OAuth PKCE, A2A v1.0 gRPC binding: deferred to v0.12.5
+
 ## [Unreleased]
 
 ## [0.12.3] - 2026-03-17

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ See [examples/wire-02-minimal/](examples/wire-02-minimal/) for the full source. 
 
 PEAC is most useful where logs are not enough: payments, cross-boundary verification, audit, dispute review, and multi-agent workflows.
 
-- **Agentic commerce and payments:** Prove what was offered, challenged, paid, or settled across x402 and machine-to-machine commerce flows. See [x402 Integration Kit](integrator-kits/x402/README.md).
+- **Agentic commerce and payments:** Prove what was offered, challenged, paid, or settled across paymentauth/MPP, x402, ACP, Stripe SPT, and other commerce flows. See [paymentauth Kit](integrator-kits/paymentauth/README.md), [ACP Kit](integrator-kits/acp/README.md), [x402 Kit](integrator-kits/x402/README.md).
 - **Audit and dispute review:** Keep signed evidence that survives organizational boundaries, not just local logs. See [Governance Mappings](docs/governance/).
 - **MCP tools and APIs:** Verify, issue, and carry signed receipts for tool calls, API responses, and automated actions. See [MCP Integration Kit](integrator-kits/mcp/README.md).
 - **Agent-to-agent workflows:** Carry verifiable receipts across A2A task/state transitions and multi-agent chains. See [A2A Integration Kit](integrator-kits/a2a/README.md).
@@ -129,7 +129,7 @@ PEAC is most useful where logs are not enough: payments, cross-boundary verifica
 - **I want to verify a receipt**: [Agent Operator Quickstart](docs/guides/quickstart-agent-operator.md) (5 minutes)
 - **I build A2A agents**: [A2A Integration Kit](integrator-kits/a2a/README.md)
 
-More paths: [Go SDK](sdks/go/) | [x402 Integration Kit](integrator-kits/x402/README.md) | [Governance Mappings](docs/governance/)
+More paths: [Go SDK](sdks/go/) | [paymentauth Kit](integrator-kits/paymentauth/README.md) | [ACP Kit](integrator-kits/acp/README.md) | [x402 Kit](integrator-kits/x402/README.md) | [Governance Mappings](docs/governance/)
 
 ---
 
@@ -141,8 +141,9 @@ More paths: [Go SDK](sdks/go/) | [x402 Integration Kit](integrator-kits/x402/REA
 | **OpenTelemetry**                      | Signed evidence that correlates to traces              |
 | **MCP / A2A**                          | Proof carried alongside tool calls and agent exchanges |
 | **AP2 / ACP (Agentic Commerce) / UCP** | Proof of terms and outcomes                            |
+| **paymentauth / MPP**                  | Evidence from HTTP 402 payment challenges and receipts |
 | **x402**                               | Settlement proof mapping with offline verification     |
-| **Payment rails**                      | Settlement references made verifiable offline          |
+| **Stripe SPT / Payment rails**         | Delegation and settlement references made verifiable   |
 
 **What changes in your stack:** keep auth, keep payments, keep observability. Add `/.well-known/peac.txt` and return `PEAC-Receipt` on governed responses.
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-api",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "PEAC Protocol API server with OpenAPI 3.1, RFC 9457 Problem Details, and content negotiation",
   "type": "module",
   "main": "dist/index.js",

--- a/apps/bridge/package.json
+++ b/apps/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-bridge",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "PEAC Protocol Bridge - Local development sidecar",
   "type": "module",
   "main": "dist/server.js",

--- a/apps/sandbox-issuer/package.json
+++ b/apps/sandbox-issuer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-sandbox-issuer",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "PEAC Protocol Sandbox Issuer - Test receipt issuance for development",
   "type": "module",
   "main": "dist/node.js",

--- a/apps/verifier/package.json
+++ b/apps/verifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-verifier",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "PEAC Protocol Browser Verifier - Client-side receipt verification",
   "type": "module",
   "private": true,

--- a/docs/README_LONG.md
+++ b/docs/README_LONG.md
@@ -39,6 +39,20 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for full design rationale.
 
 ## Integration paths
 
+### Commerce evidence integrations (v0.12.4+)
+
+PEAC records evidence from commerce protocols without executing payments:
+
+| Protocol          | Package                      | What it records                                    |
+| ----------------- | ---------------------------- | -------------------------------------------------- |
+| paymentauth / MPP | `@peac/mappings-paymentauth` | HTTP 402 challenges, receipts, carrier coexistence |
+| ACP               | `@peac/mappings-acp`         | Session lifecycle, payment observations            |
+| Stripe SPT        | `@peac/rails-stripe`         | Delegation grants, PI observations                 |
+| x402              | `@peac/adapter-x402`         | Offer/receipt verification, v1/v2 read             |
+| UCP               | `@peac/mappings-ucp`         | Order-vs-payment separation                        |
+
+See [Commerce Evidence Spec](specs/COMMERCE-EVIDENCE.md) and [Commerce Semantics](specs/COMMERCE-SEMANTICS.md) for boundary rules.
+
 ### Settlement fields
 
 Add payment evidence via the commerce extension:

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -46,15 +46,18 @@ Key packages: `@peac/mappings-a2a`, `@peac/protocol`
 
 ## Strategic wedges
 
-### x402 and payment proofs
+### Commerce and payment evidence
 
-You want verifiable payment and settlement evidence for x402 and machine-to-machine commerce. Prove what was offered, challenged, paid, or settled across organizational boundaries.
+You want verifiable evidence from commerce and payment flows across paymentauth/MPP, ACP, Stripe SPT, x402, or UCP. Prove what was offered, challenged, paid, or settled across organizational boundaries.
 
-1. Install: `pnpm add @peac/adapter-x402`
-2. Read the [x402 Integration Kit](../integrator-kits/x402/README.md)
-3. See [examples/x402-node-server](../examples/x402-node-server/) for a payment evidence example
+1. Choose your protocol:
+   - **paymentauth/MPP**: [paymentauth Integration Kit](../integrator-kits/paymentauth/README.md)
+   - **ACP**: [ACP Integration Kit](../integrator-kits/acp/README.md)
+   - **x402**: [x402 Integration Kit](../integrator-kits/x402/README.md)
+2. See [Commerce Evidence Spec](specs/COMMERCE-EVIDENCE.md) for boundary rules
+3. See [examples/](../examples/) for runnable demos
 
-Key packages: `@peac/adapter-x402`
+Key packages: `@peac/mappings-paymentauth`, `@peac/mappings-acp`, `@peac/rails-stripe`, `@peac/adapter-x402`, `@peac/mappings-ucp`
 
 ### Audit, dispute, and governance evidence
 

--- a/docs/releases/current.json
+++ b/docs/releases/current.json
@@ -1,8 +1,8 @@
 {
   "description": "PEAC release manifest: CI-enforceable source of truth for release state",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "wire_format_version": "0.2",
   "dist_tag": "latest",
   "registries_version": "0.5.0",
-  "errors_version": "0.12.3"
+  "errors_version": "0.12.4"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/monorepo",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "private": true,
   "description": "PEAC Protocol - Cryptographic receipts for agentic commerce",
   "repository": {

--- a/packages/access/package.json
+++ b/packages/access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/access",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "private": true,
   "description": "PEAC access pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/adapters/core/package.json
+++ b/packages/adapters/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-core",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Shared utilities for PEAC payment rail adapters",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/eat/package.json
+++ b/packages/adapters/eat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-eat",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "EAT (Entity Attestation Token, RFC 9711) passport decoder and PEAC claim mapper",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/openai-compatible/package.json
+++ b/packages/adapters/openai-compatible/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-openai-compatible",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "OpenAI-compatible chat completion adapter for PEAC interaction evidence (hash-first)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/openclaw/package.json
+++ b/packages/adapters/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-openclaw",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "OpenClaw adapter for PEAC interaction evidence capture",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/daydreams/package.json
+++ b/packages/adapters/x402/daydreams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402-daydreams",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Daydreams AI inference event normalizer for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/fluora/package.json
+++ b/packages/adapters/x402/fluora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402-fluora",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Fluora MCP marketplace event normalizer for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/package.json
+++ b/packages/adapters/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "x402 offer/receipt verification, term-matching, and PEAC record mapping",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/pinata/package.json
+++ b/packages/adapters/x402/pinata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402-pinata",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Pinata private IPFS objects event normalizer for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/aipref/package.json
+++ b/packages/aipref/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/pref",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "AIPREF resolver with robots.txt bridge",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/attribution/package.json
+++ b/packages/attribution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/attribution",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "PEAC attribution attestation - content derivation and usage proofs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/audit",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Audit logging and case bundle generation for PEAC protocol disputes",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/capture/core/package.json
+++ b/packages/capture/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/capture-core",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Runtime-neutral capture pipeline for PEAC interaction evidence",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/capture/node/package.json
+++ b/packages/capture/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/capture-node",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Node.js durable storage for PEAC capture pipeline (filesystem spool store and dedupe index)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/cli",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "PEAC protocol command-line tools",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/compliance/package.json
+++ b/packages/compliance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/compliance",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "private": true,
   "description": "PEAC compliance pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/conformance-harness/package.json
+++ b/packages/conformance-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/conformance-harness",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "private": true,
   "description": "Conformance test harness for PEAC protocol fixtures",
   "main": "dist/index.cjs",

--- a/packages/consent/package.json
+++ b/packages/consent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/consent",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "private": true,
   "description": "PEAC consent pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/contracts",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "PEAC canonical error codes and verification mode contracts",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/control/package.json
+++ b/packages/control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/control",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "PEAC Protocol Control - control engine interfaces and validation",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/core",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "DEPRECATED - Use @peac/kernel, @peac/schema, @peac/crypto, @peac/protocol instead",
   "type": "module",
   "homepage": "https://www.peacprotocol.org",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/crypto",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Ed25519 JWS signing and verification for PEAC protocol",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/disc",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "PEAC discovery with ≤20 lines enforcement",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/http-signatures/package.json
+++ b/packages/http-signatures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/http-signatures",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "RFC 9421 HTTP Message Signatures parsing and verification",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/intelligence/package.json
+++ b/packages/intelligence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/intelligence",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "private": true,
   "description": "PEAC intelligence pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/jwks-cache/package.json
+++ b/packages/jwks-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/jwks-cache",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Edge-safe JWKS fetch and cache with SSRF protection",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/kernel",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "PEAC protocol kernel - normative constants, errors, and registries",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/kernel/src/error-categories.generated.ts
+++ b/packages/kernel/src/error-categories.generated.ts
@@ -3,7 +3,7 @@
  *
  * AUTO-GENERATED from specs/kernel/errors.json
  * DO NOT EDIT MANUALLY - run: npx tsx scripts/codegen-errors.ts
- * Spec version: 0.12.3
+ * Spec version: 0.12.4
  */
 
 /**

--- a/packages/kernel/src/errors.generated.ts
+++ b/packages/kernel/src/errors.generated.ts
@@ -3,7 +3,7 @@
  *
  * AUTO-GENERATED from specs/kernel/errors.json
  * DO NOT EDIT MANUALLY - run: npx tsx scripts/codegen-errors.ts
- * Spec version: 0.12.3
+ * Spec version: 0.12.4
  */
 
 import type { ErrorDefinition } from './types.js';

--- a/packages/mappings/a2a/package.json
+++ b/packages/mappings/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-a2a",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Agent-to-Agent Protocol (A2A) integration for PEAC",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/mappings/acp/package.json
+++ b/packages/mappings/acp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-acp",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Agentic Commerce Protocol (ACP) integration for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/aipref/package.json
+++ b/packages/mappings/aipref/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-aipref",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "IETF AIPREF vocabulary mapping for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/content-signals/package.json
+++ b/packages/mappings/content-signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-content-signals",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Content use policy signal parsing for PEAC (robots.txt, tdmrep.json, Content-Usage)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/mappings/mcp/package.json
+++ b/packages/mappings/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-mcp",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Model Context Protocol (MCP) integration for PEAC",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/mappings/paymentauth/package.json
+++ b/packages/mappings/paymentauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-paymentauth",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "HTTP Payment authentication scheme (paymentauth/MPP) mapping for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/rsl/package.json
+++ b/packages/mappings/rsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-rsl",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "RSL (Robots Specification Layer) mapping for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/tap/package.json
+++ b/packages/mappings/tap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-tap",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Visa Trusted Agent Protocol mapping to PEAC control evidence",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mappings/ucp/package.json
+++ b/packages/mappings/ucp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-ucp",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Google Universal Commerce Protocol (UCP) mapping to PEAC receipts and dispute evidence",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp-server/manifest.json
+++ b/packages/mcp-server/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "peac-mcp-server",
   "display_name": "PEAC Protocol",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Verify, inspect, decode, issue, and bundle PEAC receipts. Portable, offline-verifiable evidence for AI agent interactions.",
   "long_description": "PEAC Protocol provides cryptographically signed, offline-verifiable receipts that record what happened during automated interactions. Each receipt is a compact JWS (JSON Web Signature) using Ed25519 signatures. This MCP server exposes 5 tools for receipt operations: verify (signature + claims), inspect (metadata without verification), decode (raw JWS structure), issue (sign new receipts), and create_bundle (portable evidence directories).",
   "author": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mcp-server",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "PEAC receipt operations as MCP tools (verify, inspect, decode, issue, bundle)",
   "mcpName": "io.github.peacprotocol/peac",
   "main": "dist/index.cjs",

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "subfolder": "packages/mcp-server"
   },
-  "version": "0.12.3",
+  "version": "0.12.4",
   "websiteUrl": "https://www.peacprotocol.org",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@peac/mcp-server",
-      "version": "0.12.3",
+      "version": "0.12.4",
       "transport": {
         "type": "stdio"
       }

--- a/packages/mcp-server/src/infra/constants.ts
+++ b/packages/mcp-server/src/infra/constants.ts
@@ -3,7 +3,7 @@
  */
 
 export const SERVER_NAME = 'peac-mcp-server';
-export const SERVER_VERSION = '0.11.2';
+export const SERVER_VERSION = '0.12.4';
 export const MCP_PROTOCOL_VERSION = '2025-11-25';
 export const DEFAULT_MAX_JWS_BYTES = 16_384; // 16 KB
 export const DEFAULT_MAX_RESPONSE_BYTES = 65_536; // 64 KB

--- a/packages/mcp-server/tests/infra/constants.test.ts
+++ b/packages/mcp-server/tests/infra/constants.test.ts
@@ -14,7 +14,9 @@ describe('infra/constants', () => {
   });
 
   it('exports version matching package.json', () => {
-    expect(SERVER_VERSION).toBe('0.11.2');
+    // Dynamic: read from package.json so version bumps don't break this test
+    const pkg = require('../../package.json');
+    expect(SERVER_VERSION).toBe(pkg.version);
   });
 
   it('exports MCP protocol version', () => {

--- a/packages/middleware-core/package.json
+++ b/packages/middleware-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/middleware-core",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Framework-agnostic middleware primitives for PEAC receipt issuance",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/middleware-express/package.json
+++ b/packages/middleware-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/middleware-express",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Express.js middleware for automatic PEAC receipt issuance",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/net/node/package.json
+++ b/packages/net/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/net-node",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "SSRF-safe network utilities for PEAC Protocol with DNS resolution pinning (Node.js only)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/pay402/package.json
+++ b/packages/pay402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/pay402",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Generic HTTP 402 adapter with multi-rail payment negotiation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/policy-kit/package.json
+++ b/packages/policy-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/policy-kit",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "PEAC Policy Kit - deterministic policy evaluation for CAL semantics",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/privacy/package.json
+++ b/packages/privacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/privacy",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "private": true,
   "description": "Privacy pillar for PEAC protocol - k-anonymity, privacy-preserving hashing, data protection",
   "main": "dist/index.js",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/protocol",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "PEAC protocol implementation - receipt issuance and verification",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/provenance/package.json
+++ b/packages/provenance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/provenance",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "private": true,
   "description": "Provenance pillar for PEAC protocol - content provenance, C2PA integration, and chain-of-custody",
   "main": "dist/index.js",

--- a/packages/rails/card/package.json
+++ b/packages/rails/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-card",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Card payment rail adapter for PEAC protocol (Flowglad, Stripe Billing, Lago)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rails/razorpay/package.json
+++ b/packages/rails/razorpay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-razorpay",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "private": true,
   "description": "Razorpay payment rail adapter for PEAC protocol (UPI, cards, netbanking)",
   "main": "dist/index.js",

--- a/packages/rails/stripe/package.json
+++ b/packages/rails/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-stripe",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Stripe payment rail adapter for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rails/x402/package.json
+++ b/packages/rails/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-x402",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "x402 payment rail adapter for PEAC protocol",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/receipts/package.json
+++ b/packages/receipts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/receipts",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "PEAC Protocol receipt builders, parsers, and validators with CBOR support",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/schema",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "PEAC Protocol JSON schemas, OpenAPI specs, and TypeScript types",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/sdk",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "PEAC client SDK with discover/verify functions",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/server",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "PEAC verification server with DoS protection and rate limiting",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry-otel/package.json
+++ b/packages/telemetry-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/telemetry-otel",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "OpenTelemetry adapter for PEAC telemetry",
   "keywords": [
     "peac",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/telemetry",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Telemetry interfaces and no-op implementation for PEAC protocol",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/transport/grpc/package.json
+++ b/packages/transport/grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-grpc",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "private": true,
   "description": "PEAC gRPC transport layer with HTTP StatusCode parity",
   "type": "module",

--- a/packages/transport/http/package.json
+++ b/packages/transport/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-http",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "private": true,
   "description": "PEAC HTTP transport layer - headers, middleware, DPoP L3/L4",
   "type": "module",

--- a/packages/transport/ws/package.json
+++ b/packages/transport/ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-ws",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "private": true,
   "description": "PEAC WebSocket transport layer (placeholder for v0.9.17+)",
   "type": "module",

--- a/packages/worker-core/package.json
+++ b/packages/worker-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-core",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Runtime-neutral TAP verification handler for edge workers",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/worker-shared/package.json
+++ b/packages/worker-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-shared",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "private": true,
   "description": "Shared runtime-neutral TAP verification logic for edge worker surfaces",
   "type": "module",

--- a/scripts/publish-manifest.json
+++ b/scripts/publish-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Single source of truth for PEAC Protocol npm publish order",
-  "version": "0.12.3",
-  "lastUpdated": "2026-03-17",
+  "version": "0.12.4",
+  "lastUpdated": "2026-03-25",
   "totalPackages": 29,
   "packages": [
     "@peac/kernel",

--- a/specs/conformance/fixtures/inventory.json
+++ b/specs/conformance/fixtures/inventory.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://www.peacprotocol.org/schemas/conformance/inventory.schema.json",
-  "generated_at": "2026-03-17T06:47:42.100Z",
-  "version": "0.12.3",
-  "schema_version": "0.12.3",
+  "generated_at": "2026-03-25T05:56:24.249Z",
+  "version": "0.12.4",
+  "schema_version": "0.12.4",
   "total_fixtures": 688,
   "total_with_requirements": 243,
   "total_unmapped": 445,

--- a/specs/kernel/error-categories.json
+++ b/specs/kernel/error-categories.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.peacprotocol.org/schemas/kernel/error-categories.schema.json",
   "$comment": "AUTO-GENERATED from specs/kernel/errors.json - DO NOT EDIT MANUALLY",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "source_file": "specs/kernel/errors.json",
   "categories": [
     "attribution",

--- a/specs/kernel/errors.json
+++ b/specs/kernel/errors.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "PEAC error codes - normative source of truth",
   "errors": [
     {


### PR DESCRIPTION
## Summary

Release preparation for v0.12.4: Commerce Evidence + Integration Depth.

This release hardens PEAC as the evidence layer across paymentauth, ACP, Stripe SPT, UCP, and x402. It does not expand PEAC into a payment or checkout protocol.

## Version Bumps

- All packages (80 files): 0.12.3 -> 0.12.4
- MCP server `SERVER_VERSION`: 0.11.2 -> 0.12.4
- Release manifest: 0.12.4, lastUpdated 2026-03-25
- server.json, manifest.json: version 0.12.4
- errors.json: version 0.12.4
- Conformance inventory regenerated
- MCP server constants test: dynamic version from package.json (no more hardcoded)

## Public Docs Updated

- README.md: added paymentauth/MPP and Stripe SPT to "Where it fits" table and "Common use cases"; added paymentauth/ACP/x402 kit links to "Start here"
- docs/README_LONG.md: added commerce evidence integrations table (v0.12.4+) covering five commerce surfaces
- docs/START_HERE.md: expanded "x402 and payment proofs" to "Commerce and payment evidence" covering five commerce integrations

## Design Decisions Shipped

- DD-187: UCP order-vs-payment semantic separation
- DD-188: ACP session lifecycle evidence
- DD-190: paymentauth rail registration
- DD-191: @peac/mappings-paymentauth
- DD-192: experimental commerce evidence bundle
- DD-193: x402 v2 dual-header read compatibility

## Release Facts (from main)

- 6664 tests passing (260 test files)
- 361 conformance tests passing (21 cross-boundary commerce)
- 91 build targets
- 29 packages in publish manifest
- 6 commerce examples passing via `verify:examples-commerce`
- Release gate: core typecheck, build, lint, test, conformance, codegen-drift, registries-schema, guard, examples-commerce all green. Legacy typecheck remains advisory (pre-existing import.meta issues).