### PR TITLE
feat: runnable (x402, acp, mpp) commerce evidence examples

### DIFF
--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -9,7 +9,7 @@
     "tests": 7392,
     "test_files": 296,
     "published_packages": 37,
-    "build_targets": 102,
+    "build_targets": 105,
     "conformance_requirement_ids": 224,
     "conformance_sections": 25
   },

--- a/examples/acp-delegated-checkout/README.md
+++ b/examples/acp-delegated-checkout/README.md
@@ -1,0 +1,19 @@
+# ACP delegated-payment observation -> PEAC commerce evidence
+
+Offline demo: record an ACP-shaped delegated-payment authorization and a separate settlement as PEAC commerce evidence, with the `artifact_kind` discriminator preventing a settlement from being synthesized off an authorization-only artifact.
+
+## Run
+
+```bash
+pnpm install
+pnpm --filter @peac/example-acp-delegated-checkout demo
+```
+
+## What it shows
+
+1. `fromACPDelegatedPaymentObservation` with `observed_payment_state='authorized'` + `artifact_kind='authorization'` emits `commerce.event=authorization`.
+2. A separate observation with `observed_payment_state='settled'` + `artifact_kind='settlement'` emits `commerce.event=settlement`.
+3. Non-finality states (`pending`, `failed`, `revoked`) produce evidence with no commerce event; downstream consumers cannot infer settlement from a non-settlement observation.
+4. Pairing `observed_payment_state='settled'` with `artifact_kind='authorization'` throws `MapperBoundaryError` (`commerce.finality_synthesis_blocked`) in all strictness modes. Token material is never carried; only `payment_method_token_ref` is preserved.
+
+See also: [`docs/profiles/acp-delegated-payment.md`](../../docs/profiles/acp-delegated-payment.md).

--- a/examples/acp-delegated-checkout/demo.ts
+++ b/examples/acp-delegated-checkout/demo.ts
@@ -1,0 +1,119 @@
+/**
+ * ACP delegated-payment observation -> PEAC commerce evidence demo.
+ *
+ * Offline, no network. Shows the full lane: (1) an upstream ACP-aware
+ * payment surface produces a delegated-payment authorization artifact
+ * and later a settlement artifact; (2) PEAC records each observation
+ * separately via fromACPDelegatedPaymentObservation; (3) the
+ * artifact_kind discriminator prevents an authorization-only artifact
+ * from being treated as a settlement proof.
+ *
+ * Run: npx tsx examples/acp-delegated-checkout/demo.ts
+ */
+
+import {
+  fromACPDelegatedPaymentObservation,
+  type ACPDelegatedPaymentObservation,
+} from '@peac/mappings-acp';
+import { MapperBoundaryError } from '@peac/adapter-core';
+
+/** Narrow view over the JsonObject evidence field for demo logging. */
+type DemoEvidence = {
+  commerce_event?: string;
+  observed_payment_state?: string;
+};
+
+function section(title: string): void {
+  console.log(`\n=== ${title} ===\n`);
+}
+
+// ---------------------------------------------------------------------------
+// 1. Delegated-payment authorization observation
+// ---------------------------------------------------------------------------
+section('1. Authorization observation (artifact_kind=authorization)');
+
+const authObservation: ACPDelegatedPaymentObservation = {
+  delegation_id: 'del_demo_001',
+  resource_uri: 'https://merchant.example.com/checkout/acp-demo',
+  principal: 'user_alice',
+  delegate: 'agent_bob',
+  payment_method_token_ref: 'pmt_ref_opaque_demo',
+  authorized_amount_minor: '2599',
+  currency: 'USD',
+  env: 'live',
+  observed_payment_state: 'authorized',
+  artifact_kind: 'authorization',
+  upstream_artifact: {
+    source: 'acp.delegated_payment.v1',
+    raw: { authorization_id: 'auth_demo_xyz', created_at: '2026-05-01T10:00:00Z' },
+  },
+  session_id: 'sess_demo_001',
+};
+
+const authEvidence = fromACPDelegatedPaymentObservation(authObservation);
+console.log(`rail:            ${authEvidence.payment.rail}`);
+console.log(`amount (minor):  ${authEvidence.payment.amount}`);
+console.log(`currency:        ${authEvidence.payment.currency}`);
+const authEv = authEvidence.payment.evidence as DemoEvidence;
+console.log(`commerce.event:  ${authEv.commerce_event}`);
+console.log(`observed_state:  ${authEv.observed_payment_state}`);
+
+// ---------------------------------------------------------------------------
+// 2. Settlement observation (separate artifact with artifact_kind=settlement)
+// ---------------------------------------------------------------------------
+section('2. Settlement observation (artifact_kind=settlement)');
+
+const settlementEvidence = fromACPDelegatedPaymentObservation({
+  ...authObservation,
+  observed_payment_state: 'settled',
+  artifact_kind: 'settlement',
+  upstream_artifact: {
+    source: 'acp.delegated_payment.v1',
+    raw: { settlement_id: 'sett_demo_xyz', settled_at: '2026-05-01T10:05:00Z' },
+  },
+});
+const settlementEv = settlementEvidence.payment.evidence as DemoEvidence;
+console.log(`commerce.event:  ${settlementEv.commerce_event}`);
+console.log(`observed_state:  ${settlementEv.observed_payment_state}`);
+
+// ---------------------------------------------------------------------------
+// 3. Non-finality states: pending/failed/revoked MUST NOT emit events
+// ---------------------------------------------------------------------------
+section('3. Non-finality states produce NO commerce event');
+
+for (const state of ['pending', 'failed', 'revoked'] as const) {
+  const out = fromACPDelegatedPaymentObservation({
+    ...authObservation,
+    observed_payment_state: state,
+    artifact_kind: undefined,
+  });
+  const ev = out.payment.evidence as DemoEvidence;
+  console.log(`  state=${state}: commerce.event=${ev.commerce_event ?? '<none>'}`);
+}
+
+// ---------------------------------------------------------------------------
+// 4. Negative path: settled with authorization-only artifact REJECTS
+// ---------------------------------------------------------------------------
+section('4. Settlement-proof discriminator rejects cross-kind misuse (ALL modes)');
+
+for (const mode of ['strict', 'interop', 'legacy'] as const) {
+  try {
+    fromACPDelegatedPaymentObservation(
+      {
+        ...authObservation,
+        observed_payment_state: 'settled',
+        artifact_kind: 'authorization',
+      },
+      { mode }
+    );
+    console.log(`  mode=${mode}: UNEXPECTED pass (rule 1 should reject)`);
+  } catch (err) {
+    if (err instanceof MapperBoundaryError) {
+      console.log(`  mode=${mode}: rejected (${err.code}) at pointer ${err.pointer}`);
+    } else {
+      throw err;
+    }
+  }
+}
+
+console.log('\nDone.');

--- a/examples/acp-delegated-checkout/package.json
+++ b/examples/acp-delegated-checkout/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@peac/example-acp-delegated-checkout",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Demo: ACP delegated-payment observation -> PEAC commerce evidence (authorization + settlement)",
+  "scripts": {
+    "demo": "tsx demo.ts",
+    "build": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@peac/mappings-acp": "workspace:*",
+    "@peac/adapter-core": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/examples/acp-delegated-checkout/tsconfig.json
+++ b/examples/acp-delegated-checkout/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true
+  },
+  "include": ["*.ts"]
+}

--- a/examples/mpp-payment-attempt/README.md
+++ b/examples/mpp-payment-attempt/README.md
@@ -1,0 +1,19 @@
+# MPP / paymentauth payment-attempt -> PEAC commerce evidence
+
+Offline demo: record a paymentauth payment-attempt and a separate settlement as PEAC commerce evidence, with the `artifact_kind` discriminator preventing cross-kind misuse and optional facilitator attestations preserved verbatim.
+
+## Run
+
+```bash
+pnpm install
+pnpm --filter @peac/example-mpp-payment-attempt demo
+```
+
+## What it shows
+
+1. `fromMPPPaymentAttempt` with `artifact_kind='authorization'` emits `commerce.event=authorization`. Optional `facilitator_attestation` is preserved verbatim under `proofs.paymentauth.attempt.facilitator_attestation`.
+2. `fromMPPSettlement` with `artifact_kind='settlement'` emits `commerce.event=settlement`. Settlement attestation is preserved under `proofs.paymentauth.settlement.facilitator_attestation`.
+3. Pairing `fromMPPSettlement` with `artifact_kind='authorization'` throws `MapperBoundaryError` (`commerce.finality_synthesis_blocked`) in all strictness modes.
+4. `paymentauth` is the canonical code and registry term aligned with the active draft `draft-ryan-httpauth-payment-01`. MPP is an ecosystem prose term; token material is never carried.
+
+See also: [`docs/profiles/mpp-payment-evidence.md`](../../docs/profiles/mpp-payment-evidence.md).

--- a/examples/mpp-payment-attempt/demo.ts
+++ b/examples/mpp-payment-attempt/demo.ts
@@ -1,0 +1,113 @@
+/**
+ * MPP / paymentauth payment-attempt + settlement -> PEAC commerce evidence.
+ *
+ * Offline, no network. Shows the full lane: (1) a paymentauth-aware
+ * payment surface produces a payment-attempt artifact with an optional
+ * facilitator attestation; (2) PEAC records the attempt via
+ * fromMPPPaymentAttempt, emitting commerce.event=authorization;
+ * (3) a separate settlement attestation arrives and PEAC records it via
+ * fromMPPSettlement with commerce.event=settlement; (4) the
+ * artifact_kind discriminator prevents cross-kind misuse.
+ *
+ * Run: npx tsx examples/mpp-payment-attempt/demo.ts
+ */
+
+import {
+  fromMPPPaymentAttempt,
+  fromMPPSettlement,
+  type MPPPaymentAttemptInput,
+  type MPPSettlementInput,
+} from '@peac/mappings-paymentauth';
+import { MapperBoundaryError } from '@peac/adapter-core';
+
+/** Narrow view over the JsonObject evidence field for demo logging. */
+type DemoEvidence = {
+  commerce_event?: string;
+  challenge_id?: string;
+  paymentauth_attempt_id?: string;
+};
+
+function section(title: string): void {
+  console.log(`\n=== ${title} ===\n`);
+}
+
+// ---------------------------------------------------------------------------
+// 1. Payment-attempt observation (authorization)
+// ---------------------------------------------------------------------------
+section('1. Payment-attempt observation (artifact_kind=authorization)');
+
+const attempt: MPPPaymentAttemptInput = {
+  attempt_id: 'att_demo_001',
+  currency: 'USD',
+  amount_minor: '2500',
+  env: 'live',
+  payment_token_ref: 'tok_ref_opaque_demo',
+  artifact_kind: 'authorization',
+  facilitator_attestation: {
+    signer: 'facilitator.example',
+    signed_at: '2026-05-01T10:00:00Z',
+    signature: 'opaque-bytes-facilitator',
+  },
+  upstream_artifact: {
+    source: 'paymentauth.attempt.v1',
+    attempt_token: 'eyJvcGFxdWUuYXR0ZW1wdA...',
+  },
+  challenge_id: 'ch_demo_001',
+};
+
+const attemptEvidence = fromMPPPaymentAttempt(attempt);
+console.log(`rail:            ${attemptEvidence.rail}`);
+console.log(`amount (minor):  ${attemptEvidence.amount}`);
+console.log(`currency:        ${attemptEvidence.currency}`);
+const attemptEv = attemptEvidence.evidence as DemoEvidence;
+console.log(`commerce.event:  ${attemptEv.commerce_event}`);
+console.log(`challenge_id:    ${attemptEv.challenge_id}`);
+
+// ---------------------------------------------------------------------------
+// 2. Settlement observation (requires artifact_kind=settlement)
+// ---------------------------------------------------------------------------
+section('2. Settlement observation (artifact_kind=settlement)');
+
+const settlement: MPPSettlementInput = {
+  settlement_id: 'set_demo_001',
+  attempt_id: attempt.attempt_id,
+  currency: 'USD',
+  amount_minor: '2500',
+  env: 'live',
+  artifact_kind: 'settlement',
+  facilitator_attestation: {
+    signer: 'facilitator.example',
+    signed_at: '2026-05-01T10:05:00Z',
+    signature: 'opaque-bytes-settlement',
+  },
+  upstream_artifact: {
+    source: 'paymentauth.settlement.v1',
+    settlement_token: 'eyJvcGFxdWUuc2V0dGxlbWVudA...',
+  },
+};
+
+const settlementEvidence = fromMPPSettlement(settlement);
+console.log(`rail:            ${settlementEvidence.rail}`);
+const settlementEv = settlementEvidence.evidence as DemoEvidence;
+console.log(`commerce.event:  ${settlementEv.commerce_event}`);
+console.log(`attempt_id:      ${settlementEv.paymentauth_attempt_id}`);
+
+// ---------------------------------------------------------------------------
+// 3. Negative path: cross-kind misuse rejected in ALL modes
+// ---------------------------------------------------------------------------
+section('3. Cross-kind misuse rejected in ALL modes');
+
+for (const mode of ['strict', 'interop', 'legacy'] as const) {
+  try {
+    fromMPPSettlement({ ...settlement, artifact_kind: 'authorization' }, { mode });
+    console.log(`  mode=${mode}: UNEXPECTED pass (rule 1 should reject)`);
+  } catch (err) {
+    if (err instanceof MapperBoundaryError) {
+      console.log(`  mode=${mode}: rejected (${err.code}) at pointer ${err.pointer}`);
+    } else {
+      throw err;
+    }
+  }
+}
+
+console.log('\nDone.');

--- a/examples/mpp-payment-attempt/package.json
+++ b/examples/mpp-payment-attempt/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@peac/example-mpp-payment-attempt",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Demo: MPP / paymentauth payment-attempt and settlement observations -> PEAC commerce evidence",
+  "scripts": {
+    "demo": "tsx demo.ts",
+    "build": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@peac/mappings-paymentauth": "workspace:*",
+    "@peac/adapter-core": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/examples/mpp-payment-attempt/tsconfig.json
+++ b/examples/mpp-payment-attempt/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true
+  },
+  "include": ["*.ts"]
+}

--- a/examples/x402-upto-evidence/README.md
+++ b/examples/x402-upto-evidence/README.md
@@ -1,0 +1,17 @@
+# x402 upto -> PEAC settlement evidence
+
+Offline demo: extract a settlement proof from x402 response headers in dual-header precedence order, map it to PEAC commerce evidence with `commerce.event=settlement` using the `upto` scheme, and show that offer-only (empty proof) data is rejected as a finality-rule violation in every strictness mode.
+
+## Run
+
+```bash
+pnpm install
+pnpm --filter @peac/example-x402-upto-evidence demo
+```
+
+## What it shows
+
+1. `extractSettlementProofFromHeaders` returns proofs in the canonical order `PEAC-Receipt > PAYMENT-RESPONSE (v2) > X-PAYMENT-RESPONSE (v1)`.
+2. `fromX402SettlementObservation` produces settlement evidence only when the supplied proof has a non-empty `raw_value`. The raw proof is preserved verbatim under `proofs.x402.settlement`.
+3. Scheme (`upto`), network, `pay_to`, facilitator, and offer reference are preserved without PEAC verifying any scheme invariants. Scheme-specific checks remain upstream responsibility; see `docs/compatibility/x402-scheme-coverage.md`.
+4. A proof whose `raw_value` is an empty string (offer-only) throws `MapperBoundaryError` with code `commerce.finality_synthesis_blocked` in strict, interop, and legacy modes.

--- a/examples/x402-upto-evidence/demo.ts
+++ b/examples/x402-upto-evidence/demo.ts
@@ -1,0 +1,98 @@
+/**
+ * x402 upto -> settlement proof -> PEAC commerce evidence demo.
+ *
+ * Offline, no network. Shows the full lane: (1) upstream x402 response
+ * headers carry a settlement proof, (2) PEAC extracts the proof in
+ * dual-header precedence order, (3) fromX402SettlementObservation
+ * produces commerce.event=settlement evidence only when an explicit
+ * non-empty proof is supplied. Also demonstrates the negative path:
+ * offer-only data (empty proof) rejects in every strictness mode.
+ *
+ * Run: npx tsx examples/x402-upto-evidence/demo.ts
+ */
+
+import {
+  extractSettlementProofFromHeaders,
+  fromX402SettlementObservation,
+} from '@peac/adapter-x402';
+import { MapperBoundaryError } from '@peac/adapter-core';
+
+function section(title: string): void {
+  console.log(`\n=== ${title} ===\n`);
+}
+
+// ---------------------------------------------------------------------------
+// 1. Happy path: x402 v2 response header carries a settlement proof
+// ---------------------------------------------------------------------------
+section('1. Extract settlement proof from response headers (dual-header order)');
+
+const responseHeaders = {
+  'PAYMENT-RESPONSE': 'eyJvcGFxdWUudjI.settlement-bytes',
+  'X-PAYMENT-RESPONSE': 'legacy-v1-bytes',
+};
+const proofs = extractSettlementProofFromHeaders(responseHeaders);
+console.log(`Extracted ${proofs.length} proof(s) in precedence order:`);
+for (const p of proofs) {
+  console.log(`  - source=${p.source} wire=${p.wire_version} bytes=${p.raw_value.slice(0, 24)}...`);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Map the v2 proof to PEAC settlement evidence (upto scheme passthrough)
+// ---------------------------------------------------------------------------
+section('2. Map the v2 proof to PEAC commerce evidence (upto scheme)');
+
+const v2Proof = proofs[0]!;
+const evidence = fromX402SettlementObservation({
+  proof: v2Proof,
+  scheme: 'upto',
+  network: 'base-sepolia',
+  asset: '0xUSDC',
+  currency: 'USD',
+  amount_minor: '2500',
+  env: 'live',
+  pay_to: '0xRecipientDemo',
+  facilitator: 'cdp.coinbase',
+  offer_reference: 'offer_demo_001',
+});
+console.log(`rail:            ${evidence.rail}`);
+console.log(`amount (minor):  ${evidence.amount}`);
+console.log(`currency:        ${evidence.currency}`);
+console.log(`commerce.event:  ${evidence.evidence.commerce_event}`);
+console.log(`scheme:          ${evidence.evidence.x402_scheme}`);
+console.log(`network:         ${evidence.evidence.x402_network}`);
+console.log(`proof.source:    ${evidence.evidence.proofs.x402.settlement.source}`);
+console.log(
+  `proof preserved: ${evidence.evidence.proofs.x402.settlement.raw_value.slice(0, 24)}...`
+);
+
+// ---------------------------------------------------------------------------
+// 3. Negative path: offer-only data MUST NOT produce settlement evidence
+// ---------------------------------------------------------------------------
+section('3. Negative path: offer-only (empty raw_value) rejected in ALL modes');
+
+const offerOnly = { source: 'PEAC-Receipt' as const, wire_version: 'peac' as const, raw_value: '' };
+for (const mode of ['strict', 'interop', 'legacy'] as const) {
+  try {
+    fromX402SettlementObservation(
+      {
+        proof: offerOnly,
+        scheme: 'upto',
+        network: 'base-sepolia',
+        asset: '0xUSDC',
+        currency: 'USD',
+        amount_minor: '2500',
+        env: 'live',
+      },
+      { mode }
+    );
+    console.log(`  mode=${mode}: UNEXPECTED pass (rule 1 should reject)`);
+  } catch (err) {
+    if (err instanceof MapperBoundaryError) {
+      console.log(`  mode=${mode}: rejected (${err.code}) at pointer ${err.pointer}`);
+    } else {
+      throw err;
+    }
+  }
+}
+
+console.log('\nDone.');

--- a/examples/x402-upto-evidence/package.json
+++ b/examples/x402-upto-evidence/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@peac/example-x402-upto-evidence",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Demo: x402 upto offer -> settlement-proof header -> PEAC settlement evidence",
+  "scripts": {
+    "demo": "tsx demo.ts",
+    "build": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@peac/adapter-x402": "workspace:*",
+    "@peac/adapter-core": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/examples/x402-upto-evidence/tsconfig.json
+++ b/examples/x402-upto-evidence/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true
+  },
+  "include": ["*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,6 +248,22 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
 
+  examples/acp-delegated-checkout:
+    dependencies:
+      '@peac/adapter-core':
+        specifier: workspace:*
+        version: link:../../packages/adapters/core
+      '@peac/mappings-acp':
+        specifier: workspace:*
+        version: link:../../packages/mappings/acp
+    devDependencies:
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+
   examples/acp-session-lifecycle:
     dependencies:
       '@peac/mappings-acp':
@@ -427,6 +443,22 @@ importers:
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
+
+  examples/mpp-payment-attempt:
+    dependencies:
+      '@peac/adapter-core':
+        specifier: workspace:*
+        version: link:../../packages/adapters/core
+      '@peac/mappings-paymentauth':
+        specifier: workspace:*
+        version: link:../../packages/mappings/paymentauth
+    devDependencies:
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
 
   examples/openclaw-capture:
     dependencies:
@@ -724,6 +756,22 @@ importers:
       '@peac/schema':
         specifier: workspace:*
         version: link:../../packages/schema
+    devDependencies:
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+
+  examples/x402-upto-evidence:
+    dependencies:
+      '@peac/adapter-core':
+        specifier: workspace:*
+        version: link:../../packages/adapters/core
+      '@peac/adapter-x402':
+        specifier: workspace:*
+        version: link:../../packages/adapters/x402
     devDependencies:
       tsx:
         specifier: ^4.21.0


### PR DESCRIPTION
## Summary

Adds three offline, no-network runnable demos that exercise the v0.12.11 commerce evidence mappings end-to-end. Each demo prints its output, covers a happy path plus the non-negotiable negative path (settlement or finality synthesis rejected in strict, interop, and legacy modes), and pins exact workspace dependencies.


## Scope

Examples only. No wire, schema, kernel, control, or error-registry change.

- `examples/x402-upto-evidence/`: extract settlement proofs from response headers in dual-header precedence order (`PEAC-Receipt` > `PAYMENT-RESPONSE` v2 > `X-PAYMENT-RESPONSE` v1), map the v2 proof to PEAC settlement evidence with the `upto` scheme passed through, then reject offer-only (empty `raw_value`) data in every strictness mode.
- `examples/acp-delegated-checkout/`: observe an authorization, then a separate settlement, iterate through non-finality states (`pending`, `failed`, `revoked`) showing no commerce event emitted, then reject cross-kind misuse (`settled` with `artifact_kind='authorization'`) in every mode.
- `examples/mpp-payment-attempt/`: observe a paymentauth attempt with a facilitator attestation preserved verbatim, then the settlement with its own attestation, then reject cross-kind misuse in every mode.

Each example pins exact workspace dependencies (`@peac/mappings-acp`, `@peac/mappings-paymentauth`, `@peac/adapter-x402`, `@peac/adapter-core`). Token material is never carried; only opaque references are preserved.


## Notes

The examples demonstrate that non-finality states (`pending`, `failed`, `revoked`) and cross-kind artifact misuse are rejected before any commerce event is emitted. The stable string code `commerce.finality_synthesis_blocked` is a mapper-boundary identifier, not a wire-level error code.
