### PR TITLE
feat: add observational mpp and x402 payment evidence mapping

### DIFF
--- a/docs/profiles/README.md
+++ b/docs/profiles/README.md
@@ -42,6 +42,7 @@ PEAC receipts for a specific integration.
 | [Stripe x402 Machine Payments](stripe-x402-machine-payments.md) | `@peac/rails-stripe`               | v0.10.11 | Draft  |
 | [Runtime Governance](runtime-governance.md)                     | `@peac/adapter-runtime-governance` | v0.12.10 | Draft  |
 | [ACP Delegated Payment](acp-delegated-payment.md)               | `@peac/mappings-acp`               | v0.12.11 | Draft  |
+| [MPP Payment Evidence](mpp-payment-evidence.md)                 | `@peac/mappings-paymentauth`       | v0.12.11 | Draft  |
 
 ## Profile Templates
 

--- a/docs/profiles/mpp-payment-evidence.md
+++ b/docs/profiles/mpp-payment-evidence.md
@@ -1,0 +1,108 @@
+# MPP Payment Evidence Profile
+
+**Status:** Draft
+**Since:** v0.12.11
+**Extension Namespace:** `org.peacprotocol/commerce`
+**Package:** `@peac/mappings-paymentauth`
+**Spec:** [COMMERCE-EVIDENCE.md](../specs/COMMERCE-EVIDENCE.md)
+**Coverage:** [commerce-protocol-coverage.md](../compatibility/commerce-protocol-coverage.md)
+
+## Abstract
+
+Records observations of MPP / paymentauth payment-attempt and settlement
+artifacts as signed PEAC Interaction Records. Observational only: PEAC
+records what an upstream paymentauth-aware payment surface attested.
+PEAC does not verify payment tokens cryptographically, bind facilitators,
+or reason about refund or chargeback semantics.
+
+`paymentauth` is the canonical code and registry term aligned with the
+active draft `draft-ryan-httpauth-payment-01`. MPP is an ecosystem prose
+term; it is not used in package names, registry entries, fixture paths,
+or schema enums.
+
+## Use case
+
+A merchant or facilitator that issues paymentauth payment attempts and
+settlement attestations wants portable, signed records of authorization
+and settlement events that a third party can verify without accessing
+the merchant's backing systems.
+
+## Package / Functions
+
+```typescript
+import { fromMPPPaymentAttempt, fromMPPSettlement } from '@peac/mappings-paymentauth';
+```
+
+## Mapping
+
+| Function                | Output `commerce.event` | Required `artifact_kind` |
+| ----------------------- | ----------------------- | ------------------------ |
+| `fromMPPPaymentAttempt` | `authorization`         | `'authorization'`        |
+| `fromMPPSettlement`     | `settlement`            | `'settlement'`           |
+
+| Input field                    | PEAC Record Field                                                        | Semantics                                                                  |
+| ------------------------------ | ------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| `attempt_id` / `settlement_id` | `payment.reference`, `payment.evidence.paymentauth_*_id`                 | Preserved as string                                                        |
+| `payment_token_ref`            | `payment.evidence.payment_token_ref`                                     | Opaque reference; NEVER token material                                     |
+| `amount_minor`                 | `payment.amount` (integer minor units)                                   | Base-10 integer string per RFC 8785; smallest currency unit                |
+| `currency`                     | `payment.currency`                                                       | Required in strict mode; rejected if UNKNOWN/empty                         |
+| `env`                          | `payment.env`                                                            | Closed enum `live` \| `test`; required in strict mode                      |
+| `artifact_kind`                | `payment.evidence.proofs.paymentauth.{attempt,settlement}.artifact_kind` | Required; mismatch with the function rejected in ALL modes                 |
+| `facilitator_attestation`      | `payment.evidence.proofs.paymentauth.*.facilitator_attestation`          | Optional; preserved verbatim when present; PEAC does NOT bind facilitators |
+| `upstream_artifact`            | `payment.evidence.proofs.paymentauth.*.upstream_artifact`                | Preserved verbatim; opaque to PEAC                                         |
+| `challenge_id`                 | `payment.evidence.challenge_id`                                          | Optional correlation reference for the originating 402 challenge           |
+| `attempt_id` (settlement)      | `payment.evidence.paymentauth_attempt_id`                                | Optional correlation reference for the originating attempt                 |
+
+## Settlement-proof discriminator
+
+The `artifact_kind` field self-describes the upstream artifact and
+prevents an authorization-bearing artifact from being treated as a
+settlement proof. The mapper rejects mismatches in all strictness modes:
+
+- `fromMPPPaymentAttempt` requires `artifact_kind: 'authorization'`.
+- `fromMPPSettlement` requires `artifact_kind: 'settlement'`.
+
+A mismatch produces a `MapperBoundaryError` with code
+`commerce.finality_synthesis_blocked` and pointer
+`/proofs/paymentauth/attempt` or `/proofs/paymentauth/settlement`.
+
+## Amount semantics
+
+`payment.amount` is the integer minor-unit value (smallest currency unit)
+parsed from `amount_minor`. PEAC does NOT apply currency-aware scaling.
+USD `'1000'` and JPY `'1000'` both produce `payment.amount = 1000`.
+Conversion to major units is the consumer's responsibility.
+
+## Strictness modes
+
+- `strict` rejects missing or `UNKNOWN` currency, env outside the closed
+  `live` | `test` enum, and silent fallbacks.
+- `interop` (default) emits a deprecation warning instead of rejecting
+  on those conditions.
+- `legacy` is silent.
+
+Rule 1 (artifact_kind mismatch and missing upstream_artifact) rejects in
+all modes.
+
+## Non-goals
+
+- PEAC does NOT verify payment tokens cryptographically.
+- PEAC does NOT bind facilitators or treat facilitator-signed statements
+  as proof beyond what the upstream artifact attests.
+- PEAC does NOT reason about refund or chargeback semantics; those would
+  appear as additional observations with their own commerce events.
+- PEAC does NOT carry token material; only `payment_token_ref` (an opaque
+  reference) is preserved.
+
+## Stability
+
+`draft-ryan-httpauth-payment-01` is treated as Experimental per the
+[commerce protocol coverage matrix](../compatibility/commerce-protocol-coverage.md).
+The mapping surface is additive in v0.12.11.
+
+## See also
+
+- [Commerce Evidence Specification](../specs/COMMERCE-EVIDENCE.md)
+- [Commerce Protocol Coverage](../compatibility/commerce-protocol-coverage.md)
+- [ACP Delegated Payment Profile](acp-delegated-payment.md)
+- [x402 Scheme Coverage](../compatibility/x402-scheme-coverage.md)

--- a/docs/specs/COMMERCE-EVIDENCE.md
+++ b/docs/specs/COMMERCE-EVIDENCE.md
@@ -53,6 +53,17 @@ HTTP `Payment` authentication scheme, aligned with the active Internet-Draft `dr
 - **Approach**: lifecycle-first; session states produce access evidence; commerce evidence only from explicit payment artifacts
 - **Package**: `@peac/mappings-acp`
 - **Boundary**: `fromACPSessionLifecycleEvent()` for session evidence; `fromACPPaymentObservation()` for commerce evidence requiring `observed_payment_state`
+- **Delegated payment** (v0.12.11): `fromACPDelegatedPaymentObservation()` maps ACP-shaped delegated-payment authorizations and settlements with an `artifact_kind` discriminator that blocks settlement synthesis from an authorization-only artifact. See [`docs/profiles/acp-delegated-payment.md`](../profiles/acp-delegated-payment.md).
+
+### MPP / paymentauth (v0.12.11)
+
+- **Package**: `@peac/mappings-paymentauth`
+- **Functions**: `fromMPPPaymentAttempt()` for authorization evidence; `fromMPPSettlement()` for settlement evidence, with an `artifact_kind` discriminator that blocks cross-kind misuse. See [`docs/profiles/mpp-payment-evidence.md`](../profiles/mpp-payment-evidence.md).
+
+### x402 settlement observation (v0.12.11)
+
+- **Package**: `@peac/adapter-x402`
+- **Settlement observation**: `extractSettlementProofFromHeaders()` returns proofs in dual-header precedence order; `fromX402SettlementObservation()` produces commerce settlement evidence only from a non-empty extracted proof. Scheme-specific invariants remain upstream responsibility. See [`docs/specs/X402-V2-PROFILE.md`](X402-V2-PROFILE.md) §8.
 
 ### Stripe SPT (Shared Payment Tokens)
 

--- a/docs/specs/X402-V2-PROFILE.md
+++ b/docs/specs/X402-V2-PROFILE.md
@@ -72,3 +72,41 @@ Raw upstream artifacts are preserved in `proofs.x402` (proof preservation discip
 ## 7. Drift CI
 
 `x402-drift.yml` monitors upstream `specs/transports-v2/http.md` for changes.
+
+## 8. Settlement Observation Boundary (v0.12.11)
+
+PEAC records x402 settlement proofs as observation only. The
+`extractSettlementProofFromHeaders()` extractor in `@peac/adapter-x402`
+returns the raw proof artifact and a minimal normalized projection
+(source header, wire version, raw value). PEAC does NOT verify scheme-
+specific invariants:
+
+- single-use semantics
+- time-bound expiry
+- recipient binding
+- facilitator binding
+- max-vs-actual settlement correctness
+
+These remain the responsibility of the upstream x402 protocol and per-
+operator facilitator surfaces (see
+`docs/compatibility/x402-scheme-coverage.md` for the three-truth-surface
+separation).
+
+`fromX402SettlementObservation()` produces evidence with
+`commerce.event = 'settlement'` only when supplied with an extracted
+settlement-proof artifact whose `raw_value` is a non-empty string.
+Offer-only data (no settlement header present, or an empty raw_value) is
+rejected as a finality-rule violation in all strictness modes via the
+shared mapper-boundary finality-synthesis guard from
+`@peac/adapter-core`. The pointer field on the thrown error is
+`/proofs/x402/settlement` and the stable code is
+`commerce.finality_synthesis_blocked`.
+
+Header read precedence (matches the existing carrier reader):
+
+1. `PEAC-Receipt`
+2. `PAYMENT-RESPONSE` (x402 v2)
+3. `X-PAYMENT-RESPONSE` (x402 v1)
+
+When multiple headers are present, all are returned in precedence order
+so callers can record duplicates without losing fidelity.

--- a/packages/adapters/x402/src/index.ts
+++ b/packages/adapters/x402/src/index.ts
@@ -156,3 +156,14 @@ export {
 // Challenge type mapping
 export type { ChallengeType } from './challenge.js';
 export { mapX402ToChallengeType } from './challenge.js';
+
+// x402 settlement-proof extraction and observation evidence (v0.12.11)
+export { extractSettlementProofFromHeaders, fromX402SettlementObservation } from './settlement.js';
+export type {
+  HeaderBag,
+  SettlementProofSource,
+  ExtractedSettlementProof,
+  X402SettlementObservationInput,
+  X402SettlementEvidence,
+  X402SettlementOptions,
+} from './settlement.js';

--- a/packages/adapters/x402/src/settlement.ts
+++ b/packages/adapters/x402/src/settlement.ts
@@ -1,0 +1,225 @@
+/**
+ * x402 settlement-proof extraction and observation evidence (v0.12.11).
+ *
+ * Observational only: PEAC reads what the upstream x402 settlement proof
+ * attested when present. PEAC does NOT verify scheme-specific invariants
+ * (single-use, time bounds, recipient binding, facilitator binding, max-
+ * vs-actual settlement correctness). Those remain the responsibility of
+ * the upstream x402 protocol and the per-operator facilitator surfaces;
+ * see docs/compatibility/x402-scheme-coverage.md for the three-truth-
+ * surface separation.
+ *
+ * Header read precedence (matches the existing carrier reader at
+ * src/carrier.ts):
+ *   1. PEAC-Receipt           (PEAC carrier contract)
+ *   2. PAYMENT-RESPONSE       (x402 v2)
+ *   3. X-PAYMENT-RESPONSE     (x402 v1)
+ *
+ * If multiple proofs are present, all are returned in precedence order so
+ * callers can record duplicates without losing fidelity.
+ */
+
+import {
+  assertExplicitFinality,
+  type StrictnessMode,
+  type FinalityGuardOptions,
+} from '@peac/adapter-core';
+
+/** Header-bag accepted by the extractor. Lower-case keys are tried first. */
+export type HeaderBag = Record<string, string | string[] | undefined>;
+
+/** Source identifier for an extracted settlement proof. */
+export type SettlementProofSource = 'PEAC-Receipt' | 'PAYMENT-RESPONSE' | 'X-PAYMENT-RESPONSE';
+
+/** A single settlement-proof artifact extracted from response headers. */
+export interface ExtractedSettlementProof {
+  source: SettlementProofSource;
+  /**
+   * Wire version implied by the source header. PEAC-Receipt is wire-
+   * neutral and reports `'peac'`; v2 reports `'v2'`; v1 reports `'v1'`.
+   */
+  wire_version: 'peac' | 'v2' | 'v1';
+  /** The raw header value, byte-preserved. */
+  raw_value: string;
+}
+
+/**
+ * Extract any x402 settlement-proof artifacts from the supplied response
+ * headers. Returns artifacts in dual-header precedence order (PEAC-Receipt
+ * first, then PAYMENT-RESPONSE v2, then X-PAYMENT-RESPONSE v1). An empty
+ * array means no settlement proof was supplied; callers MUST NOT treat
+ * absence as evidence of settlement.
+ *
+ * Observation only: this function does not parse or verify the artifacts.
+ * Scheme-specific invariants remain upstream responsibility.
+ */
+export function extractSettlementProofFromHeaders(headers: HeaderBag): ExtractedSettlementProof[] {
+  const out: ExtractedSettlementProof[] = [];
+  const lower = normalizeHeaders(headers);
+
+  const peac = lower['peac-receipt'];
+  if (peac !== undefined) {
+    out.push({ source: 'PEAC-Receipt', wire_version: 'peac', raw_value: peac });
+  }
+  const v2 = lower['payment-response'];
+  if (v2 !== undefined) {
+    out.push({ source: 'PAYMENT-RESPONSE', wire_version: 'v2', raw_value: v2 });
+  }
+  const v1 = lower['x-payment-response'];
+  if (v1 !== undefined) {
+    out.push({ source: 'X-PAYMENT-RESPONSE', wire_version: 'v1', raw_value: v1 });
+  }
+  return out;
+}
+
+function normalizeHeaders(headers: HeaderBag): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    if (v === undefined) continue;
+    const key = k.toLowerCase();
+    if (Array.isArray(v)) {
+      out[key] = v.join(', ');
+    } else {
+      out[key] = v;
+    }
+  }
+  return out;
+}
+
+/**
+ * Input for fromX402SettlementObservation.
+ *
+ * Models a single explicit x402 settlement observation. Callers supply
+ * the raw extracted proof plus the upstream-asserted offer / settlement
+ * fields; the mapper performs no scheme-specific verification. PEAC will
+ * reject any attempt to produce settlement evidence from offer-only data.
+ */
+export interface X402SettlementObservationInput {
+  /** Settlement-proof artifact, e.g. one element of extractSettlementProofFromHeaders. */
+  proof: ExtractedSettlementProof;
+  /** x402 scheme identifier as asserted by upstream. Preserved verbatim. */
+  scheme: string;
+  /** Network identifier as asserted by upstream. Preserved verbatim. */
+  network: string;
+  /** Asset identifier as asserted by upstream. */
+  asset: string;
+  /** Currency code as asserted by upstream. Required in strict mode. */
+  currency: string;
+  /** Settled amount in minor units (smallest currency unit). */
+  amount_minor: string;
+  /** Environment as asserted by upstream. */
+  env: 'live' | 'test';
+  /** Recipient (payTo) address from the proof. Preserved verbatim. */
+  pay_to?: string;
+  /** Optional facilitator identifier; PEAC does not bind facilitators. */
+  facilitator?: string;
+  /** Optional offer reference for correlation. Observation only. */
+  offer_reference?: string;
+}
+
+/** Output of fromX402SettlementObservation. */
+export interface X402SettlementEvidence {
+  rail: 'x402';
+  reference: string;
+  amount: number;
+  currency: string;
+  asset: string;
+  env: 'live' | 'test';
+  evidence: {
+    commerce_event: 'settlement';
+    x402_scheme: string;
+    x402_network: string;
+    x402_pay_to?: string;
+    x402_facilitator?: string;
+    x402_offer_reference?: string;
+    proofs: {
+      x402: {
+        settlement: {
+          source: SettlementProofSource;
+          wire_version: 'peac' | 'v2' | 'v1';
+          raw_value: string;
+        };
+      };
+    };
+  };
+}
+
+export interface X402SettlementOptions {
+  mode?: StrictnessMode;
+  warn?: FinalityGuardOptions['warn'];
+}
+
+/**
+ * Map an explicit x402 settlement observation to PEAC commerce evidence
+ * with commerce.event = 'settlement'. Routes through the mapper-boundary
+ * finality-synthesis guard. Refuses synthesis from offer-only data: the
+ * caller MUST supply an extracted settlement-proof artifact whose
+ * wire_version is one of 'peac' | 'v2' | 'v1'. Empty input rejects in
+ * all strictness modes (rule 1).
+ *
+ * Observation only: PEAC does not verify scheme invariants; the proof is
+ * preserved verbatim under proofs.x402.settlement.
+ */
+export function fromX402SettlementObservation(
+  input: X402SettlementObservationInput,
+  options: X402SettlementOptions = {}
+): X402SettlementEvidence {
+  if (!input.scheme) {
+    throw new Error('x402 settlement observation missing scheme');
+  }
+  if (!input.network) {
+    throw new Error('x402 settlement observation missing network');
+  }
+  if (!/^-?[0-9]+$/.test(input.amount_minor)) {
+    throw new Error('x402 settlement observation amount_minor must be a base-10 integer string');
+  }
+
+  const hasExplicitUpstreamArtifact =
+    input.proof !== undefined &&
+    typeof input.proof.raw_value === 'string' &&
+    input.proof.raw_value.length > 0;
+
+  assertExplicitFinality(
+    {
+      event: 'settlement',
+      hasExplicitUpstreamArtifact,
+      currency: input.currency,
+      env: input.env,
+      envExplicit: input.env === 'live' || input.env === 'test',
+    },
+    {
+      mode: options.mode,
+      warn: options.warn,
+      pointer: '/proofs/x402/settlement',
+    }
+  );
+
+  const amount = parseInt(input.amount_minor, 10);
+  return {
+    rail: 'x402',
+    reference: input.offer_reference ?? input.proof.source,
+    amount,
+    currency: input.currency.toUpperCase(),
+    asset: input.asset,
+    env: input.env,
+    evidence: {
+      commerce_event: 'settlement',
+      x402_scheme: input.scheme,
+      x402_network: input.network,
+      ...(input.pay_to !== undefined ? { x402_pay_to: input.pay_to } : {}),
+      ...(input.facilitator !== undefined ? { x402_facilitator: input.facilitator } : {}),
+      ...(input.offer_reference !== undefined
+        ? { x402_offer_reference: input.offer_reference }
+        : {}),
+      proofs: {
+        x402: {
+          settlement: {
+            source: input.proof.source,
+            wire_version: input.proof.wire_version,
+            raw_value: input.proof.raw_value,
+          },
+        },
+      },
+    },
+  };
+}

--- a/packages/adapters/x402/tests/settlement.test.ts
+++ b/packages/adapters/x402/tests/settlement.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Integration tests for x402 settlement-proof extraction and observation.
+ *
+ * Covers:
+ *   - dual-header extraction precedence (PEAC-Receipt -> PAYMENT-RESPONSE
+ *     v2 -> X-PAYMENT-RESPONSE v1)
+ *   - duplicate-proof handling (multiple headers present)
+ *   - offer-only rejection (no settlement proof)
+ *   - empty-proof rejection
+ *   - strict-mode currency / env enforcement
+ *   - mapper-boundary code + pointer on thrown errors
+ *   - amount semantics (minor units, no currency-aware scaling)
+ *   - case-insensitive header matching + multi-value header join
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { MapperBoundaryError, COMMERCE_FINALITY_SYNTHESIS_CODE } from '@peac/adapter-core';
+import {
+  extractSettlementProofFromHeaders,
+  fromX402SettlementObservation,
+  type ExtractedSettlementProof,
+  type X402SettlementObservationInput,
+} from '../src/index.js';
+
+function input(
+  overrides: Partial<X402SettlementObservationInput> = {}
+): X402SettlementObservationInput {
+  return {
+    proof: { source: 'PEAC-Receipt', wire_version: 'peac', raw_value: 'eyJraWQ.opaque' },
+    scheme: 'exact',
+    network: 'base-sepolia',
+    asset: '0xUSDC',
+    currency: 'USD',
+    amount_minor: '1500',
+    env: 'live',
+    pay_to: '0xRecipient',
+    facilitator: 'fac.example',
+    offer_reference: 'offer_001',
+    ...overrides,
+  };
+}
+
+describe('extractSettlementProofFromHeaders: precedence + multi-source', () => {
+  it('PEAC-Receipt only', () => {
+    const out = extractSettlementProofFromHeaders({ 'PEAC-Receipt': 'eyJ.peac' });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ source: 'PEAC-Receipt', wire_version: 'peac' });
+  });
+
+  it('PAYMENT-RESPONSE (v2) only', () => {
+    const out = extractSettlementProofFromHeaders({ 'PAYMENT-RESPONSE': 'v2-bytes' });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ source: 'PAYMENT-RESPONSE', wire_version: 'v2' });
+  });
+
+  it('X-PAYMENT-RESPONSE (v1) only', () => {
+    const out = extractSettlementProofFromHeaders({ 'X-PAYMENT-RESPONSE': 'v1-bytes' });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ source: 'X-PAYMENT-RESPONSE', wire_version: 'v1' });
+  });
+
+  it('returns all three in precedence order when all present', () => {
+    const out = extractSettlementProofFromHeaders({
+      'PEAC-Receipt': 'a',
+      'PAYMENT-RESPONSE': 'b',
+      'X-PAYMENT-RESPONSE': 'c',
+    });
+    expect(out.map((p) => p.source)).toEqual([
+      'PEAC-Receipt',
+      'PAYMENT-RESPONSE',
+      'X-PAYMENT-RESPONSE',
+    ]);
+  });
+
+  it('empty bag produces empty array (no synthesis)', () => {
+    expect(extractSettlementProofFromHeaders({})).toEqual([]);
+  });
+
+  it('case-insensitive header matching', () => {
+    const out = extractSettlementProofFromHeaders({ 'peac-receipt': 'lower' });
+    expect(out).toHaveLength(1);
+    expect(out[0]?.raw_value).toBe('lower');
+  });
+
+  it('multi-value header is joined preserving content', () => {
+    const out = extractSettlementProofFromHeaders({ 'PAYMENT-RESPONSE': ['part1', 'part2'] });
+    expect(out[0]?.raw_value).toBe('part1, part2');
+  });
+});
+
+describe('fromX402SettlementObservation: positive path', () => {
+  it('emits commerce.event=settlement with the supplied proof preserved', () => {
+    const proof: ExtractedSettlementProof = {
+      source: 'PAYMENT-RESPONSE',
+      wire_version: 'v2',
+      raw_value: 'v2-bytes',
+    };
+    const out = fromX402SettlementObservation(input({ proof }));
+    expect(out.rail).toBe('x402');
+    expect(out.evidence.commerce_event).toBe('settlement');
+    expect(out.evidence.proofs.x402.settlement.raw_value).toBe('v2-bytes');
+    expect(out.evidence.proofs.x402.settlement.source).toBe('PAYMENT-RESPONSE');
+    expect(out.evidence.proofs.x402.settlement.wire_version).toBe('v2');
+  });
+
+  it('preserves scheme, network, pay_to, facilitator, offer_reference verbatim', () => {
+    const out = fromX402SettlementObservation(
+      input({ scheme: 'upto', network: 'base', pay_to: '0xX', facilitator: 'cdp.coinbase' })
+    );
+    expect(out.evidence.x402_scheme).toBe('upto');
+    expect(out.evidence.x402_network).toBe('base');
+    expect(out.evidence.x402_pay_to).toBe('0xX');
+    expect(out.evidence.x402_facilitator).toBe('cdp.coinbase');
+    expect(out.evidence.x402_offer_reference).toBe('offer_001');
+  });
+});
+
+describe('fromX402SettlementObservation: rejection paths', () => {
+  it('rejects offer-only data (empty raw_value) in ALL modes', () => {
+    const offerOnly: ExtractedSettlementProof = {
+      source: 'PAYMENT-RESPONSE',
+      wire_version: 'v2',
+      raw_value: '',
+    };
+    for (const mode of ['strict', 'interop', 'legacy'] as const) {
+      expect(() => fromX402SettlementObservation(input({ proof: offerOnly }), { mode })).toThrow(
+        MapperBoundaryError
+      );
+    }
+  });
+
+  it('strict rejects UNKNOWN currency', () => {
+    expect(() =>
+      fromX402SettlementObservation(input({ currency: 'UNKNOWN' }), { mode: 'strict' })
+    ).toThrow(MapperBoundaryError);
+  });
+
+  it('strict rejects out-of-enum env', () => {
+    expect(() =>
+      fromX402SettlementObservation(input({ env: 'production' as 'live' | 'test' }), {
+        mode: 'strict',
+      })
+    ).toThrow(MapperBoundaryError);
+  });
+
+  it('thrown error carries stable code and pointer', () => {
+    const offerOnly: ExtractedSettlementProof = {
+      source: 'PEAC-Receipt',
+      wire_version: 'peac',
+      raw_value: '',
+    };
+    try {
+      fromX402SettlementObservation(input({ proof: offerOnly }));
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MapperBoundaryError);
+      expect((err as MapperBoundaryError).code).toBe(COMMERCE_FINALITY_SYNTHESIS_CODE);
+      expect((err as MapperBoundaryError).pointer).toBe('/proofs/x402/settlement');
+    }
+  });
+
+  it('interop warns on UNKNOWN currency without throwing', () => {
+    const warn = vi.fn();
+    fromX402SettlementObservation(input({ currency: 'UNKNOWN' }), { mode: 'interop', warn });
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe('fromX402SettlementObservation: amount semantics (minor units)', () => {
+  it('payment.amount is integer minor-unit value', () => {
+    const out = fromX402SettlementObservation(input({ amount_minor: '99999' }));
+    expect(out.amount).toBe(99999);
+  });
+
+  it('does not apply currency-aware scaling', () => {
+    const usd = fromX402SettlementObservation(input({ currency: 'USD', amount_minor: '1000' }));
+    const jpy = fromX402SettlementObservation(input({ currency: 'JPY', amount_minor: '1000' }));
+    expect(usd.amount).toBe(1000);
+    expect(jpy.amount).toBe(1000);
+  });
+});

--- a/packages/mappings/paymentauth/src/index.ts
+++ b/packages/mappings/paymentauth/src/index.ts
@@ -73,6 +73,10 @@ export {
 // Evidence mapping
 export { fromPaymentauthReceipt, toCommerceExtensionFields } from './map.js';
 
+// MPP / paymentauth payment-attempt and settlement (v0.12.11)
+export { fromMPPPaymentAttempt, fromMPPSettlement } from './map.js';
+export type { PaymentauthArtifactKind, MPPPaymentAttemptInput, MPPSettlementInput } from './map.js';
+
 // Evidence Carrier Contract
 export type {
   PaymentauthHeaderMap,

--- a/packages/mappings/paymentauth/src/map.ts
+++ b/packages/mappings/paymentauth/src/map.ts
@@ -158,3 +158,230 @@ export function toCommerceExtensionFields(
 
   return { ...fields, env: 'live' } as ReturnType<typeof toCommerceExtensionFields>;
 }
+
+// ---------------------------------------------------------------------------
+// MPP / paymentauth payment-attempt and settlement evidence (v0.12.11)
+// ---------------------------------------------------------------------------
+
+/**
+ * Closed enum of paymentauth artifact kinds. Mirrors the pattern used by
+ * the ACP delegated-payment mapper so that a settlement-bearing artifact
+ * is never confused with an authorization-bearing artifact.
+ */
+export type PaymentauthArtifactKind = 'authorization' | 'settlement';
+
+/**
+ * Input for fromMPPPaymentAttempt.
+ *
+ * Models an upstream payment-attempt artifact in the paymentauth /
+ * draft-ryan-httpauth-payment-01 family. Observation only: PEAC does not
+ * verify payment tokens, bind facilitators, or reason about settlement
+ * guarantees. Token material is NEVER carried; only an opaque token
+ * reference is preserved.
+ */
+export interface MPPPaymentAttemptInput {
+  /** Upstream attempt identifier. */
+  attempt_id: string;
+  /** Currency code as supplied by upstream. Required in strict mode. */
+  currency: string;
+  /** Amount in minor units (smallest currency unit) as a base-10 string. */
+  amount_minor: string;
+  /** Environment as supplied by upstream. */
+  env: 'live' | 'test';
+  /** Opaque payment-token reference. NEVER token material. */
+  payment_token_ref: string;
+  /**
+   * Discriminator naming what the upstream artifact attests. MUST be
+   * 'authorization' for fromMPPPaymentAttempt.
+   */
+  artifact_kind: PaymentauthArtifactKind;
+  /**
+   * Optional facilitator attestation, preserved verbatim under
+   * proofs.paymentauth.attempt.facilitator_attestation when present.
+   */
+  facilitator_attestation?: unknown;
+  /**
+   * Raw upstream attempt artifact, preserved verbatim under
+   * proofs.paymentauth.attempt.upstream_artifact. Opaque to PEAC.
+   */
+  upstream_artifact: unknown;
+  /** Optional correlation reference (e.g. challenge id from preceding 402). */
+  challenge_id?: string;
+}
+
+/**
+ * Input for fromMPPSettlement.
+ *
+ * Models an upstream settlement attestation. The artifact_kind MUST be
+ * 'settlement'; absent or 'authorization' is rejected by the mapper-
+ * boundary finality-synthesis guard in all strictness modes.
+ */
+export interface MPPSettlementInput {
+  /** Settlement identifier from upstream. */
+  settlement_id: string;
+  /** Originating attempt id (correlates with fromMPPPaymentAttempt). */
+  attempt_id?: string;
+  /** Currency code as supplied by upstream. Required in strict mode. */
+  currency: string;
+  /** Settled amount in minor units (smallest currency unit). */
+  amount_minor: string;
+  /** Environment as supplied by upstream. */
+  env: 'live' | 'test';
+  /**
+   * Discriminator naming what the upstream artifact attests. MUST be
+   * 'settlement' for fromMPPSettlement.
+   */
+  artifact_kind: PaymentauthArtifactKind;
+  /** Optional facilitator-signed settlement statement. */
+  facilitator_attestation?: unknown;
+  /**
+   * Raw upstream settlement artifact, preserved verbatim under
+   * proofs.paymentauth.settlement.upstream_artifact. Opaque to PEAC.
+   */
+  upstream_artifact: unknown;
+}
+
+/**
+ * Map an MPP / paymentauth payment-attempt artifact to PEAC commerce
+ * evidence with commerce.event = 'authorization'. Routes through the
+ * mapper-boundary finality-synthesis guard.
+ *
+ * Observational mapping only. PEAC does not verify payment tokens or bind
+ * facilitators. Strict mode rejects missing or UNKNOWN currency, env
+ * outside the closed live|test enum, missing or mismatched artifact_kind,
+ * or non-integer amount_minor. Interop emits a deprecation warning on
+ * silent fallbacks; legacy is silent. Rule 1 (artifact_kind mismatch)
+ * rejects in all modes.
+ */
+export function fromMPPPaymentAttempt(
+  input: MPPPaymentAttemptInput,
+  options: PaymentauthMapOptions = {}
+): PaymentEvidence {
+  if (!input.attempt_id) {
+    throw new Error('MPP payment-attempt missing attempt_id');
+  }
+  if (!input.payment_token_ref) {
+    throw new Error('MPP payment-attempt missing payment_token_ref');
+  }
+  if (!/^-?[0-9]+$/.test(input.amount_minor)) {
+    throw new Error('MPP payment-attempt amount_minor must be a base-10 integer string');
+  }
+
+  const hasExplicitUpstreamArtifact =
+    input.upstream_artifact !== undefined && input.artifact_kind === 'authorization';
+
+  assertExplicitFinality(
+    {
+      event: 'authorization',
+      hasExplicitUpstreamArtifact,
+      currency: input.currency,
+      env: input.env,
+      envExplicit: input.env === 'live' || input.env === 'test',
+    },
+    {
+      mode: options.mode,
+      warn: options.warn,
+      pointer: '/proofs/paymentauth/attempt',
+    }
+  );
+
+  const evidence: JsonObject = {
+    paymentauth_method: 'paymentauth',
+    paymentauth_attempt_id: input.attempt_id,
+    payment_token_ref: input.payment_token_ref,
+    commerce_event: 'authorization',
+    proofs: {
+      paymentauth: {
+        attempt: {
+          upstream_artifact: input.upstream_artifact as JsonObject,
+          artifact_kind: input.artifact_kind,
+          ...(input.facilitator_attestation !== undefined
+            ? { facilitator_attestation: input.facilitator_attestation as JsonObject }
+            : {}),
+        },
+      },
+    } as JsonObject,
+  };
+  if (input.challenge_id) {
+    evidence.challenge_id = input.challenge_id;
+  }
+
+  const amount = parseInt(input.amount_minor, 10);
+  return {
+    rail: PAYMENTAUTH_RAIL,
+    reference: input.attempt_id,
+    amount,
+    currency: input.currency.toUpperCase(),
+    asset: input.currency.toUpperCase(),
+    env: input.env,
+    evidence,
+  };
+}
+
+/**
+ * Map an MPP / paymentauth settlement attestation to PEAC commerce
+ * evidence with commerce.event = 'settlement'. Routes through the
+ * mapper-boundary finality-synthesis guard. Settlement requires an
+ * artifact_kind = 'settlement' discriminator; mismatch or absence is a
+ * finality-rule violation rejected in all strictness modes.
+ */
+export function fromMPPSettlement(
+  input: MPPSettlementInput,
+  options: PaymentauthMapOptions = {}
+): PaymentEvidence {
+  if (!input.settlement_id) {
+    throw new Error('MPP settlement missing settlement_id');
+  }
+  if (!/^-?[0-9]+$/.test(input.amount_minor)) {
+    throw new Error('MPP settlement amount_minor must be a base-10 integer string');
+  }
+
+  const hasExplicitUpstreamArtifact =
+    input.upstream_artifact !== undefined && input.artifact_kind === 'settlement';
+
+  assertExplicitFinality(
+    {
+      event: 'settlement',
+      hasExplicitUpstreamArtifact,
+      currency: input.currency,
+      env: input.env,
+      envExplicit: input.env === 'live' || input.env === 'test',
+    },
+    {
+      mode: options.mode,
+      warn: options.warn,
+      pointer: '/proofs/paymentauth/settlement',
+    }
+  );
+
+  const evidence: JsonObject = {
+    paymentauth_method: 'paymentauth',
+    paymentauth_settlement_id: input.settlement_id,
+    commerce_event: 'settlement',
+    proofs: {
+      paymentauth: {
+        settlement: {
+          upstream_artifact: input.upstream_artifact as JsonObject,
+          artifact_kind: input.artifact_kind,
+          ...(input.facilitator_attestation !== undefined
+            ? { facilitator_attestation: input.facilitator_attestation as JsonObject }
+            : {}),
+        },
+      },
+    } as JsonObject,
+  };
+  if (input.attempt_id) {
+    evidence.paymentauth_attempt_id = input.attempt_id;
+  }
+
+  const amount = parseInt(input.amount_minor, 10);
+  return {
+    rail: PAYMENTAUTH_RAIL,
+    reference: input.settlement_id,
+    amount,
+    currency: input.currency.toUpperCase(),
+    asset: input.currency.toUpperCase(),
+    env: input.env,
+    evidence,
+  };
+}

--- a/packages/mappings/paymentauth/tests/mpp-payment-evidence.test.ts
+++ b/packages/mappings/paymentauth/tests/mpp-payment-evidence.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Integration tests for fromMPPPaymentAttempt and fromMPPSettlement.
+ *
+ * Verifies:
+ *  - default (interop) mode preserves expected behavior
+ *  - strict mode rejects missing/UNKNOWN currency, out-of-enum env
+ *  - artifact_kind discriminator is enforced in ALL modes (rule 1)
+ *  - amount semantics use minor units consistently
+ *  - thrown errors carry the stable mapper-boundary code
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { MapperBoundaryError, COMMERCE_FINALITY_SYNTHESIS_CODE } from '@peac/adapter-core';
+import {
+  fromMPPPaymentAttempt,
+  fromMPPSettlement,
+  PAYMENTAUTH_RAIL,
+  type MPPPaymentAttemptInput,
+  type MPPSettlementInput,
+} from '../src/index.js';
+
+function attempt(overrides: Partial<MPPPaymentAttemptInput> = {}): MPPPaymentAttemptInput {
+  return {
+    attempt_id: 'att_001',
+    currency: 'USD',
+    amount_minor: '1500',
+    env: 'live',
+    payment_token_ref: 'tok_ref_opaque',
+    artifact_kind: 'authorization',
+    upstream_artifact: { source: 'paymentauth.attempt.v1', raw: { id: 'att_001' } },
+    challenge_id: 'ch_001',
+    ...overrides,
+  };
+}
+
+function settlement(overrides: Partial<MPPSettlementInput> = {}): MPPSettlementInput {
+  return {
+    settlement_id: 'set_001',
+    attempt_id: 'att_001',
+    currency: 'USD',
+    amount_minor: '1500',
+    env: 'live',
+    artifact_kind: 'settlement',
+    upstream_artifact: { source: 'paymentauth.settlement.v1', raw: { id: 'set_001' } },
+    ...overrides,
+  };
+}
+
+describe('fromMPPPaymentAttempt', () => {
+  it('positive path emits commerce.event=authorization', () => {
+    const out = fromMPPPaymentAttempt(attempt());
+    expect(out.rail).toBe(PAYMENTAUTH_RAIL);
+    expect(out.amount).toBe(1500);
+    expect(out.currency).toBe('USD');
+    expect(out.evidence?.commerce_event).toBe('authorization');
+  });
+
+  it('rejects artifact_kind=settlement on attempt in ALL modes', () => {
+    for (const mode of ['strict', 'interop', 'legacy'] as const) {
+      expect(() =>
+        fromMPPPaymentAttempt(attempt({ artifact_kind: 'settlement' }), { mode })
+      ).toThrow(MapperBoundaryError);
+    }
+  });
+
+  it('strict rejects missing currency', () => {
+    expect(() => fromMPPPaymentAttempt(attempt({ currency: '' }), { mode: 'strict' })).toThrow(
+      MapperBoundaryError
+    );
+  });
+
+  it('preserves facilitator_attestation under proofs.paymentauth.attempt', () => {
+    const facilitator = { signed_by: 'fac.example', sig: 'opaque-bytes' };
+    const out = fromMPPPaymentAttempt(attempt({ facilitator_attestation: facilitator }));
+    const block = (
+      out.evidence as {
+        proofs: { paymentauth: { attempt: { facilitator_attestation?: unknown } } };
+      }
+    ).proofs.paymentauth.attempt;
+    expect(block.facilitator_attestation).toEqual(facilitator);
+  });
+
+  it('does not apply currency-aware scaling (minor units only)', () => {
+    const usd = fromMPPPaymentAttempt(attempt({ currency: 'USD', amount_minor: '1000' }));
+    const jpy = fromMPPPaymentAttempt(attempt({ currency: 'JPY', amount_minor: '1000' }));
+    expect(usd.amount).toBe(1000);
+    expect(jpy.amount).toBe(1000);
+  });
+
+  it('thrown error carries stable code and pointer', () => {
+    try {
+      fromMPPPaymentAttempt(attempt({ artifact_kind: 'settlement' }));
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MapperBoundaryError);
+      expect((err as MapperBoundaryError).code).toBe(COMMERCE_FINALITY_SYNTHESIS_CODE);
+      expect((err as MapperBoundaryError).pointer).toBe('/proofs/paymentauth/attempt');
+    }
+  });
+});
+
+describe('fromMPPSettlement', () => {
+  it('positive path emits commerce.event=settlement', () => {
+    const out = fromMPPSettlement(settlement());
+    expect(out.evidence?.commerce_event).toBe('settlement');
+  });
+
+  it('rejects missing artifact_kind in ALL modes', () => {
+    for (const mode of ['strict', 'interop', 'legacy'] as const) {
+      expect(() =>
+        fromMPPSettlement(settlement({ artifact_kind: undefined as unknown as 'settlement' }), {
+          mode,
+        })
+      ).toThrow(MapperBoundaryError);
+    }
+  });
+
+  it('rejects artifact_kind=authorization on settlement in ALL modes', () => {
+    for (const mode of ['strict', 'interop', 'legacy'] as const) {
+      expect(() =>
+        fromMPPSettlement(settlement({ artifact_kind: 'authorization' }), { mode })
+      ).toThrow(MapperBoundaryError);
+    }
+  });
+
+  it('interop warns on missing currency without throwing', () => {
+    const warn = vi.fn();
+    fromMPPSettlement(settlement({ currency: '' }), { mode: 'interop', warn });
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('legacy is silent on missing currency', () => {
+    const warn = vi.fn();
+    fromMPPSettlement(settlement({ currency: '' }), { mode: 'legacy', warn });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('thrown error carries stable code and pointer', () => {
+    try {
+      fromMPPSettlement(settlement({ artifact_kind: 'authorization' }));
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MapperBoundaryError);
+      expect((err as MapperBoundaryError).code).toBe(COMMERCE_FINALITY_SYNTHESIS_CODE);
+      expect((err as MapperBoundaryError).pointer).toBe('/proofs/paymentauth/settlement');
+    }
+  });
+});

--- a/specs/conformance/commerce/paymentauth/attempt-missing-artifact-kind-rejected.json
+++ b/specs/conformance/commerce/paymentauth/attempt-missing-artifact-kind-rejected.json
@@ -1,0 +1,26 @@
+{
+  "requirement_id": "C-S26-paymentauth-attempt-missing-artifact-kind-rejected",
+  "description": "Negative finality: payment-attempt with artifact_kind=settlement is a mismatch. Throws in ALL modes.",
+  "guard_module": "@peac/adapter-core finality.ts",
+  "function": "fromMPPPaymentAttempt",
+  "input": {
+    "attempt_id": "att_002",
+    "currency": "USD",
+    "amount_minor": "1500",
+    "env": "live",
+    "payment_token_ref": "tok_ref_opaque",
+    "artifact_kind": "settlement",
+    "upstream_artifact": {
+      "source": "paymentauth.settlement.v1"
+    }
+  },
+  "expected": {
+    "modes": {
+      "strict": "throw",
+      "interop": "throw",
+      "legacy": "throw"
+    },
+    "error_code": "commerce.finality_synthesis_blocked",
+    "error_pointer": "/proofs/paymentauth/attempt"
+  }
+}

--- a/specs/conformance/commerce/paymentauth/attempt-positive.json
+++ b/specs/conformance/commerce/paymentauth/attempt-positive.json
@@ -1,0 +1,25 @@
+{
+  "requirement_id": "C-S26-paymentauth-attempt-positive",
+  "description": "Positive: payment-attempt with explicit upstream artifact and matching artifact_kind=authorization. Emits commerce.event=authorization.",
+  "guard_module": "@peac/adapter-core finality.ts",
+  "function": "fromMPPPaymentAttempt",
+  "input": {
+    "attempt_id": "att_001",
+    "currency": "USD",
+    "amount_minor": "1500",
+    "env": "live",
+    "payment_token_ref": "tok_ref_opaque",
+    "artifact_kind": "authorization",
+    "upstream_artifact": {
+      "source": "paymentauth.attempt.v1"
+    }
+  },
+  "expected": {
+    "modes": {
+      "strict": "pass",
+      "interop": "pass",
+      "legacy": "pass"
+    },
+    "emits_commerce_event": "authorization"
+  }
+}

--- a/specs/conformance/commerce/paymentauth/currency-fallback-rejected-strict.json
+++ b/specs/conformance/commerce/paymentauth/currency-fallback-rejected-strict.json
@@ -1,0 +1,26 @@
+{
+  "requirement_id": "C-S26-paymentauth-currency-fallback-rejected-strict",
+  "description": "Negative: UNKNOWN currency on payment-attempt. Strict throws; interop warns; legacy silent.",
+  "guard_module": "@peac/adapter-core finality.ts",
+  "function": "fromMPPPaymentAttempt",
+  "input": {
+    "attempt_id": "att_003",
+    "currency": "UNKNOWN",
+    "amount_minor": "1500",
+    "env": "live",
+    "payment_token_ref": "tok_ref_opaque",
+    "artifact_kind": "authorization",
+    "upstream_artifact": {
+      "source": "paymentauth.attempt.v1"
+    }
+  },
+  "expected": {
+    "modes": {
+      "strict": "throw",
+      "interop": "warn",
+      "legacy": "pass"
+    },
+    "error_code": "commerce.finality_synthesis_blocked",
+    "error_pointer": "/proofs/paymentauth/attempt"
+  }
+}

--- a/specs/conformance/commerce/paymentauth/env-default-rejected-strict.json
+++ b/specs/conformance/commerce/paymentauth/env-default-rejected-strict.json
@@ -1,0 +1,25 @@
+{
+  "requirement_id": "C-S26-paymentauth-env-default-rejected-strict",
+  "description": "Negative: env outside live|test enum. Strict throws; interop warns; legacy silent.",
+  "guard_module": "@peac/adapter-core finality.ts",
+  "function": "fromMPPSettlement",
+  "input": {
+    "settlement_id": "set_003",
+    "currency": "USD",
+    "amount_minor": "1500",
+    "env": "production",
+    "artifact_kind": "settlement",
+    "upstream_artifact": {
+      "source": "paymentauth.settlement.v1"
+    }
+  },
+  "expected": {
+    "modes": {
+      "strict": "throw",
+      "interop": "warn",
+      "legacy": "pass"
+    },
+    "error_code": "commerce.finality_synthesis_blocked",
+    "error_pointer": "/proofs/paymentauth/settlement"
+  }
+}

--- a/specs/conformance/commerce/paymentauth/manifest.json
+++ b/specs/conformance/commerce/paymentauth/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "commerce/paymentauth",
+  "version": "0.12.11",
+  "section": 26,
+  "subsection": "paymentauth",
+  "description": "Conformance vectors for the v0.12.11 paymentauth commerce evidence mapping.",
+  "spec_revision": "docs/profiles/mpp-payment-evidence.md (v0.12.11)",
+  "guard_module": "@peac/adapter-core finality.ts",
+  "consumer": "@peac/mappings-paymentauth",
+  "stable_error_code": "commerce.finality_synthesis_blocked",
+  "fixture_count": 6,
+  "fixtures": [
+    "attempt-positive.json",
+    "attempt-missing-artifact-kind-rejected.json",
+    "settlement-positive.json",
+    "settlement-without-attestation-rejected.json",
+    "currency-fallback-rejected-strict.json",
+    "env-default-rejected-strict.json"
+  ]
+}

--- a/specs/conformance/commerce/paymentauth/settlement-positive.json
+++ b/specs/conformance/commerce/paymentauth/settlement-positive.json
@@ -1,0 +1,25 @@
+{
+  "requirement_id": "C-S26-paymentauth-settlement-positive",
+  "description": "Positive: settlement with explicit upstream artifact and matching artifact_kind=settlement. Emits commerce.event=settlement.",
+  "guard_module": "@peac/adapter-core finality.ts",
+  "function": "fromMPPSettlement",
+  "input": {
+    "settlement_id": "set_001",
+    "attempt_id": "att_001",
+    "currency": "USD",
+    "amount_minor": "1500",
+    "env": "live",
+    "artifact_kind": "settlement",
+    "upstream_artifact": {
+      "source": "paymentauth.settlement.v1"
+    }
+  },
+  "expected": {
+    "modes": {
+      "strict": "pass",
+      "interop": "pass",
+      "legacy": "pass"
+    },
+    "emits_commerce_event": "settlement"
+  }
+}

--- a/specs/conformance/commerce/paymentauth/settlement-without-attestation-rejected.json
+++ b/specs/conformance/commerce/paymentauth/settlement-without-attestation-rejected.json
@@ -1,0 +1,25 @@
+{
+  "requirement_id": "C-S26-paymentauth-settlement-without-attestation-rejected",
+  "description": "Negative finality: settlement with artifact_kind=authorization (mismatch) is rejected in ALL modes.",
+  "guard_module": "@peac/adapter-core finality.ts",
+  "function": "fromMPPSettlement",
+  "input": {
+    "settlement_id": "set_002",
+    "currency": "USD",
+    "amount_minor": "1500",
+    "env": "live",
+    "artifact_kind": "authorization",
+    "upstream_artifact": {
+      "source": "paymentauth.attempt.v1"
+    }
+  },
+  "expected": {
+    "modes": {
+      "strict": "throw",
+      "interop": "throw",
+      "legacy": "throw"
+    },
+    "error_code": "commerce.finality_synthesis_blocked",
+    "error_pointer": "/proofs/paymentauth/settlement"
+  }
+}

--- a/specs/conformance/commerce/x402/dual-header-precedence.json
+++ b/specs/conformance/commerce/x402/dual-header-precedence.json
@@ -1,0 +1,21 @@
+{
+  "requirement_id": "C-S26-x402-dual-header-precedence",
+  "description": "Header extraction precedence: PEAC-Receipt > PAYMENT-RESPONSE (v2) > X-PAYMENT-RESPONSE (v1) when all three are present.",
+  "guard_module": "@peac/adapter-core finality.ts",
+  "function": "extractSettlementProofFromHeaders",
+  "input": {
+    "headers": {
+      "PEAC-Receipt": "a",
+      "PAYMENT-RESPONSE": "b",
+      "X-PAYMENT-RESPONSE": "c"
+    }
+  },
+  "expected": {
+    "modes": {
+      "strict": "pass",
+      "interop": "pass",
+      "legacy": "pass"
+    },
+    "extracted_sources": ["PEAC-Receipt", "PAYMENT-RESPONSE", "X-PAYMENT-RESPONSE"]
+  }
+}

--- a/specs/conformance/commerce/x402/duplicate-proof-precedence.json
+++ b/specs/conformance/commerce/x402/duplicate-proof-precedence.json
@@ -1,0 +1,20 @@
+{
+  "requirement_id": "C-S26-x402-duplicate-proof-precedence",
+  "description": "Duplicate proofs (PEAC-Receipt + PAYMENT-RESPONSE) returned in precedence order; callers can record duplicates.",
+  "guard_module": "@peac/adapter-core finality.ts",
+  "function": "extractSettlementProofFromHeaders",
+  "input": {
+    "headers": {
+      "PEAC-Receipt": "peac-bytes",
+      "PAYMENT-RESPONSE": "v2-bytes"
+    }
+  },
+  "expected": {
+    "modes": {
+      "strict": "pass",
+      "interop": "pass",
+      "legacy": "pass"
+    },
+    "extracted_sources": ["PEAC-Receipt", "PAYMENT-RESPONSE"]
+  }
+}

--- a/specs/conformance/commerce/x402/manifest.json
+++ b/specs/conformance/commerce/x402/manifest.json
@@ -1,0 +1,19 @@
+{
+  "name": "commerce/x402",
+  "version": "0.12.11",
+  "section": 26,
+  "subsection": "x402",
+  "description": "Conformance vectors for the v0.12.11 x402 commerce evidence mapping.",
+  "spec_revision": "docs/specs/X402-V2-PROFILE.md §8 (v0.12.11)",
+  "guard_module": "@peac/adapter-core finality.ts",
+  "consumer": "@peac/adapter-x402",
+  "stable_error_code": "commerce.finality_synthesis_blocked",
+  "fixture_count": 5,
+  "fixtures": [
+    "settlement-proof-positive.json",
+    "offer-only-rejected.json",
+    "dual-header-precedence.json",
+    "duplicate-proof-precedence.json",
+    "scheme-agnostic-passthrough.json"
+  ]
+}

--- a/specs/conformance/commerce/x402/offer-only-rejected.json
+++ b/specs/conformance/commerce/x402/offer-only-rejected.json
@@ -1,0 +1,28 @@
+{
+  "requirement_id": "C-S26-x402-offer-only-rejected",
+  "description": "Negative finality: offer-only (empty raw_value) MUST NOT produce settlement evidence. Throws in ALL modes.",
+  "guard_module": "@peac/adapter-core finality.ts",
+  "function": "fromX402SettlementObservation",
+  "input": {
+    "proof": {
+      "source": "PEAC-Receipt",
+      "wire_version": "peac",
+      "raw_value": ""
+    },
+    "scheme": "exact",
+    "network": "base-sepolia",
+    "asset": "0xUSDC",
+    "currency": "USD",
+    "amount_minor": "1500",
+    "env": "live"
+  },
+  "expected": {
+    "modes": {
+      "strict": "throw",
+      "interop": "throw",
+      "legacy": "throw"
+    },
+    "error_code": "commerce.finality_synthesis_blocked",
+    "error_pointer": "/proofs/x402/settlement"
+  }
+}

--- a/specs/conformance/commerce/x402/scheme-agnostic-passthrough.json
+++ b/specs/conformance/commerce/x402/scheme-agnostic-passthrough.json
@@ -1,0 +1,28 @@
+{
+  "requirement_id": "C-S26-x402-scheme-agnostic-passthrough",
+  "description": "Scheme is preserved verbatim; PEAC does not verify scheme invariants. Emits commerce.event=settlement for an upto-scheme proof.",
+  "guard_module": "@peac/adapter-core finality.ts",
+  "function": "fromX402SettlementObservation",
+  "input": {
+    "proof": {
+      "source": "PAYMENT-RESPONSE",
+      "wire_version": "v2",
+      "raw_value": "upto-bytes"
+    },
+    "scheme": "upto",
+    "network": "base",
+    "asset": "0xUSDC",
+    "currency": "USD",
+    "amount_minor": "999999",
+    "env": "live"
+  },
+  "expected": {
+    "modes": {
+      "strict": "pass",
+      "interop": "pass",
+      "legacy": "pass"
+    },
+    "emits_commerce_event": "settlement",
+    "preserves_scheme": "upto"
+  }
+}

--- a/specs/conformance/commerce/x402/settlement-proof-positive.json
+++ b/specs/conformance/commerce/x402/settlement-proof-positive.json
@@ -1,0 +1,29 @@
+{
+  "requirement_id": "C-S26-x402-settlement-proof-positive",
+  "description": "Positive: explicit settlement proof from PAYMENT-RESPONSE (v2). Emits commerce.event=settlement.",
+  "guard_module": "@peac/adapter-core finality.ts",
+  "function": "fromX402SettlementObservation",
+  "input": {
+    "proof": {
+      "source": "PAYMENT-RESPONSE",
+      "wire_version": "v2",
+      "raw_value": "v2-bytes"
+    },
+    "scheme": "exact",
+    "network": "base-sepolia",
+    "asset": "0xUSDC",
+    "currency": "USD",
+    "amount_minor": "1500",
+    "env": "live",
+    "pay_to": "0xRecipient",
+    "facilitator": "fac.example"
+  },
+  "expected": {
+    "modes": {
+      "strict": "pass",
+      "interop": "pass",
+      "legacy": "pass"
+    },
+    "emits_commerce_event": "settlement"
+  }
+}


### PR DESCRIPTION
## Summary

Adds MPP / paymentauth payment-attempt and settlement evidence mapping plus x402 settlement-proof extraction and observation. All wiring routes through the shared mapper-boundary finality-synthesis guard from `@peac/adapter-core`.

Observational only: PEAC records what each upstream artifact attested. PEAC does not verify scheme invariants, bind facilitators, verify payment tokens, or reason about settlement guarantees.

## Scope

Layer 4 mapping, profile doc, spec prose, and conformance fixtures only. No wire format change, no schema change, no kernel registry change, no error-code registry change.

- `@peac/mappings-paymentauth`:
  - `fromMPPPaymentAttempt` (commerce.event=authorization, requires `artifact_kind='authorization'`).
  - `fromMPPSettlement` (commerce.event=settlement, requires `artifact_kind='settlement'`; mismatch or absence rejects in all modes).
  - Optional `facilitator_attestation` preserved verbatim. Token material never carried.
- `@peac/adapter-x402`:
  - `extractSettlementProofFromHeaders` returns proofs in dual-header precedence order (PEAC-Receipt > PAYMENT-RESPONSE v2 > X-PAYMENT-RESPONSE v1). Case-insensitive matching; multi-value join.
  - `fromX402SettlementObservation` produces commerce.event=settlement only when supplied with a non-empty extracted proof; offer-only data rejects in all modes. Scheme, network, pay_to, facilitator preserved verbatim; PEAC does not verify scheme invariants.
- Documentation:
  - `docs/profiles/mpp-payment-evidence.md` (new pillar profile).
  - `docs/specs/X402-V2-PROFILE.md` gains §8 Settlement Observation Boundary.
  - `docs/profiles/README.md` adds the new profile entry alongside the ACP Delegated Payment row.
  - `docs/specs/COMMERCE-EVIDENCE.md` gains per-protocol cross-references to the new v0.12.11 surfaces: ACP delegated-payment (`fromACPDelegatedPaymentObservation`, already merged via #655), MPP / paymentauth (this PR), and x402 settlement observation (this PR). Spec prose only; no wire, schema, kernel, or error-registry change.
- Conformance fixtures (11 total + 2 manifests):
  - `specs/conformance/commerce/paymentauth/`: 6 fixtures.
  - `specs/conformance/commerce/x402/`: 5 fixtures.

Amount semantics match the ACP delegated-payment profile pattern: `payment.amount` is the integer minor-unit value parsed from `amount_minor` with no currency-aware scaling.

This PR contains two commits: the functional mapping surfaces, and a docs-only follow-up adding the `COMMERCE-EVIDENCE.md` cross-references.


## Notes

`paymentauth` is the canonical code and registry term aligned with the active draft `draft-ryan-httpauth-payment-01`. MPP is an ecosystem prose term; it does not appear in package names, registry entries, fixture paths, or schema enums. The stable string code `commerce.finality_synthesis_blocked` is a mapper-boundary identifier, not a wire-level error code.
