### PR TITLE
fix: bump MCP server SERVER_VERSION

### DIFF
--- a/packages/mcp-server/src/infra/constants.ts
+++ b/packages/mcp-server/src/infra/constants.ts
@@ -3,7 +3,7 @@
  */
 
 export const SERVER_NAME = 'peac-mcp-server';
-export const SERVER_VERSION = '0.12.9';
+export const SERVER_VERSION = '0.12.10';
 export const MCP_PROTOCOL_VERSION = '2025-11-25';
 export const DEFAULT_MAX_JWS_BYTES = 16_384; // 16 KB
 export const DEFAULT_MAX_RESPONSE_BYTES = 65_536; // 64 KB


### PR DESCRIPTION
Hardcoded SERVER_VERSION in packages/mcp-server/src/infra/constants.ts was still 0.12.9. Fixes CI test failure in constants.test.ts.