### PR TITLE
chore: stamp v0.12.10 release date

### DIFF
--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable surface classification for PEAC Protocol workspace. CI fails if any workspace member is missing. See docs/PACKAGE_STATUS.md for human-readable view.",
   "version": "0.12.9",
-  "updated": "2026-04-11",
+  "updated": "2026-04-14",
   "states": {
     "default": "Current recommended path. Actively maintained, Wire 0.2 native.",
     "supported": "Actively maintained, published, production-ready. May not be on default quickstart path.",

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -3,7 +3,7 @@
 Generated from `REPO_SURFACE_STATUS.json` by `scripts/generate-surface-status.mjs`.
 Do not edit manually.
 
-**Version:** 0.12.9 | **Updated:** 2026-04-11
+**Version:** 0.12.9 | **Updated:** 2026-04-14
 
 ## Layer 1
 

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -4,7 +4,7 @@
   "version": "0.12.10",
   "wire_format_version": "0.2",
   "dist_tag": "latest",
-  "release_date": "2026-04-11",
+  "release_date": "2026-04-14",
   "metrics": {
     "tests": 7392,
     "test_files": 296,


### PR DESCRIPTION
Post-publish stamping: set release_date to 2026-04-14 and REPO_SURFACE_STATUS.updated to 2026-04-14. Generated by scripts/stamp-release-state.mjs --publish.