### PR TITLE
docs: artifacts, contracts, and compatibility sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,12 @@ jobs:
       - name: Spec drift verification (constants parity)
         run: pnpm verify:spec-drift
 
+      - name: Surface status drift verification
+        run: pnpm verify:surface-status
+
+      - name: Public API contract drift verification
+        run: pnpm verify:contracts:drift
+
       - name: Release facts verification
         run: pnpm verify:release
 

--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable surface classification for PEAC Protocol workspace. CI fails if any workspace member is missing. See docs/PACKAGE_STATUS.md for human-readable view.",
-  "version": "0.12.9",
-  "updated": "2026-04-15",
+  "version": "0.12.12",
+  "updated": "2026-04-18",
   "states": {
     "default": "Current recommended path. Actively maintained, Wire 0.2 native.",
     "supported": "Actively maintained, published, production-ready. May not be on default quickstart path.",
@@ -16,182 +16,208 @@
       "state": "default",
       "wire": "0.2",
       "layer": 0,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/schema": {
       "npm": "@peac/schema",
       "state": "default",
       "wire": "0.2",
       "layer": 1,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/crypto": {
       "npm": "@peac/crypto",
       "state": "default",
       "wire": "0.2",
       "layer": 2,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/protocol": {
       "npm": "@peac/protocol",
       "state": "default",
       "wire": "0.2",
       "layer": 3,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/control": {
       "npm": "@peac/control",
       "state": "default",
       "wire": "0.2",
       "layer": 3,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/discovery": {
       "npm": "@peac/disc",
       "state": "default",
       "wire": "0.2",
       "layer": 3,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/audit": {
       "npm": "@peac/audit",
       "state": "default",
       "wire": "0.2",
       "layer": 3,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/policy-kit": {
       "npm": "@peac/policy-kit",
       "state": "default",
       "wire": "0.2",
       "layer": 3,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/telemetry": {
       "npm": "@peac/telemetry",
       "state": "supported",
       "wire": "0.2",
       "layer": 2.5,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/telemetry-otel": {
       "npm": "@peac/telemetry-otel",
       "state": "supported",
       "wire": "0.2",
       "layer": 2.5,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/capture/core": {
       "npm": "@peac/capture-core",
       "state": "supported",
       "wire": "0.2",
       "layer": 2.5,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/capture/node": {
       "npm": "@peac/capture-node",
       "state": "supported",
       "wire": "0.2",
       "layer": 2.5,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/middleware-core": {
       "npm": "@peac/middleware-core",
       "state": "default",
       "wire": "0.2",
       "layer": 3.5,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/middleware-express": {
       "npm": "@peac/middleware-express",
       "state": "default",
       "wire": "0.2",
       "layer": 3.5,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/contracts": {
       "npm": "@peac/contracts",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/http-signatures": {
       "npm": "@peac/http-signatures",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/jwks-cache": {
       "npm": "@peac/jwks-cache",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/adapters/core": {
       "npm": "@peac/adapter-core",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/adapters/x402": {
       "npm": "@peac/adapter-x402",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/adapters/x402/daydreams": {
       "npm": "@peac/adapter-x402-daydreams",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/adapters/x402/fluora": {
       "npm": "@peac/adapter-x402-fluora",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/adapters/x402/pinata": {
       "npm": "@peac/adapter-x402-pinata",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/adapters/did": {
       "npm": "@peac/adapter-did",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/adapters/eat": {
       "npm": "@peac/adapter-eat",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/adapters/openai-compatible": {
       "npm": "@peac/adapter-openai-compatible",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/adapters/openclaw": {
       "npm": "@peac/adapter-openclaw",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/adapters/managed-agents": {
       "npm": "@peac/adapter-managed-agents",
@@ -199,7 +225,8 @@
       "wire": "0.2",
       "layer": 4,
       "published": true,
-      "note": "Vendor-neutral managed agent runtime event adapter. 6 event families."
+      "note": "Vendor-neutral managed agent runtime event adapter. 6 event families.",
+      "target_state": "keep"
     },
     "packages/adapters/runtime-governance": {
       "npm": "@peac/adapter-runtime-governance",
@@ -207,7 +234,8 @@
       "wire": "0.2",
       "layer": 4,
       "published": true,
-      "note": "Runtime governance adapter. 6 observation-specific type URIs. AGT first mapper."
+      "note": "Runtime governance adapter. 6 observation-specific type URIs. AGT first mapper.",
+      "target_state": "keep"
     },
     "packages/adapters/eas": {
       "npm": null,
@@ -215,126 +243,144 @@
       "wire": "0.2",
       "layer": 4,
       "published": false,
-      "note": "EAS anchoring paused (ERC-8004 PR #20 closed)"
+      "note": "EAS anchoring paused (ERC-8004 PR #20 closed)",
+      "target_state": "keep"
     },
     "packages/mappings/mcp": {
       "npm": "@peac/mappings-mcp",
       "state": "default",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/mappings/a2a": {
       "npm": "@peac/mappings-a2a",
       "state": "default",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/mappings/acp": {
       "npm": "@peac/mappings-acp",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/mappings/ucp": {
       "npm": "@peac/mappings-ucp",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/mappings/paymentauth": {
       "npm": "@peac/mappings-paymentauth",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/mappings/content-signals": {
       "npm": "@peac/mappings-content-signals",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/mappings/aipref": {
       "npm": "@peac/mappings-aipref",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/mappings/rsl": {
       "npm": "@peac/mappings-rsl",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/mappings/tap": {
       "npm": "@peac/mappings-tap",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/mappings/intoto": {
       "npm": "@peac/mappings-intoto",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/mappings/slsa": {
       "npm": "@peac/mappings-slsa",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/rails/x402": {
       "npm": "@peac/rails-x402",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/rails/stripe": {
       "npm": "@peac/rails-stripe",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/rails/card": {
       "npm": "@peac/rails-card",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/rails/razorpay": {
       "npm": "@peac/rails-razorpay",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/transport/grpc": {
       "npm": "@peac/transport-grpc",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/transport/http": {
       "npm": null,
       "state": "experimental",
       "wire": "0.2",
       "layer": 4,
-      "published": false
+      "published": false,
+      "target_state": "keep"
     },
     "packages/transport/ws": {
       "npm": null,
@@ -342,56 +388,64 @@
       "wire": "0.2",
       "layer": 4,
       "published": false,
-      "note": "WebSocket transport deferred"
+      "note": "WebSocket transport deferred",
+      "target_state": "keep"
     },
     "packages/net/node": {
       "npm": "@peac/net-node",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/mcp-server": {
       "npm": "@peac/mcp-server",
       "state": "default",
       "wire": "0.2",
       "layer": 5,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/cli": {
       "npm": "@peac/cli",
       "state": "default",
       "wire": "0.2",
       "layer": 5,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/server": {
       "npm": "@peac/server",
       "state": "supported",
       "wire": "0.2",
       "layer": 5,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/pay402": {
       "npm": "@peac/pay402",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/receipts": {
       "npm": "@peac/receipts",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/aipref": {
       "npm": "@peac/pref",
       "state": "supported",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/access": {
       "npm": null,
@@ -399,14 +453,16 @@
       "wire": "0.2",
       "layer": 6,
       "published": false,
-      "note": "Pillar package"
+      "note": "Pillar package",
+      "target_state": "keep"
     },
     "packages/attribution": {
       "npm": "@peac/attribution",
       "state": "supported",
       "wire": "0.2",
       "layer": 6,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/compliance": {
       "npm": null,
@@ -414,7 +470,8 @@
       "wire": "0.2",
       "layer": 6,
       "published": false,
-      "note": "Pillar package"
+      "note": "Pillar package",
+      "target_state": "keep"
     },
     "packages/consent": {
       "npm": null,
@@ -422,7 +479,8 @@
       "wire": "0.2",
       "layer": 6,
       "published": false,
-      "note": "Pillar package"
+      "note": "Pillar package",
+      "target_state": "keep"
     },
     "packages/intelligence": {
       "npm": null,
@@ -430,7 +488,8 @@
       "wire": "0.2",
       "layer": 6,
       "published": false,
-      "note": "Pillar package"
+      "note": "Pillar package",
+      "target_state": "keep"
     },
     "packages/privacy": {
       "npm": null,
@@ -438,7 +497,8 @@
       "wire": "0.2",
       "layer": 6,
       "published": false,
-      "note": "Pillar package"
+      "note": "Pillar package",
+      "target_state": "keep"
     },
     "packages/provenance": {
       "npm": null,
@@ -446,7 +506,8 @@
       "wire": "0.2",
       "layer": 6,
       "published": false,
-      "note": "Pillar package"
+      "note": "Pillar package",
+      "target_state": "keep"
     },
     "packages/conformance-harness": {
       "npm": null,
@@ -454,21 +515,24 @@
       "wire": "0.2",
       "layer": 5,
       "published": false,
-      "note": "Internal test infrastructure"
+      "note": "Internal test infrastructure",
+      "target_state": "keep"
     },
     "packages/worker-core": {
       "npm": "@peac/worker-core",
       "state": "supported",
       "wire": "0.2",
       "layer": 5,
-      "published": true
+      "published": true,
+      "target_state": "keep"
     },
     "packages/worker-shared": {
       "npm": null,
       "state": "supported",
       "wire": "0.2",
       "layer": 5,
-      "published": false
+      "published": false,
+      "target_state": "keep"
     },
     "packages/core": {
       "npm": "@peac/core",
@@ -477,7 +541,8 @@
       "layer": "legacy",
       "published": true,
       "removal": "v0.13.0",
-      "note": "Monolithic pre-v0.10.0 package. Use @peac/kernel, @peac/schema, @peac/crypto, @peac/protocol instead."
+      "note": "Monolithic pre-v0.10.0 package. Use @peac/kernel, @peac/schema, @peac/crypto, @peac/protocol instead.",
+      "target_state": "deprecate"
     },
     "packages/sdk-js": {
       "npm": "@peac/sdk",
@@ -485,7 +550,8 @@
       "wire": "0.1",
       "layer": "legacy",
       "published": false,
-      "note": "Moved to archive/sdk-js/. Uses deprecated @peac/core. Replaced by @peac/protocol."
+      "note": "Moved to archive/sdk-js/. Uses deprecated @peac/core. Replaced by @peac/protocol.",
+      "target_state": "archive"
     },
     "apps/api": {
       "npm": null,
@@ -493,14 +559,16 @@
       "wire": "0.2",
       "layer": 5,
       "published": false,
-      "note": "Legacy /verify endpoint deprecated (Sunset: Nov 1, 2026). Current: /api/v1/verify."
+      "note": "Legacy /verify endpoint deprecated (Sunset: Nov 1, 2026). Current: /api/v1/verify.",
+      "target_state": "keep"
     },
     "apps/verifier": {
       "npm": null,
       "state": "default",
       "wire": "0.2",
       "layer": 5,
-      "published": false
+      "published": false,
+      "target_state": "keep"
     },
     "apps/sandbox-issuer": {
       "npm": null,
@@ -508,7 +576,8 @@
       "wire": "0.1",
       "layer": 5,
       "published": false,
-      "note": "Wire 0.1 test fixture generator. Kept for legacy integration tests."
+      "note": "Wire 0.1 test fixture generator. Kept for legacy integration tests.",
+      "target_state": "deprecate"
     },
     "apps/bridge": {
       "npm": null,
@@ -516,7 +585,8 @@
       "wire": "0.9.13",
       "layer": "legacy",
       "published": false,
-      "note": "Moved to archive/bridge/. Unused dev sidecar. Imports deprecated @peac/core."
+      "note": "Moved to archive/bridge/. Unused dev sidecar. Imports deprecated @peac/core.",
+      "target_state": "archive"
     },
     "sdks/go": {
       "npm": null,
@@ -524,7 +594,8 @@
       "wire": "0.2",
       "layer": "sdk",
       "published": false,
-      "note": "Go SDK. Wire 0.2 core parity shipped in v0.12.8 (Issue, VerifyLocal, JCS, 22 cross-language vectors). Middleware (chi, gin) experimental."
+      "note": "Go SDK. Wire 0.2 core parity shipped in v0.12.8 (Issue, VerifyLocal, JCS, 22 cross-language vectors). Middleware (chi, gin) experimental.",
+      "target_state": "keep"
     },
     "surfaces/plugin-pack/codex": {
       "npm": null,
@@ -532,7 +603,8 @@
       "wire": "0.2",
       "layer": 5,
       "published": false,
-      "note": "Codex MCP server configuration (secondary install channel)"
+      "note": "Codex MCP server configuration (secondary install channel)",
+      "target_state": "keep"
     },
     "surfaces/analytics": {
       "npm": null,
@@ -540,28 +612,32 @@
       "wire": "0.2",
       "layer": 5,
       "published": false,
-      "note": "Analytics integration surface"
+      "note": "Analytics integration surface",
+      "target_state": "keep"
     },
     "surfaces/workers/akamai": {
       "npm": null,
       "state": "supported",
       "wire": "0.2",
       "layer": 5,
-      "published": false
+      "published": false,
+      "target_state": "keep"
     },
     "surfaces/workers/cloudflare": {
       "npm": null,
       "state": "supported",
       "wire": "0.2",
       "layer": 5,
-      "published": false
+      "published": false,
+      "target_state": "keep"
     },
     "surfaces/workers/fastly": {
       "npm": null,
       "state": "supported",
       "wire": "0.2",
       "layer": 5,
-      "published": false
+      "published": false,
+      "target_state": "keep"
     },
     "surfaces/nextjs/middleware": {
       "npm": null,
@@ -569,7 +645,15 @@
       "wire": "0.2",
       "layer": 5,
       "published": false,
-      "note": "One test quarantined due to @peac/contracts workspace linking issue"
+      "note": "One test quarantined due to @peac/contracts workspace linking issue",
+      "target_state": "keep"
     }
+  },
+  "target_states": {
+    "keep": "Maintain in published state; package has a defensible reason to remain published.",
+    "deprecate": "Scheduled for removal in a future release with migration guidance.",
+    "archive": "Move to archived, unmaintained state; not recommended for new integrations.",
+    "fold": "Candidate for folding into a neighboring package to reduce published-package count.",
+    "examples-only": "Demote from published to examples-only (private workspace member)."
   }
 }

--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -1,10 +1,14 @@
-openapi: 3.1.0
+openapi: 3.1.1
 info:
   title: PEAC Hosted Verify API
-  version: 0.12.8
+  version: 0.12.12
   description: >
     Hosted verification service for signed interaction records.
     Returns deterministic DD-210 verification reports with RFC 9457 errors.
+    The canonical request body carries a compact JWS with `typ: interaction-record+jwt`
+    (Wire 0.2). The legacy `POST /verify` endpoint is retained for compatibility
+    and carries RFC 9745 `Deprecation` and RFC 8594 `Sunset` response headers;
+    it is scheduled for removal no earlier than 2026-11-01.
   contact:
     url: https://www.peacprotocol.org
   license:

--- a/apps/api/src/openapi-sync.test.js
+++ b/apps/api/src/openapi-sync.test.js
@@ -18,8 +18,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 describe('openapi-sync', () => {
   const spec = parseYaml(readFileSync(join(__dirname, '..', 'openapi.yaml'), 'utf-8'));
 
-  test('declares OpenAPI 3.1.0', () => {
-    assert.strictEqual(spec.openapi, '3.1.0');
+  test('declares OpenAPI 3.1.1', () => {
+    assert.strictEqual(spec.openapi, '3.1.1');
   });
 
   test('POST /v1/verify path exists with operationId', () => {

--- a/contracts/api/crypto.json
+++ b/contracts/api/crypto.json
@@ -1,7 +1,7 @@
 {
   "package": "@peac/crypto",
-  "version": "0.12.4",
-  "extracted_at": "2026-03-27",
+  "version": "0.12.11",
+  "extracted_at": "2026-04-18",
   "node_version": "v24.13.0",
   "value_exports": [
     {

--- a/contracts/api/kernel.json
+++ b/contracts/api/kernel.json
@@ -1,7 +1,7 @@
 {
   "package": "@peac/kernel",
-  "version": "0.12.4",
-  "extracted_at": "2026-03-27",
+  "version": "0.12.11",
+  "extracted_at": "2026-04-18",
   "node_version": "v24.13.0",
   "value_exports": [
     {

--- a/contracts/api/protocol.json
+++ b/contracts/api/protocol.json
@@ -1,7 +1,7 @@
 {
   "package": "@peac/protocol",
-  "version": "0.12.4",
-  "extracted_at": "2026-03-27",
+  "version": "0.12.11",
+  "extracted_at": "2026-04-18",
   "node_version": "v24.13.0",
   "value_exports": [
     {

--- a/contracts/api/schema.json
+++ b/contracts/api/schema.json
@@ -1,7 +1,7 @@
 {
   "package": "@peac/schema",
-  "version": "0.12.4",
-  "extracted_at": "2026-03-27",
+  "version": "0.12.11",
+  "extracted_at": "2026-04-18",
   "node_version": "v24.13.0",
   "value_exports": [
     {

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -1,6 +1,6 @@
 # Compatibility Matrix
 
-Current as of v0.12.10.
+Current as of v0.12.12.
 
 ## Wire Format Support
 
@@ -29,27 +29,65 @@ Current as of v0.12.10.
 
 ## Hosted Services
 
-| Service                                           | Status                    | Endpoint                                                                                                                                                  |
-| ------------------------------------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Reference Verifier (`POST /v1/verify`)            | **Operational** (v0.12.9) | `POST /v1/verify` (RFC 9457, OpenAPI 3.1, content negotiation: `application/json`, `application/peac-report+json`, `text/plain`; `PEAC-Report-Id` header) |
-| Reference Issuer Health (`GET /v1/issuer-health`) | **Operational** (v0.12.9) | `GET /v1/issuer-health?issuer=<url>` (SSRF-safe, independent rate limit, cached)                                                                          |
-| Hosted Issue (`POST /v1/issue`)                   | **Alpha** (v0.12.8)       | Disabled by default; BYO-key, provisional                                                                                                                 |
+| Service                                           | Status                     | Endpoint                                                                                                                                                   |
+| ------------------------------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Reference Verifier (`POST /v1/verify`)            | **Operational** (v0.12.11) | `POST /v1/verify` (RFC 9457, OpenAPI 3.1, content negotiation: `application/json`, `application/peac-report+json`, `text/plain`; `PEAC-Report-Id` header). |
+| Reference Issuer Health (`GET /v1/issuer-health`) | **Operational** (v0.12.11) | `GET /v1/issuer-health?issuer=<url>` (SSRF-safe, independent rate limit, cached).                                                                          |
+| Hosted Issue (`POST /v1/issue`)                   | **Alpha** (v0.12.8)        | Disabled by default; BYO-key, provisional.                                                                                                                 |
 
-## Adapters and Mappings
+## Adapters, Mappings, Rails, and Transports
 
-All adapter and mapping packages support Wire 0.2 exclusively. See `REPO_SURFACE_STATUS.json` for the full list with per-package state.
+This table covers the adapters and mappings most commonly referenced from the reference verifier flows and the adapter test vectors. The full Layer 4 surface set is machine-readable in [`REPO_SURFACE_STATUS.json`](../REPO_SURFACE_STATUS.json) and rendered at [`docs/SURFACE_STATUS.md`](SURFACE_STATUS.md). Every Layer 4 surface supports Wire 0.2 exclusively.
 
-| Adapter                            | Coverage                                                            | Since    | Status      |
-| ---------------------------------- | ------------------------------------------------------------------- | -------- | ----------- |
-| `@peac/adapter-runtime-governance` | 6 observation-specific type URIs, AGT first mapper, session summary | v0.12.10 | **Shipped** |
-| `@peac/adapter-managed-agents`     | 6 event families, session summary                                   | v0.12.9  | **Shipped** |
-| `@peac/adapter-x402`               | 4-layer verification, dual-header, V2 support                       | v0.12.1  | **Shipped** |
-| `@peac/adapter-eat`                | COSE_Sign1, Ed25519, privacy-first mapping                          | v0.12.0  | **Shipped** |
-| `@peac/adapter-did`                | did:key, did:web, DID Document resolver                             | v0.12.6  | **Shipped** |
+The **Adapter Readiness** column classifies each surface using the rubric below. Classifications default to the weaker, more conservative claim under ambiguity.
+
+| Surface                            | Coverage                                                                         | Since    | Status      | Adapter Readiness          |
+| ---------------------------------- | -------------------------------------------------------------------------------- | -------- | ----------- | -------------------------- |
+| `@peac/adapter-core`               | Mapper-boundary finality guard (`assertExplicitFinality`, `MapperBoundaryError`) | v0.12.11 | **Shipped** | `conformance-fixture-only` |
+| `@peac/adapter-runtime-governance` | 6 observation-specific type URIs, AGT first mapper, session summary              | v0.12.10 | **Shipped** | `conformance-fixture-only` |
+| `@peac/adapter-managed-agents`     | 6 event families, session summary                                                | v0.12.9  | **Shipped** | `conformance-fixture-only` |
+| `@peac/adapter-x402`               | 4-layer verification, dual-header, V2 support, settlement extractor              | v0.12.1  | **Shipped** | `conformance-fixture-only` |
+| `@peac/adapter-x402-daydreams`     | Daydreams bridge for x402                                                        | v0.12.1  | **Shipped** | `types-only`               |
+| `@peac/adapter-x402-fluora`        | Fluora bridge for x402                                                           | v0.12.1  | **Shipped** | `types-only`               |
+| `@peac/adapter-x402-pinata`        | Pinata bridge for x402                                                           | v0.12.1  | **Shipped** | `types-only`               |
+| `@peac/adapter-eat`                | COSE_Sign1, Ed25519, privacy-first mapping                                       | v0.12.0  | **Shipped** | `conformance-fixture-only` |
+| `@peac/adapter-did`                | did:key, did:web, DID Document resolver                                          | v0.12.6  | **Shipped** | `conformance-fixture-only` |
+| `@peac/adapter-openai-compatible`  | OpenAI-compatible API surface observation                                        | v0.12.6  | **Shipped** | `types-only`               |
+| `@peac/adapter-openclaw`           | OpenClaw bridge                                                                  | v0.12.6  | **Shipped** | `types-only`               |
+| `@peac/mappings-mcp`               | MCP tool-call receipt attachment                                                 | v0.11.x  | **Shipped** | `conformance-fixture-only` |
+| `@peac/mappings-a2a`               | A2A v1.0 normalizer                                                              | v0.12.3  | **Shipped** | `conformance-fixture-only` |
+| `@peac/mappings-acp`               | ACP delegated-payment observation mapper                                         | v0.12.11 | **Shipped** | `conformance-fixture-only` |
+| `@peac/mappings-paymentauth`       | MPP / paymentauth payment-attempt and settlement mappers                         | v0.12.11 | **Shipped** | `conformance-fixture-only` |
+| `@peac/mappings-ucp`               | UCP / AP2 envelope mapping                                                       | v0.12.4  | **Shipped** | `conformance-fixture-only` |
+| `@peac/mappings-content-signals`   | Content signals observation mapping                                              | v0.11.2  | **Shipped** | `conformance-fixture-only` |
+| `@peac/mappings-aipref`            | AI preferences mapping                                                           | v0.12.4  | **Shipped** | `types-only`               |
+| `@peac/mappings-rsl`               | Really Simple Licensing mapping                                                  | v0.12.0  | **Shipped** | `types-only`               |
+| `@peac/mappings-tap`               | Transaction Authorization Protocol mapping                                       | v0.12.0  | **Shipped** | `types-only`               |
+| `@peac/mappings-intoto`            | in-toto attestation bridge                                                       | v0.12.6  | **Shipped** | `conformance-fixture-only` |
+| `@peac/mappings-slsa`              | SLSA provenance bridge                                                           | v0.12.6  | **Shipped** | `conformance-fixture-only` |
+| `@peac/rails-x402`                 | x402 rail                                                                        | v0.12.1  | **Shipped** | `conformance-fixture-only` |
+| `@peac/rails-stripe`               | Stripe rail (SPT observation)                                                    | v0.12.4  | **Shipped** | `conformance-fixture-only` |
+| `@peac/rails-card`                 | Card-network rail                                                                | v0.12.4  | **Shipped** | `types-only`               |
+| `@peac/rails-razorpay`             | Razorpay rail                                                                    | v0.12.4  | **Shipped** | `types-only`               |
+| `@peac/transport-grpc`             | gRPC carrier transport                                                           | v0.12.6  | **Shipped** | `types-only`               |
+
+### Adapter Readiness rubric
+
+One classification per Layer 4 surface. Under ambiguity between two defensible classifications, choose the one making the **weaker claim** about current readiness. Strength ordering from weakest to strongest: `paused` < `experimental` < `types-only` < `conformance-fixture-only` < `live-upstream-tested`.
+
+| Classification             | Binding definition                                                                                                                                                            | Typical evidence                                                                      |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `live-upstream-tested`     | CI exercises the real upstream (or a faithful, dated fixture replay of a real upstream artifact) within the last release window. Upstream format changes surface as CI diffs. | Recorded round-trip against live endpoint; fixture set stamped with upstream release. |
+| `conformance-fixture-only` | Pinned conformance fixtures only, no upstream coupling. Mapper behavior is tested; upstream conformance is asserted against frozen fixtures.                                  | `specs/conformance/<mapper>/` vectors plus stable test; no network.                   |
+| `types-only`               | TS and/or Go types compile against the upstream shape; no end-to-end runtime flow exercised in CI.                                                                            | Type-definition file committed; no runtime assertions beyond structural checks.       |
+| `experimental`             | Public but explicitly subject to change; `@experimental` JSDoc; listed in `docs/STABILITY-CONTRACT.md` as experimental; breaking changes allowed with CHANGELOG note.         | JSDoc tag plus STABILITY-CONTRACT row.                                                |
+| `paused`                   | Intentionally not maintained in this release window; `paused_reason` and `resumption_target` recorded in the row.                                                             | Row-level rationale documented in the matrix.                                         |
+
+No Layer 4 surface in v0.12.12 is `live-upstream-tested`: no CI step exercises a live upstream endpoint today. Promotion from `conformance-fixture-only` to `live-upstream-tested` requires committing a recorded round-trip fixture stamped with the upstream release and wiring it into CI.
 
 ## Performance Targets
 
-Informational and regression-oriented. See [BENCHMARK-SLO.md](specs/BENCHMARK-SLO.md).
+Informational and regression-oriented. Operator-facing service-level objectives are tracked in [`docs/SLO.md`](SLO.md) when published. Benchmark methodology: [`docs/BENCHMARK-METHODOLOGY.md`](BENCHMARK-METHODOLOGY.md) when published.
 
 | Operation       | p95 Target (CI) | p95 Target (Prod) | Model            |
 | --------------- | --------------- | ----------------- | ---------------- |
@@ -58,10 +96,10 @@ Informational and regression-oriented. See [BENCHMARK-SLO.md](specs/BENCHMARK-SL
 
 ## Deprecation Schedule
 
-| Surface                   | Deprecated since | Removal target           | Migration                                                               |
-| ------------------------- | ---------------- | ------------------------ | ----------------------------------------------------------------------- |
-| `@peac/core`              | v0.10.0          | v0.13.0                  | Use `@peac/kernel` + `@peac/schema` + `@peac/crypto` + `@peac/protocol` |
-| `@peac/sdk`               | v0.12.7          | v0.13.0                  | Use `@peac/protocol` directly                                           |
-| API `/verify` endpoint    | v0.12.7          | v0.13.0 (or Nov 1, 2026) | Use `/api/v1/verify`                                                    |
-| `apps/bridge`             | v0.12.7          | v0.13.0                  | Use `@peac/protocol` or `/api/v1/verify`                                |
-| Wire 0.1 default teaching | v0.12.7          | Immediate                | All defaults now Wire 0.2                                               |
+| Surface                   | Deprecated since | Removal target           | Migration                                                                                            |
+| ------------------------- | ---------------- | ------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `@peac/core`              | v0.10.0          | v0.13.0                  | Use `@peac/kernel` plus `@peac/schema` plus `@peac/crypto` plus `@peac/protocol`.                    |
+| `@peac/sdk`               | v0.12.7          | v0.13.0                  | Use `@peac/protocol` directly.                                                                       |
+| API `/verify` endpoint    | v0.12.7          | v0.13.0 (or Nov 1, 2026) | Use `/api/v1/verify`. Legacy `/verify` carries RFC 9745 `Deprecation` and RFC 8594 `Sunset` headers. |
+| `apps/bridge`             | v0.12.7          | v0.13.0                  | Use `@peac/protocol` or `/api/v1/verify`.                                                            |
+| Wire 0.1 default teaching | v0.12.7          | Immediate                | All defaults now Wire 0.2.                                                                           |

--- a/docs/PACKAGE_STATUS.md
+++ b/docs/PACKAGE_STATUS.md
@@ -109,3 +109,95 @@ Do not edit manually.
 | `packages/transport/http`    |                                                                     |
 | `packages/transport/ws`      | WebSocket transport deferred                                        |
 | `surfaces/nextjs/middleware` | One test quarantined due to @peac/contracts workspace linking issue |
+
+## Package census
+
+Each workspace surface carries a `target_state` field in `REPO_SURFACE_STATUS.json`. The census is published here as the current target-state baseline; values may be revised in a future release. Target-state definitions:
+
+| target_state    | Meaning                                                                             |
+| --------------- | ----------------------------------------------------------------------------------- |
+| `keep`          | Maintain in published state; package has a defensible reason to remain published.   |
+| `deprecate`     | Scheduled for removal in a future release with migration guidance.                  |
+| `archive`       | Move to archived, unmaintained state; not recommended for new integrations.         |
+| `fold`          | Candidate for folding into a neighboring package to reduce published-package count. |
+| `examples-only` | Demote from published to examples-only (private workspace member).                  |
+
+| Package                                | npm                                | State        | target_state |
+| -------------------------------------- | ---------------------------------- | ------------ | ------------ |
+| `apps/api`                             | -                                  | default      | `keep`       |
+| `apps/bridge`                          | -                                  | archived     | `archive`    |
+| `apps/sandbox-issuer`                  | -                                  | compat-only  | `deprecate`  |
+| `apps/verifier`                        | -                                  | default      | `keep`       |
+| `packages/access`                      | -                                  | supported    | `keep`       |
+| `packages/adapters/core`               | `@peac/adapter-core`               | supported    | `keep`       |
+| `packages/adapters/did`                | `@peac/adapter-did`                | supported    | `keep`       |
+| `packages/adapters/eas`                | -                                  | experimental | `keep`       |
+| `packages/adapters/eat`                | `@peac/adapter-eat`                | supported    | `keep`       |
+| `packages/adapters/managed-agents`     | `@peac/adapter-managed-agents`     | supported    | `keep`       |
+| `packages/adapters/openai-compatible`  | `@peac/adapter-openai-compatible`  | supported    | `keep`       |
+| `packages/adapters/openclaw`           | `@peac/adapter-openclaw`           | supported    | `keep`       |
+| `packages/adapters/runtime-governance` | `@peac/adapter-runtime-governance` | supported    | `keep`       |
+| `packages/adapters/x402`               | `@peac/adapter-x402`               | supported    | `keep`       |
+| `packages/adapters/x402/daydreams`     | `@peac/adapter-x402-daydreams`     | supported    | `keep`       |
+| `packages/adapters/x402/fluora`        | `@peac/adapter-x402-fluora`        | supported    | `keep`       |
+| `packages/adapters/x402/pinata`        | `@peac/adapter-x402-pinata`        | supported    | `keep`       |
+| `packages/aipref`                      | `@peac/pref`                       | supported    | `keep`       |
+| `packages/attribution`                 | `@peac/attribution`                | supported    | `keep`       |
+| `packages/audit`                       | `@peac/audit`                      | default      | `keep`       |
+| `packages/capture/core`                | `@peac/capture-core`               | supported    | `keep`       |
+| `packages/capture/node`                | `@peac/capture-node`               | supported    | `keep`       |
+| `packages/cli`                         | `@peac/cli`                        | default      | `keep`       |
+| `packages/compliance`                  | -                                  | supported    | `keep`       |
+| `packages/conformance-harness`         | -                                  | supported    | `keep`       |
+| `packages/consent`                     | -                                  | supported    | `keep`       |
+| `packages/contracts`                   | `@peac/contracts`                  | supported    | `keep`       |
+| `packages/control`                     | `@peac/control`                    | default      | `keep`       |
+| `packages/core`                        | `@peac/core`                       | deprecated   | `deprecate`  |
+| `packages/crypto`                      | `@peac/crypto`                     | default      | `keep`       |
+| `packages/discovery`                   | `@peac/disc`                       | default      | `keep`       |
+| `packages/http-signatures`             | `@peac/http-signatures`            | supported    | `keep`       |
+| `packages/intelligence`                | -                                  | supported    | `keep`       |
+| `packages/jwks-cache`                  | `@peac/jwks-cache`                 | supported    | `keep`       |
+| `packages/kernel`                      | `@peac/kernel`                     | default      | `keep`       |
+| `packages/mappings/a2a`                | `@peac/mappings-a2a`               | default      | `keep`       |
+| `packages/mappings/acp`                | `@peac/mappings-acp`               | supported    | `keep`       |
+| `packages/mappings/aipref`             | `@peac/mappings-aipref`            | supported    | `keep`       |
+| `packages/mappings/content-signals`    | `@peac/mappings-content-signals`   | supported    | `keep`       |
+| `packages/mappings/intoto`             | `@peac/mappings-intoto`            | supported    | `keep`       |
+| `packages/mappings/mcp`                | `@peac/mappings-mcp`               | default      | `keep`       |
+| `packages/mappings/paymentauth`        | `@peac/mappings-paymentauth`       | supported    | `keep`       |
+| `packages/mappings/rsl`                | `@peac/mappings-rsl`               | supported    | `keep`       |
+| `packages/mappings/slsa`               | `@peac/mappings-slsa`              | supported    | `keep`       |
+| `packages/mappings/tap`                | `@peac/mappings-tap`               | supported    | `keep`       |
+| `packages/mappings/ucp`                | `@peac/mappings-ucp`               | supported    | `keep`       |
+| `packages/mcp-server`                  | `@peac/mcp-server`                 | default      | `keep`       |
+| `packages/middleware-core`             | `@peac/middleware-core`            | default      | `keep`       |
+| `packages/middleware-express`          | `@peac/middleware-express`         | default      | `keep`       |
+| `packages/net/node`                    | `@peac/net-node`                   | supported    | `keep`       |
+| `packages/pay402`                      | `@peac/pay402`                     | supported    | `keep`       |
+| `packages/policy-kit`                  | `@peac/policy-kit`                 | default      | `keep`       |
+| `packages/privacy`                     | -                                  | supported    | `keep`       |
+| `packages/protocol`                    | `@peac/protocol`                   | default      | `keep`       |
+| `packages/provenance`                  | -                                  | supported    | `keep`       |
+| `packages/rails/card`                  | `@peac/rails-card`                 | supported    | `keep`       |
+| `packages/rails/razorpay`              | `@peac/rails-razorpay`             | supported    | `keep`       |
+| `packages/rails/stripe`                | `@peac/rails-stripe`               | supported    | `keep`       |
+| `packages/rails/x402`                  | `@peac/rails-x402`                 | supported    | `keep`       |
+| `packages/receipts`                    | `@peac/receipts`                   | supported    | `keep`       |
+| `packages/schema`                      | `@peac/schema`                     | default      | `keep`       |
+| `packages/sdk-js`                      | `@peac/sdk`                        | archived     | `archive`    |
+| `packages/server`                      | `@peac/server`                     | supported    | `keep`       |
+| `packages/telemetry`                   | `@peac/telemetry`                  | supported    | `keep`       |
+| `packages/telemetry-otel`              | `@peac/telemetry-otel`             | supported    | `keep`       |
+| `packages/transport/grpc`              | `@peac/transport-grpc`             | supported    | `keep`       |
+| `packages/transport/http`              | -                                  | experimental | `keep`       |
+| `packages/transport/ws`                | -                                  | experimental | `keep`       |
+| `packages/worker-core`                 | `@peac/worker-core`                | supported    | `keep`       |
+| `packages/worker-shared`               | -                                  | supported    | `keep`       |
+| `sdks/go`                              | -                                  | supported    | `keep`       |
+| `surfaces/analytics`                   | -                                  | supported    | `keep`       |
+| `surfaces/nextjs/middleware`           | -                                  | experimental | `keep`       |
+| `surfaces/plugin-pack/codex`           | -                                  | supported    | `keep`       |
+| `surfaces/workers/akamai`              | -                                  | supported    | `keep`       |
+| `surfaces/workers/cloudflare`          | -                                  | supported    | `keep`       |
+| `surfaces/workers/fastly`              | -                                  | supported    | `keep`       |

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -3,7 +3,7 @@
 Generated from `REPO_SURFACE_STATUS.json` by `scripts/generate-surface-status.mjs`.
 Do not edit manually.
 
-**Version:** 0.12.9 | **Updated:** 2026-04-15
+**Version:** 0.12.12 | **Updated:** 2026-04-18
 
 ## Layer 1
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,7 +1,7 @@
 # PEAC Protocol
 
-> Open standard for portable, offline-verifiable evidence receipts across AI agent interactions, APIs, and organizational boundaries.
-> Last reviewed: 2026-04-01
+> Open standard for verifiable interaction records across agent, tool, API, and cross-runtime systems. Portable signed records anyone can verify offline.
+> Last reviewed: 2026-04-18
 
 ## What is PEAC
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@peac/monorepo",
   "version": "0.12.11",
   "private": true,
-  "description": "PEAC Protocol - Cryptographic receipts for agentic commerce",
+  "description": "Portable signed records for agent, API, MCP, and cross-runtime interactions.",
   "repository": {
     "type": "git",
     "url": "https://github.com/peacprotocol/peac.git"
@@ -58,6 +58,8 @@
     "verify:release": "node scripts/verify-release.mjs",
     "api-contract:extract": "tsx scripts/extract-api-contract.ts",
     "api-contract:check": "tsx scripts/extract-api-contract.ts --check",
+    "verify:contracts:drift": "tsx scripts/extract-api-contract.ts --check",
+    "verify:surface-status": "node scripts/generate-surface-status.mjs --check",
     "fixtures:new": "node scripts/fixtures-new.mjs",
     "conformance:regen:bundle": "tsx scripts/generate-bundle-vectors.ts",
     "bench": "pnpm --filter @peac/crypto bench && pnpm --filter @peac/schema bench && pnpm --filter @peac/protocol bench",

--- a/packages/schema/openapi/verify.yaml
+++ b/packages/schema/openapi/verify.yaml
@@ -1,40 +1,75 @@
-openapi: 3.1.0
+openapi: 3.1.1
 info:
-  title: PEAC Protocol Verification API
-  version: 0.9.15
+  title: PEAC Reference Verifier API
+  version: 0.12.12
+  summary: Portable signed records for agent, API, MCP, and cross-runtime interactions.
   description: |
-    Public endpoint for verifying PEAC cryptographic receipts.
-    Wire format frozen at peac.receipt/0.9 with v1.0-equivalent semantics.
-  license:
-    name: Apache-2.0
-    url: https://www.apache.org/licenses/LICENSE-2.0.html
+    Package-level OpenAPI contract for the PEAC reference verifier (`apps/api/`).
+
+    The canonical request body carries a compact JWS with `typ: interaction-record+jwt`
+    (Wire 0.2). The hosted `/v1/verify` endpoint returns the deterministic
+    DD-210 verification report shape; content negotiation supports
+    `application/json` (default), `application/peac-report+json` (extended
+    report with timing, report_id, key_resolution, and failure_reasons),
+    and `text/plain` (human-readable summary).
+
+    Error responses use RFC 9457 Problem Details (`application/problem+json`)
+    extended with PEAC-canonical fields (`peac_error_code`, `peac_trace_id`).
+
+    The legacy `POST /verify` endpoint is retained for compatibility and
+    carries RFC 9745 `Deprecation` and RFC 8594 `Sunset` response headers;
+    it is scheduled for removal no earlier than 2026-11-01.
+
+    Size caps (enforced by the kernel and verifier, documented here for contract completeness):
+      - receipt JWS (request body): 256 KiB (262 144 bytes)
+      - any single extension group: 64 KiB (65 536 bytes)
+      - all extensions combined: 256 KiB (262 144 bytes)
   contact:
     name: PEAC Protocol
     url: https://www.peacprotocol.org
+  license:
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+
 servers:
-  - url: https://api.example.com
-    description: Example PEAC issuer
+  - url: http://localhost:3000
+    description: Local development (self-hosted reference verifier)
+
+tags:
+  - name: Verify
+    description: Verification endpoints (canonical and legacy).
+  - name: Issue
+    description: Hosted issue endpoints (alpha).
+  - name: Health
+    description: Issuer health and reference-verifier liveness.
 
 paths:
-  /verify:
+  /v1/verify:
     post:
       operationId: verifyReceipt
-      summary: Verify a PEAC receipt
+      tags: [Verify]
+      summary: Verify a signed interaction record
       description: |
-        Verifies the cryptographic signature and claims of a PEAC receipt.
-
-        **Security features:**
-        - Rate limiting: 100 req/s per IP, 1000 req/s global
-        - Circuit breaker for JWKS fetch (5 failures → 60s open)
-        - Response caching: 5min valid, 1min invalid
-        - CPU budget: ≤50ms per request
-
-        **DoS mitigation:**
-        - SSRF-safe JWKS fetching
-        - JWS size limits (≤16KB)
-        - Signature verification timeout
-      tags:
-        - Verification
+        Verify a compact JWS interaction record. Returns a deterministic
+        verification report (DD-210 shape). Supports caller-provided public
+        key or allowlisted issuer JWKS resolution. Accepts three response
+        formats via content negotiation.
+      parameters:
+        - name: Accept
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - application/json
+              - application/peac-report+json
+              - text/plain
+            default: application/json
+          description: |
+            `application/json` returns the byte-identical DD-210 report.
+            `application/peac-report+json` adds `report_id`, `verified_at`,
+            `duration_ms`, `key_resolution`, and `failure_reasons`.
+            `text/plain` returns a human-readable summary.
       requestBody:
         required: true
         content:
@@ -42,407 +77,533 @@ paths:
             schema:
               $ref: '#/components/schemas/VerifyRequest'
             examples:
-              valid_stripe_receipt:
-                summary: Valid Stripe receipt
+              wire_0_2_success:
+                summary: Wire 0.2 interaction-record+jwt receipt with issuer discovery
                 value:
-                  receipt_jws: 'eyJ0eXAiOiJwZWFjLnJlY2VpcHQvMC45IiwiYWxnIjoiRWREU0EiLCJraWQiOiIyMDI1LTAxLTE1VDEwOjMwOjAwWiJ9.eyJpc3MiOiJodHRwczovL2FwaS5leGFtcGxlLmNvbSIsImF1ZCI6Imh0dHBzOi8vYXBwLmV4YW1wbGUuY29tIiwiaWF0IjoxNzM2OTM0NjAwLCJyaWQiOiIwMTkzYzRkMC0wMDAwLTcwMDAtODAwMC0wMDAwMDAwMDAwMDAiLCJhbXQiOjk5OTksImN1ciI6IlVTRCIsInBheW1lbnQiOnsic2NoZW1lIjoic3RyaXBlIiwicmVmZXJlbmNlIjoiY3NfMTIzNDU2Iiwi YW1vdW50Ijo5OTk5LCJjdXJyZW5jeSI6IlVTRCJ9fQ.signature'
+                  receipt: eyJ0eXAiOiJpbnRlcmFjdGlvbi1yZWNvcmQrand0IiwiYWxnIjoiRWREU0EiLCJraWQiOiIyMDI2LTA0LTE4In0.eyJpc3MiOiJodHRwczovL2FwaS5leGFtcGxlLmNvbSIsImlhdCI6MTc4MTYwOTYwMCwianRpIjoiMDE5Njc2ZDAtMDAwMC03MDAwLTgwMDAtMDAwMDAwMDAwMDAwIiwidHlwZSI6Im9yZy5wZWFjcHJvdG9jb2wvYXBpLXJlY2VpcHQiLCJwaWxsYXJzIjpbImFjY2VzcyJdLCJwZWFjX3ZlcnNpb24iOiIwLjIiLCJzY2hlbWEiOiJpbnRlcmFjdGlvbi1yZWNvcmQrand0In0.signature_bytes_placeholder
+                  options:
+                    strictness: strict
+              wire_0_2_with_public_key:
+                summary: Wire 0.2 receipt with caller-provided Ed25519 public key
+                value:
+                  receipt: eyJ0eXAiOiJpbnRlcmFjdGlvbi1yZWNvcmQrand0IiwiYWxnIjoiRWREU0EiLCJraWQiOiJkaWQ6a2V5OnoifQ.eyJpc3MiOiJkaWQ6a2V5OnoifQ.signature_bytes_placeholder
+                  public_key: MCowBQYDK2VwAyEAGb9ECWmEzf6FQbrBZ9w7lshQhqowtrbLDFw4rXAxZuE
+                  options:
+                    strictness: interop
       responses:
         '200':
-          description: Verification result (success or failure)
+          description: Verification completed. Response body indicates verified/failed state.
           headers:
+            PEAC-Report-Id:
+              description: UUID v4 report identifier unique per response.
+              schema:
+                type: string
+                format: uuid
+            Content-Type:
+              description: Selected response representation.
+              schema:
+                type: string
+            X-Content-Type-Options:
+              description: nosniff (always present).
+              schema:
+                type: string
+                const: nosniff
             Cache-Control:
-              description: Caching directive
+              description: no-store (always present).
               schema:
                 type: string
-                example: 'public, max-age=300'
+                const: no-store
+            Referrer-Policy:
+              description: no-referrer (always present).
+              schema:
+                type: string
+                const: no-referrer
             Vary:
-              description: Vary header for cache invalidation
+              description: PEAC-Receipt (always present).
               schema:
                 type: string
-                example: 'PEAC-Receipt'
+                const: PEAC-Receipt
+            RateLimit-Limit:
+              description: Maximum requests per window (RFC 9333-style).
+              schema:
+                type: string
+            RateLimit-Remaining:
+              description: Remaining requests in current window.
+              schema:
+                type: string
+            RateLimit-Reset:
+              description: Seconds until rate-limit window resets.
+              schema:
+                type: string
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/VerifyResponseSuccess'
-                  - $ref: '#/components/schemas/VerifyResponseFailure'
-              examples:
-                success:
-                  summary: Successful verification
-                  value:
-                    ok: true
-                    header:
-                      typ: 'peac.receipt/0.9'
-                      alg: 'EdDSA'
-                      kid: '2025-01-15T10:30:00Z'
-                    claims:
-                      iss: 'https://api.example.com'
-                      aud: 'https://app.example.com'
-                      iat: 1736934600
-                      rid: '0193c4d0-0000-7000-8000-000000000000'
-                      amt: 9999
-                      cur: 'USD'
-                      payment:
-                        scheme: 'stripe'
-                        reference: 'cs_123456'
-                        amount: 9999
-                        currency: 'USD'
-                    perf:
-                      verify_ms: 8.2
-                      jwks_fetch_ms: 45.1
-                failure_invalid_signature:
-                  summary: Invalid signature
-                  value:
-                    ok: false
-                    reason: 'invalid_signature'
-                    details: 'Ed25519 signature verification failed'
-                failure_expired:
-                  summary: Expired receipt
-                  value:
-                    ok: false
-                    reason: 'expired'
-                    details: 'Receipt expired at 2025-01-15T12:00:00Z'
-        '400':
-          description: Bad request (malformed input)
-          content:
-            application/problem+json:
+                $ref: '#/components/schemas/VerifySuccessResponse'
+            application/peac-report+json:
               schema:
-                $ref: '#/components/schemas/ProblemDetails'
-              examples:
-                malformed_jws:
-                  summary: Malformed JWS
-                  value:
-                    type: 'https://www.peacprotocol.org/errors/malformed-jws'
-                    title: 'Malformed JWS'
-                    status: 400
-                    detail: 'JWS does not have three dot-separated parts'
-                    instance: '/verify'
-        '429':
-          description: Rate limit exceeded
-          headers:
-            Retry-After:
-              description: Seconds to wait before retrying
-              schema:
-                type: integer
-                example: 60
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ProblemDetails'
-              examples:
-                rate_limit:
-                  summary: Rate limit exceeded
-                  value:
-                    type: 'https://www.peacprotocol.org/errors/rate-limit'
-                    title: 'Rate Limit Exceeded'
-                    status: 429
-                    detail: 'IP-based rate limit: 100 requests per second'
-                    instance: '/verify'
-        '503':
-          description: Service unavailable (circuit breaker open)
-          headers:
-            Retry-After:
-              description: Seconds to wait before retrying
-              schema:
-                type: integer
-                example: 60
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ProblemDetails'
-              examples:
-                circuit_breaker:
-                  summary: Circuit breaker open
-                  value:
-                    type: 'https://www.peacprotocol.org/errors/circuit-breaker'
-                    title: 'Service Unavailable'
-                    status: 503
-                    detail: 'JWKS fetch circuit breaker is open (5 consecutive failures)'
-                    instance: '/verify'
-
-  /.well-known/peac.txt:
-    get:
-      operationId: getDiscovery
-      summary: Get PEAC discovery manifest
-      description: |
-        Returns the PEAC discovery manifest in YAML format (≤20 lines).
-
-        **Format:** YAML only (no JSON mirror)
-        **Size limit:** 2000 bytes
-        **Cache:** public, max-age=3600
-      tags:
-        - Discovery
-      responses:
-        '200':
-          description: PEAC discovery manifest
-          headers:
-            Cache-Control:
-              schema:
-                type: string
-                example: 'public, max-age=3600'
-          content:
+                $ref: '#/components/schemas/ExtendedVerifyReport'
             text/plain:
               schema:
                 type: string
-              example: |
-                version: peac/0.9
-                issuer: https://api.example.com
-                verify: https://api.example.com/verify
-                jwks: https://keys.peacprotocol.org/jwks.json
-                payments:
-                  - scheme: stripe
-                    info: https://docs.example.com/payments/stripe
-                  - scheme: x402
-                    info: https://docs.example.com/payments/x402
-                aipref: https://api.example.com/.well-known/aipref.json
-                slos: https://api.example.com/slo
-                security: security@example.com
+                description: Human-readable verification summary.
+        '400':
+          description: Invalid request format.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '413':
+          description: Request body too large (receipt exceeds 256 KiB).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '422':
+          description: Verification or validation failure (signature invalid, claims invalid, policy mismatch).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '429':
+          description: Rate limit exceeded.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: string
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '502':
+          description: Upstream resolution failure (JWKS fetch, issuer config fetch).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+
+  /verify:
+    post:
+      operationId: verifyReceiptLegacy
+      tags: [Verify]
+      deprecated: true
+      summary: '[DEPRECATED] Legacy verify endpoint'
+      description: |
+        Legacy verification endpoint retained for backward compatibility.
+        New integrations MUST use `POST /v1/verify`. Every response from
+        this path carries RFC 9745 `Deprecation` and RFC 8594 `Sunset`
+        headers plus an RFC 8288 `Link` relation pointing at the migration
+        guide. Scheduled removal: no earlier than 2026-11-01.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VerifyRequest'
+      responses:
+        '200':
+          description: Verification completed (deprecated response shape).
+          headers:
+            Deprecation:
+              description: RFC 9745 marker indicating the endpoint is deprecated.
+              schema:
+                type: string
+                const: 'true'
+            Sunset:
+              description: RFC 8594 HTTP-date at which the endpoint is scheduled for removal.
+              schema:
+                type: string
+                example: 'Sat, 01 Nov 2026 00:00:00 GMT'
+            Link:
+              description: RFC 8288 Link header with rel="deprecation" pointing at the migration guide.
+              schema:
+                type: string
+                example: '<https://www.peacprotocol.org/docs/migration>; rel="deprecation"'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VerifySuccessResponse'
+        '400':
+          description: Invalid request format.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '422':
+          description: Verification failure.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+
+  /v1/issue:
+    post:
+      operationId: issueReceipt
+      tags: [Issue]
+      summary: '[ALPHA] BYO-key hosted issue'
+      description: |
+        Provisional hosted issue endpoint (alpha). Disabled by default;
+        operators enable via `PEAC_HOSTED_ISSUE=true`. The caller supplies
+        the signing key; the service produces a signed JWS. Rate-limited
+        independently from verify. Semantics subject to change until GA.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IssueRequest'
+      responses:
+        '200':
+          description: Signed receipt issued.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IssueSuccessResponse'
+        '400':
+          description: Invalid request format.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          description: Hosted issue disabled (`PEAC_HOSTED_ISSUE=false`).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '422':
+          description: Validation failure.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+
+  /v1/issuer-health:
+    get:
+      operationId: getIssuerHealth
+      tags: [Health]
+      summary: Check an issuer's discovery and JWKS availability
+      description: |
+        SSRF-safe issuer-health probe. Performs bounded HTTPS fetches of
+        `/.well-known/peac-issuer.json` and the referenced `jwks_uri`.
+        Private/loopback/reserved addresses are blocked; redirects are
+        disabled; every fetch enforces an explicit timeout.
+      parameters:
+        - name: issuer
+          in: query
+          required: true
+          description: Issuer URI (https-only, no private/loopback/reserved addresses).
+          schema:
+            type: string
+            format: uri
+            pattern: '^https://'
+      responses:
+        '200':
+          description: Issuer discovery and JWKS resolution succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IssuerHealthResponse'
+        '400':
+          description: Invalid issuer parameter.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '502':
+          description: Issuer discovery or JWKS fetch failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+
+  /health:
+    get:
+      operationId: getLiveness
+      tags: [Health]
+      summary: Reference-verifier liveness check
+      responses:
+        '200':
+          description: Reference verifier is live.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ok]
+                properties:
+                  ok:
+                    type: boolean
+                    const: true
 
 components:
   schemas:
     VerifyRequest:
       type: object
-      required:
-        - receipt_jws
+      required: [receipt]
       additionalProperties: false
+      description: |
+        Request body for verification. `receipt` MUST be a compact JWS
+        with `typ: interaction-record+jwt` (Wire 0.2) or `typ: peac-receipt/0.1`
+        (legacy Wire 0.1, verify-only).
       properties:
-        receipt_jws:
+        receipt:
           type: string
-          minLength: 16
-          maxLength: 16384
-          description: JWS compact serialization of the PEAC receipt
-          example: 'eyJ0eXAiOiJwZWFjLnJlY2VpcHQvMC45IiwiYWxnIjoiRWREU0EiLCJraWQiOiIyMDI1LTAxLTE1VDEwOjMwOjAwWiJ9...'
-
-    VerifyResponseSuccess:
-      type: object
-      required:
-        - ok
-        - header
-        - claims
-      additionalProperties: false
-      properties:
-        ok:
-          type: boolean
-          const: true
-          description: Verification succeeded
-        header:
-          $ref: '#/components/schemas/JWSHeader'
-        claims:
-          $ref: '#/components/schemas/ReceiptClaims'
-        perf:
+          minLength: 1
+          maxLength: 262144
+          description: Compact JWS string. Maximum size 256 KiB (262 144 bytes).
+          example: eyJ0eXAiOiJpbnRlcmFjdGlvbi1yZWNvcmQrand0IiwiYWxnIjoiRWREU0EiLCJraWQiOiIyMDI2LTA0LTE4In0...
+        public_key:
+          type: string
+          minLength: 1
+          description: |
+            Optional base64url-encoded Ed25519 public key (32 bytes). When
+            supplied, skips issuer discovery and JWKS resolution.
+        policy:
           type: object
+          additionalProperties: false
+          description: Optional policy expectation. Used for `policy_binding` check.
           properties:
-            verify_ms:
-              type: number
-              description: Time spent verifying signature (milliseconds)
-            jwks_fetch_ms:
-              type: number
-              description: Time spent fetching JWKS (milliseconds, if not cached)
+            uri:
+              type: string
+              format: uri
+            version:
+              type: string
+        options:
+          type: object
+          additionalProperties: false
+          properties:
+            issuer:
+              type: string
+              format: uri
+              description: Expected issuer URI for binding check.
+            max_clock_skew:
+              type: integer
+              minimum: 1
+              maximum: 3600
+              description: Clock-skew tolerance in seconds (default 300).
+            strictness:
+              type: string
+              enum: [strict, interop]
+              description: Verification strictness mode. Default `strict`.
 
-    VerifyResponseFailure:
+    VerifySuccessResponse:
       type: object
       required:
-        - ok
-        - reason
-      additionalProperties: false
-      properties:
-        ok:
-          type: boolean
-          const: false
-          description: Verification failed
-        reason:
-          type: string
-          enum:
-            - invalid_signature
-            - expired
-            - invalid_claims
-            - unknown_issuer
-            - jwks_fetch_failed
-            - malformed_jws
-          description: Machine-readable failure reason
-        details:
-          type: string
-          description: Human-readable error details
-
-    JWSHeader:
-      type: object
-      required:
-        - typ
-        - alg
+        - verified
+        - receipt_ref
+        - claims
+        - warnings
+        - policy_binding
+        - issuer
         - kid
+        - wire_version
       additionalProperties: false
+      description: DD-210 deterministic verification report (byte-identical across runs).
       properties:
-        typ:
+        verified:
+          type: boolean
+          description: Whether the receipt passed all verification checks.
+        receipt_ref:
           type: string
-          const: 'peac.receipt/0.9'
-          description: Wire format version (frozen at 0.9 until GA)
-        alg:
+          pattern: '^sha256:[a-f0-9]{64}$'
+          description: SHA-256 of the compact JWS bytes (`sha256:<hex>`).
+        claims:
+          type: object
+          description: Validated interaction-record claims.
+        warnings:
+          type: array
+          items:
+            $ref: '#/components/schemas/VerificationWarning'
+          description: Non-fatal verification warnings (W_* codes).
+        policy_binding:
           type: string
-          const: 'EdDSA'
-          description: Signature algorithm (Ed25519)
+          enum: [unavailable, verified, failed]
+          description: Three-state policy-binding result.
+        issuer:
+          type: string
+          description: Issuer URI from the receipt.
         kid:
           type: string
-          minLength: 8
-          description: Key ID (ISO 8601 timestamp)
-          example: '2025-01-15T10:30:00Z'
+          description: Key ID from the JWS header.
+        wire_version:
+          type: string
+          description: Wire format version (for example "0.2").
 
-    ReceiptClaims:
+    VerificationWarning:
       type: object
-      required:
-        - iss
-        - aud
-        - iat
-        - rid
-        - amt
-        - cur
-        - payment
+      required: [code, message]
       additionalProperties: false
       properties:
-        iss:
+        code:
           type: string
-          format: uri
-          pattern: '^https://'
-          description: Issuer URL (must be https://)
-          example: 'https://api.example.com'
-        aud:
+          description: Warning code (for example `W_UNREGISTERED_TYPE`).
+        message:
           type: string
-          format: uri
-          pattern: '^https://'
-          description: Audience / resource URL
-          example: 'https://app.example.com'
-        iat:
-          type: integer
-          minimum: 0
-          description: Issued at timestamp (Unix seconds)
-          example: 1736934600
-        exp:
-          type: integer
-          minimum: 0
-          description: Expiry timestamp (Unix seconds, optional)
-        rid:
+          description: Human-readable warning message.
+        pointer:
           type: string
-          pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
-          description: Receipt ID (UUIDv7)
-          example: '0193c4d0-0000-7000-8000-000000000000'
-        amt:
-          type: integer
-          minimum: 0
-          description: Amount in smallest currency unit
-          example: 9999
-        cur:
-          type: string
-          pattern: '^[A-Z]{3}$'
-          description: ISO 4217 currency code (uppercase)
-          example: 'USD'
-        payment:
-          $ref: '#/components/schemas/NormalizedPayment'
-        subject:
-          $ref: '#/components/schemas/Subject'
-        ext:
-          $ref: '#/components/schemas/Extensions'
+          description: RFC 6901 JSON Pointer to the problematic field.
 
-    NormalizedPayment:
+    FailureReason:
       type: object
-      required:
-        - scheme
-        - reference
-        - amount
-        - currency
+      required: [code, detail]
       additionalProperties: false
       properties:
-        scheme:
+        code:
           type: string
-          minLength: 1
-          description: Payment rail identifier
-          example: 'stripe'
-        reference:
+          description: Kernel error code (for example `E_INVALID_SIGNATURE`).
+        detail:
           type: string
-          minLength: 1
-          description: Rail-specific payment ID
-          example: 'cs_123456'
-        amount:
-          type: integer
-          minimum: 0
-          description: Amount in smallest currency unit
-          example: 9999
-        currency:
+          description: Human-readable failure reason.
+
+    ExtendedVerifyReport:
+      type: object
+      required:
+        - report_id
+        - verified
+        - verified_at
+        - duration_ms
+        - receipt_ref
+        - key_resolution
+        - failure_reasons
+      additionalProperties: false
+      description: |
+        Extended verification report with timing, report ID, key-resolution
+        method, and failure reasons. Returned when Accept header contains
+        `application/peac-report+json`.
+      properties:
+        report_id:
           type: string
-          pattern: '^[A-Z]{3}$'
-          description: ISO 4217 currency code
-          example: 'USD'
-        idempotency_key:
+          format: uuid
+        verified:
+          type: boolean
+        verified_at:
           type: string
-          description: Idempotency key for deduplication
-        metadata:
+          format: date-time
+        duration_ms:
+          type: number
+        receipt_ref:
+          type: string
+          pattern: '^sha256:[a-f0-9]{64}$'
+        claims:
           type: object
-          description: Rail-specific metadata (non-normative)
+        warnings:
+          type: array
+          items:
+            $ref: '#/components/schemas/VerificationWarning'
+        policy_binding:
+          type: string
+          enum: [unavailable, verified, failed]
+        issuer:
+          type: string
+        kid:
+          type: string
+        wire_version:
+          type: string
+        key_resolution:
+          type: string
+          enum: [provided, allowlist, discovery]
+        failure_reasons:
+          type: array
+          items:
+            $ref: '#/components/schemas/FailureReason'
 
-    Subject:
+    IssueRequest:
       type: object
-      required:
-        - uri
+      required: [claims, signing_key]
       additionalProperties: false
       properties:
-        uri:
+        claims:
+          type: object
+          description: Interaction-record claims object (Wire 0.2).
+        signing_key:
           type: string
-          format: uri
-          pattern: '^https://'
-          description: URI of the resource being paid for
-          example: 'https://app.example.com/api/resource/123'
+          description: Base64url-encoded Ed25519 private key (32 bytes). Caller-custody only.
+        kid:
+          type: string
+          description: Key identifier to embed in JWS header.
 
-    Extensions:
+    IssueSuccessResponse:
       type: object
-      properties:
-        aipref_snapshot:
-          $ref: '#/components/schemas/AIPREFSnapshot'
-      description: Extension fields (additive-only, PEIP-defined)
-
-    AIPREFSnapshot:
-      type: object
-      required:
-        - url
-        - hash
+      required: [receipt, receipt_ref, kid, wire_version]
       additionalProperties: false
       properties:
-        url:
+        receipt:
+          type: string
+          description: Signed compact JWS.
+        receipt_ref:
+          type: string
+          pattern: '^sha256:[a-f0-9]{64}$'
+        kid:
+          type: string
+        wire_version:
+          type: string
+
+    IssuerHealthResponse:
+      type: object
+      required: [issuer, discovery_ok, jwks_ok, duration_ms]
+      additionalProperties: false
+      properties:
+        issuer:
           type: string
           format: uri
-          pattern: '^https://'
-          description: URL of the AIPREF document
-          example: 'https://api.example.com/.well-known/aipref.json'
-        hash:
+        discovery_ok:
+          type: boolean
+          description: Whether `/.well-known/peac-issuer.json` resolved.
+        jwks_ok:
+          type: boolean
+          description: Whether the referenced `jwks_uri` resolved and parsed.
+        jwks_uri:
           type: string
-          minLength: 8
-          description: JCS+SHA-256 hash of the AIPREF document
-          example: 'a1b2c3d4e5f67890'
+          format: uri
+        duration_ms:
+          type: number
+        warnings:
+          type: array
+          items:
+            type: string
 
     ProblemDetails:
       type: object
-      required:
-        - type
-        - title
-        - status
+      required: [type, title, status, detail, peac_error_code]
+      additionalProperties: true
+      description: |
+        RFC 9457 Problem Details with PEAC extensions. Returned with
+        `Content-Type: application/problem+json` on any error response.
       properties:
         type:
           type: string
           format: uri
-          description: URI reference identifying the problem type (RFC 9457)
-          example: 'https://www.peacprotocol.org/errors/rate-limit'
+          description: Problem-type URI under `https://www.peacprotocol.org/problems/`.
         title:
           type: string
-          description: Short, human-readable summary
-          example: 'Rate Limit Exceeded'
+          description: Short human-readable summary of the problem type.
         status:
           type: integer
-          description: HTTP status code
-          example: 429
+          description: HTTP status code for this occurrence.
         detail:
           type: string
-          description: Human-readable explanation specific to this occurrence
-          example: 'IP-based rate limit: 100 requests per second'
+          description: Human-readable explanation specific to this occurrence.
         instance:
           type: string
-          format: uri
-          description: URI reference identifying the specific occurrence
-          example: '/verify'
-      description: RFC 9457 Problem Details for HTTP APIs
+          description: URI reference identifying the specific occurrence.
+        peac_error_code:
+          type: string
+          description: Kernel-canonical error code (for example `E_INVALID_FORMAT`).
+        peac_trace_id:
+          type: string
+          description: Request trace identifier.
+        errors:
+          type: array
+          description: Multi-error details for validation failures.
+          items:
+            type: object
+            required: [pointer, detail]
+            additionalProperties: false
+            properties:
+              pointer:
+                type: string
+                description: RFC 6901 JSON Pointer.
+              detail:
+                type: string
+                description: Field-level error detail.

--- a/scripts/check-public-artifacts.mjs
+++ b/scripts/check-public-artifacts.mjs
@@ -34,6 +34,8 @@ const BUILTIN_PATTERNS = [
   /reference\/.*_LOCAL\./i,
   /[\u200B-\u200F\u2028-\u202F\u2060-\u206F\uFEFF]/, // hidden/bidi Unicode
   /MEMORY\.md/,
+  // Retired category tagline; never valid on any tracked artifact.
+  /cryptographic receipts for agentic commerce/i,
 ];
 
 /**

--- a/scripts/generate-surface-status.mjs
+++ b/scripts/generate-surface-status.mjs
@@ -104,6 +104,32 @@ function generatePackageStatus() {
     lines.push('');
   }
 
+  // Package census
+  lines.push('## Package census', '');
+  lines.push(
+    'Each workspace surface carries a `target_state` field in `REPO_SURFACE_STATUS.json`. The census is published here as the current target-state baseline; values may be revised in a future release. Target-state definitions:',
+    '',
+  );
+  if (status.target_states) {
+    lines.push('| target_state | Meaning |');
+    lines.push('|--------------|---------|');
+    for (const [key, meaning] of Object.entries(status.target_states)) {
+      lines.push(`| \`${key}\` | ${meaning} |`);
+    }
+    lines.push('');
+  }
+  lines.push('| Package | npm | State | target_state |');
+  lines.push('|---------|-----|-------|--------------|');
+  const allSurfaces = Object.entries(surfaces)
+    .map(([path, info]) => ({ path, ...info }))
+    .sort((a, b) => a.path.localeCompare(b.path));
+  for (const s of allSurfaces) {
+    const npm = s.npm ? `\`${s.npm}\`` : '-';
+    const target = s.target_state ? `\`${s.target_state}\`` : '-';
+    lines.push(`| \`${s.path}\` | ${npm} | ${s.state} | ${target} |`);
+  }
+  lines.push('');
+
   return lines.join('\n') + '\n';
 }
 


### PR DESCRIPTION
## Summary

Mechanical truth repair across machine-readable status surfaces, public
API contracts, and the reference-verifier OpenAPI contract. Brings every
artifact onto v0.12.12 and the current Wire 0.2 default.
Publishes a workspace-wide target-state census and an Adapter Readiness
classification. Adds CI drift gates so this class of skew cannot
accumulate again.

No wire format, schema, kernel, crypto, protocol public API, registries,
or errors taxonomy changes. No code behavior change.

## Scope

In scope:

- Regenerate `REPO_SURFACE_STATUS.json`, `docs/SURFACE_STATUS.md`,
  `docs/PACKAGE_STATUS.md`, `docs/COMPATIBILITY_MATRIX.md` against the
  v0.12.12 release line.
- Re-extract `contracts/api/{crypto,kernel,protocol,schema}.json` against
  current package surfaces.
- Rewrite `packages/schema/openapi/verify.yaml` as an OpenAPI 3.1.1 spec
  at `info.version: 0.12.12` covering `POST /v1/verify`, legacy `POST
/verify` (marked `deprecated: true` with RFC 9745 `Deprecation` and
  RFC 8594 `Sunset` response headers), alpha `POST /v1/issue`, and
  `GET /v1/issuer-health` / `GET /health`. Request and response examples
  use `application/interaction-record+jwt`; error responses use RFC 9457
  Problem Details (`application/problem+json`) with PEAC extensions
  (`peac_error_code`, `peac_trace_id`). Receipt and extension-group
  size caps are documented in the schema.
- Align `apps/api/openapi.yaml` to the same 3.1.1 / 0.12.12 stamps;
  update the openapi-sync test accordingly.
- Update root `package.json.description` to the canonical short
  description; add `verify:contracts:drift` and `verify:surface-status`
  pnpm aliases.
- Update `llms.txt` review stamp.
- Add Adapter Readiness column to `docs/COMPATIBILITY_MATRIX.md` with
  conservative classifications and a rubric subsection (weakest-claim
  default under ambiguity).
- Publish a workspace-wide package census in `docs/PACKAGE_STATUS.md`
  driven by a new `target_state` field per surface in
  `REPO_SURFACE_STATUS.json`. Publication only; no deprecation, archive,
  or fold actions execute here.
- Extend `scripts/check-public-artifacts.mjs` with an exact-match rule
  forbidding the retired category tagline on any tracked artifact.
- Wire two drift gates into `.github/workflows/ci.yml`:
  `pnpm verify:surface-status` and `pnpm verify:contracts:drift`.

## Changes

### Machine-readable status

- `REPO_SURFACE_STATUS.json`: `version` 0.12.9 -> 0.12.12; `updated`
  2026-04-18; new `target_states` block with version-neutral
  descriptions (`keep` / `deprecate` / `archive` / `fold` /
  `examples-only`) and a `target_state` field on each of the 77 surface
  entries.
- `docs/SURFACE_STATUS.md`, `docs/PACKAGE_STATUS.md`: regenerated.
  `PACKAGE_STATUS.md` includes the package census table with one row
  per workspace surface.
- `docs/COMPATIBILITY_MATRIX.md`: regenerated; reference-verifier and
  issuer-health rows refreshed; new Adapter Readiness column covering
  27 Layer-4 surfaces plus a rubric section with five classifications.
- `scripts/generate-surface-status.mjs`: extended to emit the census
  section from the JSON source.
- `llms.txt`: `Last reviewed` stamp refreshed; category line aligned
  with the canonical public framing.
- Root `package.json.description`: set to
  `"Portable signed records for agent, API, MCP, and cross-runtime interactions."`.

### Public API contracts

- `contracts/api/{crypto,kernel,protocol,schema}.json`: re-extracted.
  Metadata refresh only; no public-API drift (832 total exports
  unchanged in shape).

### OpenAPI (reference verifier)

- `packages/schema/openapi/verify.yaml`: full rewrite to OpenAPI 3.1.1
  at `info.version: 0.12.12`. Five paths, nine schemas; legacy `/verify`
  marked `deprecated: true` with RFC 9745 + RFC 8594 + RFC 8288 Link
  headers. Every error path uses RFC 9457 Problem Details.
- `apps/api/openapi.yaml`: `openapi` 3.1.0 -> 3.1.1; `info.version`
  0.12.8 -> 0.12.12.
- `apps/api/src/openapi-sync.test.js`: asserts OpenAPI 3.1.1.

### Tooling

- `package.json`: new `verify:contracts:drift` (runs
  `tsx scripts/extract-api-contract.ts --check`) and
  `verify:surface-status` (runs
  `node scripts/generate-surface-status.mjs --check`) pnpm aliases.
- `scripts/check-public-artifacts.mjs`: built-in pattern list extended
  with the retired category tagline as an exact-match.
- `.github/workflows/ci.yml`: two new drift-verification steps
  co-located with the existing spec-drift / release-facts checks.

## Notes

This PR lands the truth-sync and contract layer of v0.12.12.
Subsequent PRs in the release layer rewrite and trust
artifacts on top of these accurate contracts.