### PR TITLE
chore: stamp v0.12.9 release date

### DIFF
--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable surface classification for PEAC Protocol workspace. CI fails if any workspace member is missing. See docs/PACKAGE_STATUS.md for human-readable view.",
   "version": "0.12.9",
-  "updated": "2026-04-10",
+  "updated": "2026-04-11",
   "states": {
     "default": "Current recommended path. Actively maintained, Wire 0.2 native.",
     "supported": "Actively maintained, published, production-ready. May not be on default quickstart path.",

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -3,7 +3,7 @@
 Generated from `REPO_SURFACE_STATUS.json` by `scripts/generate-surface-status.mjs`.
 Do not edit manually.
 
-**Version:** 0.12.9 | **Updated:** 2026-04-10
+**Version:** 0.12.9 | **Updated:** 2026-04-11
 
 ## Layer 1
 

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -4,7 +4,7 @@
   "version": "0.12.9",
   "wire_format_version": "0.2",
   "dist_tag": "next",
-  "release_date": "2026-04-10",
+  "release_date": "2026-04-11",
   "metrics": {
     "tests": 7336,
     "test_files": 290,


### PR DESCRIPTION
Stamps `release_date` in `docs/releases/facts.json` and `updated` in `REPO_SURFACE_STATUS.json` to `2026-04-11` per release checklist step 8, following the successful `publish.yml` run publishing 36 packages to the `next` dist-tag.

Regenerated `docs/SURFACE_STATUS.md` from `REPO_SURFACE_STATUS.json`.

`dist_tag` remains `next` — promoted to `latest` in a separate follow-up micro-PR after `promote-latest.yml` succeeds.

## Verification

```
pnpm release:stamp:check:publish 2026-04-11
OK: docs/releases/facts.json release_date = "2026-04-11"
OK: REPO_SURFACE_STATUS.json updated = "2026-04-11"
```