### PR TITLE
docs: runtime-governance profile, compatibility matrix, and adapter usage

### DIFF
--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -39,6 +39,19 @@ Current as of v0.12.9.
 
 All adapter and mapping packages support Wire 0.2 exclusively. See `REPO_SURFACE_STATUS.json` for the full list with per-package state.
 
+| Adapter                        | Coverage                                      | Since   | Status      |
+| ------------------------------ | --------------------------------------------- | ------- | ----------- |
+| `@peac/adapter-managed-agents` | 6 event families, session summary             | v0.12.9 | **Shipped** |
+| `@peac/adapter-x402`           | 4-layer verification, dual-header, V2 support | v0.12.1 | **Shipped** |
+| `@peac/adapter-eat`            | COSE_Sign1, Ed25519, privacy-first mapping    | v0.12.0 | **Shipped** |
+| `@peac/adapter-did`            | did:key, did:web, DID Document resolver       | v0.12.6 | **Shipped** |
+
+### Planned (v0.12.10)
+
+| Adapter                            | Coverage                                                            | Target   |
+| ---------------------------------- | ------------------------------------------------------------------- | -------- |
+| `@peac/adapter-runtime-governance` | 6 observation-specific type URIs, AGT first mapper, session summary | v0.12.10 |
+
 ## Deprecation Schedule
 
 | Surface                   | Deprecated since | Removal target           | Migration                                                               |

--- a/docs/WHEN_NOT_TO_USE_PEAC.md
+++ b/docs/WHEN_NOT_TO_USE_PEAC.md
@@ -28,9 +28,13 @@ PEAC receipts are signed artifacts created after an interaction completes. They 
 
 PEAC does not issue, verify, or manage identities. It uses existing identity systems (Ed25519 keys, DIDs, JWKS) to sign and verify receipts. If you need identity infrastructure, use your organization's IdP, DID methods, or key management system. PEAC's `actor` and `iss` fields reference identities but do not create them.
 
+## When you need runtime governance enforcement
+
+PEAC records what runtime governance systems decided. It does not enforce policies, manage sandboxes, evaluate trust, or make allow/deny decisions. If you need runtime governance enforcement, use Microsoft Agent Governance Toolkit, your managed runtime's native controls, or a dedicated policy engine. PEAC can record signed, portable records of what those systems reported, enabling cross-boundary verification by third parties.
+
 ## When you need a trust score or reputation system
 
-PEAC provides raw, verifiable evidence. It does not compute trust scores, reputation metrics, or risk assessments. If you need reputation, use ERC-8004, Observer Protocol, or a dedicated reputation layer. PEAC evidence can serve as input to a reputation system, but it does not replace one.
+PEAC provides raw, verifiable records. It does not compute trust scores, reputation metrics, or risk assessments. If you need reputation, use ERC-8004, Observer Protocol, or a dedicated reputation layer. PEAC records can serve as input to a reputation system, but PEAC does not replace one.
 
 ## When a simpler format is enough
 

--- a/docs/adapters/runtime-governance.md
+++ b/docs/adapters/runtime-governance.md
@@ -1,0 +1,116 @@
+# Runtime Governance Adapter
+
+> Part of [PEAC Adapters](./README.md) | Since: v0.12.10
+
+Records runtime governance artifacts as signed PEAC Interaction Records.
+Generic surface with source-specific mappers. Microsoft AGT is the first
+mapper; the architecture supports additional mappers for other runtimes.
+
+**Package:** `@peac/adapter-runtime-governance`
+**Layer:** 4 (Adapters)
+**Extension Namespace:** `org.peacprotocol/runtime-governance`
+**Spec:** [RUNTIME-GOVERNANCE-PROFILE.md](../specs/RUNTIME-GOVERNANCE-PROFILE.md)
+**Status:** Planned (v0.12.10)
+
+## Overview
+
+Runtime governance systems enforce policy inside a runtime boundary.
+This adapter records what those systems reported as portable, signed
+Interaction Records. The boundary is intentional and load-bearing:
+
+| Layer                   | Owner               | Responsibility                                                             |
+| ----------------------- | ------------------- | -------------------------------------------------------------------------- |
+| Runtime enforcement     | AGT, Claude MA, ACP | Policy evaluation, trust scoring, sandbox management                       |
+| Portable signed records | PEAC                | Record decisions, preserve upstream artifacts, enable offline verification |
+
+PEAC validates the structure and signature of the PEAC record, not the truth
+of the upstream governance decision or the operating effectiveness of the
+upstream control plane. PEAC does not verify AGT's Merkle chain integrity or
+ML-DSA-65 signatures in v0.12.10. It records upstream artifacts observationally.
+
+## Architecture
+
+```text
+issueRuntimeGovernanceRecord(event, opts)    <-- generic issuance
+  ^
+  |
+mapAgtEvent(agtInput) --> event              <-- AGT mapper
+mapManagedAgentEvent(...) --> event           <-- future mapper
+```
+
+## Record Categories
+
+| Category               | Type URI                                                     | Description                                                |
+| ---------------------- | ------------------------------------------------------------ | ---------------------------------------------------------- |
+| Policy Decision        | `org.peacprotocol/runtime-governance-policy-decision`        | Governance decision: action, rule, policy, evaluation time |
+| Audit Entry            | `org.peacprotocol/runtime-governance-audit-entry`            | Audit log entry with upstream integrity references         |
+| Authority Scope        | `org.peacprotocol/runtime-governance-authority-scope`        | Scope narrowing, privilege tier, matched invariants        |
+| Lifecycle Event        | `org.peacprotocol/runtime-governance-lifecycle-event`        | Agent state transitions                                    |
+| Trust Observation      | `org.peacprotocol/runtime-governance-trust-observation`      | Trust signals (opaque, never computed by PEAC)             |
+| Compliance Observation | `org.peacprotocol/runtime-governance-compliance-observation` | Framework assessments (opaque, never determined by PEAC)   |
+
+## What this adapter does
+
+- Issues signed Interaction Records for 6 governance event categories
+- Validates input with discriminated union per-family validators
+- Preserves upstream artifacts (Merkle hashes, CloudEvents types) as opaque data
+- Provides source-specific mappers (AGT first, others later)
+- Caller-supplied `provider` field (never hardcoded)
+
+## What this adapter does NOT do
+
+- Enforce policies or make allow/deny decisions
+- Compute, validate, or weight trust scores
+- Make compliance determinations or issue certifications
+- Verify upstream Merkle chain integrity
+- Verify upstream ML-DSA-65 or SPIFFE signatures
+- Import any vendor SDK as a runtime dependency
+
+## Quick start
+
+Proposed API (lands with adapter package in v0.12.10):
+
+```typescript
+// Planned API -- not yet runnable; package ships with adapter PR
+import { generateKeypair, verifyLocal } from '@peac/protocol';
+import {
+  issueRuntimeGovernanceRecord,
+  mapAgtEvent,
+  buildSessionSummary,
+} from '@peac/adapter-runtime-governance';
+
+// 1. Generate keypair
+const kp = await generateKeypair();
+
+// 2. Map an AGT-shaped event to the generic model
+const event = mapAgtEvent({
+  family: 'policy_decision',
+  event: 'policy.evaluated',
+  data: {
+    action: 'allow',
+    matched_rule: 'default-allow',
+    policy_name: 'agent-web-access',
+    evaluation_ms: 2.3,
+  },
+  source: {
+    system: 'microsoft-agt',
+    event_type: 'ai.agentmesh.policy.evaluation',
+  },
+});
+
+// 3. Issue a signed Interaction Record
+const result = await issueRuntimeGovernanceRecord(event, {
+  privateKey: kp.privateKey,
+  kid: 'gov-key-1',
+  issuer: 'https://governance.example.com',
+  sessionId: 'sess-001',
+  agentId: 'agent-001',
+  provider: 'example-runtime',
+});
+
+// 4. Verify locally
+const verification = await verifyLocal(result.jws, kp.publicKey);
+
+// 5. Build session summary (decode-only, no verification)
+const summary = buildSessionSummary([result.jws]);
+```

--- a/docs/compatibility/runtime-governance-coverage.md
+++ b/docs/compatibility/runtime-governance-coverage.md
@@ -1,0 +1,88 @@
+# Runtime Governance Record Coverage
+
+**Snapshot date:** Microsoft AGT v3.1.0 pre-release state as of April 13, 2026.
+For current upstream status, see
+[microsoft/agent-governance-toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+This document distinguishes three truth surfaces so readers can reason about
+where a given capability lives. Collapsing them into one blended "supported"
+statement leads to drift and overclaim. PEAC keeps them separate.
+
+1. **Upstream AGT architecture** -- what Microsoft AGT ships as of v3.1.0
+   pre-release, referenced to public source.
+2. **PEAC adapter coverage** -- what `@peac/adapter-runtime-governance` maps,
+   preserves, and intentionally does not cover.
+3. **Verified interoperability** -- what PEAC CI proves end-to-end.
+
+## Control-plane vs records-plane
+
+| Dimension                 | AGT (control-plane)               | PEAC (records-plane)                                                    |
+| ------------------------- | --------------------------------- | ----------------------------------------------------------------------- |
+| Runtime enforcement       | Yes (allow/deny/warn)             | No (observational only)                                                 |
+| Policy evaluation         | Yes (Rego/Cedar/YAML)             | No (records decisions, does not evaluate)                               |
+| Trust scoring             | Yes (0-1000, computed)            | No (preserves upstream scores as opaque values)                         |
+| Compliance assessment     | Yes (documentary self-assessment) | No (records assessments, does not determine)                            |
+| Portable signed record    | No                                | Yes (Wire 0.2 `interaction-record+jwt`)                                 |
+| Cross-vendor verification | No (requires AGT stack)           | Yes (any party with public key)                                         |
+| Conformance suite         | No (0 executable vectors)         | Yes (217+ requirement IDs; runtime-governance IDs planned for v0.12.10) |
+
+Both layers are needed. AGT governs inside the runtime; PEAC produces portable,
+signed records across boundaries. A third-party auditor can verify a PEAC
+receipt with a public key. A third-party auditor cannot verify an AGT decision
+without access to the AGT runtime or its backing database.
+
+PEAC validates the structure and signature of the PEAC record, not the truth
+of the upstream governance decision or the operating effectiveness of the
+upstream control plane.
+
+## Truth Surface 1: Upstream AGT Architecture
+
+As of v3.1.0 pre-release (April 11, 2026). All claims reference AGT public
+documentation and source code. No endorsement or evaluation.
+
+| Concept            | Notes                                                                                           |
+| ------------------ | ----------------------------------------------------------------------------------------------- |
+| Policy enforcement | OPA Rego, Cedar, native YAML policy engines                                                     |
+| Agent identity     | Ed25519 + ML-DSA-65 (quantum-safe). SPIFFE/SVID. `did:mesh:` bare string identifiers            |
+| Trust scoring      | Exists (0-1000 scale); computed by the runtime, not portable                                    |
+| Audit logging      | Merkle tree hash chain. CloudEvents export                                                      |
+| Compliance mapping | SOC 2, NIST AI RMF, EU AI Act, OWASP; all internal self-assessment, not validated certification |
+| Lifecycle          | Multi-state lifecycle model                                                                     |
+| Status             | Public preview (not GA); breaking changes possible                                              |
+
+AGT's own SOC 2 mapping states deployers remain responsible for operating
+procedures, policies, and evidence collection. AGT's NIST RFI mapping is
+described as automated static analysis of repository contents only.
+
+## Truth Surface 2: PEAC Adapter Coverage
+
+What `@peac/adapter-runtime-governance` maps, preserves, and does not cover.
+
+| AGT Concept               | PEAC Family              | Coverage       | Notes                                                                           |
+| ------------------------- | ------------------------ | -------------- | ------------------------------------------------------------------------------- |
+| PolicyDecision            | `policy-decision`        | observational  | Decision recorded; not enforced                                                 |
+| AuditEntry (Merkle chain) | `audit-entry`            | observational  | Merkle hashes preserved as opaque strings; PEAC does not verify chain integrity |
+| AuthorityDecision         | `authority-scope`        | observational  | Scope narrowing recorded                                                        |
+| LifecycleEvent (8-state)  | `lifecycle-event`        | observational  | All lifecycle types via `lifecycle_event_type` field                            |
+| TrustRecord (0-1000)      | `trust-observation`      | observational  | Score and delta preserved; PEAC never computes or validates trust               |
+| ComplianceReport          | `compliance-observation` | observational  | Framework, score, violation count; PEAC never makes compliance determinations   |
+| CloudEvents types         | (correlation)            | reference-only | `source_cloud_event_type` field for cross-system tracing; not normative         |
+| ML-DSA-65 / PQC           | (not applicable)         | not-applicable | PEAC signs Ed25519; upstream PQC preserved as opaque metadata                   |
+| Privilege rings           | (not applicable)         | not-applicable | Runtime enforcement, not records                                                |
+| Kill switch               | (not applicable)         | not-applicable | Runtime control, not records                                                    |
+| MCP security scanner      | (not applicable)         | not-applicable | Runtime scanning, not records                                                   |
+| Governance dashboard      | (not applicable)         | not-applicable | Runtime visualization, not records                                              |
+| `agt doctor` CLI          | (not applicable)         | not-applicable | Runtime diagnostics, not records                                                |
+| Agent Marketplace         | (not applicable)         | not-applicable | Plugin lifecycle, not governance records                                        |
+
+## Truth Surface 3: Verified Interoperability
+
+| Verification                                | Status                          | Method                                                    |
+| ------------------------------------------- | ------------------------------- | --------------------------------------------------------- |
+| Issue + verifyLocal round-trip (6 families) | Planned for v0.12.10 adapter PR | Pinned AGT-shaped fixtures from v3.1.0 docs               |
+| Session summary aggregation                 | Planned for v0.12.10 adapter PR | Mixed-family receipt decoding with deterministic ordering |
+| Per-family normalization and validation     | Planned for v0.12.10 adapter PR | Discriminated union validation with malformed rejection   |
+| Unknown upstream field containment          | Planned for v0.12.10 adapter PR | Unknown fields do not become extension keys               |
+| Live AGT v3.1.0 runtime integration         | Not yet tested                  | Requires AGT runtime instance                             |
+| Merkle chain integrity verification         | Not performed by PEAC           | Upstream runtime responsibility                           |
+| ML-DSA-65 signature verification            | Not performed by PEAC           | PEAC signs with Ed25519 only                              |

--- a/docs/profiles/README.md
+++ b/docs/profiles/README.md
@@ -37,9 +37,10 @@ regulatory, operational, or evidence workflow.
 Adapter profiles document how to normalize external protocol artifacts into
 PEAC receipts for a specific integration.
 
-| Profile                                                         | Package              | Since    | Status |
-| --------------------------------------------------------------- | -------------------- | -------- | ------ |
-| [Stripe x402 Machine Payments](stripe-x402-machine-payments.md) | `@peac/rails-stripe` | v0.10.11 | Draft  |
+| Profile                                                         | Package                            | Since    | Status |
+| --------------------------------------------------------------- | ---------------------------------- | -------- | ------ |
+| [Stripe x402 Machine Payments](stripe-x402-machine-payments.md) | `@peac/rails-stripe`               | v0.10.11 | Draft  |
+| [Runtime Governance](runtime-governance.md)                     | `@peac/adapter-runtime-governance` | v0.12.10 | Draft  |
 
 ## Profile Templates
 

--- a/docs/profiles/runtime-governance.md
+++ b/docs/profiles/runtime-governance.md
@@ -1,0 +1,98 @@
+# Runtime Governance Profile
+
+**Status:** Draft
+**Since:** v0.12.10
+**Extension Namespace:** `org.peacprotocol/runtime-governance`
+**Package:** `@peac/adapter-runtime-governance` (planned, lands with adapter PR)
+**Spec:** [RUNTIME-GOVERNANCE-PROFILE.md](../specs/RUNTIME-GOVERNANCE-PROFILE.md)
+
+## Abstract
+
+Records governance decisions, audit entries, authority scope changes, lifecycle
+transitions, trust signals, and compliance assessments from managed runtimes as
+signed PEAC Interaction Records. Observational only: PEAC records what the
+runtime reported; PEAC does not enforce, compute, or determine.
+
+## Use case
+
+An operator running a managed runtime (Microsoft AGT, Claude Managed Agents,
+OpenAI ACP-backed runtime, or similar) wants portable, signed records of
+governance actions that a third party can verify without accessing the
+runtime's backing database.
+
+## Package / Function
+
+The adapter package `@peac/adapter-runtime-governance` is planned for v0.12.10.
+The API below is the proposed design; it is not yet runnable.
+
+```typescript
+// Proposed API (lands with adapter package in v0.12.10)
+import { issueRuntimeGovernanceRecord, mapAgtEvent } from '@peac/adapter-runtime-governance';
+```
+
+## Mapping
+
+| Input (upstream governance artifact)  | PEAC Record Field                                                | Semantics                                                   |
+| ------------------------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------- |
+| Governance decision (allow/deny/warn) | Extension: `action`                                              | Observational; not enforced by PEAC                         |
+| Matched policy rule                   | Extension: `matched_rule`                                        | Preserved as string                                         |
+| Policy name / reference               | Extension: `policy_name`                                         | Preserved as string                                         |
+| Audit entry with hash chain           | Extension: `previous_hash`, `entry_hash`                         | Opaque; PEAC does not verify chain integrity                |
+| Trust score / delta                   | Extension: `trust_score`, `trust_delta`                          | Opaque observational values; PEAC does not compute trust    |
+| Compliance framework assessment       | Extension: `framework`, `compliance_score`                       | Observational; PEAC does not make compliance determinations |
+| Agent lifecycle transition            | Extension: `lifecycle_event_type`, `previous_state`, `new_state` | State change recorded                                       |
+
+See [RUNTIME-GOVERNANCE-PROFILE.md](../specs/RUNTIME-GOVERNANCE-PROFILE.md)
+for the full specification, preserved upstream artifact block, and
+anti-pattern rules.
+
+## Validation rules
+
+1. All records MUST use `kind: "evidence"` (Wire 0.2 protocol value)
+2. Type URIs MUST use `org.peacprotocol/runtime-governance-` prefix
+3. Provider field MUST be caller-supplied and present; never hardcoded
+4. Adapter MUST NOT import any vendor runtime SDK as a dependency
+5. Trust scores are carried as observational values; PEAC MUST NOT derive, recompute, rank, or authoritatively assess trust
+6. Compliance observations are recorded; PEAC MUST NOT make compliance determinations
+7. Upstream integrity artifacts (Merkle hashes, chain references) are preserved as opaque strings
+8. Input validation fails closed on malformed values (non-finite numbers, out-of-range scores, oversized arrays)
+
+## Conformance vectors
+
+Planned for v0.12.10 adapter PR. Fixtures will be located at
+`specs/conformance/fixtures/runtime-governance/` with provenance documentation
+linking each fixture to verified AGT v3.1.0 pre-release documentation.
+
+Conformance section: Section 25 (RTGOV-001 through RTGOV-007).
+
+## Quick demo
+
+The adapter package is planned for v0.12.10. A runnable demo will land with
+the adapter PR at `examples/runtime-governance-records/`.
+
+## Example
+
+Proposed API (not yet runnable):
+
+```typescript
+// Planned API -- lands with @peac/adapter-runtime-governance package
+const event = mapAgtEvent({
+  family: 'policy_decision',
+  event: 'policy.evaluated',
+  data: {
+    action: 'allow',
+    matched_rule: 'default-allow',
+    policy_name: 'agent-web-access',
+    evaluation_ms: 2.3,
+  },
+});
+
+const result = await issueRuntimeGovernanceRecord(event, {
+  privateKey: kp.privateKey,
+  kid: 'gov-key-1',
+  issuer: 'https://governance.example.com',
+  sessionId: 'sess-001',
+  agentId: 'agent-001',
+  provider: 'example-runtime',
+});
+```

--- a/docs/specs/RUNTIME-GOVERNANCE-PROFILE.md
+++ b/docs/specs/RUNTIME-GOVERNANCE-PROFILE.md
@@ -1,0 +1,139 @@
+# Runtime Governance Profile
+
+> Part of [PEAC Specs](../specs/) | Since: v0.12.10 | Status: Draft
+
+Defines how runtime-governance records map to existing PEAC primitives.
+Documentary overlay: no wire change, no new frozen extension group.
+
+PEAC validates the structure and signature of the PEAC record, not the truth
+of the upstream governance decision or the operating effectiveness of the
+upstream control plane.
+
+## 1. Abstract
+
+Managed runtimes (such as Microsoft Agent Governance Toolkit, Claude Managed
+Agents, and OpenAI ACP-backed runtimes) produce governance artifacts: policy
+decisions, audit entries, authority scope changes, lifecycle transitions, trust
+signals, and compliance assessments. This profile defines how to record those
+artifacts as signed PEAC Interaction Records using existing Wire 0.2 primitives.
+
+PEAC is the records plane beneath these runtimes, not the control plane itself.
+A runtime decides and enforces; PEAC records what the runtime reported, in a
+form any third party can verify with the issuer's public key.
+
+## 2. Scope
+
+This profile covers **observational records** from runtime governance systems.
+
+**In scope:**
+
+- Recording governance decisions (allow, deny, warn, require_approval, log)
+- Recording audit entries with upstream integrity references
+- Recording authority and scope changes
+- Recording agent lifecycle state transitions
+- Recording trust signals as opaque observational data
+- Recording compliance assessments as opaque observational data
+
+**Out of scope:**
+
+- Policy enforcement (runtime responsibility)
+- Trust score computation or validation (runtime responsibility)
+- Compliance determination (auditor responsibility)
+- Runtime control (sandbox management, kill switch, privilege rings)
+- Upstream cryptographic verification (ML-DSA-65, SPIFFE, Merkle chain)
+- Identity issuance or management
+
+## 3. Record Categories
+
+Six observation-specific categories, each mapped to a distinct type URI.
+All categories produce Interaction Records with `kind: "evidence"`.
+
+| #   | Category               | Type URI                                                     | Description                                                                                                                       |
+| --- | ---------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Policy Decision        | `org.peacprotocol/runtime-governance-policy-decision`        | Observational record of a governance decision: action taken, rule matched, policy referenced, evaluation duration                 |
+| 2   | Audit Entry            | `org.peacprotocol/runtime-governance-audit-entry`            | Observational record of a runtime audit log entry, preserving upstream integrity references (hash chain, entry ID) as opaque data |
+| 3   | Authority Scope        | `org.peacprotocol/runtime-governance-authority-scope`        | Observational record of scope narrowing, privilege tier assignment, or invariant matching                                         |
+| 4   | Lifecycle Event        | `org.peacprotocol/runtime-governance-lifecycle-event`        | Observational record of agent state transitions (provisioning, credential rotation, suspension, decommissioning, etc.)            |
+| 5   | Trust Observation      | `org.peacprotocol/runtime-governance-trust-observation`      | Observational record of trust signals. PEAC never computes, validates, or weights trust scores                                    |
+| 6   | Compliance Observation | `org.peacprotocol/runtime-governance-compliance-observation` | Observational record of compliance framework assessments. PEAC never makes compliance determinations                              |
+
+## 4. Extension Namespace
+
+All runtime-governance adapters share a single extension namespace:
+
+```
+org.peacprotocol/runtime-governance
+```
+
+This namespace is used by `@peac/adapter-runtime-governance` and any future
+runtime-governance adapters. It is NOT frozen as a first-party typed extension
+group unless two independent integrations require the identical structure.
+
+## 5. Type URI Pattern
+
+```
+org.peacprotocol/runtime-governance-{observation-type}
+```
+
+The `{observation-type}` suffix is observation-specific (e.g., `policy-decision`,
+`trust-observation`). This prevents semantic bleed into authoritative claims:
+a `trust-observation` is explicitly observational, not a trust determination.
+
+## 6. Interaction Record Kind
+
+All runtime-governance records use `kind: "evidence"` (Wire 0.2 protocol value).
+This is the standard kind for observational records in PEAC.
+
+## 7. Preserved Upstream Artifact
+
+Adapters SHOULD include a `upstream` block in the extension data with stable
+observational fields for source correlation:
+
+| Field                     | Type     | Description                                                  |
+| ------------------------- | -------- | ------------------------------------------------------------ |
+| `source_system`           | `string` | Identifier for the upstream system (e.g., `"microsoft-agt"`) |
+| `source_event_type`       | `string` | Upstream event type identifier                               |
+| `source_event_id`         | `string` | Upstream event identifier for deduplication                  |
+| `source_timestamp`        | `string` | Upstream event timestamp (ISO 8601)                          |
+| `source_artifact_hash`    | `string` | Hash of the upstream artifact, if available                  |
+| `source_artifact_ref`     | `string` | URI or reference to the upstream artifact                    |
+| `source_cloud_event_type` | `string` | CloudEvents type URI for cross-system correlation            |
+
+All fields are optional. All fields are observational: they record what the
+upstream system reported, not what PEAC verified.
+
+## 8. Anti-Patterns
+
+Runtime-governance adapters MUST NOT:
+
+- Compute trust scores or risk assessments
+- Enforce policies or make allow/deny decisions
+- Make compliance determinations or issue certifications
+- Reproduce or verify upstream cryptographic operations (ML-DSA-65, SPIFFE/SVID, Merkle chain integrity)
+- Synthesize governance state from non-governance artifacts
+- Import upstream vendor SDKs as runtime dependencies
+- Hardcode vendor or provider names in type URIs, constants, or extension namespace
+
+An upstream "allow" decision is recorded as a signed record of what the runtime
+reported, not proof that the action actually completed or that policy was
+globally satisfied.
+
+## 9. CloudEvents Compatibility
+
+Adapters MAY reference upstream CloudEvents type URIs (e.g.,
+`ai.agentmesh.policy.evaluation`, `ai.agentmesh.trust.handshake`) in the
+`source_cloud_event_type` field of the preserved upstream artifact block.
+
+This is non-normative correlation metadata. PEAC does not consume, validate,
+or depend on CloudEvents semantics.
+
+## 10. Cryptographic Diversity
+
+Upstream runtime governance systems may use cryptographic schemes that differ
+from PEAC's signing algorithm. For example, Microsoft AGT uses Ed25519 plus
+ML-DSA-65 (FIPS 204, quantum-safe). PEAC signs its own Interaction Records
+with Ed25519 per the Wire 0.2 specification.
+
+Upstream cryptographic artifacts (signatures, certificates, key material) are
+preserved as opaque metadata in the extension data. PEAC does not verify,
+reproduce, or validate upstream cryptographic operations in v0.12.10.


### PR DESCRIPTION
### Summary

Documentary suite for runtime-governance records beneath managed runtimes:
profile spec, AGT compatibility truth matrix, and adapter usage documentation.
Observational only; no wire change, no code changes.

- Runtime-Governance Profile spec with 6 observation-specific record categories,
  preserved upstream artifact block, and anti-pattern rules (DD-219)
- AGT compatibility truth matrix with control-plane vs records-plane framing,
  all upstream facts dated and claim-ledger-backed (DD-221)
- Adapter usage doc for `@peac/adapter-runtime-governance`: generic surface
  architecture with AGT as first mapper (DD-220/225)
- Profile index entry in `docs/profiles/README.md`
- Updated `docs/WHEN_NOT_TO_USE_PEAC.md` with runtime governance section
- Updated `docs/COMPATIBILITY_MATRIX.md` with planned adapter subsection
