### PR TITLE
fix: pin protobufjs >=8.0.1 to patch GHSA-xq3m-2v4x-88gg

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,8 @@
       "path-to-regexp@>=8.0.0": ">=8.4.0",
       "yaml": "2.8.3",
       "@hono/node-server": ">=1.19.13",
-      "hono": ">=4.12.12"
+      "hono": ">=4.12.12",
+      "protobufjs": ">=8.0.1"
     },
     "overridesComments": {
       "minimatch": "Cross-major pin to 10.2.4: typescript-estree requires ^9.0.4 but 9.x has no patch for GHSA-3ppc-4f35-3m26. minimatch 10.x is API-compatible (same globbing interface). 10.2.4 patches GHSA-7r86-cg39-jmmj and GHSA-23c5-xmqv-rm74 (ReDoS). Drops Node 18 (fine: repo baseline is >=22.0.0). Lint verified clean.",
@@ -139,7 +140,8 @@
       "express-rate-limit": "Override 8.2.1 to >=8.2.2 (fixes GHSA-46wh-pxpv-q5gq IPv4-mapped IPv6 bypass). Prod dep via @modelcontextprotocol/sdk.",
       "flatted": "Override to >=3.4.2 (fixes GHSA-25h7-pfq9-p65f unbounded recursion DoS + GHSA-rf6f-7fwh-wjgh prototype pollution via parse()). Dev-only via eslint -> file-entry-cache -> flat-cache.",
       "path-to-regexp@>=8.0.0": "Override to >=8.4.0 (fixes GHSA-j3q9-mxjg-w52f sequential optional groups DoS). Prod dep via @modelcontextprotocol/sdk -> express@5 -> router. path-to-regexp@0.1.12 in express@4 (examples only, not published) is not overridden because 0.1.13 breaks express@4 internal API.",
-      "yaml": "Pin to 2.8.3 (fixes GHSA-48c2-rrv3-qjmp). Dep via @peac/policy-kit."
+      "yaml": "Pin to 2.8.3 (fixes GHSA-48c2-rrv3-qjmp). Dep via @peac/policy-kit.",
+      "protobufjs": "Override to >=8.0.1 (fixes GHSA-xq3m-2v4x-88gg arbitrary code execution in protobufjs@8.0.0). Transitive dep via examples/telemetry-otel -> @opentelemetry/otlp-transformer@0.212.0. Examples are private (never published); override protects local eval flows and unblocks CI prod-audit gate."
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   yaml: 2.8.3
   '@hono/node-server': '>=1.19.13'
   hono: '>=4.12.12'
+  protobufjs: '>=8.0.1'
 
 importers:
 
@@ -5038,7 +5039,7 @@ packages:
       '@opentelemetry/sdk-logs': 0.212.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
-      protobufjs: 8.0.0
+      protobufjs: 8.0.1
     dev: false
 
   /@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0):
@@ -9628,8 +9629,8 @@ packages:
       sisteransi: 1.0.5
     dev: true
 
-  /protobufjs@8.0.0:
-    resolution: {integrity: sha512-jx6+sE9h/UryaCZhsJWbJtTEy47yXoGNYI4z8ZaRncM0zBKeRqjO2JEcOUYwrYGb1WLhXM1FfMzW3annvFv0rw==}
+  /protobufjs@8.0.1:
+    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
     engines: {node: '>=12.0.0'}
     requiresBuild: true
     dependencies:


### PR DESCRIPTION
## Summary

Pins `protobufjs` to `>=8.0.1` via `pnpm.overrides` to patch GHSA-xq3m-2v4x-88gg
(arbitrary code execution in `protobufjs@8.0.0`). The vulnerable version is
pulled in transitively via `examples/telemetry-otel > @opentelemetry/otlp-transformer@0.212.0`.
