### PR TITLE
docs: commerce naming truth and integration matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ See [examples/wire-02-minimal/](examples/wire-02-minimal/) for the full source. 
 
 PEAC is most useful where logs are not enough: payments, cross-boundary verification, audit, dispute review, and multi-agent workflows.
 
-- **Agentic commerce and payments:** Prove what was offered, challenged, paid, or settled across paymentauth/MPP, x402, ACP, Stripe SPT, and other commerce flows. See [paymentauth Kit](integrator-kits/paymentauth/README.md), [ACP Kit](integrator-kits/acp/README.md), [x402 Kit](integrator-kits/x402/README.md).
+- **Agentic commerce and payments:** Prove what was offered, challenged, paid, or settled across paymentauth, x402, Agentic Commerce Protocol (ACP), Stripe SPT, and other commerce flows. See [paymentauth Kit](integrator-kits/paymentauth/README.md), [ACP Kit](integrator-kits/acp/README.md), [x402 Kit](integrator-kits/x402/README.md).
 - **Audit and dispute review:** Keep signed evidence that survives organizational boundaries, not just local logs. See [Governance Mappings](docs/governance/).
 - **MCP tools and APIs:** Verify, issue, and carry signed receipts for tool calls, API responses, and automated actions. See [MCP Integration Kit](integrator-kits/mcp/README.md).
 - **Agent-to-agent workflows:** Carry verifiable receipts across A2A task/state transitions and multi-agent chains. See [A2A Integration Kit](integrator-kits/a2a/README.md).
@@ -135,15 +135,15 @@ More paths: [Go SDK](sdks/go/) | [paymentauth Kit](integrator-kits/paymentauth/R
 
 ## Where it fits
 
-| Existing system                        | What PEAC adds                                         |
-| -------------------------------------- | ------------------------------------------------------ |
-| **Logs**                               | Portable proof that survives organizational boundaries |
-| **OpenTelemetry**                      | Signed evidence that correlates to traces              |
-| **MCP / A2A**                          | Proof carried alongside tool calls and agent exchanges |
-| **AP2 / ACP (Agentic Commerce) / UCP** | Proof of terms and outcomes                            |
-| **paymentauth / MPP**                  | Evidence from HTTP 402 payment challenges and receipts |
-| **x402**                               | Settlement proof mapping with offline verification     |
-| **Stripe SPT / Payment rails**         | Delegation and settlement references made verifiable   |
+| Existing system                                 | What PEAC adds                                                    |
+| ----------------------------------------------- | ----------------------------------------------------------------- |
+| **Logs**                                        | Portable proof that survives organizational boundaries            |
+| **OpenTelemetry**                               | Signed evidence that correlates to traces                         |
+| **MCP / A2A**                                   | Proof carried alongside tool calls and agent exchanges            |
+| **AP2 / ACP (Agentic Commerce Protocol) / UCP** | Proof of terms and outcomes across commerce protocols             |
+| **paymentauth**                                 | Evidence from HTTP Payment authentication challenges and receipts |
+| **x402**                                        | Settlement proof mapping with offline verification                |
+| **Stripe SPT / Payment rails**                  | Delegation and settlement references made verifiable              |
 
 **What changes in your stack:** keep auth, keep payments, keep observability. Add `/.well-known/peac.txt` and return `PEAC-Receipt` on governed responses.
 

--- a/docs/profiles/commerce.md
+++ b/docs/profiles/commerce.md
@@ -22,15 +22,15 @@ Do NOT use this profile for:
 
 ## 3. Required / Recommended / Prohibited Fields
 
-| Field          | Level                  | Guidance                                                                                             |
-| -------------- | ---------------------- | ---------------------------------------------------------------------------------------------------- |
-| `payment_rail` | REQUIRED               | Must identify the payment rail or protocol                                                           |
-| `amount_minor` | REQUIRED               | Base-10 integer string in smallest currency unit                                                     |
-| `currency`     | REQUIRED               | ISO 4217 code or asset identifier, uppercase                                                         |
-| `reference`    | RECOMMENDED            | Payment reference from the upstream system                                                           |
-| `env`          | RECOMMENDED            | `live` or `test`; defaults to `live` if omitted                                                      |
-| `event`        | CONDITIONAL            | Only set when the upstream artifact explicitly proves the payment state; observational only (DD-184) |
-| `asset`        | RECOMMENDED for crypto | Token address or ticker for non-fiat assets                                                          |
+| Field          | Level                  | Guidance                                                                                    |
+| -------------- | ---------------------- | ------------------------------------------------------------------------------------------- |
+| `payment_rail` | REQUIRED               | Must identify the payment rail or protocol                                                  |
+| `amount_minor` | REQUIRED               | Base-10 integer string in smallest currency unit                                            |
+| `currency`     | REQUIRED               | ISO 4217 code or asset identifier, uppercase                                                |
+| `reference`    | RECOMMENDED            | Payment reference from the upstream system                                                  |
+| `env`          | RECOMMENDED            | `live` or `test`; defaults to `live` if omitted                                             |
+| `event`        | CONDITIONAL            | Only set when the upstream artifact explicitly proves the payment state; observational only |
+| `asset`        | RECOMMENDED for crypto | Token address or ticker for non-fiat assets                                                 |
 
 ## 4. Minimal Valid Receipt
 
@@ -138,7 +138,7 @@ This profile:
 
 ## 10. Notes / Caveats
 
-- The `event` field is observational metadata only (DD-184). It records what the upstream system reported; it does not enforce or guarantee that state.
+- The `event` field is observational metadata only. It records what the upstream system reported; it does not enforce or guarantee that state.
 - Commerce evidence from different sources (paymentauth, ACP, Stripe, x402, UCP) uses the same extension group but follows source-specific extraction patterns documented in `docs/specs/COMMERCE-EVIDENCE.md`.
 - `amount_minor` is a string (not a number) for arbitrary precision. Use base-10 integer representation in smallest currency units.
 - In strict verification mode, registered commerce receipt types require the commerce extension group to be present.

--- a/docs/specs/COMMERCE-EVIDENCE.md
+++ b/docs/specs/COMMERCE-EVIDENCE.md
@@ -19,7 +19,7 @@ Commerce extension `event` fields (`authorization`, `capture`, `settlement`, `re
 
 ## Rail Neutrality
 
-Per DD-95, PEAC core packages never mandate a specific payment rail. The commerce extension `payment_rail` field is a free string (max 128 chars). Registered rails are informational; unregistered values are accepted.
+PEAC core packages never mandate a specific payment rail. The commerce extension `payment_rail` field is a free string (max 128 chars). Registered rails are informational; unregistered values are accepted.
 
 ## Commerce Extension
 
@@ -35,13 +35,13 @@ The `org.peacprotocol/commerce` extension group carries observational payment me
 | `env`          | enum   | No       | `live` or `test`                             |
 | `event`        | enum   | No       | Observational lifecycle phase                |
 
-The `event` field values: `authorization`, `capture`, `settlement`, `refund`, `void`, `chargeback`. This field is observational metadata only (DD-184): it does not encode settlement finality, protocol state transitions, or lifecycle enforcement.
+The `event` field values: `authorization`, `capture`, `settlement`, `refund`, `void`, `chargeback`. This field is observational metadata only: it does not encode settlement finality, protocol state transitions, or lifecycle enforcement.
 
 ## Evidence Extraction Patterns
 
-### paymentauth / MPP
+### paymentauth
 
-HTTP `Payment` authentication scheme (`draft-ryan-httpauth-payment`), commonly referred to in the MPP ecosystem.
+HTTP `Payment` authentication scheme, aligned with the active Internet-Draft `draft-ryan-httpauth-payment-01`. The term `paymentauth` is the code and registry identifier used in PEAC packages, schema enums, and fixture paths. MPP is an ecosystem prose term and must not appear in code identifiers, package names, fixture paths, or schema enums.
 
 - **Approach**: envelope-first; method-specific payloads treated as `unknown`
 - **Package**: `@peac/mappings-paymentauth`
@@ -64,15 +64,30 @@ HTTP `Payment` authentication scheme (`draft-ryan-httpauth-payment`), commonly r
 
 - **Approach**: verification-first; 4-layer architecture (A1/A2/B/C)
 - **Package**: `@peac/adapter-x402`
-- **v0.12.4**: dual-header read compatibility (DD-193); reads PEAC-Receipt, PAYMENT-RESPONSE (v2), X-PAYMENT-RESPONSE (v1)
-- **v0.12.5**: full v2 adapter (plugin arch, CAIP, multi-facilitator, wallet sessions)
+- **Header read order**: PEAC-Receipt, PAYMENT-RESPONSE (v2), X-PAYMENT-RESPONSE (v1)
 
 ### UCP (Universal Commerce Protocol)
 
-- **Approach**: order-vs-payment separation (DD-187); order state distinct from payment state
+- **Approach**: order-vs-payment separation; order state distinct from payment state
 - **Package**: `@peac/mappings-ucp`
 - **Boundary**: `payment_state_source` marker distinguishes `explicit` from `derived_order_fallback`
 
 ## Cross-Ecosystem Evidence
 
 PEAC can normalize evidence from multiple commerce protocols into a single audit bundle. The experimental `CommerceEvidenceBundle` in `@peac/audit` correlates receipts across payment rails without aggregating or asserting settlement totals.
+
+## Naming Conventions
+
+### paymentauth vs MPP
+
+`paymentauth` is the canonical code and registry term, aligned with the active Internet-Draft `draft-ryan-httpauth-payment-01`. It appears in package names (`@peac/mappings-paymentauth`), registry entries, fixture paths, and schema values. MPP is an ecosystem prose term; it must not appear in code identifiers, package names, fixture paths, or schema enums.
+
+### ACP
+
+ACP refers to the Agentic Commerce Protocol (maintained by OpenAI and Stripe). It must not be confused with Agent Communication Protocol (IBM/BeeAI, now merged into A2A). On first mention in each document, expand to "Agentic Commerce Protocol (ACP)".
+
+## Related Specifications
+
+- [Commerce Integration Matrix](COMMERCE-INTEGRATION-MATRIX.md): summary table of all commerce rails
+- [Commerce Semantics](COMMERCE-SEMANTICS.md): mapping rules and payment state vocabulary
+- [Evidence Carrier Contract](EVIDENCE-CARRIER-CONTRACT.md): transport placement rules

--- a/docs/specs/COMMERCE-INTEGRATION-MATRIX.md
+++ b/docs/specs/COMMERCE-INTEGRATION-MATRIX.md
@@ -1,0 +1,59 @@
+# Commerce Integration Matrix
+
+Reference table for PEAC commerce evidence integrations across supported rails and protocols.
+
+## Rail and Protocol Summary
+
+| Rail / Protocol                                  | Mapping Package              | Registered ID                     | Evidence Types                          | `commerce.event` Support                      | Carrier Transport       |
+| ------------------------------------------------ | ---------------------------- | --------------------------------- | --------------------------------------- | --------------------------------------------- | ----------------------- |
+| paymentauth (HTTP Payment authentication scheme) | `@peac/mappings-paymentauth` | `paymentauth`                     | Payment challenges, receipts            | No direct `commerce.event`; attestation-based | `PEAC-Receipt` header   |
+| Agentic Commerce Protocol (ACP)                  | `@peac/mappings-acp`         | `acp` (session), varies (payment) | Session lifecycle, payment observations | Only from explicit `observed_payment_state`   | `PEAC-Receipt` header   |
+| Stripe SPT (Shared Payment Tokens)               | `@peac/rails-stripe`         | `stripe`                          | Delegation lifecycle, PI observations   | Only from PI observation with terminal status | `PEAC-Receipt` header   |
+| x402                                             | `@peac/adapter-x402`         | `x402`                            | Offer/receipt verification              | Per receipt content                           | `PEAC-Receipt` header   |
+| Universal Commerce Protocol (UCP)                | `@peac/mappings-ucp`         | `ucp` (order), varies (payment)   | Order lifecycle, payment evidence       | Only with explicit `payment_state`            | Webhook `peac_evidence` |
+
+## Evidence Extraction Approach
+
+| Rail / Protocol | Approach           | Key Function(s)                                                          |
+| --------------- | ------------------ | ------------------------------------------------------------------------ |
+| paymentauth     | Envelope-first     | `parsePaymentauthChallenges()`, `fromPaymentauthReceipt()`               |
+| ACP             | Lifecycle-first    | `fromACPSessionLifecycleEvent()`, `fromACPPaymentObservation()`          |
+| Stripe SPT      | Delegation-first   | `fromSPTGrant()`, `fromSPTUse()`, `fromStripePaymentIntentObservation()` |
+| x402            | Verification-first | `extractReceiptArtifactFromHeaders()`                                    |
+| UCP             | Order-vs-payment   | `mapUcpOrderToReceipt()`, `payment_state_source` marker                  |
+
+## Semantic Boundary Rules
+
+All commerce integrations follow the same boundary rule: PEAC preserves raw upstream artifacts and does not synthesize payment finality from non-payment artifacts or lifecycle states alone.
+
+- **paymentauth**: a receipt proves what the upstream server attested, not more
+- **ACP**: a session "completed" does not prove payment settlement; commerce evidence requires explicit `observed_payment_state`
+- **Stripe SPT**: a grant does not prove payment authorization; only `fromStripePaymentIntentObservation()` emits commerce events
+- **x402**: PEAC-Receipt is the carrier; upstream PAYMENT-RESPONSE is observational material, not a PEAC carrier
+- **UCP**: an order "completed" does not prove payment captured; `payment_state_source` distinguishes explicit from derived
+
+## Header Coexistence
+
+paymentauth introduces a second receipt header (`Payment-Receipt`) that can coexist with `PEAC-Receipt` on the same HTTP response. The two headers serve different purposes and have no semantic coupling:
+
+- `PEAC-Receipt`: signed PEAC interaction record (compact JWS)
+- `Payment-Receipt`: paymentauth payment receipt (base64url JSON)
+
+## Upstream Compatibility
+
+| Rail / Protocol | Current Upstream Version                                 | Notes                                                 |
+| --------------- | -------------------------------------------------------- | ----------------------------------------------------- |
+| paymentauth     | `draft-ryan-httpauth-payment-01` (active Internet-Draft) | Not a settled standard; aligned with the active draft |
+| ACP             | `API-Version: 2026-01-30`                                | Previous `2026-01-22` deprecated; see note below      |
+| A2A             | `v1.0.0` (released March 12, 2026)                       | PEAC adapter shipped in v0.12.3                       |
+| UCP             | `v2026-01-23`                                            | Date-based versioning; active development             |
+| x402            | v2 (recommended per Coinbase migration guide)            | PEAC reads both v1 and v2 headers                     |
+
+ACP compatibility versioning is sourced from the [ACP repository changelog](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/tree/main/changelog). The public documentation website may lag behind the repository; when versions differ, the repository changelog is authoritative.
+
+## Related Specifications
+
+- [Commerce Evidence Specification](COMMERCE-EVIDENCE.md): extraction patterns and boundary rules
+- [Commerce Semantics](COMMERCE-SEMANTICS.md): mapping rules and payment state vocabulary
+- [Evidence Carrier Contract](EVIDENCE-CARRIER-CONTRACT.md): transport placement rules
+- [Registries](REGISTRIES.md): registered payment rails


### PR DESCRIPTION
## Summary

- Creates commerce integration matrix with upstream compatibility table
- Cleans up naming: paymentauth as canonical code term (no MPP in code surfaces), ACP expanded on first mention
- Extends naming sweep to README.md front door
- Removes internal shorthand from public spec prose and profile docs
- Documents ACP API-Version 2026-01-30 (previous 2025-12-12 deprecated)

## Scope

4 files changed. Documentation only; no code, schema, or test changes.

### Explicitly not changed

- No code changes to mapping packages
- TempoMockAdapter legacy note deferred: symbol exists in @peac/pay402 (internal test utility, not user-facing docs); code comment planned for v0.12.6
- Matrix is a reference page; CI-backed example validation already exists via verify:examples-commerce

## Changes

- **New:** `docs/specs/COMMERCE-INTEGRATION-MATRIX.md`: 5-rail summary table, extraction approach, semantic boundaries, header coexistence, upstream compatibility table (ACP 2026-01-30, paymentauth draft-01, A2A v1.0.0, UCP v2026-01-23, x402 v2)
- **Modified:** `docs/specs/COMMERCE-EVIDENCE.md`: paymentauth naming (code term vs ecosystem term), internal reference cleanup, naming conventions section, related spec links
- **Modified:** `docs/profiles/commerce.md`: internal reference cleanup
- **Modified:** `README.md`: paymentauth/MPP to paymentauth, ACP expanded on first mention, table alignment

## Validation

- 261 test files, 6872 tests passing
- Format clean, forbid-strings clean, bidi/unicode scrub clean