### PR TITLE
docs: reconcile doc surfaces for v0.12.9

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # PEAC Protocol Architecture
 
-**Version:** 0.12.7
+**Version:** 0.12.9
 **Status:** Authoritative
 
 This document describes the kernel-first architecture of the PEAC Protocol monorepo.
@@ -128,38 +128,45 @@ peac/
 │   ├── architecture/       # Architecture deep-dives
 │   └── security/           # Threat models and security controls
 ├── packages/
-│   ├── kernel/             # Layer 0: Zero-dependency constants
-│   ├── schema/             # Layer 1: Types, Zod validators, JSON Schema
-│   ├── crypto/             # Layer 2: Ed25519 JWS, JCS, base64url
-│   ├── protocol/           # Layer 3: issue(), verify(), discovery
+│   ├── kernel/             # Layer 0: Zero-dependency constants, types, errors
+│   ├── schema/             # Layer 1: Zod validators, Wire 0.2 extension groups
+│   ├── crypto/             # Layer 2: Ed25519 JWS, JCS (RFC 8785), base64url
+│   ├── protocol/           # Layer 3: issue(), verifyLocal(), discovery
 │   ├── control/            # Layer 3: Constraint types and enforcement
-│   ├── policy-kit/         # Layer 3: YAML/JSON policy evaluation
+│   ├── middleware-core/    # Layer 3.5: Framework-agnostic receipt middleware
+│   ├── middleware-express/  # Layer 3.5: Express.js receipt middleware
 │   ├── server/             # Layer 5: HTTP verification server
+│   ├── mcp-server/         # Layer 5: MCP server (8 tools, stdio + HTTP)
 │   ├── cli/                # Layer 5: Command-line tools
-│   ├── http-signatures/    # Layer 4: RFC 9421 HTTP Message Signatures
-│   ├── jwks-cache/         # Layer 4: Edge-safe JWKS fetch
+│   ├── adapters/           # Layer 4: Evidence adapters
+│   │   ├── x402/           # x402 v1+v2 (Linux Foundation)
+│   │   ├── did/            # DID resolution (did:key, did:web)
+│   │   ├── eat/            # EAT passport (COSE_Sign1, RFC 9052)
+│   │   ├── managed-agents/ # Vendor-neutral managed runtime evidence
+│   │   └── openclaw/       # OpenClaw agent framework
+│   ├── mappings/           # Layer 4: Protocol mappings
+│   │   ├── a2a/            # A2A v1.0.0 (Linux Foundation)
+│   │   ├── acp/            # Agentic Commerce Protocol (OpenAI/Stripe)
+│   │   ├── paymentauth/    # MPP/paymentauth (Stripe/Tempo)
+│   │   ├── ucp/            # Unified Commerce Protocol (Google)
+│   │   ├── content-signals/ # Content signals observation
+│   │   ├── intoto/         # in-toto v1.0 provenance
+│   │   └── slsa/           # SLSA v1.2 provenance
 │   ├── rails/              # Layer 4: Payment rail adapters
-│   │   ├── x402/
-│   │   └── stripe/
-│   ├── mappings/           # Layer 4: Agent protocol mappings
-│   │   ├── mcp/
-│   │   ├── acp/
-│   │   ├── rsl/            # Robots Specification Layer (RSL 1.0)
-│   │   └── tap/            # Trusted Agent Protocol
-│   ├── access/             # Layer 6: Access control
-│   ├── attribution/        # Layer 6: Attribution and revenue sharing
-│   ├── compliance/         # Layer 6: Regulatory compliance
-│   ├── consent/            # Layer 6: Consent lifecycle
-│   ├── intelligence/       # Layer 6: Analytics
-│   ├── privacy/            # Layer 6: Privacy budgeting
-│   └── provenance/         # Layer 6: Content provenance, C2PA
-├── surfaces/               # Platform integration surfaces
-│   ├── workers/cloudflare/ # Cloudflare Worker TAP verifier
-│   └── nextjs/middleware/  # Next.js Edge middleware
-├── examples/               # Canonical flow examples
-│   ├── pay-per-inference/  # 402 flow: agent obtains receipt, retries
-│   ├── pay-per-crawl/      # Policy Kit + receipt flow for AI crawlers
-│   └── rsl-collective/     # RSL token mapping + core claims parity
+│   │   ├── x402/           # x402 payment rail
+│   │   └── stripe/         # Stripe payment rail
+│   ├── transport-grpc/     # Layer 4: gRPC carrier binding
+│   ├── net-node/           # Layer 4: SSRF-safe network utilities
+│   ├── http-signatures/    # Layer 4: RFC 9421 HTTP Message Signatures
+│   └── jwks-cache/         # Layer 4: Edge-safe JWKS fetch
+├── apps/                   # Internal applications (not published)
+│   ├── api/                # Reference verifier (self-hostable, tenantless)
+│   └── sandbox-issuer/     # Sandbox receipt issuer
+├── examples/               # 30 canonical flow examples
+│   ├── minimal/            # Minimal issue + verify
+│   ├── mcp-http-quickstart/ # MCP Streamable HTTP quickstart
+│   ├── external-pilot/     # External pilot kit with JSON Schema gate
+│   └── ...                 # (27 more; see examples/ directory)
 ├── tests/                  # Global test harness
 │   ├── conformance/
 │   ├── performance/
@@ -172,67 +179,66 @@ peac/
 
 ---
 
-## Package Inventory
+## Package Inventory (36 published packages as of v0.12.9)
 
-### Core (Normative)
+### Core (Normative, Layers 0-3)
 
-| Package            | Layer | Description                                   |
-| ------------------ | ----- | --------------------------------------------- |
-| `@peac/kernel`     | 0     | Zero-dependency constants from specs/kernel   |
-| `@peac/schema`     | 1     | TypeScript types, Zod validators, JSON Schema |
-| `@peac/crypto`     | 2     | Ed25519 JWS, JCS canonicalization (RFC 8785)  |
-| `@peac/protocol`   | 3     | High-level issue() and verify() functions     |
-| `@peac/control`    | 3     | Constraint types and enforcement              |
-| `@peac/policy-kit` | 3     | YAML/JSON policy evaluation for CAL semantics |
+| Package          | Layer | Description                                                                          |
+| ---------------- | ----- | ------------------------------------------------------------------------------------ |
+| `@peac/kernel`   | 0     | Zero-dependency constants, types, errors                                             |
+| `@peac/schema`   | 1     | Zod validators, Wire 0.2 extension groups (12 groups), type-to-extension enforcement |
+| `@peac/crypto`   | 2     | Ed25519 JWS, JCS canonicalization (RFC 8785), JOSE hardening                         |
+| `@peac/protocol` | 3     | `issue()`, `issueWire02()`, `verifyLocal()` with strict/interop profiles             |
+| `@peac/control`  | 3     | Constraint types and kernel constraint enforcement                                   |
 
-### Runtime
+### Middleware (Layer 3.5)
 
-| Package        | Layer | Description                                |
-| -------------- | ----- | ------------------------------------------ |
-| `@peac/server` | 5     | HTTP verification server with 402 support  |
-| `@peac/cli`    | 5     | Command-line tools for receipts and policy |
+| Package                    | Layer | Description                           |
+| -------------------------- | ----- | ------------------------------------- |
+| `@peac/middleware-core`    | 3.5   | Framework-agnostic receipt middleware |
+| `@peac/middleware-express` | 3.5   | Express.js receipt middleware         |
 
-### Rails (Payment Adapters)
+### Adapters (Layer 4)
 
-| Package              | Layer | Description                 |
-| -------------------- | ----- | --------------------------- |
-| `@peac/rails-x402`   | 4     | x402 payment rail adapter   |
-| `@peac/rails-stripe` | 4     | Stripe payment rail adapter |
+| Package                           | Layer | Description                                                      |
+| --------------------------------- | ----- | ---------------------------------------------------------------- |
+| `@peac/adapter-x402`              | 4     | x402 v1+v2 evidence (4-layer architecture, scheme-agnostic)      |
+| `@peac/adapter-did`               | 4     | DID resolution (did:key Ed25519 zero-I/O, did:web SSRF-hardened) |
+| `@peac/adapter-eat`               | 4     | EAT passport (COSE_Sign1, RFC 9052/9053, Ed25519)                |
+| `@peac/adapter-managed-agents`    | 4     | Vendor-neutral managed runtime evidence (6 event families)       |
+| `@peac/adapter-openclaw`          | 4     | OpenClaw agent framework integration                             |
+| `@peac/adapter-openai-compatible` | 4     | Hash-first inference receipts (OpenAI-compatible APIs)           |
 
-### Mappings (Agent Protocol Adapters)
+### Mappings (Layer 4)
 
-| Package              | Layer | Description                           |
-| -------------------- | ----- | ------------------------------------- |
-| `@peac/mappings-mcp` | 4     | Model Context Protocol integration    |
-| `@peac/mappings-acp` | 4     | Agentic Commerce Protocol integration |
-| `@peac/mappings-rsl` | 4     | Robots Specification Layer (RSL 1.0)  |
-| `@peac/mappings-tap` | 4     | Trusted Agent Protocol (Visa TAP)     |
+| Package                          | Layer | Description                                                       |
+| -------------------------------- | ----- | ----------------------------------------------------------------- |
+| `@peac/mappings-a2a`             | 4     | A2A v1.0.0 artifact embedding + Agent Card discovery              |
+| `@peac/mappings-acp`             | 4     | Agentic Commerce Protocol session lifecycle + payment observation |
+| `@peac/mappings-paymentauth`     | 4     | MPP/paymentauth envelope-first HTTP Payment scheme parsing        |
+| `@peac/mappings-ucp`             | 4     | Unified Commerce Protocol order-vs-payment separation             |
+| `@peac/mappings-content-signals` | 4     | Content signals observation (3-state, source precedence)          |
+| `@peac/mappings-intoto`          | 4     | in-toto v1.0 provenance mapping                                   |
+| `@peac/mappings-slsa`            | 4     | SLSA v1.2 provenance mapping                                      |
 
-### Infrastructure
+### Infrastructure (Layer 4)
 
-| Package                 | Layer | Description                               |
-| ----------------------- | ----- | ----------------------------------------- |
-| `@peac/http-signatures` | 4     | RFC 9421 HTTP Message Signatures          |
-| `@peac/jwks-cache`      | 4     | Edge-safe JWKS fetch with SSRF protection |
+| Package                 | Layer | Description                                                |
+| ----------------------- | ----- | ---------------------------------------------------------- |
+| `@peac/net-node`        | 4     | SSRF-safe network utilities with DNS pinning               |
+| `@peac/transport-grpc`  | 4     | gRPC carrier binding (metadata interceptor, status parity) |
+| `@peac/http-signatures` | 4     | RFC 9421 HTTP Message Signatures                           |
+| `@peac/jwks-cache`      | 4     | Edge-safe JWKS fetch with SSRF protection                  |
 
-### Surfaces (Platform Integrations)
+### Applications (Layer 5)
 
-| Package                   | Layer | Description                          |
-| ------------------------- | ----- | ------------------------------------ |
-| `@peac/worker-cloudflare` | 5     | Cloudflare Worker TAP verifier       |
-| `@peac/middleware-nextjs` | 5     | Next.js Edge middleware TAP verifier |
+| Package            | Layer | Description                                                 |
+| ------------------ | ----- | ----------------------------------------------------------- |
+| `@peac/server`     | 5     | HTTP verification server                                    |
+| `@peac/mcp-server` | 5     | MCP server (8 tools, stdio + Streamable HTTP, RFC 9728 PRM) |
+| `@peac/cli`        | 5     | Command-line tools for receipts, policy, reconciliation     |
 
-### Pillars
-
-| Package              | Layer | Description                             |
-| -------------------- | ----- | --------------------------------------- |
-| `@peac/access`       | 6     | Access control and policy evaluation    |
-| `@peac/attribution`  | 6     | Attribution and revenue sharing         |
-| `@peac/compliance`   | 6     | Regulatory compliance helpers           |
-| `@peac/consent`      | 6     | Consent lifecycle management            |
-| `@peac/intelligence` | 6     | Analytics and insights                  |
-| `@peac/privacy`      | 6     | Privacy budgeting and data protection   |
-| `@peac/provenance`   | 6     | Content provenance and C2PA integration |
+See `scripts/publish-manifest.json` and `REPO_SURFACE_STATUS.json` for the full authoritative package list. Additional published packages (rails, telemetry, audit, pillar-specific) are listed there.
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -91,7 +91,7 @@ The verifier and networking layer include SSRF protection by default:
 
 ## Next Steps
 
-- See [examples/](https://github.com/peacprotocol/peac/tree/main/examples) for 18 runnable examples
+- See [examples/](https://github.com/peacprotocol/peac/tree/main/examples) for 30 runnable examples
 - Read [PROTOCOL-BEHAVIOR.md](specs/PROTOCOL-BEHAVIOR.md) for normative protocol specification
 - Read [WIRE-0.2.md](specs/WIRE-0.2.md) for the current Interaction Record format specification
 - See [Error Handling](errors.md) for RFC 9457 Problem Details

--- a/docs/specs/INTEROP.md
+++ b/docs/specs/INTEROP.md
@@ -2,15 +2,15 @@
 
 **Status**: INFORMATIVE
 
-**Version**: 0.12.5
+**Version**: 0.12.9
 
 ---
 
 ## 1. Introduction
 
-This document describes how PEAC interoperates with adjacent protocols and standards. PEAC is designed as the **enforcement and receipts layer** that complements existing systems rather than replacing them.
+This document describes how PEAC interoperates with adjacent protocols and standards. PEAC is the **portable signed evidence layer** that complements existing systems rather than replacing them.
 
-**Positioning**: PEAC provides verifiable receipts for access control decisions. It works alongside preference signals, payment rails, and agent protocols.
+**Positioning**: PEAC records signed interaction evidence across agent, API, MCP, commerce, and cross-runtime workflows. It works alongside preference signals, payment rails, agent protocols, and runtime governance systems.
 
 ---
 
@@ -75,7 +75,7 @@ const scope = controlPurposeToAiprefScope('inference');
 ### 3.2 Integration Pattern
 
 1. **Publisher declares** RSL directives in `robots.txt` or RSL manifest
-2. **PEAC parses** RSL via `@peac/pref` (includes RSL parsing)
+2. **PEAC parses** RSL via `@peac/mappings-rsl`
 3. **Policy Kit** generates policy rules from RSL declarations
 4. **Receipt** captures which RSL-derived purpose was enforced
 
@@ -115,73 +115,76 @@ const result = rslToControlPurposes(['ai-all', 'search']);
 
 ### 4.3 Package
 
-`@peac/mappings-mcp` provides MCP context to PEAC receipt mapping:
+`@peac/mcp-server` provides 8 tools for issuing and verifying receipts over MCP (stdio and Streamable HTTP transports). Evidence is carried in MCP `_meta` keys `org.peacprotocol/receipt_ref` and `org.peacprotocol/receipt_jws`:
 
 ```typescript
-import { mcpContextToIssueOptions } from '@peac/mappings-mcp';
-
-const issueOptions = mcpContextToIssueOptions(mcpRequest);
-// Maps MCP budget to PEAC constraints, tool to purpose, etc.
+// MCP server issues and verifies receipts as tool responses.
+// See integrator-kits/mcp/README.md for full quickstart.
+// Install: npx -y @peac/mcp-server --transport http
 ```
 
 ---
 
 ## 5. A2A (Agent-to-Agent)
 
-**Standard**: Google A2A (Agent-to-Agent Protocol)
+**Standard**: A2A Protocol v1.0.0 (Linux Foundation, 150+ organizations). Official SDKs: Python, Go, Java, JavaScript, C#/.NET, Rust.
 
-**Relationship**: A2A defines agent communication patterns. PEAC receipts can be carried in A2A messages as proof of access rights.
+**Relationship**: A2A defines agent-to-agent communication patterns. PEAC receipts travel as Evidence Carriers inside A2A TaskStatus metadata using the `org.peacprotocol` extension URI.
 
 ### 5.1 Integration Points
 
-| A2A Concept    | PEAC Integration                   |
-| -------------- | ---------------------------------- |
-| Agent Card     | Can advertise PEAC policy endpoint |
-| Task execution | Receipt proves execution authority |
-| Delegation     | Receipt chain proves delegation    |
+| A2A Concept   | PEAC Integration                                        |
+| ------------- | ------------------------------------------------------- |
+| Agent Card    | Advertises PEAC evidence support via extension URI      |
+| Task metadata | Receipts carried in `metadata[extensionURI].carriers[]` |
+| Delegation    | Receipt chain proves delegation authority               |
 
 ### 5.2 Integration Pattern
 
-1. **Agent Card** includes PEAC policy URI and capabilities
-2. **A2A task request** includes `PEAC-Purpose` header
-3. **Receiving agent** evaluates policy and issues receipt
-4. **Receipt returned** in A2A response
+1. **Agent Card** declares PEAC evidence capability
+2. **A2A task execution** produces signed Interaction Record
+3. **Receipt embedded** in A2A TaskStatus metadata
+4. **Receiving agent** extracts and verifies offline
 
 ### 5.3 Package
 
-`@peac/mappings-acp` provides mapping utilities for the Agentic Commerce Protocol (ACP).
+`@peac/mappings-a2a` provides A2A v1.0.0 artifact embedding, Agent Card discovery, and carrier extraction. A2A v0.3.0 compat shim retained through v0.12.x; removal in v0.13.0.
 
 ---
 
-## 6. Payment Rails
+## 6. Commerce and Payment Evidence
 
-PEAC integrates with payment rails through adapter packages. Receipts capture payment evidence without coupling to specific vendors.
+PEAC integrates with commerce and payment protocols through adapter and mapping packages. Evidence is captured in the `org.peacprotocol/commerce` extension group using the Interaction Record format (Wire 0.2).
 
-### 6.1 Supported Rails
+### 6.1 Supported Protocols
 
-| Rail     | Package                | Notes             |
-| -------- | ---------------------- | ----------------- |
-| x402     | `@peac/rails-x402`     | HTTP 402 payments |
-| Stripe   | `@peac/rails-stripe`   | Card payments     |
-| Razorpay | `@peac/rails-razorpay` | India payments    |
+| Protocol                       | Package                      | Notes                                                                 |
+| ------------------------------ | ---------------------------- | --------------------------------------------------------------------- |
+| x402 (Linux Foundation)        | `@peac/adapter-x402`         | v1+v2 dual-header read, scheme-agnostic (exact, upto, future schemes) |
+| MPP/paymentauth (Stripe/Tempo) | `@peac/mappings-paymentauth` | Envelope-first HTTP Payment scheme parsing                            |
+| ACP (OpenAI/Stripe)            | `@peac/mappings-acp`         | Session lifecycle + payment observation (two-function boundary)       |
+| UCP (Google)                   | `@peac/mappings-ucp`         | Order-vs-payment separation with `payment_state_source` marker        |
+| Stripe SPT                     | `@peac/rails-stripe`         | Delegation vocabulary, PaymentIntent observation                      |
 
-### 6.2 Receipt Pattern
+### 6.2 Evidence Pattern (Wire 0.2)
 
-Payment evidence is captured in `evidence.payment`:
+Commerce evidence uses the `org.peacprotocol/commerce` extension group with `amount_minor` as a string:
 
 ```json
 {
-  "evidence": {
-    "payment": {
-      "rail": "x402",
-      "facilitator": "daydreams",
-      "amount_cents": 100,
+  "kind": "evidence",
+  "type": "org.peacprotocol/commerce.payment",
+  "extensions": {
+    "org.peacprotocol/commerce": {
+      "amount_minor": "10000",
       "currency": "USD",
-      "evidence": { ... }
+      "event": "authorization"
     }
   }
 }
 ```
+
+Commerce evidence mappings MUST preserve raw upstream artifacts and MUST NOT synthesize payment finality from non-payment artifacts.
 
 ---
 
@@ -272,15 +275,19 @@ Vendor-specific details live in adapter packages:
 
 ---
 
-## 10. Future Interoperability
+## 10. Additional Interoperability Surfaces
 
-The following are under consideration for future versions:
-
-| Standard                  | Status                | Target Version |
-| ------------------------- | --------------------- | -------------- |
-| C2PA (Content Provenance) | ISO standard expected | v0.10.0+       |
-| CC Signals                | Stabilizing           | v0.10.0+       |
-| EU AI Act traceability    | Aug 2026              | v0.9.26+       |
+| Standard                               | PEAC Status                            | Package                                                          |
+| -------------------------------------- | -------------------------------------- | ---------------------------------------------------------------- |
+| in-toto v1.0 (supply-chain provenance) | Shipped (v0.12.6)                      | `@peac/mappings-intoto`                                          |
+| SLSA v1.2 (build provenance)           | Shipped (v0.12.6)                      | `@peac/mappings-slsa`                                            |
+| ERC-8128 (on-chain agent trust)        | Conformance fixtures shipped (v0.12.6) | Conformance only                                                 |
+| DID resolution (did:key, did:web)      | Shipped (v0.12.6)                      | `@peac/adapter-did`                                              |
+| gRPC transport carrier binding         | Shipped (v0.12.6)                      | `@peac/transport-grpc`                                           |
+| EAT passport (COSE_Sign1, RFC 9052)    | Shipped (v0.12.0-preview.2)            | `@peac/adapter-eat`                                              |
+| Content signals observation            | Shipped (v0.11.2)                      | `@peac/mappings-content-signals`                                 |
+| Managed runtime evidence               | Shipped (v0.12.9)                      | `@peac/adapter-managed-agents`                                   |
+| EU AI Act Annex IV evidence            | Planned (v0.12.12)                     | Extension groups + compliance profile shipped; packaging planned |
 
 ---
 

--- a/integrator-kits/a2a/README.md
+++ b/integrator-kits/a2a/README.md
@@ -6,7 +6,7 @@ Carry signed receipts across A2A agent flows: declare PEAC support in your Agent
 
 PEAC integrates with A2A at the metadata layer. Receipts travel as Evidence Carriers inside A2A TaskStatus metadata, using the reverse-DNS extension URI `org.peacprotocol`. No A2A protocol changes are required; PEAC uses the standard metadata extension mechanism.
 
-**Compatibility:** The current `@peac/mappings-a2a` package targets A2A v0.3.0. A2A v1.0.0 dual-version transition support (Agent Card, enums, parts model) is landing in the next release.
+**Compatibility:** `@peac/mappings-a2a` targets A2A v1.0.0 (shipped in v0.12.3). A2A v0.3.0 compat shim is retained through v0.12.x; removal scheduled for v0.13.0.
 
 ## Prerequisites
 

--- a/integrator-kits/content-signals/README.md
+++ b/integrator-kits/content-signals/README.md
@@ -4,7 +4,7 @@ Integration guide for adding PEAC receipts to Content Signals (C2PA adjacent) wo
 
 ## Status
 
-Integration kit: expanding to full guide. The `@peac/mappings-content-signals` package is published and stable since v0.11.2. AIPREF vocab draft-05 version pinning shipped in v0.12.3.
+Stable. The `@peac/mappings-content-signals` package has been published and stable since v0.11.2. AIPREF vocab draft-05 version pinning shipped in v0.12.3.
 
 ## Quick Start
 

--- a/integrator-kits/x402/README.md
+++ b/integrator-kits/x402/README.md
@@ -72,7 +72,7 @@ const carrier = await toPeacCarrier(receiptJws);
 
 ## Attach Path
 
-PEAC writes `PEAC-Receipt` only. No v2 write support in v0.12.4. Full v2 adapter (plugin arch, CAIP, multi-facilitator, wallet sessions) deferred to v0.12.5.
+PEAC writes `PEAC-Receipt` only. x402 V2 full adapter (mapping, verification, unified dispatchers) shipped in v0.12.6. Dual-header read (v1 + v2) shipped in v0.12.4. Scheme-agnostic posture (`exact`, `upto`, and future schemes) verified in v0.12.9.
 
 ## Reference
 


### PR DESCRIPTION
## Summary

Reconcile stale version numbers, package inventories, API references, and forward-looking claims across 6 tracked doc surfaces to match the v0.12.9 shipped state (36 packages, Wire 0.2 stable, 217 conformance IDs across 24 sections, 100 build targets).

## Changes

- **docs/ARCHITECTURE.md**: version 0.12.7 to 0.12.9; `verify()` to `verifyLocal()`; package inventory rewritten from legacy 0.10.x-era tables to current 36-package reality (adapters, mappings, middleware, infrastructure, applications); directory tree updated
- **docs/specs/INTEROP.md**: version 0.12.5 to 0.12.9; "enforcement and receipts layer" to "portable signed evidence layer"; wrong package references fixed (`@peac/pref` to `@peac/mappings-rsl`, `@peac/mappings-acp` to `@peac/mappings-a2a` in A2A section); non-existent `mcpContextToIssueOptions` API replaced; stale Wire 0.1 payment JSON replaced with Wire 0.2 commerce extension group pattern; unpublished `@peac/rails-razorpay` removed; payment rails section rewritten as commerce and payment evidence; future interoperability table replaced with shipped surfaces
- **docs/quickstart.md**: example count 18 to 30
- **integrator-kits/a2a/README.md**: "landing in the next release" replaced with shipped state (v0.12.3)
- **integrator-kits/x402/README.md**: stale v0.12.4 deferral note replaced with shipped v0.12.6 capability
- **integrator-kits/content-signals/README.md**: "expanding to full guide" stub replaced with "Stable"

## Validation

- `pnpm format:check` passes
- `bash scripts/guard.sh` passes (all safety invariants clean)