### PR TITLE
test(conformance): add execution-backed commerce rail coverage and version pins

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ci:all": "pnpm run ci:guards && pnpm run ci:surface && pnpm run lint && pnpm run check:unicode && pnpm run typecheck && pnpm test",
     "examples:check": "pnpm --filter './examples/*' exec tsc --noEmit",
     "verify:examples-commerce": "pnpm --filter @peac/example-paymentauth-evidence build && pnpm --filter @peac/example-paymentauth-jsonrpc build && pnpm --filter @peac/example-acp-session-lifecycle build && pnpm --filter @peac/example-stripe-spt-evidence build && pnpm --filter @peac/example-commerce-evidence-bundle build && pnpm --filter @peac/example-x402-dual-header-read build && pnpm --filter @peac/example-paymentauth-evidence demo && pnpm --filter @peac/example-paymentauth-jsonrpc demo && pnpm --filter @peac/example-acp-session-lifecycle demo && pnpm --filter @peac/example-stripe-spt-evidence demo && pnpm --filter @peac/example-commerce-evidence-bundle demo && pnpm --filter @peac/example-x402-dual-header-read demo",
+    "verify:commerce-coverage": "node scripts/conformance/check-commerce-coverage.mjs",
     "verify:protocol-strings": "node scripts/verify-protocol-strings.mjs",
     "verify:spec-drift": "node scripts/verify-spec-drift.mjs",
     "verify:bundle-drift": "node scripts/verify-bundle-drift.mjs",

--- a/scripts/conformance/check-commerce-coverage.mjs
+++ b/scripts/conformance/check-commerce-coverage.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+/**
+ * Commerce conformance coverage gate.
+ *
+ * Validates that each commerce rail with a conformance fixture manifest
+ * meets the minimum vector floor (10 vectors: 3 valid, 4 invalid, 2 edge,
+ * 1 security).
+ *
+ * Rail list derived from specs/kernel/registries.json (canonical source).
+ * Fixture manifests discovered from specs/conformance/fixtures/<rail>/manifest.json.
+ *
+ * Exit 0: all manifested rails meet the floor
+ * Exit 1: coverage gap found
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..', '..');
+const FIXTURES_ROOT = join(ROOT, 'specs', 'conformance', 'fixtures');
+
+// ---------------------------------------------------------------------------
+// Coverage floor (minimum vectors per category)
+// ---------------------------------------------------------------------------
+const FLOOR = {
+  valid: 3,
+  invalid: 4,
+  edge: 2,
+  security: 1,
+};
+const FLOOR_TOTAL = Object.values(FLOOR).reduce((a, b) => a + b, 0);
+
+// ---------------------------------------------------------------------------
+// Load registered commerce rails from canonical registry
+// ---------------------------------------------------------------------------
+const registries = JSON.parse(readFileSync(join(ROOT, 'specs/kernel/registries.json'), 'utf-8'));
+
+// Collect rails from payment_rails and commerce-category agent_protocols
+const registeredRails = new Set();
+
+for (const rail of registries.payment_rails) {
+  registeredRails.add(rail.id);
+}
+
+for (const proto of registries.agent_protocols) {
+  if (proto.category === 'commerce-protocol') {
+    registeredRails.add(proto.id);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Discover and validate manifested rails
+// ---------------------------------------------------------------------------
+let bad = 0;
+const manifested = [];
+const unmanifested = [];
+
+for (const railId of [...registeredRails].sort()) {
+  const manifestPath = join(FIXTURES_ROOT, railId, 'manifest.json');
+
+  if (!existsSync(manifestPath)) {
+    unmanifested.push(railId);
+    continue;
+  }
+
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+  const categories = manifest.categories || {};
+
+  // Category alias mapping: manifest category names -> floor bucket
+  const CATEGORY_ALIASES = {
+    valid: 'valid',
+    invalid: 'invalid',
+    edge: 'edge',
+    'edge-cases': 'edge',
+    security: 'security',
+  };
+
+  const counts = { valid: 0, invalid: 0, edge: 0, security: 0 };
+  let total = 0;
+  const missing = [];
+
+  // Count vectors from all manifest categories, mapping to floor buckets
+  for (const [manifestCat, catDef] of Object.entries(categories)) {
+    const vectors = catDef?.vectors || [];
+    const bucket = CATEGORY_ALIASES[manifestCat];
+
+    for (const vecFile of vectors) {
+      const vecPath = join(FIXTURES_ROOT, railId, vecFile);
+      if (!existsSync(vecPath)) {
+        console.error(`  MISSING FILE: ${railId}/${vecFile}`);
+        bad = 1;
+      }
+      total++;
+    }
+
+    if (bucket && counts[bucket] !== undefined) {
+      counts[bucket] += vectors.length;
+    }
+    // Categories not in CATEGORY_ALIASES (e.g., "consistency") count
+    // toward total but not toward any specific floor bucket
+  }
+
+  for (const [cat, floor] of Object.entries(FLOOR)) {
+    if ((counts[cat] || 0) < floor) {
+      missing.push(`${cat}: ${counts[cat] || 0}/${floor}`);
+    }
+  }
+
+  // Eligibility contract:
+  // - Manifests with `commerce_rail` (v0.12.5+): enforce per-category floor.
+  //   These are rails with dedicated PEAC mapping packages and execution-backed
+  //   conformance vectors.
+  // - Legacy manifests without `commerce_rail` (e.g., x402 v0.12.3): enforce
+  //   total vector count only. These predate the per-category floor and use
+  //   different category naming (e.g., "edge-cases", "consistency").
+  //   Planned: migrate x402 manifest to commerce_rail format in v0.12.6.
+  const enforceFloor = !!manifest.commerce_rail;
+  const statusLabel = enforceFloor ? '' : ' (legacy)';
+  const status = enforceFloor
+    ? missing.length === 0
+      ? 'PASS'
+      : 'FAIL'
+    : total >= FLOOR_TOTAL
+      ? 'PASS'
+      : 'FAIL';
+  if (status === 'FAIL') bad = 1;
+
+  manifested.push({
+    rail: railId,
+    status,
+    statusLabel,
+    total,
+    counts,
+    missing,
+    specRevision: manifest.spec_revision || null,
+    intentSpecRevision: manifest.intent_spec_revision || null,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+console.log(`Commerce Conformance Coverage Gate`);
+console.log(
+  `  Floor: ${FLOOR_TOTAL} vectors (${Object.entries(FLOOR)
+    .map(([k, v]) => `${v} ${k}`)
+    .join(', ')})`
+);
+console.log(`  Registered rails: ${registeredRails.size}`);
+console.log(`  Manifested rails: ${manifested.length}`);
+console.log(`  Unmanifested rails: ${unmanifested.length}`);
+console.log('');
+
+for (const entry of manifested) {
+  const specInfo = entry.specRevision ? ` [${entry.specRevision}]` : '';
+  const intentInfo = entry.intentSpecRevision ? ` [intent: ${entry.intentSpecRevision}]` : '';
+  console.log(
+    `  ${entry.status}${entry.statusLabel} ${entry.rail} (${entry.total} vectors)${specInfo}${intentInfo}`
+  );
+  if (entry.missing.length > 0) {
+    for (const m of entry.missing) {
+      console.error(`    below floor: ${m}`);
+    }
+  }
+}
+
+if (unmanifested.length > 0) {
+  console.log('');
+  console.log('  Unmanifested (informational, no fixture directory):');
+  for (const rail of unmanifested) {
+    console.log(`    - ${rail}`);
+  }
+}
+
+console.log('');
+if (bad === 0) {
+  console.log('OK: all manifested commerce rails meet coverage floor.');
+} else {
+  console.error('FAIL: one or more rails below coverage floor or missing vector files.');
+}
+
+process.exit(bad);

--- a/scripts/gate.sh
+++ b/scripts/gate.sh
@@ -81,6 +81,9 @@ else
   run_check "prod audit" node scripts/audit-gate.mjs
 fi
 
+# --- Commerce conformance coverage ---
+run_check "commerce coverage" node scripts/conformance/check-commerce-coverage.mjs
+
 # --- Planning leak (local-only script; skipped on fresh clones/CI) ---
 if [ -f scripts/check-planning-leak.sh ]; then
   run_check "planning leak" bash scripts/check-planning-leak.sh

--- a/specs/conformance/category-tracking.json
+++ b/specs/conformance/category-tracking.json
@@ -2,6 +2,7 @@
   "$comment": "Category tracking registry for conformance fixture directories. Keep arrays sorted alphabetically. Version consistency is enforced only for tracked categories.",
   "tracked": ["attribution", "content-usage", "interaction", "wire-02"],
   "untracked": {
+    "acp": "Per-directory manifest; commerce rail coverage validated by check-commerce-coverage.mjs",
     "agent-identity": "Fixtures span multiple releases (v0.9.25 + v0.11.3 DD-142); version consistency not enforced",
     "bundle": "Not yet migrated to tracked validation; fixture_count needs reconciliation",
     "carrier": "Single-carrier fixtures with per-file expected_valid/expected_violation; not fixture packs",
@@ -20,8 +21,10 @@
     "paymentauth": "Paymentauth evidence mapping fixtures (DD-191); receipt mapping and challenge parse vectors",
     "policy": "Not yet migrated to tracked validation; needs fixture pack audit",
     "purpose": "Legacy category; no fixture_count tracking",
+    "stripe": "Per-directory manifest; commerce rail coverage validated by check-commerce-coverage.mjs",
     "stripe-crypto": "Per-category manifest; uses profile-scoped manifest.json, not global fixture_count",
     "treaty": "Treaty extension fixtures (DD-147); single fixture pack",
+    "ucp": "Per-directory manifest; commerce rail coverage validated by check-commerce-coverage.mjs",
     "valid": "Single-receipt fixtures, not fixture packs",
     "verifier": "Fixtures span multiple releases (v0.10.8 + v0.10.10 DD-49); version consistency not enforced",
     "workflow": "Not yet migrated to tracked validation; fixture_count needs reconciliation",

--- a/specs/conformance/fixtures/acp/edge-completed-no-payment.json
+++ b/specs/conformance/fixtures/acp/edge-completed-no-payment.json
@@ -1,0 +1,22 @@
+{
+  "id": "acp-edge-completed-no-payment",
+  "description": "Completed session without payment artifact: access evidence only, no commerce event",
+  "category": "edge",
+  "input": {
+    "type": "session_lifecycle",
+    "event": {
+      "session_id": "sess_edge_01",
+      "state": "completed",
+      "resource_uri": "https://shop.example.com/free-trial"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "rail": "acp",
+    "amt": 0,
+    "cur": "NONE",
+    "has_commerce_event": false,
+    "has_observed_payment_state": false
+  },
+  "notes": "An ACP session 'completed' does not prove payment settlement. This is the asymmetric safety boundary: session lifecycle must not emit settlement-like commerce events."
+}

--- a/specs/conformance/fixtures/acp/edge-payment-authorized.json
+++ b/specs/conformance/fixtures/acp/edge-payment-authorized.json
@@ -1,0 +1,29 @@
+{
+  "id": "acp-edge-payment-authorized",
+  "description": "Payment artifact with authorized state produces authorization event",
+  "category": "edge",
+  "input": {
+    "type": "payment_observation",
+    "event": {
+      "session_id": "sess_edge_02",
+      "state": "in_progress",
+      "resource_uri": "https://shop.example.com/checkout/edge"
+    },
+    "payment_artifact": {
+      "rail": "stripe",
+      "reference": "pi_edge_02",
+      "amount": 3000,
+      "currency": "EUR",
+      "observed_payment_state": "authorized"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "rail": "stripe",
+    "amt": 3000,
+    "has_commerce_event": true,
+    "commerce_event": "authorization",
+    "observed_payment_state": "authorized"
+  },
+  "notes": "Authorization is a valid commerce event when explicitly observed. Session state (in_progress) does not gate the payment observation."
+}

--- a/specs/conformance/fixtures/acp/invalid-missing-resource-uri.json
+++ b/specs/conformance/fixtures/acp/invalid-missing-resource-uri.json
@@ -1,0 +1,17 @@
+{
+  "id": "acp-invalid-missing-resource-uri",
+  "description": "Session event without resource_uri is rejected",
+  "category": "invalid",
+  "input": {
+    "type": "session_lifecycle",
+    "event": {
+      "session_id": "sess_conf_06",
+      "state": "completed"
+    }
+  },
+  "expected": {
+    "valid": false,
+    "error_reason": "missing_resource_uri"
+  },
+  "notes": "resource_uri is required to identify the commerce context."
+}

--- a/specs/conformance/fixtures/acp/invalid-missing-session-id.json
+++ b/specs/conformance/fixtures/acp/invalid-missing-session-id.json
@@ -1,0 +1,17 @@
+{
+  "id": "acp-invalid-missing-session-id",
+  "description": "Session event without session_id is rejected",
+  "category": "invalid",
+  "input": {
+    "type": "session_lifecycle",
+    "event": {
+      "state": "completed",
+      "resource_uri": "https://shop.example.com/checkout/missing"
+    }
+  },
+  "expected": {
+    "valid": false,
+    "error_reason": "missing_session_id"
+  },
+  "notes": "session_id is required for all ACP session lifecycle events."
+}

--- a/specs/conformance/fixtures/acp/invalid-payment-missing-rail.json
+++ b/specs/conformance/fixtures/acp/invalid-payment-missing-rail.json
@@ -1,0 +1,24 @@
+{
+  "id": "acp-invalid-payment-missing-rail",
+  "description": "Payment artifact without rail field is rejected",
+  "category": "invalid",
+  "input": {
+    "type": "payment_observation",
+    "event": {
+      "session_id": "sess_conf_04",
+      "state": "completed",
+      "resource_uri": "https://shop.example.com/checkout/04"
+    },
+    "payment_artifact": {
+      "reference": "pi_conf_04",
+      "amount": 1000,
+      "currency": "USD",
+      "observed_payment_state": "settled"
+    }
+  },
+  "expected": {
+    "valid": false,
+    "error_reason": "missing_rail"
+  },
+  "notes": "Payment artifact must declare which rail the payment was observed on."
+}

--- a/specs/conformance/fixtures/acp/invalid-payment-missing-reference.json
+++ b/specs/conformance/fixtures/acp/invalid-payment-missing-reference.json
@@ -1,0 +1,24 @@
+{
+  "id": "acp-invalid-payment-missing-reference",
+  "description": "Payment artifact without reference field is rejected",
+  "category": "invalid",
+  "input": {
+    "type": "payment_observation",
+    "event": {
+      "session_id": "sess_conf_05",
+      "state": "completed",
+      "resource_uri": "https://shop.example.com/checkout/05"
+    },
+    "payment_artifact": {
+      "rail": "stripe",
+      "amount": 500,
+      "currency": "USD",
+      "observed_payment_state": "settled"
+    }
+  },
+  "expected": {
+    "valid": false,
+    "throws": true
+  },
+  "notes": "Payment artifact must declare reference to identify the upstream payment."
+}

--- a/specs/conformance/fixtures/acp/manifest.json
+++ b/specs/conformance/fixtures/acp/manifest.json
@@ -1,0 +1,40 @@
+{
+  "name": "acp",
+  "version": "0.12.5",
+  "description": "Conformance vectors for @peac/mappings-acp: Agentic Commerce Protocol session lifecycle and payment observation evidence mapping",
+  "commerce_rail": "acp",
+  "categories": {
+    "valid": {
+      "description": "Valid session lifecycle and payment observation scenarios",
+      "vectors": [
+        "valid-session-completed.json",
+        "valid-payment-settled.json",
+        "valid-session-created.json"
+      ]
+    },
+    "invalid": {
+      "description": "Invalid inputs that must be rejected",
+      "vectors": [
+        "invalid-missing-session-id.json",
+        "invalid-payment-missing-rail.json",
+        "invalid-payment-missing-reference.json",
+        "invalid-missing-resource-uri.json"
+      ]
+    },
+    "edge": {
+      "description": "Boundary conditions between access and commerce evidence",
+      "vectors": ["edge-completed-no-payment.json", "edge-payment-authorized.json"]
+    },
+    "security": {
+      "description": "Security boundary enforcement",
+      "vectors": ["security-xss-resource-uri.json"]
+    }
+  },
+  "invariants": [
+    "Session lifecycle events produce access evidence only; commerce evidence requires explicit payment artifact",
+    "ACP session 'completed' does not prove payment settlement",
+    "Payment artifact must declare rail, reference, amount, currency, and observed_payment_state",
+    "observed_payment_state maps to commerce.event per the ACP payment state vocabulary",
+    "No implicit fetch from resource_uri (SSRF-hardened)"
+  ]
+}

--- a/specs/conformance/fixtures/acp/security-xss-resource-uri.json
+++ b/specs/conformance/fixtures/acp/security-xss-resource-uri.json
@@ -1,0 +1,18 @@
+{
+  "id": "acp-security-xss-resource-uri",
+  "description": "Resource URI with script injection attempt is preserved as-is but not executed",
+  "category": "security",
+  "input": {
+    "type": "session_lifecycle",
+    "event": {
+      "session_id": "sess_sec_01",
+      "state": "completed",
+      "resource_uri": "https://shop.example.com/<script>alert(1)</script>"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "resource_uri_preserved": true
+  },
+  "notes": "PEAC is an evidence layer: it records what happened. URI is stored as-is. Consumers must sanitize for display contexts. No implicit fetch (SSRF-hardened)."
+}

--- a/specs/conformance/fixtures/acp/valid-payment-settled.json
+++ b/specs/conformance/fixtures/acp/valid-payment-settled.json
@@ -1,0 +1,30 @@
+{
+  "id": "acp-valid-payment-settled",
+  "description": "ACP session with explicit payment artifact produces commerce evidence",
+  "category": "valid",
+  "input": {
+    "type": "payment_observation",
+    "event": {
+      "session_id": "sess_conf_02",
+      "state": "completed",
+      "resource_uri": "https://shop.example.com/checkout/02"
+    },
+    "payment_artifact": {
+      "rail": "stripe",
+      "reference": "pi_conf_02",
+      "amount": 2500,
+      "currency": "USD",
+      "observed_payment_state": "settled"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "rail": "stripe",
+    "amt": 2500,
+    "cur": "USD",
+    "has_commerce_event": true,
+    "commerce_event": "settlement",
+    "observed_payment_state": "settled"
+  },
+  "notes": "Explicit payment artifact with settled state produces commerce evidence with settlement event."
+}

--- a/specs/conformance/fixtures/acp/valid-session-completed.json
+++ b/specs/conformance/fixtures/acp/valid-session-completed.json
@@ -1,0 +1,21 @@
+{
+  "id": "acp-valid-session-completed",
+  "description": "Completed ACP session maps to access evidence without commerce event",
+  "category": "valid",
+  "input": {
+    "type": "session_lifecycle",
+    "event": {
+      "session_id": "sess_conf_01",
+      "state": "completed",
+      "resource_uri": "https://shop.example.com/checkout/01"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "rail": "acp",
+    "amt": 0,
+    "cur": "NONE",
+    "has_commerce_event": false
+  },
+  "notes": "Completed session without payment artifact is access evidence only. No commerce event emitted."
+}

--- a/specs/conformance/fixtures/acp/valid-session-created.json
+++ b/specs/conformance/fixtures/acp/valid-session-created.json
@@ -1,0 +1,21 @@
+{
+  "id": "acp-valid-session-created",
+  "description": "Created ACP session maps to access evidence",
+  "category": "valid",
+  "input": {
+    "type": "session_lifecycle",
+    "event": {
+      "session_id": "sess_conf_03",
+      "state": "created",
+      "resource_uri": "https://shop.example.com/checkout/03"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "rail": "acp",
+    "amt": 0,
+    "cur": "NONE",
+    "has_commerce_event": false
+  },
+  "notes": "Session creation is a lifecycle event. No payment observation."
+}

--- a/specs/conformance/fixtures/paymentauth/edge-receipt-extra-fields.json
+++ b/specs/conformance/fixtures/paymentauth/edge-receipt-extra-fields.json
@@ -1,0 +1,17 @@
+{
+  "id": "paymentauth-edge-receipt-extra-fields",
+  "description": "Receipt with unknown fields collected in extras",
+  "category": "edge",
+  "input": {
+    "type": "receipt_normalize",
+    "header": "eyJzdGF0dXMiOiJzdWNjZXNzIiwibWV0aG9kIjoiZXhhbXBsZSIsInRpbWVzdGFtcCI6IjIwMjUtMDEtMTVUMTI6MDA6MDBaIiwiY3VzdG9tX2ZpZWxkIjoiY3VzdG9tX3ZhbHVlIiwiZGV0YWlscyI6eyJuZXN0ZWQiOnRydWV9fQ"
+  },
+  "expected": {
+    "valid": true,
+    "status": "success",
+    "method": "example",
+    "has_extras": true,
+    "extra_keys": ["custom_field", "details"]
+  },
+  "notes": "Unknown receipt fields go into extras map. Proves forward-compatibility with method-specific extensions."
+}

--- a/specs/conformance/fixtures/paymentauth/edge-unknown-method.json
+++ b/specs/conformance/fixtures/paymentauth/edge-unknown-method.json
@@ -1,0 +1,15 @@
+{
+  "id": "paymentauth-edge-unknown-method",
+  "description": "Challenge with unrecognized payment method parses successfully",
+  "category": "edge",
+  "input": {
+    "type": "challenge",
+    "header": "Payment id=\"edge_method\", realm=\"api.example.com\", method=\"future-crypto-v9\", intent=\"charge\", request=\"eyJhbW91bnQiOiIxMDAwIn0\""
+  },
+  "expected": {
+    "valid": true,
+    "method": "future-crypto-v9",
+    "intent": "charge"
+  },
+  "notes": "Envelope-first design: parser accepts any method string. Method-specific payloads are typed unknown."
+}

--- a/specs/conformance/fixtures/paymentauth/invalid-missing-challenge-id.json
+++ b/specs/conformance/fixtures/paymentauth/invalid-missing-challenge-id.json
@@ -1,0 +1,14 @@
+{
+  "id": "paymentauth-invalid-missing-challenge-id",
+  "description": "Challenge header missing required id parameter",
+  "category": "invalid",
+  "input": {
+    "type": "challenge",
+    "header": "Payment realm=\"api.example.com\", method=\"example\", intent=\"charge\", request=\"eyJhbW91bnQiOiIxMDAwIn0\""
+  },
+  "expected": {
+    "valid": false,
+    "error_code": "NORMALIZE_MISSING_FIELD"
+  },
+  "notes": "The id param is required per draft-ryan-httpauth-payment-01 Section 5.1."
+}

--- a/specs/conformance/fixtures/paymentauth/invalid-missing-scheme.json
+++ b/specs/conformance/fixtures/paymentauth/invalid-missing-scheme.json
@@ -1,0 +1,14 @@
+{
+  "id": "paymentauth-invalid-missing-scheme",
+  "description": "Credential header without Payment scheme prefix",
+  "category": "invalid",
+  "input": {
+    "type": "credential",
+    "header": "Bearer eyJhbGciOiJIUzI1NiJ9"
+  },
+  "expected": {
+    "valid": false,
+    "error_code": "PARSE_MISSING_SCHEME"
+  },
+  "notes": "Authorization header must start with 'Payment ' prefix (case-insensitive)."
+}

--- a/specs/conformance/fixtures/paymentauth/invalid-receipt-not-json.json
+++ b/specs/conformance/fixtures/paymentauth/invalid-receipt-not-json.json
@@ -1,0 +1,14 @@
+{
+  "id": "paymentauth-invalid-receipt-not-json",
+  "description": "Receipt decodes to non-JSON content",
+  "category": "invalid",
+  "input": {
+    "type": "receipt_normalize",
+    "header": "bm90LWpzb24tdGV4dA"
+  },
+  "expected": {
+    "valid": false,
+    "error_code": "NORMALIZE_MISSING_FIELD"
+  },
+  "notes": "Decoded receipt is 'not-json-text'. Normalization requires object-shaped JSON."
+}

--- a/specs/conformance/fixtures/paymentauth/invalid-truncated-base64.json
+++ b/specs/conformance/fixtures/paymentauth/invalid-truncated-base64.json
@@ -1,0 +1,14 @@
+{
+  "id": "paymentauth-invalid-truncated-base64",
+  "description": "Credential with corrupted base64url payload",
+  "category": "invalid",
+  "input": {
+    "type": "credential",
+    "header": "Payment !!!not-valid-base64url!!!"
+  },
+  "expected": {
+    "valid": false,
+    "error_code": "PARSE_INVALID_BASE64URL"
+  },
+  "notes": "Base64url must contain only [A-Za-z0-9_-] characters per RFC 4648 Section 5."
+}

--- a/specs/conformance/fixtures/paymentauth/manifest.json
+++ b/specs/conformance/fixtures/paymentauth/manifest.json
@@ -1,0 +1,42 @@
+{
+  "name": "paymentauth",
+  "version": "0.12.5",
+  "description": "Conformance vectors for @peac/mappings-paymentauth: envelope-first header parsing, normalization, and evidence mapping per draft-ryan-httpauth-payment-01",
+  "commerce_rail": "paymentauth",
+  "spec_revision": "draft-ryan-httpauth-payment-01",
+  "intent_spec_revision": "draft-ryan-payment-intents-charge-00 (provisional; not publicly listed on datatracker.ietf.org as of 2026-03-27)",
+  "categories": {
+    "valid": {
+      "description": "Valid parsing and mapping scenarios",
+      "vectors": [
+        "valid-receipt-mapping.json",
+        "valid-challenge-parse.json",
+        "valid-credential-parse.json"
+      ]
+    },
+    "invalid": {
+      "description": "Invalid inputs that must produce specific error codes",
+      "vectors": [
+        "invalid-missing-scheme.json",
+        "invalid-missing-challenge-id.json",
+        "invalid-truncated-base64.json",
+        "invalid-receipt-not-json.json"
+      ]
+    },
+    "edge": {
+      "description": "Edge cases and forward-compatibility scenarios",
+      "vectors": ["edge-unknown-method.json", "edge-receipt-extra-fields.json"]
+    },
+    "security": {
+      "description": "Security boundary enforcement",
+      "vectors": ["security-oversized-header.json"]
+    }
+  },
+  "invariants": [
+    "Raw header values MUST NOT appear in thrown errors or debug output",
+    "Parser limits enforced: header size (8 KiB), param count (32), payload size (64 KiB), JSON depth (10)",
+    "Decoded bytes preserved alongside strings for non-UTF-8 safety",
+    "Method-specific payloads typed as unknown; no eager interpretation",
+    "Envelope-first: challenge id, realm, method, intent, request are required; all else is optional"
+  ]
+}

--- a/specs/conformance/fixtures/paymentauth/security-oversized-header.json
+++ b/specs/conformance/fixtures/paymentauth/security-oversized-header.json
@@ -1,0 +1,15 @@
+{
+  "id": "paymentauth-security-oversized-header",
+  "description": "Header exceeding MAX_HEADER_BYTES (8192) is rejected",
+  "category": "security",
+  "input": {
+    "type": "challenge",
+    "construct": "oversized_header",
+    "min_bytes": 9000
+  },
+  "expected": {
+    "valid": false,
+    "error_code": "PARSE_HEADER_TOO_LARGE"
+  },
+  "notes": "MAX_HEADER_BYTES (8192) enforced at parse entry point. Test constructs header exceeding limit."
+}

--- a/specs/conformance/fixtures/paymentauth/valid-credential-parse.json
+++ b/specs/conformance/fixtures/paymentauth/valid-credential-parse.json
@@ -1,0 +1,16 @@
+{
+  "id": "paymentauth-valid-credential-parse",
+  "description": "Valid paymentauth credential parsed from Authorization header",
+  "category": "valid",
+  "input": {
+    "type": "credential",
+    "header": "Payment eyJjaGFsbGVuZ2UiOnsiaWQiOiJ4N1RnMnBMcVI5bUt2TndZM2hCY1phIiwibWV0aG9kIjoiZXhhbXBsZSIsImludGVudCI6ImNoYXJnZSJ9LCJwYXlsb2FkIjp7InRva2VuIjoiYWJjMTIzIn19"
+  },
+  "expected": {
+    "valid": true,
+    "challengeId": "x7Tg2pLqR9mKvNwY3hBcZa",
+    "method": "example",
+    "intent": "charge"
+  },
+  "notes": "Authorization: Payment <base64url> with JSON payload containing challenge envelope fields."
+}

--- a/specs/conformance/fixtures/stripe/edge-pi-processing.json
+++ b/specs/conformance/fixtures/stripe/edge-pi-processing.json
@@ -1,0 +1,17 @@
+{
+  "id": "stripe-edge-pi-processing",
+  "description": "PI observation with processing status produces no commerce event",
+  "category": "edge",
+  "input": {
+    "type": "pi_observation",
+    "data": {
+      "payment_intent_id": "pi_edge_02",
+      "status": "processing"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "has_commerce_event": false
+  },
+  "notes": "Processing is an intermediate state. No commerce event until terminal status (succeeded or requires_capture)."
+}

--- a/specs/conformance/fixtures/stripe/edge-spt-use-with-pi.json
+++ b/specs/conformance/fixtures/stripe/edge-spt-use-with-pi.json
@@ -1,0 +1,22 @@
+{
+  "id": "stripe-edge-spt-use-with-pi",
+  "description": "SPT use referencing a PaymentIntent does not upgrade to commerce event",
+  "category": "edge",
+  "input": {
+    "type": "spt_use",
+    "data": {
+      "id": "use_edge_01",
+      "token_id": "tok_edge_01",
+      "amount": "5000",
+      "currency": "usd",
+      "merchant_id": "merch_01",
+      "payment_intent_id": "pi_exists"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "has_commerce_event": false,
+    "spt_action": "delegated_payment_presented"
+  },
+  "notes": "SPT use is delegation evidence. The presence of payment_intent_id is a correlation hint, not a proof of settlement. Commerce events require explicit PI observation via fromStripePaymentIntentObservation()."
+}

--- a/specs/conformance/fixtures/stripe/invalid-pi-missing-id.json
+++ b/specs/conformance/fixtures/stripe/invalid-pi-missing-id.json
@@ -1,0 +1,21 @@
+{
+  "id": "stripe-invalid-pi-missing-id",
+  "description": "PI observation without payment_intent_id produces evidence with undefined reference",
+  "category": "invalid",
+  "input": {
+    "type": "pi_observation",
+    "data": {
+      "status": "succeeded",
+      "amount": "5000",
+      "currency": "usd"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "degraded": true,
+    "reference_undefined": true,
+    "has_commerce_event": true,
+    "commerce_event": "settlement"
+  },
+  "notes": "Stripe PI functions do not throw on missing fields. Missing payment_intent_id produces undefined reference but still maps commerce event from status."
+}

--- a/specs/conformance/fixtures/stripe/invalid-pi-unknown-status.json
+++ b/specs/conformance/fixtures/stripe/invalid-pi-unknown-status.json
@@ -1,0 +1,18 @@
+{
+  "id": "stripe-invalid-pi-unknown-status",
+  "description": "PI observation with unrecognized status produces no commerce event",
+  "category": "invalid",
+  "input": {
+    "type": "pi_observation",
+    "data": {
+      "payment_intent_id": "pi_inv_03",
+      "status": "requires_payment_method"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "degraded": true,
+    "has_commerce_event": false
+  },
+  "notes": "Stripe PI functions do not throw. Statuses other than succeeded and requires_capture produce no commerce event."
+}

--- a/specs/conformance/fixtures/stripe/invalid-spt-missing-token.json
+++ b/specs/conformance/fixtures/stripe/invalid-spt-missing-token.json
@@ -1,0 +1,20 @@
+{
+  "id": "stripe-invalid-spt-missing-token",
+  "description": "SPT grant without token_id produces evidence with undefined reference",
+  "category": "invalid",
+  "input": {
+    "type": "spt_grant",
+    "data": {
+      "id": "grant_inv_01",
+      "seller_scope": { "merchant_id": "merch_01" },
+      "amount_limit": "10000",
+      "currency": "usd"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "degraded": true,
+    "reference_undefined": true
+  },
+  "notes": "Stripe SPT functions do not throw on missing fields. Missing token_id produces undefined reference (downstream signing would fail)."
+}

--- a/specs/conformance/fixtures/stripe/invalid-spt-negative-amount.json
+++ b/specs/conformance/fixtures/stripe/invalid-spt-negative-amount.json
@@ -1,0 +1,21 @@
+{
+  "id": "stripe-invalid-spt-negative-amount",
+  "description": "SPT use with negative amount string falls back to zero",
+  "category": "invalid",
+  "input": {
+    "type": "spt_use",
+    "data": {
+      "id": "use_inv_01",
+      "token_id": "tok_inv_01",
+      "amount": "-500",
+      "currency": "usd",
+      "merchant_id": "merch_01"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "degraded": true,
+    "amount": 0
+  },
+  "notes": "Stripe SPT functions do not throw. Negative amount fails /^[0-9]+$/ regex and falls back to 0."
+}

--- a/specs/conformance/fixtures/stripe/manifest.json
+++ b/specs/conformance/fixtures/stripe/manifest.json
@@ -1,0 +1,40 @@
+{
+  "name": "stripe",
+  "version": "0.12.5",
+  "description": "Conformance vectors for @peac/rails-stripe: SPT delegation lifecycle and PaymentIntent observation evidence mapping",
+  "commerce_rail": "stripe",
+  "categories": {
+    "valid": {
+      "description": "Valid SPT and PaymentIntent observation scenarios",
+      "vectors": [
+        "valid-spt-grant.json",
+        "valid-pi-succeeded.json",
+        "valid-pi-requires-capture.json"
+      ]
+    },
+    "invalid": {
+      "description": "Invalid inputs that must be rejected",
+      "vectors": [
+        "invalid-spt-missing-token.json",
+        "invalid-pi-missing-id.json",
+        "invalid-spt-negative-amount.json",
+        "invalid-pi-unknown-status.json"
+      ]
+    },
+    "edge": {
+      "description": "Delegation vs commerce finality boundaries",
+      "vectors": ["edge-spt-use-with-pi.json", "edge-pi-processing.json"]
+    },
+    "security": {
+      "description": "Metadata sanitization enforcement",
+      "vectors": ["security-metadata-sanitization.json"]
+    }
+  },
+  "invariants": [
+    "SPT grant/use/deactivate produce delegation evidence only; no commerce event",
+    "Only fromStripePaymentIntentObservation() may emit commerce events",
+    "succeeded -> settlement; requires_capture -> authorization",
+    "processing and canceled produce observation metadata only (no commerce event)",
+    "Metadata policy (omit/passthrough/allowlist) enforced; sensitive keys filtered"
+  ]
+}

--- a/specs/conformance/fixtures/stripe/security-metadata-sanitization.json
+++ b/specs/conformance/fixtures/stripe/security-metadata-sanitization.json
@@ -1,0 +1,29 @@
+{
+  "id": "stripe-security-metadata-sanitization",
+  "description": "Metadata with sensitive keys is sanitized per metadata policy",
+  "category": "security",
+  "input": {
+    "type": "pi_observation",
+    "data": {
+      "payment_intent_id": "pi_sec_01",
+      "status": "succeeded",
+      "amount": "1000",
+      "currency": "usd",
+      "metadata": {
+        "customer_email": "secret@example.com",
+        "internal_ref": "private_123",
+        "order_id": "ord_public"
+      }
+    },
+    "options": {
+      "metadataPolicy": "allowlist",
+      "metadataAllowedKeys": ["order_id"]
+    }
+  },
+  "expected": {
+    "valid": true,
+    "metadata_keys_present": ["order_id"],
+    "metadata_keys_absent": ["customer_email", "internal_ref"]
+  },
+  "notes": "Metadata allowlist policy: only explicitly allowed keys pass through. Prevents PII leakage into evidence receipts."
+}

--- a/specs/conformance/fixtures/stripe/valid-pi-requires-capture.json
+++ b/specs/conformance/fixtures/stripe/valid-pi-requires-capture.json
@@ -1,0 +1,20 @@
+{
+  "id": "stripe-valid-pi-requires-capture",
+  "description": "PaymentIntent observation with requires_capture produces authorization event",
+  "category": "valid",
+  "input": {
+    "type": "pi_observation",
+    "data": {
+      "payment_intent_id": "pi_conf_02",
+      "status": "requires_capture",
+      "amount": "3000",
+      "currency": "usd"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "has_commerce_event": true,
+    "commerce_event": "authorization"
+  },
+  "notes": "requires_capture means funds are held but not yet captured: authorization, not settlement."
+}

--- a/specs/conformance/fixtures/stripe/valid-pi-succeeded.json
+++ b/specs/conformance/fixtures/stripe/valid-pi-succeeded.json
@@ -1,0 +1,20 @@
+{
+  "id": "stripe-valid-pi-succeeded",
+  "description": "PaymentIntent observation with succeeded status produces settlement event",
+  "category": "valid",
+  "input": {
+    "type": "pi_observation",
+    "data": {
+      "payment_intent_id": "pi_conf_01",
+      "status": "succeeded",
+      "amount": "5000",
+      "currency": "usd"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "has_commerce_event": true,
+    "commerce_event": "settlement"
+  },
+  "notes": "PaymentIntent 'succeeded' is the only Stripe status that proves payment completion."
+}

--- a/specs/conformance/fixtures/stripe/valid-spt-grant.json
+++ b/specs/conformance/fixtures/stripe/valid-spt-grant.json
@@ -1,0 +1,24 @@
+{
+  "id": "stripe-valid-spt-grant",
+  "description": "SPT grant maps to delegation evidence without commerce event",
+  "category": "valid",
+  "input": {
+    "type": "spt_grant",
+    "data": {
+      "id": "grant_conf_01",
+      "token_id": "tok_conf_01",
+      "seller_scope": {
+        "merchant_id": "merch_01",
+        "restrictions": {}
+      },
+      "amount_limit": "10000",
+      "currency": "usd"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "has_commerce_event": false,
+    "spt_action": "delegated_payment_granted"
+  },
+  "notes": "SPT grant is delegation evidence. No commerce event. The grant proves delegation scope, not payment finality."
+}

--- a/specs/conformance/fixtures/ucp/edge-derived-fallback.json
+++ b/specs/conformance/fixtures/ucp/edge-derived-fallback.json
@@ -1,0 +1,35 @@
+{
+  "id": "ucp-edge-derived-fallback",
+  "description": "Completed order without payment_state: payment_state_source is derived_order_fallback",
+  "category": "edge",
+  "input": {
+    "type": "order_mapping",
+    "order": {
+      "id": "order_edge_01",
+      "line_items": [
+        {
+          "id": "li_01",
+          "item": { "id": "p1", "title": "Widget", "price": 500 },
+          "quantity": { "total": 1, "fulfilled": 1 },
+          "status": "fulfilled"
+        }
+      ],
+      "totals": [
+        { "type": "subtotal", "amount": 500 },
+        { "type": "total", "amount": 500 }
+      ]
+    },
+    "options": {
+      "issuer": "https://merchant.example.com",
+      "subject": "agent:edge_01",
+      "currency": "USD"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "payment_state_source": "derived_order_fallback",
+    "order_state": "completed",
+    "has_payment_state": false
+  },
+  "notes": "Asymmetric safety: order 'completed' does not prove payment. payment_state_source marks the derivation path."
+}

--- a/specs/conformance/fixtures/ucp/edge-zero-amount.json
+++ b/specs/conformance/fixtures/ucp/edge-zero-amount.json
@@ -1,0 +1,34 @@
+{
+  "id": "ucp-edge-zero-amount",
+  "description": "Order with zero total amount is valid",
+  "category": "edge",
+  "input": {
+    "type": "order_mapping",
+    "order": {
+      "id": "order_edge_02",
+      "line_items": [
+        {
+          "id": "li_01",
+          "item": { "id": "free_trial", "title": "Free Trial", "price": 0 },
+          "quantity": { "total": 1, "fulfilled": 1 },
+          "status": "fulfilled"
+        }
+      ],
+      "totals": [
+        { "type": "subtotal", "amount": 0 },
+        { "type": "total", "amount": 0 }
+      ]
+    },
+    "options": {
+      "issuer": "https://merchant.example.com",
+      "subject": "agent:edge_02",
+      "currency": "USD"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "order_state": "completed",
+    "total_amount": 0
+  },
+  "notes": "Zero-amount orders are valid: free trials, demos, promotional access."
+}

--- a/specs/conformance/fixtures/ucp/invalid-empty-id.json
+++ b/specs/conformance/fixtures/ucp/invalid-empty-id.json
@@ -1,0 +1,30 @@
+{
+  "id": "ucp-invalid-empty-id",
+  "description": "Order with empty id is rejected",
+  "category": "invalid",
+  "input": {
+    "type": "order_mapping",
+    "order": {
+      "id": "",
+      "line_items": [
+        {
+          "id": "li_01",
+          "item": { "id": "p1", "title": "Widget", "price": 100 },
+          "quantity": { "total": 1, "fulfilled": 1 },
+          "status": "fulfilled"
+        }
+      ],
+      "totals": [{ "type": "total", "amount": 100 }]
+    },
+    "options": {
+      "issuer": "https://merchant.example.com",
+      "subject": "agent:inv_02",
+      "currency": "USD"
+    }
+  },
+  "expected": {
+    "valid": false,
+    "error_reason": "empty_order_id"
+  },
+  "notes": "Order id must be a non-empty string."
+}

--- a/specs/conformance/fixtures/ucp/invalid-missing-line-items.json
+++ b/specs/conformance/fixtures/ucp/invalid-missing-line-items.json
@@ -1,0 +1,22 @@
+{
+  "id": "ucp-invalid-missing-line-items",
+  "description": "Order without line_items is rejected",
+  "category": "invalid",
+  "input": {
+    "type": "order_mapping",
+    "order": {
+      "id": "order_inv_01",
+      "totals": [{ "type": "total", "amount": 0 }]
+    },
+    "options": {
+      "issuer": "https://merchant.example.com",
+      "subject": "agent:inv_01",
+      "currency": "USD"
+    }
+  },
+  "expected": {
+    "valid": false,
+    "error_reason": "missing_line_items"
+  },
+  "notes": "line_items is required for UCP order mapping."
+}

--- a/specs/conformance/fixtures/ucp/invalid-missing-total-entry.json
+++ b/specs/conformance/fixtures/ucp/invalid-missing-total-entry.json
@@ -1,0 +1,31 @@
+{
+  "id": "ucp-invalid-missing-total-entry",
+  "description": "Order with totals array but no 'total' entry throws UcpError",
+  "category": "invalid",
+  "input": {
+    "type": "order_mapping",
+    "order": {
+      "id": "order_inv_04",
+      "line_items": [
+        {
+          "id": "li_01",
+          "item": { "id": "p1", "title": "Widget", "price": 100 },
+          "quantity": { "total": 1, "fulfilled": 1 },
+          "status": "fulfilled"
+        }
+      ],
+      "totals": [{ "type": "subtotal", "amount": 100 }]
+    },
+    "options": {
+      "issuer": "https://merchant.example.com",
+      "subject": "agent:inv_04",
+      "currency": "USD"
+    }
+  },
+  "expected": {
+    "valid": false,
+    "throws": true,
+    "error_code": "E_UCP_ORDER_MISSING_TOTALS"
+  },
+  "notes": "totals array must include a 'total' entry. Having only 'subtotal' is not sufficient."
+}

--- a/specs/conformance/fixtures/ucp/invalid-missing-totals.json
+++ b/specs/conformance/fixtures/ucp/invalid-missing-totals.json
@@ -1,0 +1,30 @@
+{
+  "id": "ucp-invalid-missing-totals",
+  "description": "Order without totals array throws UcpError",
+  "category": "invalid",
+  "input": {
+    "type": "order_mapping",
+    "order": {
+      "id": "order_inv_03",
+      "line_items": [
+        {
+          "id": "li_01",
+          "item": { "id": "p1", "title": "Widget", "price": 100 },
+          "quantity": { "total": 1, "fulfilled": 1 },
+          "status": "fulfilled"
+        }
+      ]
+    },
+    "options": {
+      "issuer": "https://merchant.example.com",
+      "subject": "agent:inv_03",
+      "currency": "USD"
+    }
+  },
+  "expected": {
+    "valid": false,
+    "throws": true,
+    "error_code": "E_UCP_ORDER_MISSING_TOTALS"
+  },
+  "notes": "Order must have totals array with at least one 'total' entry."
+}

--- a/specs/conformance/fixtures/ucp/manifest.json
+++ b/specs/conformance/fixtures/ucp/manifest.json
@@ -1,0 +1,40 @@
+{
+  "name": "ucp",
+  "version": "0.12.5",
+  "description": "Conformance vectors for @peac/mappings-ucp: Universal Commerce Protocol order-to-receipt mapping with order-vs-payment state separation",
+  "commerce_rail": "ucp",
+  "categories": {
+    "valid": {
+      "description": "Valid order mapping scenarios",
+      "vectors": [
+        "valid-order-completed.json",
+        "valid-explicit-payment-state.json",
+        "valid-partial-fulfillment.json"
+      ]
+    },
+    "invalid": {
+      "description": "Invalid inputs that must be rejected",
+      "vectors": [
+        "invalid-missing-line-items.json",
+        "invalid-empty-id.json",
+        "invalid-missing-totals.json",
+        "invalid-missing-total-entry.json"
+      ]
+    },
+    "edge": {
+      "description": "Order-vs-payment state boundary conditions",
+      "vectors": ["edge-derived-fallback.json", "edge-zero-amount.json"]
+    },
+    "security": {
+      "description": "Resource bounding and evidence size limits",
+      "vectors": ["security-oversized-line-items.json"]
+    }
+  },
+  "invariants": [
+    "Order state is distinct from payment state; completed order does not prove payment settlement",
+    "payment_state_source marks derivation path: explicit vs derived_order_fallback",
+    "Explicit payment_state overrides derived order status",
+    "Zero-amount orders are valid (free trials, demos, promotions)",
+    "Line item summary extraction provides bounded evidence projection"
+  ]
+}

--- a/specs/conformance/fixtures/ucp/security-oversized-line-items.json
+++ b/specs/conformance/fixtures/ucp/security-oversized-line-items.json
@@ -1,0 +1,16 @@
+{
+  "id": "ucp-security-oversized-line-items",
+  "description": "Order with many line items: evidence uses count, not full objects",
+  "category": "security",
+  "input": {
+    "type": "order_mapping",
+    "construct": "oversized_order",
+    "line_items_count": 500
+  },
+  "expected": {
+    "valid": true,
+    "bounded": true,
+    "evidence_uses_count": true
+  },
+  "notes": "Evidence receipt stores line_items as a count (number), not full objects. Proves bounded evidence projection regardless of order size."
+}

--- a/specs/conformance/fixtures/ucp/valid-explicit-payment-state.json
+++ b/specs/conformance/fixtures/ucp/valid-explicit-payment-state.json
@@ -1,0 +1,36 @@
+{
+  "id": "ucp-valid-explicit-payment-state",
+  "description": "Order with explicit payment_state overrides derived state",
+  "category": "valid",
+  "input": {
+    "type": "order_mapping",
+    "order": {
+      "id": "order_conf_02",
+      "line_items": [
+        {
+          "id": "li_01",
+          "item": { "id": "p1", "title": "Widget", "price": 1000 },
+          "quantity": { "total": 1, "fulfilled": 1 },
+          "status": "fulfilled"
+        }
+      ],
+      "totals": [
+        { "type": "subtotal", "amount": 1000 },
+        { "type": "total", "amount": 1000 }
+      ]
+    },
+    "options": {
+      "issuer": "https://merchant.example.com",
+      "subject": "agent:conf_02",
+      "currency": "USD",
+      "payment_state": "settled"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "payment_state_source": "explicit",
+    "payment_state": "settled",
+    "order_state": "completed"
+  },
+  "notes": "Explicit payment_state wins over derived order state."
+}

--- a/specs/conformance/fixtures/ucp/valid-order-completed.json
+++ b/specs/conformance/fixtures/ucp/valid-order-completed.json
@@ -1,0 +1,34 @@
+{
+  "id": "ucp-valid-order-completed",
+  "description": "Completed UCP order maps to receipt claims with derived payment state",
+  "category": "valid",
+  "input": {
+    "type": "order_mapping",
+    "order": {
+      "id": "order_conf_01",
+      "line_items": [
+        {
+          "id": "li_01",
+          "item": { "id": "p1", "title": "Widget", "price": 2500 },
+          "quantity": { "total": 1, "fulfilled": 1 },
+          "status": "fulfilled"
+        }
+      ],
+      "totals": [
+        { "type": "subtotal", "amount": 2500 },
+        { "type": "total", "amount": 2500 }
+      ]
+    },
+    "options": {
+      "issuer": "https://merchant.example.com",
+      "subject": "agent:conf_01",
+      "currency": "USD"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "payment_state_source": "derived_order_fallback",
+    "order_state": "completed"
+  },
+  "notes": "Completed order without explicit payment_state uses derived_order_fallback."
+}

--- a/specs/conformance/fixtures/ucp/valid-partial-fulfillment.json
+++ b/specs/conformance/fixtures/ucp/valid-partial-fulfillment.json
@@ -1,0 +1,40 @@
+{
+  "id": "ucp-valid-partial-fulfillment",
+  "description": "Partially fulfilled order maps correctly",
+  "category": "valid",
+  "input": {
+    "type": "order_mapping",
+    "order": {
+      "id": "order_conf_03",
+      "line_items": [
+        {
+          "id": "li_01",
+          "item": { "id": "p1", "title": "Alpha", "price": 500 },
+          "quantity": { "total": 2, "fulfilled": 1 },
+          "status": "partial"
+        },
+        {
+          "id": "li_02",
+          "item": { "id": "p2", "title": "Beta", "price": 300 },
+          "quantity": { "total": 1, "fulfilled": 0 },
+          "status": "pending"
+        }
+      ],
+      "totals": [
+        { "type": "subtotal", "amount": 1300 },
+        { "type": "total", "amount": 1300 }
+      ]
+    },
+    "options": {
+      "issuer": "https://merchant.example.com",
+      "subject": "agent:conf_03",
+      "currency": "USD"
+    }
+  },
+  "expected": {
+    "valid": true,
+    "order_state": "partial",
+    "payment_state_source": "derived_order_fallback"
+  },
+  "notes": "Partial fulfillment: 1 of 2 fulfilled in first item, 0 of 1 in second."
+}

--- a/tests/conformance/commerce-rails.spec.ts
+++ b/tests/conformance/commerce-rails.spec.ts
@@ -1,0 +1,602 @@
+/**
+ * Execution-backed commerce rail conformance tests.
+ *
+ * Loads fixture manifests from specs/conformance/fixtures/{paymentauth,acp,stripe,ucp}/
+ * and validates both structural integrity AND real protocol behavior by calling
+ * the actual public APIs of each commerce mapping/rail package.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+
+// paymentauth
+import {
+  parsePaymentauthChallenges,
+  parsePaymentauthCredential,
+  parsePaymentauthReceipt,
+  normalizeChallenge,
+  normalizeReceipt,
+  normalizeCredential,
+  PaymentauthError,
+} from '@peac/mappings-paymentauth';
+
+// ACP
+import { fromACPSessionLifecycleEvent, fromACPPaymentObservation } from '@peac/mappings-acp';
+
+// Stripe
+import { fromSPTGrant, fromSPTUse, fromStripePaymentIntentObservation } from '@peac/rails-stripe';
+
+// UCP
+import { mapUcpOrderToReceipt, UcpError } from '@peac/mappings-ucp';
+
+const FIXTURES_ROOT = join(__dirname, '..', '..', 'specs', 'conformance', 'fixtures');
+
+interface Manifest {
+  name: string;
+  version: string;
+  commerce_rail?: string;
+  spec_revision?: string;
+  intent_spec_revision?: string;
+  categories: Record<string, { description: string; vectors: string[] }>;
+  invariants?: string[];
+}
+
+function loadManifest(rail: string): Manifest | null {
+  const p = join(FIXTURES_ROOT, rail, 'manifest.json');
+  if (!existsSync(p)) return null;
+  return JSON.parse(readFileSync(p, 'utf-8'));
+}
+
+function loadFixture(rail: string, file: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(FIXTURES_ROOT, rail, file), 'utf-8'));
+}
+
+// ---------------------------------------------------------------------------
+// 1. Structural validation (manifest integrity, file existence, uniqueness)
+// ---------------------------------------------------------------------------
+
+describe('commerce rail fixture structural validation', () => {
+  const COMMERCE_RAILS = ['paymentauth', 'acp', 'stripe', 'ucp', 'x402'] as const;
+  const allIds = new Map<string, string>();
+
+  for (const rail of COMMERCE_RAILS) {
+    const manifest = loadManifest(rail);
+    if (!manifest) continue;
+
+    describe(`${rail}: manifest integrity`, () => {
+      it('has required metadata', () => {
+        expect(manifest.name).toBeTruthy();
+        expect(manifest.version).toBeTruthy();
+      });
+
+      if (rail !== 'x402') {
+        it('declares commerce_rail', () => {
+          expect(manifest.commerce_rail).toBe(rail);
+        });
+
+        it('has documented invariants', () => {
+          expect(manifest.invariants).toBeDefined();
+          expect(manifest.invariants!.length).toBeGreaterThan(0);
+        });
+      }
+
+      for (const [cat, catDef] of Object.entries(manifest.categories)) {
+        for (const vecFile of catDef.vectors) {
+          it(`${cat}/${vecFile} exists`, () => {
+            expect(existsSync(join(FIXTURES_ROOT, rail, vecFile))).toBe(true);
+          });
+
+          it(`${cat}/${vecFile} has unique id`, () => {
+            const vec = loadFixture(rail, vecFile);
+            if (vec.id) {
+              const existing = allIds.get(vec.id as string);
+              expect(existing, `duplicate id "${vec.id}": ${existing}`).toBeUndefined();
+              allIds.set(vec.id as string, `${rail}/${vecFile}`);
+            }
+          });
+        }
+      }
+    });
+  }
+
+  describe('coverage floor (structural)', () => {
+    const FLOOR = { valid: 3, invalid: 4, edge: 2, security: 1 };
+    for (const rail of ['paymentauth', 'acp', 'stripe', 'ucp'] as const) {
+      it(`${rail}: meets minimum coverage floor`, () => {
+        const m = loadManifest(rail)!;
+        for (const [cat, min] of Object.entries(FLOOR)) {
+          const vecs = m.categories[cat]?.vectors || [];
+          expect(vecs.length, `${rail}/${cat}: ${vecs.length} < ${min}`).toBeGreaterThanOrEqual(
+            min
+          );
+        }
+      });
+    }
+  });
+
+  describe('spec_revision pinning', () => {
+    it('paymentauth: pins spec_revision to active Internet-Draft', () => {
+      const m = loadManifest('paymentauth')!;
+      expect(m.spec_revision).toBe('draft-ryan-httpauth-payment-01');
+    });
+
+    it('paymentauth: pins intent_spec_revision (provisional)', () => {
+      const m = loadManifest('paymentauth')!;
+      // Provisional: draft-ryan-payment-intents-charge-00 is not publicly listed
+      // on datatracker.ietf.org as of 2026-03-27. Pin is source-local.
+      expect(m.intent_spec_revision).toContain('draft-ryan-payment-intents-charge-00');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Execution-backed behavioral conformance: paymentauth
+// ---------------------------------------------------------------------------
+
+describe('paymentauth: execution-backed conformance', () => {
+  it('valid-challenge-parse: parses and normalizes challenge header', () => {
+    const fix = loadFixture('paymentauth', 'valid-challenge-parse.json');
+    const input = fix.input as { header: string };
+    const expected = fix.expected as Record<string, unknown>;
+
+    const challenges = parsePaymentauthChallenges(input.header);
+    expect(challenges.length).toBe(1);
+
+    const normalized = normalizeChallenge(challenges[0]);
+    expect(normalized.id).toBe(expected.id);
+    expect(normalized.realm).toBe(expected.realm);
+    expect(normalized.method).toBe(expected.method);
+    expect(normalized.intent).toBe(expected.intent);
+  });
+
+  it('valid-credential-parse: parses credential and normalizes envelope', () => {
+    const fix = loadFixture('paymentauth', 'valid-credential-parse.json');
+    const input = fix.input as { header: string };
+    const expected = fix.expected as Record<string, unknown>;
+
+    const raw = parsePaymentauthCredential(input.header);
+    expect(raw.parsedJson).toBeTruthy();
+
+    const normalized = normalizeCredential(raw);
+    expect(normalized.challengeId).toBe(expected.challengeId);
+    expect(normalized.method).toBe(expected.method);
+    expect(normalized.intent).toBe(expected.intent);
+  });
+
+  it('invalid-missing-scheme: rejects credential without Payment scheme', () => {
+    const fix = loadFixture('paymentauth', 'invalid-missing-scheme.json');
+    const input = fix.input as { header: string };
+
+    expect(() => parsePaymentauthCredential(input.header)).toThrow(PaymentauthError);
+    try {
+      parsePaymentauthCredential(input.header);
+    } catch (e) {
+      expect((e as PaymentauthError).code).toBe('PARSE_MISSING_SCHEME');
+    }
+  });
+
+  it('invalid-missing-challenge-id: normalizeChallenge rejects missing id', () => {
+    const fix = loadFixture('paymentauth', 'invalid-missing-challenge-id.json');
+    const input = fix.input as { header: string };
+
+    const challenges = parsePaymentauthChallenges(input.header);
+    expect(challenges.length).toBe(1);
+    expect(() => normalizeChallenge(challenges[0])).toThrow(PaymentauthError);
+    try {
+      normalizeChallenge(challenges[0]);
+    } catch (e) {
+      expect((e as PaymentauthError).code).toBe('NORMALIZE_MISSING_FIELD');
+    }
+  });
+
+  it('invalid-truncated-base64: rejects corrupted base64url', () => {
+    const fix = loadFixture('paymentauth', 'invalid-truncated-base64.json');
+    const input = fix.input as { header: string };
+
+    expect(() => parsePaymentauthCredential(input.header)).toThrow(PaymentauthError);
+    try {
+      parsePaymentauthCredential(input.header);
+    } catch (e) {
+      expect((e as PaymentauthError).code).toBe('PARSE_INVALID_BASE64URL');
+    }
+  });
+
+  it('invalid-receipt-not-json: normalizeReceipt rejects non-object payload', () => {
+    const fix = loadFixture('paymentauth', 'invalid-receipt-not-json.json');
+    const input = fix.input as { header: string };
+
+    const raw = parsePaymentauthReceipt(input.header);
+    expect(() => normalizeReceipt(raw)).toThrow(PaymentauthError);
+    try {
+      normalizeReceipt(raw);
+    } catch (e) {
+      expect((e as PaymentauthError).code).toBe('NORMALIZE_MISSING_FIELD');
+    }
+  });
+
+  it('edge-unknown-method: normalizes challenge with unrecognized method', () => {
+    const fix = loadFixture('paymentauth', 'edge-unknown-method.json');
+    const input = fix.input as { header: string };
+    const expected = fix.expected as Record<string, unknown>;
+
+    const challenges = parsePaymentauthChallenges(input.header);
+    expect(challenges.length).toBe(1);
+    const normalized = normalizeChallenge(challenges[0]);
+    expect(normalized.method).toBe(expected.method);
+    expect(normalized.intent).toBe(expected.intent);
+  });
+
+  it('edge-receipt-extra-fields: extra fields collected in extras map', () => {
+    const fix = loadFixture('paymentauth', 'edge-receipt-extra-fields.json');
+    const input = fix.input as { header: string };
+    const expected = fix.expected as { extra_keys: string[] };
+
+    const raw = parsePaymentauthReceipt(input.header);
+    const normalized = normalizeReceipt(raw);
+    expect(normalized.status).toBe('success');
+    expect(normalized.method).toBe('example');
+    for (const key of expected.extra_keys) {
+      expect(normalized.extras).toHaveProperty(key);
+    }
+  });
+
+  it('security-oversized-header: rejects header exceeding 8192 bytes', () => {
+    // Construct oversized header per fixture instruction
+    const header = 'Payment id="oversized", realm="' + 'a'.repeat(9000) + '"';
+    expect(() => parsePaymentauthChallenges(header)).toThrow(PaymentauthError);
+    try {
+      parsePaymentauthChallenges(header);
+    } catch (e) {
+      expect((e as PaymentauthError).code).toBe('PARSE_HEADER_TOO_LARGE');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Execution-backed behavioral conformance: ACP
+// ---------------------------------------------------------------------------
+
+describe('ACP: execution-backed conformance', () => {
+  it('valid-session-completed: lifecycle event produces access evidence', () => {
+    const fix = loadFixture('acp', 'valid-session-completed.json');
+    const input = fix.input as { event: Record<string, unknown> };
+
+    const result = fromACPSessionLifecycleEvent(input.event as never);
+    expect(result.payment.rail).toBe('acp');
+    expect(result.amt).toBe(0);
+    expect(result.cur).toBe('NONE');
+    const ev = result.payment.evidence as Record<string, unknown>;
+    expect(ev.commerce_event).toBeUndefined();
+  });
+
+  it('valid-payment-settled: payment observation produces commerce evidence', () => {
+    const fix = loadFixture('acp', 'valid-payment-settled.json');
+    const input = fix.input as {
+      event: Record<string, unknown>;
+      payment_artifact: Record<string, unknown>;
+    };
+
+    const result = fromACPPaymentObservation(input.event as never, input.payment_artifact as never);
+    expect(result.payment.rail).toBe('stripe');
+    expect(result.amt).toBe(2500);
+    const ev = result.payment.evidence as Record<string, unknown>;
+    expect(ev.commerce_event).toBe('settlement');
+    expect(ev.observed_payment_state).toBe('settled');
+  });
+
+  it('valid-session-created: lifecycle creation event produces access evidence', () => {
+    const fix = loadFixture('acp', 'valid-session-created.json');
+    const input = fix.input as { event: Record<string, unknown> };
+
+    const result = fromACPSessionLifecycleEvent(input.event as never);
+    expect(result.payment.rail).toBe('acp');
+    expect(result.amt).toBe(0);
+  });
+
+  it('invalid-missing-session-id: throws on missing session_id', () => {
+    const fix = loadFixture('acp', 'invalid-missing-session-id.json');
+    const input = fix.input as { event: Record<string, unknown> };
+    expect(() => fromACPSessionLifecycleEvent(input.event as never)).toThrow();
+  });
+
+  it('invalid-payment-missing-rail: throws on missing rail', () => {
+    const fix = loadFixture('acp', 'invalid-payment-missing-rail.json');
+    const input = fix.input as {
+      event: Record<string, unknown>;
+      payment_artifact: Record<string, unknown>;
+    };
+    expect(() =>
+      fromACPPaymentObservation(input.event as never, input.payment_artifact as never)
+    ).toThrow();
+  });
+
+  it('invalid-payment-missing-reference: throws on missing reference', () => {
+    const fix = loadFixture('acp', 'invalid-payment-missing-reference.json');
+    const input = fix.input as {
+      event: Record<string, unknown>;
+      payment_artifact: Record<string, unknown>;
+    };
+    expect(() =>
+      fromACPPaymentObservation(input.event as never, input.payment_artifact as never)
+    ).toThrow();
+  });
+
+  it('invalid-missing-resource-uri: throws on missing resource_uri', () => {
+    const fix = loadFixture('acp', 'invalid-missing-resource-uri.json');
+    const input = fix.input as { event: Record<string, unknown> };
+    expect(() => fromACPSessionLifecycleEvent(input.event as never)).toThrow();
+  });
+
+  it('edge-completed-no-payment: completed session has no commerce event', () => {
+    const fix = loadFixture('acp', 'edge-completed-no-payment.json');
+    const input = fix.input as { event: Record<string, unknown> };
+
+    const result = fromACPSessionLifecycleEvent(input.event as never);
+    expect(result.payment.rail).toBe('acp');
+    expect(result.amt).toBe(0);
+    const ev = result.payment.evidence as Record<string, unknown>;
+    expect(ev.commerce_event).toBeUndefined();
+    expect(ev.observed_payment_state).toBeUndefined();
+  });
+
+  it('edge-payment-authorized: authorized state produces authorization event', () => {
+    const fix = loadFixture('acp', 'edge-payment-authorized.json');
+    const input = fix.input as {
+      event: Record<string, unknown>;
+      payment_artifact: Record<string, unknown>;
+    };
+
+    const result = fromACPPaymentObservation(input.event as never, input.payment_artifact as never);
+    const ev = result.payment.evidence as Record<string, unknown>;
+    expect(ev.commerce_event).toBe('authorization');
+    expect(ev.observed_payment_state).toBe('authorized');
+  });
+
+  it('security-xss-resource-uri: URI with script injection is preserved as-is', () => {
+    const fix = loadFixture('acp', 'security-xss-resource-uri.json');
+    const input = fix.input as { event: Record<string, unknown> };
+
+    const result = fromACPSessionLifecycleEvent(input.event as never);
+    expect(result.subject_uri).toContain('<script>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Execution-backed behavioral conformance: Stripe SPT
+// ---------------------------------------------------------------------------
+
+describe('Stripe: execution-backed conformance', () => {
+  it('valid-spt-grant: produces delegation evidence, no commerce event', () => {
+    const fix = loadFixture('stripe', 'valid-spt-grant.json');
+    const input = fix.input as { data: Record<string, unknown> };
+
+    const result = fromSPTGrant(input.data as never);
+    const ev = result.evidence as Record<string, unknown>;
+    expect(ev.spt_action).toBe('delegated_payment_granted');
+    expect(ev.commerce_event).toBeUndefined();
+  });
+
+  it('valid-pi-succeeded: produces settlement commerce event', () => {
+    const fix = loadFixture('stripe', 'valid-pi-succeeded.json');
+    const input = fix.input as { data: Record<string, unknown> };
+
+    const result = fromStripePaymentIntentObservation(input.data as never);
+    const ev = result.evidence as Record<string, unknown>;
+    expect(ev.commerce_event).toBe('settlement');
+  });
+
+  it('valid-pi-requires-capture: produces authorization commerce event', () => {
+    const fix = loadFixture('stripe', 'valid-pi-requires-capture.json');
+    const input = fix.input as { data: Record<string, unknown> };
+
+    const result = fromStripePaymentIntentObservation(input.data as never);
+    const ev = result.evidence as Record<string, unknown>;
+    expect(ev.commerce_event).toBe('authorization');
+  });
+
+  // Current adapter behavior: Stripe SPT/PI functions do not throw on missing
+  // or malformed fields. They produce degraded output (undefined reference,
+  // fallback amounts). These tests capture current lenient handling, not
+  // normative protocol invariants.
+
+  it('invalid-spt-missing-token: (current adapter behavior) undefined reference', () => {
+    const fix = loadFixture('stripe', 'invalid-spt-missing-token.json');
+    const input = fix.input as { data: Record<string, unknown> };
+
+    const result = fromSPTGrant(input.data as never);
+    expect(result.reference).toBeUndefined();
+  });
+
+  it('invalid-pi-missing-id: (current adapter behavior) undefined reference', () => {
+    const fix = loadFixture('stripe', 'invalid-pi-missing-id.json');
+    const input = fix.input as { data: Record<string, unknown> };
+
+    const result = fromStripePaymentIntentObservation(input.data as never);
+    expect(result.reference).toBeUndefined();
+    const ev = result.evidence as Record<string, unknown>;
+    expect(ev.commerce_event).toBe('settlement');
+  });
+
+  it('invalid-spt-negative-amount: (current adapter behavior) falls back to zero', () => {
+    const fix = loadFixture('stripe', 'invalid-spt-negative-amount.json');
+    const input = fix.input as { data: Record<string, unknown> };
+
+    const result = fromSPTUse(input.data as never);
+    expect(result.amount).toBe(0);
+  });
+
+  it('invalid-pi-unknown-status: (current adapter behavior) no commerce event', () => {
+    const fix = loadFixture('stripe', 'invalid-pi-unknown-status.json');
+    const input = fix.input as { data: Record<string, unknown> };
+
+    const result = fromStripePaymentIntentObservation(input.data as never);
+    const ev = result.evidence as Record<string, unknown>;
+    expect(ev.commerce_event).toBeUndefined();
+  });
+
+  it('edge-spt-use-with-pi: SPT use with PI ref has no commerce event', () => {
+    const fix = loadFixture('stripe', 'edge-spt-use-with-pi.json');
+    const input = fix.input as { data: Record<string, unknown> };
+
+    const result = fromSPTUse(input.data as never);
+    const ev = result.evidence as Record<string, unknown>;
+    expect(ev.spt_action).toBe('delegated_payment_presented');
+    expect(ev.commerce_event).toBeUndefined();
+  });
+
+  it('edge-pi-processing: processing status has no commerce event', () => {
+    const fix = loadFixture('stripe', 'edge-pi-processing.json');
+    const input = fix.input as { data: Record<string, unknown> };
+
+    const result = fromStripePaymentIntentObservation(input.data as never);
+    const ev = result.evidence as Record<string, unknown>;
+    expect(ev.commerce_event).toBeUndefined();
+  });
+
+  it('security-metadata-sanitization: allowlist policy filters keys', () => {
+    const fix = loadFixture('stripe', 'security-metadata-sanitization.json');
+    const input = fix.input as {
+      data: Record<string, unknown>;
+      options: Record<string, unknown>;
+    };
+
+    const result = fromStripePaymentIntentObservation(input.data as never, input.options as never);
+    const ev = result.evidence as Record<string, unknown>;
+    const metadata = ev.metadata as Record<string, unknown> | undefined;
+    if (metadata) {
+      expect(metadata).toHaveProperty('order_id');
+      expect(metadata).not.toHaveProperty('customer_email');
+      expect(metadata).not.toHaveProperty('internal_ref');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Execution-backed behavioral conformance: UCP
+// ---------------------------------------------------------------------------
+
+describe('UCP: execution-backed conformance', () => {
+  it('valid-order-completed: completed order maps with derived_order_fallback', () => {
+    const fix = loadFixture('ucp', 'valid-order-completed.json');
+    const input = fix.input as { order: Record<string, unknown>; options: Record<string, unknown> };
+
+    const result = mapUcpOrderToReceipt({
+      order: input.order as never,
+      ...input.options,
+    } as never);
+    expect(result.payment.evidence.payment_state_source).toBe('derived_order_fallback');
+    expect(result.payment.evidence.order_state).toBe('completed');
+  });
+
+  it('valid-explicit-payment-state: explicit payment_state overrides derived', () => {
+    const fix = loadFixture('ucp', 'valid-explicit-payment-state.json');
+    const input = fix.input as { order: Record<string, unknown>; options: Record<string, unknown> };
+
+    const result = mapUcpOrderToReceipt({
+      order: input.order as never,
+      ...input.options,
+    } as never);
+    expect(result.payment.evidence.payment_state_source).toBe('explicit');
+    expect(result.payment.evidence.payment_state).toBe('settled');
+    expect(result.payment.status).toBe('completed');
+  });
+
+  it('valid-partial-fulfillment: partially fulfilled order maps correctly', () => {
+    const fix = loadFixture('ucp', 'valid-partial-fulfillment.json');
+    const input = fix.input as { order: Record<string, unknown>; options: Record<string, unknown> };
+
+    const result = mapUcpOrderToReceipt({
+      order: input.order as never,
+      ...input.options,
+    } as never);
+    expect(result.payment.evidence.order_state).toBe('partial');
+  });
+
+  it('invalid-missing-line-items: throws UcpError', () => {
+    const fix = loadFixture('ucp', 'invalid-missing-line-items.json');
+    const input = fix.input as { order: Record<string, unknown>; options: Record<string, unknown> };
+
+    expect(() =>
+      mapUcpOrderToReceipt({ order: input.order as never, ...input.options } as never)
+    ).toThrow(UcpError);
+  });
+
+  it('invalid-empty-id: throws UcpError', () => {
+    const fix = loadFixture('ucp', 'invalid-empty-id.json');
+    const input = fix.input as { order: Record<string, unknown>; options: Record<string, unknown> };
+
+    expect(() =>
+      mapUcpOrderToReceipt({ order: input.order as never, ...input.options } as never)
+    ).toThrow(UcpError);
+  });
+
+  it('invalid-missing-totals: throws UcpError', () => {
+    const fix = loadFixture('ucp', 'invalid-missing-totals.json');
+    const input = fix.input as { order: Record<string, unknown>; options: Record<string, unknown> };
+
+    expect(() =>
+      mapUcpOrderToReceipt({ order: input.order as never, ...input.options } as never)
+    ).toThrow(UcpError);
+  });
+
+  it('invalid-missing-total-entry: throws UcpError', () => {
+    const fix = loadFixture('ucp', 'invalid-missing-total-entry.json');
+    const input = fix.input as { order: Record<string, unknown>; options: Record<string, unknown> };
+
+    expect(() =>
+      mapUcpOrderToReceipt({ order: input.order as never, ...input.options } as never)
+    ).toThrow(UcpError);
+  });
+
+  it('edge-derived-fallback: completed without payment_state uses fallback', () => {
+    const fix = loadFixture('ucp', 'edge-derived-fallback.json');
+    const input = fix.input as { order: Record<string, unknown>; options: Record<string, unknown> };
+
+    const result = mapUcpOrderToReceipt({
+      order: input.order as never,
+      ...input.options,
+    } as never);
+    expect(result.payment.evidence.payment_state_source).toBe('derived_order_fallback');
+    expect(result.payment.evidence.payment_state).toBeUndefined();
+  });
+
+  it('edge-zero-amount: zero-amount order is valid', () => {
+    const fix = loadFixture('ucp', 'edge-zero-amount.json');
+    const input = fix.input as { order: Record<string, unknown>; options: Record<string, unknown> };
+
+    const result = mapUcpOrderToReceipt({
+      order: input.order as never,
+      ...input.options,
+    } as never);
+    expect(result.payment.evidence.order_state).toBe('completed');
+  });
+
+  it('security-oversized-line-items: evidence uses count not full objects', () => {
+    // Construct order with many line items per fixture instruction
+    const items = Array.from({ length: 500 }, (_, i) => ({
+      id: `li_${i}`,
+      item: { id: `p${i}`, title: `Item ${i}`, price: 100 },
+      quantity: { total: 1, fulfilled: 1 },
+      status: 'fulfilled' as const,
+    }));
+
+    const result = mapUcpOrderToReceipt({
+      order: {
+        id: 'order_sec_01',
+        line_items: items,
+        totals: [
+          { type: 'subtotal', amount: 50000 },
+          { type: 'total', amount: 50000 },
+        ],
+      },
+      issuer: 'https://merchant.example.com',
+      subject: 'agent:sec_01',
+      currency: 'USD',
+    } as never);
+
+    // Evidence stores line_items as a count, proving bounded projection
+    expect(typeof result.payment.evidence.line_items).toBe('number');
+    expect(result.payment.evidence.line_items).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds execution-backed conformance fixtures and tests for 4 commerce rails: paymentauth, ACP, Stripe SPT, and UCP
- Introduces a registry-derived coverage gate that enforces a minimum vector floor (10 vectors per rail: 3 valid, 4 invalid, 2 edge, 1 security)
- Pins fixture manifests to upstream spec revisions with provisional annotation where not independently verifiable

## Scope

40 new fixture files across 4 rail directories, 4 per-rail manifests with documented invariants, 1 coverage gate script wired into gate.sh, 1 conformance test file with 208 behavioral assertions calling real package APIs. No kernel, schema, crypto, or protocol changes.

### Explicitly not changed

- x402 fixtures (legacy manifest, total-count check only; migration to commerce_rail format planned for v0.12.6)
- No new error codes, schema fields, or wire format changes
- No normative prose changes (deferred to PR 3)

## Changes

- **Fixtures:** paymentauth (8 new + manifest), ACP (10 + manifest), Stripe (10 + manifest), UCP (10 + manifest)
- **Coverage gate:** `scripts/conformance/check-commerce-coverage.mjs` derives rail list from `specs/kernel/registries.json`, validates per-category floor for `commerce_rail` manifests, total-count for legacy manifests
- **Test:** `tests/conformance/commerce-rails.spec.ts` with structural validation and execution-backed behavioral tests through `parsePaymentauthChallenges`, `normalizeChallenge`, `fromACPSessionLifecycleEvent`, `fromACPPaymentObservation`, `fromSPTGrant`, `fromStripePaymentIntentObservation`, `mapUcpOrderToReceipt`
- **Version pins:** `spec_revision: draft-ryan-httpauth-payment-01` (active Internet-Draft, verified 2026-03-27); `intent_spec_revision: draft-ryan-payment-intents-charge-00` (provisional; not on IETF Datatracker)
- **Wiring:** `verify:commerce-coverage` script in package.json, commerce coverage check in gate.sh, category-tracking.json updated

## Validation

- 261 test files, 6872 tests passing
- Format clean, guard exit 0, commerce coverage gate passing
- Upstream version pins verified against IETF Datatracker, GitHub releases, and public docs

## Notes

- Stripe degraded-output fixtures (missing token_id, negative amounts, unknown status) are labeled as current adapter behavior, not normative protocol invariants
- x402 legacy exemption is explicit in coverage gate with planned migration to v0.12.6