### PR TITLE
docs: update READMEs for v0.12.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Link: </.well-known/peac-issuer.json>; rel="issuer"
 
 ## Quick start
 
-**Requirements:** Node 24 (tested); Node 22+ (compatible)
+**Requirements:** Node 24 (tested); Node 22+ (compatible). [Go 1.26+](sdks/go/) and [Python 3.12+](examples/python/) also supported.
 
 ### Verify a receipt
 
@@ -129,7 +129,7 @@ PEAC is most useful where logs are not enough: payments, cross-boundary verifica
 - **I want to verify a receipt**: [Agent Operator Quickstart](docs/guides/quickstart-agent-operator.md) (5 minutes)
 - **I build A2A agents**: [A2A Integration Kit](integrator-kits/a2a/README.md)
 
-More paths: [Go SDK](sdks/go/) | [paymentauth Kit](integrator-kits/paymentauth/README.md) | [ACP Kit](integrator-kits/acp/README.md) | [x402 Kit](integrator-kits/x402/README.md) | [Governance Mappings](docs/governance/)
+More paths: [Go SDK](sdks/go/) | [Python examples](examples/python/) | [paymentauth Kit](integrator-kits/paymentauth/README.md) | [ACP Kit](integrator-kits/acp/README.md) | [x402 Kit](integrator-kits/x402/README.md) | [Governance Mappings](docs/governance/)
 
 ---
 

--- a/docs/README_LONG.md
+++ b/docs/README_LONG.md
@@ -173,19 +173,33 @@ Design: ZIP archive with deterministic structure (RFC 8785 canonical JSON). Veri
 
 ### Go SDK
 
-Wire 0.1 receipt issuance, verification, and policy evaluation with Ed25519 + JWS + JWKS support.
+Interaction Record issuance and local verification with Ed25519, RFC 8785 JCS, and JOSE hardening. Requires Go 1.26+.
 
 ```go
-import "github.com/peacprotocol/peac/sdks/go/peac"
+import peac "github.com/peacprotocol/peac/sdks/go"
 
-result, err := peac.Verify(receiptJWS, &peac.VerifyOptions{
-    IssuerAllowlist: []string{"https://api.example.com"},
+// Issue
+result, _ := peac.Issue(peac.IssueOptions{
+    Iss: "https://api.example.com", Kind: peac.KindEvidence,
+    Type: "org.peacprotocol/access-decision", SigningKey: key,
 })
-if err != nil {
-    log.Fatal(err)
-}
-fmt.Println("Issuer:", result.Claims.Iss)
+
+// Verify locally
+vr := peac.VerifyLocal(result.JWS, peac.VerifyLocalOptions{PublicKey: pubKey})
+fmt.Println("Valid:", vr.Valid, "Issuer:", vr.Claims.Iss)
 ```
+
+### Python (API-first examples)
+
+Verify receipts against the Hosted Verify API using httpx. Requires Python 3.12+. Examples only, not an SDK.
+
+```python
+import httpx
+resp = httpx.post("http://localhost:3000/v1/verify", json={"receipt": jws})
+print(resp.json()["verified"])
+```
+
+See [examples/python/](../examples/python/) for the full example.
 
 See [guides/go-middleware.md](guides/go-middleware.md) for net/http middleware.
 


### PR DESCRIPTION
## Summary

Minimal README updates to reflect v0.12.8 shipped state.

## Changes

- Root README: add Go 1.26+ and Python 3.12+ to requirements, add Python examples to navigation
- docs/README_LONG.md: update Go SDK section to Interaction Record API (Issue + VerifyLocal), add Python API-first examples section

## Scope

Documentation only. No code changes.