### PR TITLE
feat: benchmark SLO publication with regression checks

### DIFF
--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -52,6 +52,15 @@ All adapter and mapping packages support Wire 0.2 exclusively. See `REPO_SURFACE
 | ---------------------------------- | ------------------------------------------------------------------- | -------- |
 | `@peac/adapter-runtime-governance` | 6 observation-specific type URIs, AGT first mapper, session summary | v0.12.10 |
 
+## Performance Targets
+
+Informational and regression-oriented. See [BENCHMARK-SLO.md](specs/BENCHMARK-SLO.md).
+
+| Operation       | p95 Target (CI) | p95 Target (Prod) | Model            |
+| --------------- | --------------- | ----------------- | ---------------- |
+| `verifyLocal()` | 15 ms           | 10 ms             | Regression-based |
+| `issue()`       | 10 ms           | 5 ms              | Regression-based |
+
 ## Deprecation Schedule
 
 | Surface                   | Deprecated since | Removal target           | Migration                                                               |

--- a/docs/specs/BENCHMARK-SLO.md
+++ b/docs/specs/BENCHMARK-SLO.md
@@ -1,0 +1,47 @@
+# Benchmark SLO
+
+> Since: v0.12.10 | Status: Informational
+
+Performance targets for core PEAC operations. These targets are informational
+and regression-oriented; they are not wire-normative and not absolute
+shared-runner latency guarantees.
+
+## Targets
+
+| Operation       | p95 Target (CI) | p95 Target (Production) | Iterations | Warmup |
+| --------------- | --------------- | ----------------------- | ---------- | ------ |
+| `verifyLocal()` | 15 ms           | 10 ms                   | 300        | 50     |
+| `issue()`       | 10 ms           | 5 ms                    | 300        | 50     |
+
+## Measurement methodology
+
+- **Iterations:** 300 timed runs after 50 warmup runs
+- **Hardware baseline:** GitHub Actions shared runners (CI); operator hardware varies (production)
+- **Node.js:** 24 (canonical), 22 (compatibility floor)
+- **Timing:** `performance.now()` high-resolution timer
+- **Percentiles:** sorted ascending, index-based (p95 = timings[floor(0.95 * n)])
+
+## Regression model
+
+CI gates use regression detection, not absolute thresholds. This avoids
+flaky failures on shared runners where latency varies by hardware.
+
+- **Baseline:** checked-in `specs/benchmarks/baseline.json` from a known-good run
+- **Regression threshold:** p95 must not exceed 2x the baseline p95
+- **Absolute warning:** if p95 exceeds the CI target, a warning is emitted but the gate does not fail
+- **Gate failure:** only on regression (p95 > 2x baseline)
+
+Absolute latency gates on dedicated runners are planned for a future release.
+
+## Adapter overhead budget
+
+Adapter-layer operations (normalization, extension building, mapper dispatch)
+should add less than 5 ms per call on top of the base `issue()` cost. This
+is an informational target, not a gated invariant.
+
+## Non-goals
+
+- These targets are not wire-level guarantees
+- Production targets depend on operator hardware and deployment
+- Adapter overhead is informational, not enforced
+- Real-time latency SLAs require dedicated infrastructure beyond PEAC's scope

--- a/scripts/benchmarks/verify-slo.mjs
+++ b/scripts/benchmarks/verify-slo.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+/**
+ * verify-slo.mjs
+ *
+ * Regression-based SLO gate for PEAC performance benchmarks.
+ * Compares perf-results.json against specs/benchmarks/baseline.json.
+ *
+ * Exit 0: no regression detected
+ * Exit 1: regression detected (p95 > 2x baseline)
+ *
+ * Absolute CI target breach emits a warning but does not fail the gate.
+ * This avoids flaky failures on shared runners.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '../..');
+
+const sloPath = resolve(root, 'specs/benchmarks/slo.json');
+const baselinePath = resolve(root, 'specs/benchmarks/baseline.json');
+const perfResultsPath = resolve(root, 'perf-results.json');
+
+function loadJson(path) {
+  if (!existsSync(path)) {
+    return null;
+  }
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function main() {
+  console.log('[slo] PEAC Performance SLO Regression Check\n');
+
+  const slo = loadJson(sloPath);
+  if (!slo) {
+    console.log('[slo] SKIP: specs/benchmarks/slo.json not found');
+    process.exit(0);
+  }
+
+  const baseline = loadJson(baselinePath);
+  if (!baseline) {
+    console.log('[slo] SKIP: specs/benchmarks/baseline.json not found');
+    process.exit(0);
+  }
+
+  const perfResults = loadJson(perfResultsPath);
+  if (!perfResults || !Array.isArray(perfResults) || perfResults.length === 0) {
+    console.log('[slo] SKIP: perf-results.json not found or empty');
+    process.exit(0);
+  }
+
+  const maxRatio = slo.regression?.max_ratio ?? 2.0;
+  let hasRegression = false;
+  let hasWarning = false;
+
+  for (const target of slo.targets) {
+    const op = target.operation;
+    const baselineEntry = baseline.baselines?.find((b) => b.operation === op);
+    const perfEntry = perfResults.find((p) => p.operation === op);
+
+    if (!baselineEntry) {
+      console.log(`[slo] SKIP: no baseline for operation "${op}"`);
+      continue;
+    }
+
+    if (!perfEntry) {
+      console.log(`[slo] SKIP: no perf result for operation "${op}"`);
+      continue;
+    }
+
+    const currentP95 = perfEntry.timings_ms?.p95;
+    const baselineP95 = baselineEntry.p95_ms;
+    const ciTarget = target.p95_ms_ci;
+
+    if (currentP95 === undefined || baselineP95 === undefined) {
+      console.log(`[slo] SKIP: missing p95 data for "${op}"`);
+      continue;
+    }
+
+    const ratio = currentP95 / baselineP95;
+    const regressionThreshold = baselineP95 * maxRatio;
+
+    console.log(`[slo] ${op}:`);
+    console.log(`  baseline p95:  ${baselineP95.toFixed(3)} ms`);
+    console.log(`  current  p95:  ${currentP95.toFixed(3)} ms`);
+    console.log(`  ratio:         ${ratio.toFixed(2)}x`);
+    console.log(`  threshold:     ${regressionThreshold.toFixed(3)} ms (${maxRatio}x baseline)`);
+    console.log(`  CI target:     ${ciTarget} ms`);
+
+    if (currentP95 > regressionThreshold) {
+      console.log(`  [FAIL] REGRESSION: p95 exceeds ${maxRatio}x baseline`);
+      hasRegression = true;
+    } else if (currentP95 > ciTarget) {
+      console.log(`  [WARN] p95 exceeds CI target (informational, not blocking)`);
+      hasWarning = true;
+    } else {
+      console.log(`  [OK]`);
+    }
+    console.log('');
+  }
+
+  if (hasRegression) {
+    console.log('[slo] FAIL: regression detected');
+    process.exit(1);
+  }
+
+  if (hasWarning) {
+    console.log('[slo] WARN: absolute target breach (non-blocking)');
+  }
+
+  console.log('[slo] OK: no regression detected');
+  process.exit(0);
+}
+
+main();

--- a/scripts/benchmarks/verify-slo.test.mjs
+++ b/scripts/benchmarks/verify-slo.test.mjs
@@ -1,0 +1,116 @@
+/**
+ * Tests for verify-slo.mjs gate behavior.
+ * Run with: node scripts/benchmarks/verify-slo.test.mjs
+ */
+
+import { execSync } from 'node:child_process';
+import { writeFileSync, existsSync, renameSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '../..');
+const perfPath = resolve(root, 'perf-results.json');
+const backupPath = resolve(root, 'perf-results.json.bak');
+
+let passed = 0;
+let failed = 0;
+
+function setup() {
+  if (existsSync(perfPath)) {
+    renameSync(perfPath, backupPath);
+  }
+}
+
+function teardown() {
+  if (existsSync(backupPath)) {
+    renameSync(backupPath, perfPath);
+  } else if (existsSync(perfPath)) {
+    // Remove any test-created file if no backup
+  }
+}
+
+function runGate() {
+  try {
+    const output = execSync('node scripts/benchmarks/verify-slo.mjs', { encoding: 'utf8', cwd: root });
+    return { exitCode: 0, output };
+  } catch (err) {
+    return { exitCode: err.status, output: err.stdout || '' };
+  }
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS: ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL: ${name}: ${err.message}`);
+    failed++;
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+console.log('verify-slo.mjs gate tests\n');
+setup();
+
+try {
+  // Test 1: skip when perf-results.json is missing
+  test('skips when perf-results.json is missing', () => {
+    const { exitCode, output } = runGate();
+    assert(exitCode === 0, `expected exit 0, got ${exitCode}`);
+    assert(output.includes('SKIP'), 'expected SKIP in output');
+  });
+
+  // Test 2: OK when current matches baseline
+  test('OK when current matches baseline (no regression)', () => {
+    writeFileSync(perfPath, JSON.stringify([{
+      operation: 'verify',
+      timings_ms: { p95: 2.948 },
+    }]));
+    const { exitCode, output } = runGate();
+    assert(exitCode === 0, `expected exit 0, got ${exitCode}`);
+    assert(output.includes('[OK]'), 'expected [OK] in output');
+  });
+
+  // Test 3: WARN when exceeding CI target but not regression
+  test('warns when p95 exceeds CI target but not regression threshold', () => {
+    writeFileSync(perfPath, JSON.stringify([{
+      operation: 'verify',
+      timings_ms: { p95: 5.5 }, // > 2.948 baseline but < 5.896 (2x)
+    }]));
+    const { exitCode } = runGate();
+    assert(exitCode === 0, `expected exit 0, got ${exitCode}`);
+  });
+
+  // Test 4: FAIL on regression (p95 > 2x baseline)
+  test('fails on regression (p95 > 2x baseline)', () => {
+    writeFileSync(perfPath, JSON.stringify([{
+      operation: 'verify',
+      timings_ms: { p95: 10.0 }, // > 5.896 (2x of 2.948)
+    }]));
+    const { exitCode, output } = runGate();
+    assert(exitCode === 1, `expected exit 1, got ${exitCode}`);
+    assert(output.includes('REGRESSION'), 'expected REGRESSION in output');
+  });
+
+  // Test 5: skip when operation has no baseline
+  test('skips operations without baseline', () => {
+    writeFileSync(perfPath, JSON.stringify([{
+      operation: 'issue',
+      timings_ms: { p95: 50.0 },
+    }]));
+    const { exitCode, output } = runGate();
+    assert(exitCode === 0, `expected exit 0, got ${exitCode}`);
+    assert(output.includes('SKIP'), 'expected SKIP for issue');
+  });
+
+} finally {
+  teardown();
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/specs/benchmarks/baseline.json
+++ b/specs/benchmarks/baseline.json
@@ -1,0 +1,20 @@
+{
+  "description": "Baseline performance measurements from known-good runs. Only measured values included; estimated values excluded.",
+  "generated_at": "2026-04-13",
+  "node_version": "24",
+  "baselines": [
+    {
+      "operation": "verify",
+      "p95_ms": 2.948,
+      "p50_ms": 2.048,
+      "iterations": 300,
+      "source": "perf-results.json (v0.9.26, 2026-02-07)"
+    }
+  ],
+  "pending": [
+    {
+      "operation": "issue",
+      "reason": "No measured issue() baseline. Run perf suite and add real measurements before enabling regression gate for issue()."
+    }
+  ]
+}

--- a/specs/benchmarks/slo.json
+++ b/specs/benchmarks/slo.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://www.peacprotocol.org/schemas/benchmarks/slo.schema.json",
+  "version": "0.12.10",
+  "description": "Performance targets for core PEAC operations. Informational and regression-oriented.",
+  "targets": [
+    {
+      "operation": "verify",
+      "p95_ms_ci": 15,
+      "p95_ms_production": 10,
+      "iterations": 300,
+      "warmup": 50
+    },
+    {
+      "operation": "issue",
+      "p95_ms_ci": 10,
+      "p95_ms_production": 5,
+      "iterations": 300,
+      "warmup": 50
+    }
+  ],
+  "regression": {
+    "max_ratio": 2.0,
+    "description": "p95 must not exceed 2x baseline. Absolute CI target breach is a warning, not a failure."
+  }
+}


### PR DESCRIPTION
## Summary

Machine-readable performance targets and a regression-based CI gate for
verifyLocal and issue operations. Informational and regression-oriented;
not wire-normative and not an absolute shared-runner latency guarantee.

## Scope

- SLO spec at `docs/specs/BENCHMARK-SLO.md` with measurement methodology,
  regression model, and adapter overhead budget
- Machine-readable `specs/benchmarks/slo.json` with targets and regression config
- Checked-in `specs/benchmarks/baseline.json` from known-good measurements
- Regression gate `scripts/benchmarks/verify-slo.mjs`: warns on absolute
  target breach, fails only on regression (p95 > 2x baseline)
- Performance Targets section added to compatibility matrix