### PR TITLE
test: add RFC 9728 PRM strict compliance tests

### DIFF
--- a/packages/mcp-server/tests/http/http-transport.test.ts
+++ b/packages/mcp-server/tests/http/http-transport.test.ts
@@ -492,6 +492,99 @@ describe('HTTP Transport', () => {
     expect(status).toBe(404);
   });
 
+  // --- RFC 9728 PRM strict compliance ---
+
+  it('should set Content-Type: application/json on PRM response', async () => {
+    const port = getPort();
+    const result = await createHttpTransport({
+      port,
+      host: '127.0.0.1',
+      authorizationServers: ['https://auth.example.com'],
+      publicUrl: 'https://peac.example.com',
+      serverFactory: makeServerFactory(),
+    });
+    cleanup = result.cleanup;
+
+    const { headers } = await fetchJson(
+      `http://127.0.0.1:${port}/.well-known/oauth-protected-resource`
+    );
+    expect(headers.get('content-type')).toBe('application/json');
+  });
+
+  it('should return only resource and authorization_servers in PRM (no extra fields)', async () => {
+    const port = getPort();
+    const result = await createHttpTransport({
+      port,
+      host: '127.0.0.1',
+      authorizationServers: ['https://auth.example.com'],
+      publicUrl: 'https://peac.example.com/mcp',
+      serverFactory: makeServerFactory(),
+    });
+    cleanup = result.cleanup;
+
+    const { body } = await fetchJson(
+      `http://127.0.0.1:${port}/.well-known/oauth-protected-resource/mcp`
+    );
+    const keys = Object.keys(body as Record<string, unknown>);
+    expect(keys).toEqual(expect.arrayContaining(['resource', 'authorization_servers']));
+    expect(keys).toHaveLength(2);
+  });
+
+  it('should accept multiple authorization servers in PRM', async () => {
+    const port = getPort();
+    const result = await createHttpTransport({
+      port,
+      host: '127.0.0.1',
+      authorizationServers: ['https://auth1.example.com', 'https://auth2.example.com'],
+      publicUrl: 'https://peac.example.com',
+      serverFactory: makeServerFactory(),
+    });
+    cleanup = result.cleanup;
+
+    const { body } = await fetchJson(
+      `http://127.0.0.1:${port}/.well-known/oauth-protected-resource`
+    );
+    expect((body as { authorization_servers: string[] }).authorization_servers).toEqual([
+      'https://auth1.example.com',
+      'https://auth2.example.com',
+    ]);
+  });
+
+  it('should disable PRM when public-url is non-HTTPS on non-loopback', async () => {
+    const port = getPort();
+    const result = await createHttpTransport({
+      port,
+      host: '127.0.0.1',
+      authorizationServers: ['https://auth.example.com'],
+      publicUrl: 'http://peac.example.com/mcp',
+      serverFactory: makeServerFactory(),
+    });
+    cleanup = result.cleanup;
+
+    const { status } = await fetchJson(
+      `http://127.0.0.1:${port}/.well-known/oauth-protected-resource/mcp`
+    );
+    expect(status).toBe(404);
+  });
+
+  it('should allow http public-url on loopback for dev ergonomics', async () => {
+    const port = getPort();
+    const result = await createHttpTransport({
+      port,
+      host: '127.0.0.1',
+      authorizationServers: ['https://auth.example.com'],
+      publicUrl: `http://localhost:${port}/mcp`,
+      serverFactory: makeServerFactory(),
+    });
+    cleanup = result.cleanup;
+
+    const { status, body } = await fetchJson(
+      `http://127.0.0.1:${port}/.well-known/oauth-protected-resource/mcp`
+    );
+    expect(status).toBe(200);
+    expect((body as { resource: string }).resource).toMatch(/^http:\/\/localhost/);
+  });
+
   // --- Trust-proxy behavior ---
 
   it('should not trust X-Forwarded-For by default', async () => {


### PR DESCRIPTION
## Summary

Add 5 dedicated RFC 9728 Protected Resource Metadata compliance tests to lock the existing implementation against the MCP 2025-06-18 authorization spec requirements.

## Scope

Tests only. No implementation changes (the existing PRM implementation already complies with RFC 9728).

## Changes

- `Content-Type: application/json` header assertion on PRM response
- Strict field-count check: PRM document contains only `resource` and `authorization_servers` (no extra fields)
- Multiple authorization servers array verification
- Non-HTTPS rejection for non-loopback public URLs
- HTTP allowance on loopback for dev ergonomics

## Validation

- All 289 MCP server tests pass (including 5 new)
- `pnpm format:check` passes

## Test plan

- [ ] Verify PRM Content-Type is application/json
- [ ] Verify PRM document has exactly 2 fields
- [ ] Verify multiple auth servers serialize correctly
- [ ] Verify non-HTTPS on non-loopback returns 404
- [ ] Verify HTTP on loopback returns 200