### PR TITLE
chore: stamp v0.12.11 dist_tag latest

### DIFF
--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -3,7 +3,7 @@
   "schema_version": "1.0.0",
   "version": "0.12.11",
   "wire_format_version": "0.2",
-  "dist_tag": "next",
+  "dist_tag": "latest",
   "release_date": "2026-04-15",
   "metrics": {
     "tests": 7392,


### PR DESCRIPTION
## Summary

Stamps the v0.12.11 `dist_tag` in `docs/releases/facts.json` from `"next"`
to `"latest"` to reflect the completed promote step of the v0.12.11
release flow (OIDC publish to `next` on Apr 15, 2026, followed by
`promote-latest.yml` dispatched with `dry_run=false` moving all 37
publishable packages to `latest`).

## Scope

One-line change in `docs/releases/facts.json`. Matches the output of
`pnpm release:stamp:promote` exactly. `docs/releases/current.json`
already reflects `"latest"` from a prior stamp.

## Validation

- `pnpm release:stamp:check:promote` clean.
- `pnpm format:check docs/releases/facts.json` clean.
- `pnpm ci:local-parity` full gate green (pre-push Tier 2).
