### PR TITLE
docs: adapter READMEs

### DIFF
--- a/packages/adapters/managed-agents/README.md
+++ b/packages/adapters/managed-agents/README.md
@@ -1,22 +1,23 @@
 # @peac/adapter-managed-agents
 
-Vendor-neutral adapter for managed agent runtime event evidence. Maps 6 event families to signed PEAC Interaction Records.
+Vendor-neutral adapter for managed agent runtime event records. Maps 6 event families to signed PEAC Interaction Records.
 
-## Event Families
+## Installation
 
-| Family                  | Type URI                                    | Kind     |
-| ----------------------- | ------------------------------------------- | -------- |
-| Session lifecycle       | `org.peacprotocol/managed-agent-session`    | evidence |
-| Task submission         | `org.peacprotocol/managed-agent-task`       | evidence |
-| Tool use                | `org.peacprotocol/managed-agent-tool-use`   | evidence |
-| MCP invocation          | `org.peacprotocol/managed-agent-mcp-call`   | evidence |
-| Permission confirmation | `org.peacprotocol/managed-agent-permission` | evidence |
-| Outcome evaluation      | `org.peacprotocol/managed-agent-outcome`    | evidence |
+```bash
+pnpm add @peac/adapter-managed-agents
+```
 
-## Usage
+## What It Does
+
+`@peac/adapter-managed-agents` is a Layer 4 adapter that records managed agent runtime events as signed, portable Interaction Records. It supports 6 event families covering the full agent session lifecycle: session management, task submission, tool use, MCP invocation, permission confirmation, and outcome evaluation.
+
+## How Do I Use It?
+
+### Issue a session lifecycle event
 
 ```typescript
-import { issueSessionEvent, buildSessionSummary } from '@peac/adapter-managed-agents';
+import { issueSessionEvent } from '@peac/adapter-managed-agents';
 
 const result = await issueSessionEvent({
   privateKey, // Ed25519 32 bytes
@@ -31,14 +32,33 @@ const result = await issueSessionEvent({
 // result.jws is a signed Interaction Record (compact JWS)
 ```
 
-## Session Summary
+### Build a session summary
 
 ```typescript
+import { buildSessionSummary } from '@peac/adapter-managed-agents';
+
 const summary = buildSessionSummary([result1.jws, result2.jws, result3.jws]);
 // { sessionId, receipts: 3, families: ['session', 'task', ...], issuer }
 ```
 
 `buildSessionSummary()` decodes JWS payloads to extract metadata but does **not** verify signatures. Callers must verify receipts first (e.g., via `verifyLocal()` from `@peac/protocol`). Throws on malformed JWS input.
+
+## Event Families
+
+| Family                  | Type URI                                    | Kind       |
+| ----------------------- | ------------------------------------------- | ---------- |
+| Session lifecycle       | `org.peacprotocol/managed-agent-session`    | `evidence` |
+| Task submission         | `org.peacprotocol/managed-agent-task`       | `evidence` |
+| Tool use                | `org.peacprotocol/managed-agent-tool-use`   | `evidence` |
+| MCP invocation          | `org.peacprotocol/managed-agent-mcp-call`   | `evidence` |
+| Permission confirmation | `org.peacprotocol/managed-agent-permission` | `evidence` |
+| Outcome evaluation      | `org.peacprotocol/managed-agent-outcome`    | `evidence` |
+
+## Integrates With
+
+- `@peac/protocol` (Layer 3): Receipt issuance and local verification
+- `@peac/crypto` (Layer 2): JWS decode for session summary extraction
+- `@peac/adapter-runtime-governance`: Runtime governance records (complementary adapter)
 
 ## Design
 
@@ -47,6 +67,20 @@ const summary = buildSessionSummary([result1.jws, result2.jws, result3.jws]);
 - **Evidence kind:** All event families produce `evidence` kind Interaction Records.
 - **Extension namespace:** `org.peacprotocol/managed-agent` with `session_id`, `event`, `agent_id`, `provider` fields.
 
+## For Agent Developers
+
+If you are building an AI agent or MCP server that needs evidence receipts:
+
+- Start with [`@peac/mcp-server`](https://www.npmjs.com/package/@peac/mcp-server) for a ready-to-use MCP tool server
+- Use `@peac/protocol` for programmatic receipt issuance and verification
+- See the [llms.txt](https://github.com/peacprotocol/peac/blob/main/llms.txt) for a concise overview
+
 ## License
 
 Apache-2.0
+
+---
+
+PEAC Protocol is an open source project stewarded by Originary and community contributors.
+
+[Docs](https://www.peacprotocol.org) | [GitHub](https://github.com/peacprotocol/peac) | [Originary](https://www.originary.xyz)

--- a/packages/adapters/managed-agents/package.json
+++ b/packages/adapters/managed-agents/package.json
@@ -60,11 +60,13 @@
   "keywords": [
     "peac",
     "peacprotocol",
+    "originary",
     "interaction-records",
     "signed-records",
     "managed-agents",
-    "agent-evidence",
+    "agent-records",
     "mcp",
-    "a2a"
+    "a2a",
+    "adapter"
   ]
 }

--- a/packages/adapters/runtime-governance/README.md
+++ b/packages/adapters/runtime-governance/README.md
@@ -1,41 +1,26 @@
 # @peac/adapter-runtime-governance
 
-Runtime governance adapter for PEAC interaction records. Records governance
-decisions, audit entries, authority scope changes, lifecycle transitions,
-trust signals, and compliance assessments as signed, portable Interaction
-Records.
+Runtime governance adapter for PEAC interaction records. Records governance decisions, audit entries, authority scope changes, lifecycle transitions, trust signals, and compliance assessments as signed, portable Interaction Records.
 
-PEAC validates the structure and signature of the PEAC record, not the truth
-of the upstream governance decision or the operating effectiveness of the
-upstream control plane. PEAC does not verify upstream Merkle chain integrity
-or ML-DSA-65 signatures.
+## Installation
 
-## Architecture
+```bash
+pnpm add @peac/adapter-runtime-governance
+```
 
-Generic runtime-governance surface with source-specific mappers.
-Microsoft AGT is the first mapper; the architecture supports additional
-mappers for other runtimes.
+## What It Does
 
-## Record families
+`@peac/adapter-runtime-governance` is a Layer 4 adapter that records runtime governance artifacts as signed, portable Interaction Records. It provides a generic runtime-governance surface with source-specific mappers. Microsoft AGT is the first mapper; the architecture supports additional mappers for other runtimes.
 
-| Family                 | Type URI                                                     |
-| ---------------------- | ------------------------------------------------------------ |
-| Policy Decision        | `org.peacprotocol/runtime-governance-policy-decision`        |
-| Audit Entry            | `org.peacprotocol/runtime-governance-audit-entry`            |
-| Authority Scope        | `org.peacprotocol/runtime-governance-authority-scope`        |
-| Lifecycle Event        | `org.peacprotocol/runtime-governance-lifecycle-event`        |
-| Trust Observation      | `org.peacprotocol/runtime-governance-trust-observation`      |
-| Compliance Observation | `org.peacprotocol/runtime-governance-compliance-observation` |
+PEAC validates the structure and signature of the PEAC record, not the truth of the upstream governance decision or the operating effectiveness of the upstream control plane. PEAC does not verify upstream Merkle chain integrity or ML-DSA-65 signatures.
 
-## Usage
+## How Do I Use It?
+
+### Map and issue a governance record
 
 ```typescript
 import { generateKeypair, verifyLocal } from '@peac/protocol';
-import {
-  issueRuntimeGovernanceRecord,
-  mapAgtEvent,
-  buildSessionSummary,
-} from '@peac/adapter-runtime-governance';
+import { issueRuntimeGovernanceRecord, mapAgtEvent } from '@peac/adapter-runtime-governance';
 
 const kp = await generateKeypair();
 
@@ -52,18 +37,64 @@ const result = await issueRuntimeGovernanceRecord(event, {
   issuer: 'https://governance.example.com',
   sessionId: 'sess-001',
   agentId: 'agent-001',
-  provider: 'example-runtime',
+  provider: 'example-runtime', // caller-supplied, never hardcoded
 });
 
 const verification = await verifyLocal(result.jws, kp.publicKey);
-const summary = buildSessionSummary([result.jws]);
 ```
 
-## Design constraints
+### Build a session summary
 
-- Layer 4 only; no kernel/schema/crypto/protocol changes
-- Zero vendor SDK runtime dependencies
-- Provider field is always caller-supplied
-- All records use Wire 0.2 `evidence` kind
-- Observational only; never enforces, computes, or determines
-- Fail-closed validation on malformed input
+```typescript
+import { buildSessionSummary } from '@peac/adapter-runtime-governance';
+
+const summary = buildSessionSummary([result.jws]);
+// { sessionId, receipts: 1, families: ['policy_decision'], unknownTypeCount: 0, issuer }
+```
+
+`buildSessionSummary()` decodes JWS payloads to extract metadata but does **not** verify signatures. Callers must verify receipts first. Returns deterministic family ordering (sorted alphabetically) and counts unknown type URIs separately.
+
+## Record Families
+
+| Family                 | Type URI                                                     | Kind       |
+| ---------------------- | ------------------------------------------------------------ | ---------- |
+| Policy Decision        | `org.peacprotocol/runtime-governance-policy-decision`        | `evidence` |
+| Audit Entry            | `org.peacprotocol/runtime-governance-audit-entry`            | `evidence` |
+| Authority Scope        | `org.peacprotocol/runtime-governance-authority-scope`        | `evidence` |
+| Lifecycle Event        | `org.peacprotocol/runtime-governance-lifecycle-event`        | `evidence` |
+| Trust Observation      | `org.peacprotocol/runtime-governance-trust-observation`      | `evidence` |
+| Compliance Observation | `org.peacprotocol/runtime-governance-compliance-observation` | `evidence` |
+
+## Integrates With
+
+- `@peac/protocol` (Layer 3): Receipt issuance and local verification
+- `@peac/crypto` (Layer 2): JWS decode for session summary extraction
+- `@peac/adapter-managed-agents`: Managed agent event records (complementary adapter)
+
+## Design
+
+- **Generic surface:** Package named by concept, not vendor. AGT is the first mapper; future mappers can be added without changing the public API.
+- **Vendor-neutral:** Zero vendor SDK runtime dependencies. The `provider` field is always caller-supplied.
+- **Layer 4:** Depends on `@peac/protocol` and `@peac/crypto` only.
+- **Evidence kind:** All record families produce `evidence` kind Interaction Records.
+- **Observational only:** PEAC records what the upstream runtime reported; PEAC does not enforce, compute, or determine.
+- **Fail-closed validation:** Rejects malformed input with descriptive errors. Validates RFC 3339 timestamps, digest patterns, URI shapes, and numeric bounds.
+- **Extension namespace:** `org.peacprotocol/runtime-governance` with `session_id`, `event`, `agent_id`, `provider` fields plus family-specific payload.
+
+## For Agent Developers
+
+If you are building an AI agent or MCP server that needs evidence receipts:
+
+- Start with [`@peac/mcp-server`](https://www.npmjs.com/package/@peac/mcp-server) for a ready-to-use MCP tool server
+- Use `@peac/protocol` for programmatic receipt issuance and verification
+- See the [llms.txt](https://github.com/peacprotocol/peac/blob/main/llms.txt) for a concise overview
+
+## License
+
+Apache-2.0
+
+---
+
+PEAC Protocol is an open source project stewarded by Originary and community contributors.
+
+[Docs](https://www.peacprotocol.org) | [GitHub](https://github.com/peacprotocol/peac) | [Originary](https://www.originary.xyz)

--- a/packages/adapters/runtime-governance/package.json
+++ b/packages/adapters/runtime-governance/package.json
@@ -60,12 +60,14 @@
   "keywords": [
     "peac",
     "peacprotocol",
+    "originary",
     "interaction-records",
     "signed-records",
     "runtime-governance",
     "agent-records",
     "agent-governance",
     "mcp",
-    "a2a"
+    "a2a",
+    "adapter"
   ]
 }


### PR DESCRIPTION
### Summary

Restructure managed-agents and runtime-governance READMEs with Installation, What It Does, How Do I Use It, Integrates With, For Agent Developers, License, and footer with Docs link.