### PR TITLE
chore: stamp v0.12.9 dist_tag latest

### DIFF
--- a/docs/releases/current.json
+++ b/docs/releases/current.json
@@ -2,7 +2,7 @@
   "description": "PEAC release manifest: CI-enforceable source of truth for release state",
   "version": "0.12.9",
   "wire_format_version": "0.2",
-  "dist_tag": "next",
+  "dist_tag": "latest",
   "registries_version": "0.6.0",
   "errors_version": "0.12.9"
 }

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -3,7 +3,7 @@
   "schema_version": "1.0.0",
   "version": "0.12.9",
   "wire_format_version": "0.2",
-  "dist_tag": "next",
+  "dist_tag": "latest",
   "release_date": "2026-04-11",
   "metrics": {
     "tests": 7336,


### PR DESCRIPTION
Stamps `dist_tag` in `docs/releases/facts.json` and `docs/releases/current.json` from `next` to `latest` per release checklist step 10, following the successful `promote-latest.yml` run promoting all 36 packages from the `next` dist-tag to `latest` on npm.

## Verification

```
pnpm release:stamp:check:promote latest
OK: docs/releases/facts.json dist_tag = "latest"
OK: docs/releases/current.json dist_tag = "latest"

npm view @peac/protocol dist-tags
{ latest: '0.12.9', next: '0.12.9' }
```

All 36 packages verified at `latest: 0.12.9` via loop across `scripts/publish-manifest.json`.