### PR TITLE
chore(release): v0.12.5 commerce hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,10 +46,48 @@ PEAC as the neutral portable evidence layer across paymentauth/MPP, ACP, x402, S
 
 ### Deferred
 
-- `@peac/adapter-did`: deferred to v0.12.5
-- x402 V2 full adapter rewrite: deferred to v0.12.5
-- Go/Python SDK: deferred to v0.12.5 (gated on external signal)
-- A2A v1.0 OAuth PKCE, A2A v1.0 gRPC binding: deferred to v0.12.5
+- `@peac/adapter-did`: deferred to v0.12.6
+- x402 V2 full adapter rewrite: deferred to v0.12.6
+- Go/Python SDK: deferred to v0.12.6 (gated on external signal)
+- A2A v1.0 OAuth PKCE, A2A v1.0 gRPC binding: deferred to v0.12.6
+
+## [0.12.5] - 2026-03-27
+
+### Theme: Commerce Hardening + Interop Proofs
+
+Cross-rail conformance parity, settlement semantic equivalence, and naming truth cleanup.
+
+### Added
+
+- Execution-backed commerce rail conformance fixtures: 40 vectors across paymentauth, ACP, Stripe SPT, and UCP (3 valid, 4 invalid, 2 edge, 1 security per rail)
+- Registry-derived commerce coverage gate (`check-commerce-coverage.mjs`): enforces minimum vector floor per rail, derived from `registries.json`
+- Cross-rail settlement semantic equivalence test: one deterministic payment scenario ($25.00 USD settled) mapped through all 5 commerce rails
+- Asymmetric safety invariant: delegation/lifecycle/provisioning functions must not emit settlement-like commerce events
+- `isValidAmountMinor()` and `AmountMinorStringSchema` in `@peac/schema`: validate-and-reject utility with shared source of truth
+- Commerce integration matrix (`docs/specs/COMMERCE-INTEGRATION-MATRIX.md`) with upstream compatibility table
+- Paymentauth carrier roundtrip conformance test (attach, extract, coexistence)
+- Stripe out-of-order observation race test (authorization vs settlement ordering)
+- `verify:commerce-coverage` script in root package.json
+- Commerce coverage check wired into `gate.sh`
+
+### Changed
+
+- README: `paymentauth/MPP` to `paymentauth`; Agentic Commerce Protocol (ACP) expanded on first mention
+- Commerce evidence spec: paymentauth naming clarification (code/registry term vs ecosystem prose)
+- Commerce semantics spec: added cross-rail invariants section with equivalence and asymmetric safety prose
+- Commerce profile: removed internal shorthand from event field description
+- 6915 tests (was 6664)
+- 92 build targets (was 91)
+
+### Fixed
+
+- Fixture `spec_revision` pinned to `draft-ryan-httpauth-payment-01` (active Internet-Draft)
+- `intent_spec_revision` marked provisional (not publicly listed on datatracker.ietf.org)
+
+### Deferred
+
+- `@peac/adapter-did`: deferred to v0.12.6
+- x402 V2 full adapter rewrite: deferred to v0.12.6
 
 ## [Unreleased]
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,5 +22,5 @@ keywords:
   - content-licensing
   - agent-protocols
 license: Apache-2.0
-version: '0.12.3'
-date-released: '2026-03-17'
+version: '0.12.5'
+date-released: '2026-03-27'

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ See [packages/cli/README.md](packages/cli/README.md) for the full command refere
 
 ## Versioning
 
-- **Current stable:** Interaction Record format (`interaction-record+jwt`, v0.12.2+)
+- **Current stable:** Interaction Record format (`interaction-record+jwt`)
 - **Legacy:** Wire 0.1 (`peac-receipt/0.1`) is frozen; `verifyLocal()` returns `E_UNSUPPORTED_WIRE_VERSION`
 
 See [docs/specs/VERSIONING.md](docs/specs/VERSIONING.md) for the full versioning doctrine.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-api",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "PEAC Protocol API server with OpenAPI 3.1, RFC 9457 Problem Details, and content negotiation",
   "type": "module",
   "main": "dist/index.js",

--- a/apps/bridge/package.json
+++ b/apps/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-bridge",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "PEAC Protocol Bridge - Local development sidecar",
   "type": "module",
   "main": "dist/server.js",

--- a/apps/sandbox-issuer/package.json
+++ b/apps/sandbox-issuer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-sandbox-issuer",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "PEAC Protocol Sandbox Issuer - Test receipt issuance for development",
   "type": "module",
   "main": "dist/node.js",

--- a/apps/verifier/package.json
+++ b/apps/verifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-verifier",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "PEAC Protocol Browser Verifier - Client-side receipt verification",
   "type": "module",
   "private": true,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # PEAC Protocol Architecture
 
-**Version:** 0.12.2
+**Version:** 0.12.5
 **Status:** Authoritative
 
 This document describes the kernel-first architecture of the PEAC Protocol monorepo.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # PEAC Protocol Roadmap
 
-## Current Release: v0.12.2
+## Current Release: v0.12.5
 
 **Wire Format:** Interaction Record format (`interaction-record+jwt`, Wire 0.2, stable since v0.12.0). Legacy `peac-receipt/0.1` (Wire 0.1) frozen until v1.0.
 

--- a/docs/releases/current.json
+++ b/docs/releases/current.json
@@ -1,8 +1,8 @@
 {
   "description": "PEAC release manifest: CI-enforceable source of truth for release state",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "wire_format_version": "0.2",
   "dist_tag": "latest",
   "registries_version": "0.5.0",
-  "errors_version": "0.12.4"
+  "errors_version": "0.12.5"
 }

--- a/docs/specs/CONFORMANCE-MATRIX.md
+++ b/docs/specs/CONFORMANCE-MATRIX.md
@@ -1,7 +1,7 @@
 # PEAC Conformance Matrix
 
 > **Generated**: Do not edit manually. Source: `node scripts/conformance/generate-matrix.mjs`
-> **Version**: 0.12.3
+> **Version**: 0.12.5
 
 ## Wire 0.2 Protocol Requirements
 

--- a/docs/specs/INTEROP.md
+++ b/docs/specs/INTEROP.md
@@ -2,7 +2,7 @@
 
 **Status**: INFORMATIVE
 
-**Version**: 0.12.2
+**Version**: 0.12.5
 
 ---
 

--- a/docs/specs/WIRE-0.2.md
+++ b/docs/specs/WIRE-0.2.md
@@ -2,7 +2,7 @@
 
 **Status**: NORMATIVE
 
-**Version**: 0.12.2
+**Version**: 0.12.5
 
 **Wire Format**: `interaction-record+jwt`
 

--- a/integrator-kits/content-signals/README.md
+++ b/integrator-kits/content-signals/README.md
@@ -4,7 +4,7 @@ Integration guide for adding PEAC receipts to Content Signals (C2PA adjacent) wo
 
 ## Status
 
-Integration kit: expanding to full guide. The `@peac/mappings-content-signals` package is published and stable since v0.11.2. AIPREF vocab draft-05 version pinning planned for v0.12.3.
+Integration kit: expanding to full guide. The `@peac/mappings-content-signals` package is published and stable since v0.11.2. AIPREF vocab draft-05 version pinning shipped in v0.12.3.
 
 ## Quick Start
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/monorepo",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "private": true,
   "description": "PEAC Protocol - Cryptographic receipts for agentic commerce",
   "repository": {

--- a/packages/access/package.json
+++ b/packages/access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/access",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "private": true,
   "description": "PEAC access pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/adapters/core/package.json
+++ b/packages/adapters/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-core",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Shared utilities for PEAC payment rail adapters",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/eat/package.json
+++ b/packages/adapters/eat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-eat",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "EAT (Entity Attestation Token, RFC 9711) passport decoder and PEAC claim mapper",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/openai-compatible/package.json
+++ b/packages/adapters/openai-compatible/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-openai-compatible",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "OpenAI-compatible chat completion adapter for PEAC interaction evidence (hash-first)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/openclaw/package.json
+++ b/packages/adapters/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-openclaw",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "OpenClaw adapter for PEAC interaction evidence capture",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/daydreams/package.json
+++ b/packages/adapters/x402/daydreams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402-daydreams",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Daydreams AI inference event normalizer for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/fluora/package.json
+++ b/packages/adapters/x402/fluora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402-fluora",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Fluora MCP marketplace event normalizer for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/package.json
+++ b/packages/adapters/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "x402 offer/receipt verification, term-matching, and PEAC record mapping",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/pinata/package.json
+++ b/packages/adapters/x402/pinata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402-pinata",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Pinata private IPFS objects event normalizer for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/aipref/package.json
+++ b/packages/aipref/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/pref",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "AIPREF resolver with robots.txt bridge",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/attribution/package.json
+++ b/packages/attribution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/attribution",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "PEAC attribution attestation - content derivation and usage proofs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/audit",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Audit logging and case bundle generation for PEAC protocol disputes",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/capture/core/package.json
+++ b/packages/capture/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/capture-core",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Runtime-neutral capture pipeline for PEAC interaction evidence",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/capture/node/package.json
+++ b/packages/capture/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/capture-node",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Node.js durable storage for PEAC capture pipeline (filesystem spool store and dedupe index)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/cli",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "PEAC protocol command-line tools",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/compliance/package.json
+++ b/packages/compliance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/compliance",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "private": true,
   "description": "PEAC compliance pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/conformance-harness/package.json
+++ b/packages/conformance-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/conformance-harness",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "private": true,
   "description": "Conformance test harness for PEAC protocol fixtures",
   "main": "dist/index.cjs",

--- a/packages/consent/package.json
+++ b/packages/consent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/consent",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "private": true,
   "description": "PEAC consent pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/contracts",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "PEAC canonical error codes and verification mode contracts",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/control/package.json
+++ b/packages/control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/control",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "PEAC Protocol Control - control engine interfaces and validation",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/core",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "DEPRECATED - Use @peac/kernel, @peac/schema, @peac/crypto, @peac/protocol instead",
   "type": "module",
   "homepage": "https://www.peacprotocol.org",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/crypto",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Ed25519 JWS signing and verification for PEAC protocol",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/disc",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "PEAC discovery with ≤20 lines enforcement",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/http-signatures/package.json
+++ b/packages/http-signatures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/http-signatures",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "RFC 9421 HTTP Message Signatures parsing and verification",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/intelligence/package.json
+++ b/packages/intelligence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/intelligence",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "private": true,
   "description": "PEAC intelligence pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/jwks-cache/package.json
+++ b/packages/jwks-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/jwks-cache",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Edge-safe JWKS fetch and cache with SSRF protection",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/kernel",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "PEAC protocol kernel - normative constants, errors, and registries",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/kernel/src/error-categories.generated.ts
+++ b/packages/kernel/src/error-categories.generated.ts
@@ -3,7 +3,7 @@
  *
  * AUTO-GENERATED from specs/kernel/errors.json
  * DO NOT EDIT MANUALLY - run: npx tsx scripts/codegen-errors.ts
- * Spec version: 0.12.4
+ * Spec version: 0.12.5
  */
 
 /**

--- a/packages/kernel/src/errors.generated.ts
+++ b/packages/kernel/src/errors.generated.ts
@@ -3,7 +3,7 @@
  *
  * AUTO-GENERATED from specs/kernel/errors.json
  * DO NOT EDIT MANUALLY - run: npx tsx scripts/codegen-errors.ts
- * Spec version: 0.12.4
+ * Spec version: 0.12.5
  */
 
 import type { ErrorDefinition } from './types.js';

--- a/packages/mappings/a2a/package.json
+++ b/packages/mappings/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-a2a",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Agent-to-Agent Protocol (A2A) integration for PEAC",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/mappings/acp/package.json
+++ b/packages/mappings/acp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-acp",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Agentic Commerce Protocol (ACP) integration for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/aipref/package.json
+++ b/packages/mappings/aipref/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-aipref",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "IETF AIPREF vocabulary mapping for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/content-signals/package.json
+++ b/packages/mappings/content-signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-content-signals",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Content use policy signal parsing for PEAC (robots.txt, tdmrep.json, Content-Usage)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/mappings/mcp/package.json
+++ b/packages/mappings/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-mcp",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Model Context Protocol (MCP) integration for PEAC",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/mappings/paymentauth/package.json
+++ b/packages/mappings/paymentauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-paymentauth",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "HTTP Payment authentication scheme (paymentauth/MPP) mapping for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/rsl/package.json
+++ b/packages/mappings/rsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-rsl",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "RSL (Robots Specification Layer) mapping for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/tap/package.json
+++ b/packages/mappings/tap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-tap",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Visa Trusted Agent Protocol mapping to PEAC control evidence",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mappings/ucp/package.json
+++ b/packages/mappings/ucp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-ucp",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Google Universal Commerce Protocol (UCP) mapping to PEAC receipts and dispute evidence",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp-server/manifest.json
+++ b/packages/mcp-server/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "peac-mcp-server",
   "display_name": "PEAC Protocol",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Verify, inspect, decode, issue, and bundle PEAC receipts. Portable, offline-verifiable evidence for AI agent interactions.",
   "long_description": "PEAC Protocol provides cryptographically signed, offline-verifiable receipts that record what happened during automated interactions. Each receipt is a compact JWS (JSON Web Signature) using Ed25519 signatures. This MCP server exposes 5 tools for receipt operations: verify (signature + claims), inspect (metadata without verification), decode (raw JWS structure), issue (sign new receipts), and create_bundle (portable evidence directories).",
   "author": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mcp-server",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "PEAC receipt operations as MCP tools (verify, inspect, decode, issue, bundle)",
   "mcpName": "io.github.peacprotocol/peac",
   "main": "dist/index.cjs",

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "subfolder": "packages/mcp-server"
   },
-  "version": "0.12.4",
+  "version": "0.12.5",
   "websiteUrl": "https://www.peacprotocol.org",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@peac/mcp-server",
-      "version": "0.12.4",
+      "version": "0.12.5",
       "transport": {
         "type": "stdio"
       }

--- a/packages/mcp-server/src/infra/constants.ts
+++ b/packages/mcp-server/src/infra/constants.ts
@@ -3,7 +3,7 @@
  */
 
 export const SERVER_NAME = 'peac-mcp-server';
-export const SERVER_VERSION = '0.12.4';
+export const SERVER_VERSION = '0.12.5';
 export const MCP_PROTOCOL_VERSION = '2025-11-25';
 export const DEFAULT_MAX_JWS_BYTES = 16_384; // 16 KB
 export const DEFAULT_MAX_RESPONSE_BYTES = 65_536; // 64 KB

--- a/packages/middleware-core/package.json
+++ b/packages/middleware-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/middleware-core",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Framework-agnostic middleware primitives for PEAC receipt issuance",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/middleware-express/package.json
+++ b/packages/middleware-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/middleware-express",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Express.js middleware for automatic PEAC receipt issuance",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/net/node/package.json
+++ b/packages/net/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/net-node",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "SSRF-safe network utilities for PEAC Protocol with DNS resolution pinning (Node.js only)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/pay402/package.json
+++ b/packages/pay402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/pay402",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Generic HTTP 402 adapter with multi-rail payment negotiation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/policy-kit/package.json
+++ b/packages/policy-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/policy-kit",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "PEAC Policy Kit - deterministic policy evaluation for CAL semantics",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/privacy/package.json
+++ b/packages/privacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/privacy",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "private": true,
   "description": "Privacy pillar for PEAC protocol - k-anonymity, privacy-preserving hashing, data protection",
   "main": "dist/index.js",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/protocol",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "PEAC protocol implementation - receipt issuance and verification",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/provenance/package.json
+++ b/packages/provenance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/provenance",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "private": true,
   "description": "Provenance pillar for PEAC protocol - content provenance, C2PA integration, and chain-of-custody",
   "main": "dist/index.js",

--- a/packages/rails/card/package.json
+++ b/packages/rails/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-card",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Card payment rail adapter for PEAC protocol (Flowglad, Stripe Billing, Lago)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rails/razorpay/package.json
+++ b/packages/rails/razorpay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-razorpay",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "private": true,
   "description": "Razorpay payment rail adapter for PEAC protocol (UPI, cards, netbanking)",
   "main": "dist/index.js",

--- a/packages/rails/stripe/package.json
+++ b/packages/rails/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-stripe",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Stripe payment rail adapter for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rails/x402/package.json
+++ b/packages/rails/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-x402",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "x402 payment rail adapter for PEAC protocol",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/receipts/package.json
+++ b/packages/receipts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/receipts",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "PEAC Protocol receipt builders, parsers, and validators with CBOR support",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/schema",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "PEAC Protocol JSON schemas, OpenAPI specs, and TypeScript types",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/sdk",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "PEAC client SDK with discover/verify functions",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/server",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "PEAC verification server with DoS protection and rate limiting",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry-otel/package.json
+++ b/packages/telemetry-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/telemetry-otel",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "OpenTelemetry adapter for PEAC telemetry",
   "keywords": [
     "peac",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/telemetry",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Telemetry interfaces and no-op implementation for PEAC protocol",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/transport/grpc/package.json
+++ b/packages/transport/grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-grpc",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "private": true,
   "description": "PEAC gRPC transport layer with HTTP StatusCode parity",
   "type": "module",

--- a/packages/transport/http/package.json
+++ b/packages/transport/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-http",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "private": true,
   "description": "PEAC HTTP transport layer - headers, middleware, DPoP L3/L4",
   "type": "module",

--- a/packages/transport/ws/package.json
+++ b/packages/transport/ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-ws",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "private": true,
   "description": "PEAC WebSocket transport layer (placeholder for v0.9.17+)",
   "type": "module",

--- a/packages/worker-core/package.json
+++ b/packages/worker-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-core",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Runtime-neutral TAP verification handler for edge workers",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/worker-shared/package.json
+++ b/packages/worker-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-shared",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "private": true,
   "description": "Shared runtime-neutral TAP verification logic for edge worker surfaces",
   "type": "module",

--- a/scripts/conformance/build-registry.mjs
+++ b/scripts/conformance/build-registry.mjs
@@ -21,7 +21,7 @@ function hash(fragment) {
   return 'sha256:' + createHash('sha256').update(fragment, 'utf-8').digest('hex');
 }
 
-const VERSION = '0.12.3';
+const VERSION = '0.12.5';
 
 // Section slug mapping (markdown anchor format)
 const SECTION_ANCHORS = {

--- a/scripts/publish-manifest.json
+++ b/scripts/publish-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Single source of truth for PEAC Protocol npm publish order",
-  "version": "0.12.4",
-  "lastUpdated": "2026-03-25",
+  "version": "0.12.5",
+  "lastUpdated": "2026-03-27",
   "totalPackages": 29,
   "packages": [
     "@peac/kernel",

--- a/specs/conformance/fixtures/inventory.json
+++ b/specs/conformance/fixtures/inventory.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://www.peacprotocol.org/schemas/conformance/inventory.schema.json",
-  "generated_at": "2026-03-25T05:56:24.249Z",
-  "version": "0.12.4",
-  "schema_version": "0.12.4",
+  "generated_at": "2026-03-27T18:25:34.076Z",
+  "version": "0.12.5",
+  "schema_version": "0.12.5",
   "total_fixtures": 688,
   "total_with_requirements": 243,
   "total_unmapped": 445,

--- a/specs/kernel/error-categories.json
+++ b/specs/kernel/error-categories.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.peacprotocol.org/schemas/kernel/error-categories.schema.json",
   "$comment": "AUTO-GENERATED from specs/kernel/errors.json - DO NOT EDIT MANUALLY",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "source_file": "specs/kernel/errors.json",
   "categories": [
     "attribution",

--- a/specs/kernel/errors.json
+++ b/specs/kernel/errors.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "PEAC error codes - normative source of truth",
   "errors": [
     {

--- a/surfaces/analytics/package.json
+++ b/surfaces/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/analytics",
-  "version": "0.12.3",
+  "version": "0.12.5",
   "private": true,
   "description": "Analytics surface for PEAC Protocol - metrics API with k-anonymity protection",
   "type": "module",

--- a/surfaces/nextjs/middleware/package.json
+++ b/surfaces/nextjs/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/middleware-nextjs",
-  "version": "0.12.3",
+  "version": "0.12.5",
   "private": true,
   "description": "PEAC TAP verifier and 402 access gate for Next.js Edge Runtime",
   "type": "module",

--- a/surfaces/workers/akamai/package.json
+++ b/surfaces/workers/akamai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-akamai",
-  "version": "0.12.3",
+  "version": "0.12.5",
   "private": true,
   "description": "PEAC receipt verification worker for Akamai EdgeWorkers",
   "type": "module",

--- a/surfaces/workers/cloudflare/package.json
+++ b/surfaces/workers/cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-cloudflare",
-  "version": "0.12.3",
+  "version": "0.12.5",
   "private": true,
   "description": "PEAC receipt verification worker for Cloudflare Workers",
   "type": "module",

--- a/surfaces/workers/fastly/package.json
+++ b/surfaces/workers/fastly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-fastly",
-  "version": "0.12.3",
+  "version": "0.12.5",
   "private": true,
   "description": "PEAC receipt verification worker for Fastly Compute",
   "type": "module",


### PR DESCRIPTION
## Summary

Version bump to 0.12.5 and release documentation for the Commerce Hardening + Interop Proofs release.

## Scope

90 files changed. Version bumps (packages, apps, surfaces), CHANGELOG, doc header updates, CITATION metadata.

### Package version bumps

All publishable packages, apps, and surfaces bumped from 0.12.4 to 0.12.5. Examples stay at 0.0.0.

### Documentation updates

- CHANGELOG: new v0.12.5 section (theme, added, changed, fixed, deferred)
- CHANGELOG: v0.12.4 deferred items updated from v0.12.5 to v0.12.6
- docs/ARCHITECTURE.md: version header 0.12.2 to 0.12.5
- docs/specs/INTEROP.md: version header 0.12.2 to 0.12.5
- docs/specs/WIRE-0.2.md: version header 0.12.2 to 0.12.5
- docs/ROADMAP.md: current release v0.12.2 to v0.12.5
- README.md: version suffix removed from Interaction Record format line
- CITATION.cff: version 0.12.3 to 0.12.5, date updated
- integrator-kits/content-signals/README.md: stale forward reference corrected

### Explicitly not changed

- Legacy conformance fixture versions preserved at their original values (fixture version is protocol semantics, not release metadata)
- v0.12.4 CHANGELOG metrics preserved as historical record
- No schema, protocol, or wire format changes

## Validation

- 263 test files, 6915 tests passing
- Format clean, forbid-strings clean, gate exit 0
- Version sync check passing (69 packages, 25 examples skipped)