### PR TITLE
docs: status surfaces, API contracts, and verifier OpenAPI for v0.12.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,15 @@ jobs:
       - name: Spec drift verification (constants parity)
         run: pnpm verify:spec-drift
 
+      - name: Surface status drift verification
+        run: pnpm verify:surface-status
+
+      - name: Public API contract drift verification
+        run: pnpm verify:contracts:drift
+
+      - name: OpenAPI drift verification (package spec vs app spec)
+        run: pnpm verify:openapi:drift
+
       - name: Release facts verification
         run: pnpm verify:release
 

--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable surface classification for PEAC Protocol workspace. CI fails if any workspace member is missing. See docs/PACKAGE_STATUS.md for human-readable view.",
-  "version": "0.12.9",
-  "updated": "2026-04-15",
+  "version": "0.12.12",
+  "updated": "2026-04-18",
   "states": {
     "default": "Current recommended path. Actively maintained, Wire 0.2 native.",
     "supported": "Actively maintained, published, production-ready. May not be on default quickstart path.",

--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -1,10 +1,15 @@
-openapi: 3.1.0
+openapi: 3.1.1
 info:
   title: PEAC Hosted Verify API
-  version: 0.12.8
+  version: 0.12.12
   description: >
     Hosted verification service for signed interaction records.
+    Request body is `application/json` carrying a compact JWS in the
+    `receipt` field (JOSE header `typ: interaction-record+jwt`, Wire 0.2).
     Returns deterministic DD-210 verification reports with RFC 9457 errors.
+    The canonical package-level contract is `packages/schema/openapi/verify.yaml`;
+    CI enforces that the shared `/v1/verify` definition does not drift
+    between the two files.
   contact:
     url: https://www.peacprotocol.org
   license:

--- a/apps/api/src/openapi-sync.test.js
+++ b/apps/api/src/openapi-sync.test.js
@@ -18,8 +18,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 describe('openapi-sync', () => {
   const spec = parseYaml(readFileSync(join(__dirname, '..', 'openapi.yaml'), 'utf-8'));
 
-  test('declares OpenAPI 3.1.0', () => {
-    assert.strictEqual(spec.openapi, '3.1.0');
+  test('declares OpenAPI 3.1.1', () => {
+    assert.strictEqual(spec.openapi, '3.1.1');
   });
 
   test('POST /v1/verify path exists with operationId', () => {

--- a/contracts/api/crypto.json
+++ b/contracts/api/crypto.json
@@ -1,7 +1,7 @@
 {
   "package": "@peac/crypto",
-  "version": "0.12.4",
-  "extracted_at": "2026-03-27",
+  "version": "0.12.11",
+  "extracted_at": "2026-04-18",
   "node_version": "v24.13.0",
   "value_exports": [
     {

--- a/contracts/api/kernel.json
+++ b/contracts/api/kernel.json
@@ -1,7 +1,7 @@
 {
   "package": "@peac/kernel",
-  "version": "0.12.4",
-  "extracted_at": "2026-03-27",
+  "version": "0.12.11",
+  "extracted_at": "2026-04-18",
   "node_version": "v24.13.0",
   "value_exports": [
     {

--- a/contracts/api/protocol.json
+++ b/contracts/api/protocol.json
@@ -1,7 +1,7 @@
 {
   "package": "@peac/protocol",
-  "version": "0.12.4",
-  "extracted_at": "2026-03-27",
+  "version": "0.12.11",
+  "extracted_at": "2026-04-18",
   "node_version": "v24.13.0",
   "value_exports": [
     {

--- a/contracts/api/schema.json
+++ b/contracts/api/schema.json
@@ -1,7 +1,7 @@
 {
   "package": "@peac/schema",
-  "version": "0.12.4",
-  "extracted_at": "2026-03-27",
+  "version": "0.12.11",
+  "extracted_at": "2026-04-18",
   "node_version": "v24.13.0",
   "value_exports": [
     {

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -1,6 +1,6 @@
 # Compatibility Matrix
 
-Current as of v0.12.10.
+Current as of v0.12.12.
 
 ## Wire Format Support
 
@@ -29,27 +29,75 @@ Current as of v0.12.10.
 
 ## Hosted Services
 
-| Service                                           | Status                    | Endpoint                                                                                                                                                  |
-| ------------------------------------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Reference Verifier (`POST /v1/verify`)            | **Operational** (v0.12.9) | `POST /v1/verify` (RFC 9457, OpenAPI 3.1, content negotiation: `application/json`, `application/peac-report+json`, `text/plain`; `PEAC-Report-Id` header) |
-| Reference Issuer Health (`GET /v1/issuer-health`) | **Operational** (v0.12.9) | `GET /v1/issuer-health?issuer=<url>` (SSRF-safe, independent rate limit, cached)                                                                          |
-| Hosted Issue (`POST /v1/issue`)                   | **Alpha** (v0.12.8)       | Disabled by default; BYO-key, provisional                                                                                                                 |
+| Service                                           | Status                     | Endpoint                                                                                                                                                   |
+| ------------------------------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Reference Verifier (`POST /v1/verify`)            | **Operational** (v0.12.11) | `POST /v1/verify` (RFC 9457, OpenAPI 3.1, content negotiation: `application/json`, `application/peac-report+json`, `text/plain`; `PEAC-Report-Id` header). |
+| Reference Issuer Health (`GET /v1/issuer-health`) | **Operational** (v0.12.11) | `GET /v1/issuer-health?issuer=<url>` (SSRF-safe, independent rate limit, cached).                                                                          |
+| Hosted Issue (`POST /v1/issue`)                   | **Alpha** (v0.12.8)        | Disabled by default; BYO-key, provisional.                                                                                                                 |
 
-## Adapters and Mappings
+## Adapters, Mappings, Rails, and Transports
 
-All adapter and mapping packages support Wire 0.2 exclusively. See `REPO_SURFACE_STATUS.json` for the full list with per-package state.
+This table covers the Layer 4 surfaces most commonly referenced from the reference verifier flows and the adapter test vectors. The full Layer 4 surface set is machine-readable in [`REPO_SURFACE_STATUS.json`](../REPO_SURFACE_STATUS.json) and rendered at [`docs/SURFACE_STATUS.md`](SURFACE_STATUS.md). Every Layer 4 surface supports Wire 0.2 exclusively.
 
-| Adapter                            | Coverage                                                            | Since    | Status      |
-| ---------------------------------- | ------------------------------------------------------------------- | -------- | ----------- |
-| `@peac/adapter-runtime-governance` | 6 observation-specific type URIs, AGT first mapper, session summary | v0.12.10 | **Shipped** |
-| `@peac/adapter-managed-agents`     | 6 event families, session summary                                   | v0.12.9  | **Shipped** |
-| `@peac/adapter-x402`               | 4-layer verification, dual-header, V2 support                       | v0.12.1  | **Shipped** |
-| `@peac/adapter-eat`                | COSE_Sign1, Ed25519, privacy-first mapping                          | v0.12.0  | **Shipped** |
-| `@peac/adapter-did`                | did:key, did:web, DID Document resolver                             | v0.12.6  | **Shipped** |
+The **Adapter Readiness** column classifies each surface using the rubric below. Classifications default to the weaker, more conservative claim under ambiguity. Each row carries an evidence tag (`[e1]`..`[e5]`) whose target is documented in the Evidence section.
+
+| Surface                            | Coverage                                                                         | Since    | Status      | Adapter Readiness               |
+| ---------------------------------- | -------------------------------------------------------------------------------- | -------- | ----------- | ------------------------------- |
+| `@peac/adapter-core`               | Mapper-boundary finality guard (`assertExplicitFinality`, `MapperBoundaryError`) | v0.12.11 | **Shipped** | `conformance-fixture-only` [e1] |
+| `@peac/adapter-runtime-governance` | 6 observation-specific type URIs, AGT first mapper, session summary              | v0.12.10 | **Shipped** | `conformance-fixture-only` [e2] |
+| `@peac/adapter-managed-agents`     | 6 event families, session summary                                                | v0.12.9  | **Shipped** | `conformance-fixture-only` [e3] |
+| `@peac/adapter-x402`               | 4-layer verification, dual-header, V2 support, settlement extractor              | v0.12.1  | **Shipped** | `conformance-fixture-only` [e4] |
+| `@peac/adapter-x402-daydreams`     | Daydreams bridge for x402                                                        | v0.12.1  | **Shipped** | `types-only` [e5]               |
+| `@peac/adapter-x402-fluora`        | Fluora bridge for x402                                                           | v0.12.1  | **Shipped** | `types-only` [e5]               |
+| `@peac/adapter-x402-pinata`        | Pinata bridge for x402                                                           | v0.12.1  | **Shipped** | `types-only` [e5]               |
+| `@peac/adapter-eat`                | COSE_Sign1, Ed25519, privacy-first mapping                                       | v0.12.0  | **Shipped** | `conformance-fixture-only` [e1] |
+| `@peac/adapter-did`                | did:key, did:web, DID Document resolver                                          | v0.12.6  | **Shipped** | `conformance-fixture-only` [e1] |
+| `@peac/adapter-openai-compatible`  | OpenAI-compatible API surface observation                                        | v0.12.6  | **Shipped** | `types-only` [e5]               |
+| `@peac/adapter-openclaw`           | OpenClaw bridge                                                                  | v0.12.6  | **Shipped** | `types-only` [e5]               |
+| `@peac/mappings-mcp`               | MCP tool-call receipt attachment                                                 | v0.11.x  | **Shipped** | `conformance-fixture-only` [e1] |
+| `@peac/mappings-a2a`               | A2A v1.0 normalizer                                                              | v0.12.3  | **Shipped** | `conformance-fixture-only` [e1] |
+| `@peac/mappings-acp`               | ACP delegated-payment observation mapper                                         | v0.12.11 | **Shipped** | `conformance-fixture-only` [e4] |
+| `@peac/mappings-paymentauth`       | MPP / paymentauth payment-attempt and settlement mappers                         | v0.12.11 | **Shipped** | `conformance-fixture-only` [e4] |
+| `@peac/mappings-ucp`               | UCP / AP2 envelope mapping                                                       | v0.12.4  | **Shipped** | `conformance-fixture-only` [e1] |
+| `@peac/mappings-content-signals`   | Content signals observation mapping                                              | v0.11.2  | **Shipped** | `conformance-fixture-only` [e1] |
+| `@peac/mappings-aipref`            | AI preferences mapping                                                           | v0.12.4  | **Shipped** | `types-only` [e5]               |
+| `@peac/mappings-rsl`               | Really Simple Licensing mapping                                                  | v0.12.0  | **Shipped** | `types-only` [e5]               |
+| `@peac/mappings-tap`               | Transaction Authorization Protocol mapping                                       | v0.12.0  | **Shipped** | `types-only` [e5]               |
+| `@peac/mappings-intoto`            | in-toto attestation bridge                                                       | v0.12.6  | **Shipped** | `conformance-fixture-only` [e1] |
+| `@peac/mappings-slsa`              | SLSA provenance bridge                                                           | v0.12.6  | **Shipped** | `conformance-fixture-only` [e1] |
+| `@peac/rails-x402`                 | x402 rail                                                                        | v0.12.1  | **Shipped** | `conformance-fixture-only` [e4] |
+| `@peac/rails-stripe`               | Stripe rail (SPT observation)                                                    | v0.12.4  | **Shipped** | `conformance-fixture-only` [e4] |
+| `@peac/rails-card`                 | Card-network rail                                                                | v0.12.4  | **Shipped** | `types-only` [e5]               |
+| `@peac/rails-razorpay`             | Razorpay rail                                                                    | v0.12.4  | **Shipped** | `types-only` [e5]               |
+| `@peac/transport-grpc`             | gRPC carrier transport                                                           | v0.12.6  | **Shipped** | `types-only` [e5]               |
+
+### Adapter Readiness rubric
+
+One classification per Layer 4 surface. Under ambiguity between two defensible classifications, choose the one making the **weaker claim** about current readiness. Strength ordering from weakest to strongest: `paused` < `experimental` < `types-only` < `conformance-fixture-only` < `live-upstream-tested`.
+
+| Classification             | Binding definition                                                                                                                                                            | Typical evidence                                                                      |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `live-upstream-tested`     | CI exercises the real upstream (or a faithful, dated fixture replay of a real upstream artifact) within the last release window. Upstream format changes surface as CI diffs. | Recorded round-trip against live endpoint; fixture set stamped with upstream release. |
+| `conformance-fixture-only` | Pinned conformance fixtures only, no upstream coupling. Mapper behavior is tested; upstream conformance is asserted against frozen fixtures.                                  | `specs/conformance/<mapper>/` vectors plus stable test; no network.                   |
+| `types-only`               | TS and/or Go types compile against the upstream shape; no end-to-end runtime flow exercised in CI.                                                                            | Type-definition file committed; no runtime assertions beyond structural checks.       |
+| `experimental`             | Public but explicitly subject to change; `@experimental` JSDoc; breaking changes allowed with CHANGELOG note.                                                                 | JSDoc tag.                                                                            |
+| `paused`                   | Intentionally not maintained in this release window; `paused_reason` and `resumption_target` recorded in the row.                                                             | Row-level rationale documented in the matrix.                                         |
+
+No Layer 4 surface in v0.12.12 is `live-upstream-tested`: no CI step exercises a live upstream endpoint today. Promotion from `conformance-fixture-only` to `live-upstream-tested` requires committing a recorded round-trip fixture stamped with the upstream release and wiring it into CI.
+
+### Evidence
+
+Each tag below points at the conformance vectors and test paths that justify the classification in the row above.
+
+- **[e1]** Per-mapper conformance vectors under [`specs/conformance/`](../specs/conformance/) and package `__tests__` suites. Exercised under `pnpm test`; no network.
+- **[e2]** [`specs/conformance/runtime-governance/`](../specs/conformance/runtime-governance/) (RTGOV-001..RTGOV-007, Section 27) plus `packages/adapters/runtime-governance/__tests__/`.
+- **[e3]** [`specs/conformance/managed-agents/`](../specs/conformance/managed-agents/) event-family vectors plus `packages/adapters/managed-agents/__tests__/`.
+- **[e4]** Commerce evidence vectors for ACP / MPP / x402 under [`specs/conformance/commerce/`](../specs/conformance/commerce/) (Section 26) plus per-mapper `__tests__/` suites; the `assertExplicitFinality` boundary is asserted in `packages/adapters/core/__tests__/`.
+- **[e5]** Type-definition coverage only: TypeScript declaration file(s) in the package `src/` compile under the workspace typecheck. No runtime assertion exists beyond the declaration shape.
 
 ## Performance Targets
 
-Informational and regression-oriented. See [BENCHMARK-SLO.md](specs/BENCHMARK-SLO.md).
+Informational and regression-oriented. Operator-facing service-level objectives are tracked in [`docs/SLO.md`](SLO.md) when published. Benchmark methodology: [`docs/BENCHMARK-METHODOLOGY.md`](BENCHMARK-METHODOLOGY.md) when published.
 
 | Operation       | p95 Target (CI) | p95 Target (Prod) | Model            |
 | --------------- | --------------- | ----------------- | ---------------- |
@@ -58,10 +106,10 @@ Informational and regression-oriented. See [BENCHMARK-SLO.md](specs/BENCHMARK-SL
 
 ## Deprecation Schedule
 
-| Surface                   | Deprecated since | Removal target           | Migration                                                               |
-| ------------------------- | ---------------- | ------------------------ | ----------------------------------------------------------------------- |
-| `@peac/core`              | v0.10.0          | v0.13.0                  | Use `@peac/kernel` + `@peac/schema` + `@peac/crypto` + `@peac/protocol` |
-| `@peac/sdk`               | v0.12.7          | v0.13.0                  | Use `@peac/protocol` directly                                           |
-| API `/verify` endpoint    | v0.12.7          | v0.13.0 (or Nov 1, 2026) | Use `/api/v1/verify`                                                    |
-| `apps/bridge`             | v0.12.7          | v0.13.0                  | Use `@peac/protocol` or `/api/v1/verify`                                |
-| Wire 0.1 default teaching | v0.12.7          | Immediate                | All defaults now Wire 0.2                                               |
+| Surface                   | Deprecated since | Removal target           | Migration                                                                                            |
+| ------------------------- | ---------------- | ------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `@peac/core`              | v0.10.0          | v0.13.0                  | Use `@peac/kernel` plus `@peac/schema` plus `@peac/crypto` plus `@peac/protocol`.                    |
+| `@peac/sdk`               | v0.12.7          | v0.13.0                  | Use `@peac/protocol` directly.                                                                       |
+| API `/verify` endpoint    | v0.12.7          | v0.13.0 (or Nov 1, 2026) | Use `/api/v1/verify`. Legacy `/verify` carries RFC 9745 `Deprecation` and RFC 8594 `Sunset` headers. |
+| `apps/bridge`             | v0.12.7          | v0.13.0                  | Use `@peac/protocol` or `/api/v1/verify`.                                                            |
+| Wire 0.1 default teaching | v0.12.7          | Immediate                | All defaults now Wire 0.2.                                                                           |

--- a/docs/PACKAGE_STATUS.md
+++ b/docs/PACKAGE_STATUS.md
@@ -1,7 +1,6 @@
 # Package and Surface Status
 
-Generated from `REPO_SURFACE_STATUS.json` by `scripts/generate-surface-status.mjs`.
-Do not edit manually.
+Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scripts/generate-surface-status.mjs`.
 
 ## Default (current recommended path)
 

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -1,9 +1,8 @@
 # Surface Status by Layer
 
-Generated from `REPO_SURFACE_STATUS.json` by `scripts/generate-surface-status.mjs`.
-Do not edit manually.
+Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scripts/generate-surface-status.mjs`.
 
-**Version:** 0.12.9 | **Updated:** 2026-04-15
+**Version:** 0.12.12 | **Updated:** 2026-04-18
 
 ## Layer 1
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,7 +1,7 @@
 # PEAC Protocol
 
-> Open standard for portable, offline-verifiable evidence receipts across AI agent interactions, APIs, and organizational boundaries.
-> Last reviewed: 2026-04-01
+> Open standard for verifiable interaction records across agent, tool, API, and cross-runtime systems. Portable signed records anyone can verify offline.
+> Last reviewed: 2026-04-18
 
 ## What is PEAC
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@peac/monorepo",
   "version": "0.12.11",
   "private": true,
-  "description": "PEAC Protocol - Cryptographic receipts for agentic commerce",
+  "description": "Portable signed records for agent, API, MCP, and cross-runtime interactions.",
   "repository": {
     "type": "git",
     "url": "https://github.com/peacprotocol/peac.git"
@@ -58,6 +58,9 @@
     "verify:release": "node scripts/verify-release.mjs",
     "api-contract:extract": "tsx scripts/extract-api-contract.ts",
     "api-contract:check": "tsx scripts/extract-api-contract.ts --check",
+    "verify:contracts:drift": "tsx scripts/extract-api-contract.ts --check",
+    "verify:surface-status": "node scripts/generate-surface-status.mjs --check",
+    "verify:openapi:drift": "node scripts/verify-openapi-drift.mjs",
     "fixtures:new": "node scripts/fixtures-new.mjs",
     "conformance:regen:bundle": "tsx scripts/generate-bundle-vectors.ts",
     "bench": "pnpm --filter @peac/crypto bench && pnpm --filter @peac/schema bench && pnpm --filter @peac/protocol bench",

--- a/packages/schema/openapi/verify.yaml
+++ b/packages/schema/openapi/verify.yaml
@@ -1,40 +1,82 @@
-openapi: 3.1.0
+openapi: 3.1.1
 info:
-  title: PEAC Protocol Verification API
-  version: 0.9.15
+  title: PEAC Reference Verifier API
+  version: 0.12.12
+  summary: Portable signed records for agent, API, MCP, and cross-runtime interactions.
   description: |
-    Public endpoint for verifying PEAC cryptographic receipts.
-    Wire format frozen at peac.receipt/0.9 with v1.0-equivalent semantics.
-  license:
-    name: Apache-2.0
-    url: https://www.apache.org/licenses/LICENSE-2.0.html
+    Package-level OpenAPI contract for the PEAC reference verifier (`apps/api/`).
+
+    Requests and responses are exchanged as `application/json`. The `receipt`
+    field in the request body is a compact JWS string whose JOSE header
+    `typ` is `interaction-record+jwt` (Wire 0.2). The `receipt` field is not
+    itself an HTTP media type; it is a payload carried inside the JSON body.
+
+    `POST /v1/verify` returns the deterministic DD-210 verification report.
+    Content negotiation on the `Accept` header chooses between the
+    byte-identical `application/json` report, the extended
+    `application/peac-report+json` (which adds `report_id`, `verified_at`,
+    `duration_ms`, `key_resolution`, and `failure_reasons`), and a
+    `text/plain` human-readable summary.
+
+    Error responses use RFC 9457 Problem Details (`application/problem+json`)
+    extended with PEAC-canonical fields (`peac_error_code`, `peac_trace_id`).
+
+    The legacy `POST /verify` endpoint is retained for compatibility and
+    carries RFC 9745 `Deprecation` and RFC 8594 `Sunset` response headers;
+    it is scheduled for removal no earlier than 2026-11-01.
+
+    Size caps (enforced by the kernel and verifier, documented here for
+    contract completeness):
+      - receipt JWS (request body): 256 KiB (262 144 bytes)
+      - any single extension group: 64 KiB (65 536 bytes)
+      - all extensions combined: 256 KiB (262 144 bytes)
   contact:
     name: PEAC Protocol
     url: https://www.peacprotocol.org
+  license:
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+
 servers:
-  - url: https://api.example.com
-    description: Example PEAC issuer
+  - url: http://localhost:3000
+    description: Local development (self-hosted reference verifier)
+
+tags:
+  - name: Verify
+    description: Verification endpoints (canonical and legacy).
+  - name: Issue
+    description: Hosted issue endpoints (alpha).
+  - name: Health
+    description: Issuer health and reference-verifier liveness.
 
 paths:
-  /verify:
+  /v1/verify:
     post:
       operationId: verifyReceipt
-      summary: Verify a PEAC receipt
+      tags: [Verify]
+      summary: Verify a signed interaction record
       description: |
-        Verifies the cryptographic signature and claims of a PEAC receipt.
-
-        **Security features:**
-        - Rate limiting: 100 req/s per IP, 1000 req/s global
-        - Circuit breaker for JWKS fetch (5 failures → 60s open)
-        - Response caching: 5min valid, 1min invalid
-        - CPU budget: ≤50ms per request
-
-        **DoS mitigation:**
-        - SSRF-safe JWKS fetching
-        - JWS size limits (≤16KB)
-        - Signature verification timeout
-      tags:
-        - Verification
+        Verify a compact JWS interaction record. The request body is
+        `application/json`; its `receipt` field is the compact JWS string.
+        Returns a deterministic verification report (DD-210 shape).
+        Supports caller-provided public key or allowlisted issuer JWKS
+        resolution. Accepts three response formats via content negotiation.
+      parameters:
+        - name: Accept
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - application/json
+              - application/peac-report+json
+              - text/plain
+            default: application/json
+          description: |
+            `application/json` returns the byte-identical DD-210 report.
+            `application/peac-report+json` adds `report_id`, `verified_at`,
+            `duration_ms`, `key_resolution`, and `failure_reasons`.
+            `text/plain` returns a human-readable summary.
       requestBody:
         required: true
         content:
@@ -42,407 +84,543 @@ paths:
             schema:
               $ref: '#/components/schemas/VerifyRequest'
             examples:
-              valid_stripe_receipt:
-                summary: Valid Stripe receipt
+              wire_0_2_with_issuer_discovery:
+                summary: Wire 0.2 receipt, issuer resolved via discovery
+                description: >
+                  `receipt` is a compact JWS whose JOSE header `typ` is
+                  `interaction-record+jwt`. The HTTP request body itself is
+                  `application/json`.
                 value:
-                  receipt_jws: 'eyJ0eXAiOiJwZWFjLnJlY2VpcHQvMC45IiwiYWxnIjoiRWREU0EiLCJraWQiOiIyMDI1LTAxLTE1VDEwOjMwOjAwWiJ9.eyJpc3MiOiJodHRwczovL2FwaS5leGFtcGxlLmNvbSIsImF1ZCI6Imh0dHBzOi8vYXBwLmV4YW1wbGUuY29tIiwiaWF0IjoxNzM2OTM0NjAwLCJyaWQiOiIwMTkzYzRkMC0wMDAwLTcwMDAtODAwMC0wMDAwMDAwMDAwMDAiLCJhbXQiOjk5OTksImN1ciI6IlVTRCIsInBheW1lbnQiOnsic2NoZW1lIjoic3RyaXBlIiwicmVmZXJlbmNlIjoiY3NfMTIzNDU2Iiwi YW1vdW50Ijo5OTk5LCJjdXJyZW5jeSI6IlVTRCJ9fQ.signature'
+                  receipt: eyJ0eXAiOiJpbnRlcmFjdGlvbi1yZWNvcmQrand0IiwiYWxnIjoiRWREU0EiLCJraWQiOiIyMDI2LTA0LTE4In0.eyJpc3MiOiJodHRwczovL2FwaS5leGFtcGxlLmNvbSIsImlhdCI6MTc4MTYwOTYwMCwianRpIjoiMDE5Njc2ZDAtMDAwMC03MDAwLTgwMDAtMDAwMDAwMDAwMDAwIiwidHlwZSI6Im9yZy5wZWFjcHJvdG9jb2wvYXBpLXJlY2VpcHQiLCJwaWxsYXJzIjpbImFjY2VzcyJdLCJwZWFjX3ZlcnNpb24iOiIwLjIiLCJzY2hlbWEiOiJpbnRlcmFjdGlvbi1yZWNvcmQrand0In0.signature_bytes_placeholder
+                  options:
+                    strictness: strict
+              wire_0_2_with_caller_public_key:
+                summary: Wire 0.2 receipt, caller-provided Ed25519 public key
+                description: >
+                  `receipt` is a compact JWS; `public_key` bypasses JWKS
+                  resolution. The HTTP request body itself is `application/json`.
+                value:
+                  receipt: eyJ0eXAiOiJpbnRlcmFjdGlvbi1yZWNvcmQrand0IiwiYWxnIjoiRWREU0EiLCJraWQiOiJkaWQ6a2V5OnoifQ.eyJpc3MiOiJkaWQ6a2V5OnoifQ.signature_bytes_placeholder
+                  public_key: MCowBQYDK2VwAyEAGb9ECWmEzf6FQbrBZ9w7lshQhqowtrbLDFw4rXAxZuE
+                  options:
+                    strictness: interop
       responses:
         '200':
-          description: Verification result (success or failure)
+          description: Verification completed. Response body indicates verified/failed state.
           headers:
+            PEAC-Report-Id:
+              description: UUID v4 report identifier unique per response.
+              schema:
+                type: string
+                format: uuid
+            Content-Type:
+              description: Selected response representation.
+              schema:
+                type: string
+            X-Content-Type-Options:
+              description: nosniff (always present).
+              schema:
+                type: string
+                const: nosniff
             Cache-Control:
-              description: Caching directive
+              description: no-store (always present).
               schema:
                 type: string
-                example: 'public, max-age=300'
+                const: no-store
+            Referrer-Policy:
+              description: no-referrer (always present).
+              schema:
+                type: string
+                const: no-referrer
             Vary:
-              description: Vary header for cache invalidation
+              description: PEAC-Receipt (always present).
               schema:
                 type: string
-                example: 'PEAC-Receipt'
+                const: PEAC-Receipt
+            RateLimit-Limit:
+              description: Maximum requests per window (RFC 9333-style).
+              schema:
+                type: string
+            RateLimit-Remaining:
+              description: Remaining requests in current window.
+              schema:
+                type: string
+            RateLimit-Reset:
+              description: Seconds until rate-limit window resets.
+              schema:
+                type: string
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/VerifyResponseSuccess'
-                  - $ref: '#/components/schemas/VerifyResponseFailure'
-              examples:
-                success:
-                  summary: Successful verification
-                  value:
-                    ok: true
-                    header:
-                      typ: 'peac.receipt/0.9'
-                      alg: 'EdDSA'
-                      kid: '2025-01-15T10:30:00Z'
-                    claims:
-                      iss: 'https://api.example.com'
-                      aud: 'https://app.example.com'
-                      iat: 1736934600
-                      rid: '0193c4d0-0000-7000-8000-000000000000'
-                      amt: 9999
-                      cur: 'USD'
-                      payment:
-                        scheme: 'stripe'
-                        reference: 'cs_123456'
-                        amount: 9999
-                        currency: 'USD'
-                    perf:
-                      verify_ms: 8.2
-                      jwks_fetch_ms: 45.1
-                failure_invalid_signature:
-                  summary: Invalid signature
-                  value:
-                    ok: false
-                    reason: 'invalid_signature'
-                    details: 'Ed25519 signature verification failed'
-                failure_expired:
-                  summary: Expired receipt
-                  value:
-                    ok: false
-                    reason: 'expired'
-                    details: 'Receipt expired at 2025-01-15T12:00:00Z'
-        '400':
-          description: Bad request (malformed input)
-          content:
-            application/problem+json:
+                $ref: '#/components/schemas/VerifySuccessResponse'
+            application/peac-report+json:
               schema:
-                $ref: '#/components/schemas/ProblemDetails'
-              examples:
-                malformed_jws:
-                  summary: Malformed JWS
-                  value:
-                    type: 'https://www.peacprotocol.org/errors/malformed-jws'
-                    title: 'Malformed JWS'
-                    status: 400
-                    detail: 'JWS does not have three dot-separated parts'
-                    instance: '/verify'
-        '429':
-          description: Rate limit exceeded
-          headers:
-            Retry-After:
-              description: Seconds to wait before retrying
-              schema:
-                type: integer
-                example: 60
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ProblemDetails'
-              examples:
-                rate_limit:
-                  summary: Rate limit exceeded
-                  value:
-                    type: 'https://www.peacprotocol.org/errors/rate-limit'
-                    title: 'Rate Limit Exceeded'
-                    status: 429
-                    detail: 'IP-based rate limit: 100 requests per second'
-                    instance: '/verify'
-        '503':
-          description: Service unavailable (circuit breaker open)
-          headers:
-            Retry-After:
-              description: Seconds to wait before retrying
-              schema:
-                type: integer
-                example: 60
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ProblemDetails'
-              examples:
-                circuit_breaker:
-                  summary: Circuit breaker open
-                  value:
-                    type: 'https://www.peacprotocol.org/errors/circuit-breaker'
-                    title: 'Service Unavailable'
-                    status: 503
-                    detail: 'JWKS fetch circuit breaker is open (5 consecutive failures)'
-                    instance: '/verify'
-
-  /.well-known/peac.txt:
-    get:
-      operationId: getDiscovery
-      summary: Get PEAC discovery manifest
-      description: |
-        Returns the PEAC discovery manifest in YAML format (≤20 lines).
-
-        **Format:** YAML only (no JSON mirror)
-        **Size limit:** 2000 bytes
-        **Cache:** public, max-age=3600
-      tags:
-        - Discovery
-      responses:
-        '200':
-          description: PEAC discovery manifest
-          headers:
-            Cache-Control:
-              schema:
-                type: string
-                example: 'public, max-age=3600'
-          content:
+                $ref: '#/components/schemas/ExtendedVerifyReport'
             text/plain:
               schema:
                 type: string
-              example: |
-                version: peac/0.9
-                issuer: https://api.example.com
-                verify: https://api.example.com/verify
-                jwks: https://keys.peacprotocol.org/jwks.json
-                payments:
-                  - scheme: stripe
-                    info: https://docs.example.com/payments/stripe
-                  - scheme: x402
-                    info: https://docs.example.com/payments/x402
-                aipref: https://api.example.com/.well-known/aipref.json
-                slos: https://api.example.com/slo
-                security: security@example.com
+                description: Human-readable verification summary.
+        '400':
+          description: Invalid request format.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '413':
+          description: Request body too large (receipt exceeds 256 KiB).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '422':
+          description: Verification or validation failure (signature invalid, claims invalid, policy mismatch).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '429':
+          description: Rate limit exceeded.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying.
+              schema:
+                type: string
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '502':
+          description: Upstream resolution failure (JWKS fetch, issuer config fetch).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+
+  /verify:
+    post:
+      operationId: verifyReceiptLegacy
+      tags: [Verify]
+      deprecated: true
+      summary: '[DEPRECATED] Legacy verify endpoint'
+      description: |
+        Legacy verification endpoint retained for backward compatibility.
+        New integrations MUST use `POST /v1/verify`. Every response from
+        this path carries RFC 9745 `Deprecation` and RFC 8594 `Sunset`
+        headers plus an RFC 8288 `Link` relation pointing at the migration
+        guide. Scheduled removal: no earlier than 2026-11-01.
+        Request body is `application/json`, identical shape to
+        `POST /v1/verify`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VerifyRequest'
+      responses:
+        '200':
+          description: Verification completed (deprecated response shape).
+          headers:
+            Deprecation:
+              description: RFC 9745 marker indicating the endpoint is deprecated.
+              schema:
+                type: string
+                const: 'true'
+            Sunset:
+              description: RFC 8594 HTTP-date at which the endpoint is scheduled for removal.
+              schema:
+                type: string
+                example: 'Sat, 01 Nov 2026 00:00:00 GMT'
+            Link:
+              description: RFC 8288 Link header with rel="deprecation" pointing at the migration guide.
+              schema:
+                type: string
+                example: '<https://www.peacprotocol.org/docs/migration>; rel="deprecation"'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VerifySuccessResponse'
+        '400':
+          description: Invalid request format.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '422':
+          description: Verification failure.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+
+  /v1/issue:
+    post:
+      operationId: issueReceipt
+      tags: [Issue]
+      summary: '[ALPHA] BYO-key hosted issue'
+      description: |
+        Provisional hosted issue endpoint (alpha). Disabled by default;
+        operators enable via `PEAC_HOSTED_ISSUE=true`. The caller supplies
+        the signing key; the service returns a compact JWS whose JOSE
+        header `typ` is `interaction-record+jwt`. Rate-limited
+        independently from verify. Semantics subject to change until GA.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IssueRequest'
+      responses:
+        '200':
+          description: Signed receipt issued.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IssueSuccessResponse'
+        '400':
+          description: Invalid request format.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '404':
+          description: Hosted issue disabled (`PEAC_HOSTED_ISSUE=false`).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '422':
+          description: Validation failure.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+
+  /v1/issuer-health:
+    get:
+      operationId: getIssuerHealth
+      tags: [Health]
+      summary: Check an issuer's discovery and JWKS availability
+      description: |
+        SSRF-safe issuer-health probe. Performs bounded HTTPS fetches of
+        `/.well-known/peac-issuer.json` and the referenced `jwks_uri`.
+        Private/loopback/reserved addresses are blocked; redirects are
+        disabled; every fetch enforces an explicit timeout.
+      parameters:
+        - name: issuer
+          in: query
+          required: true
+          description: Issuer URI (https-only, no private/loopback/reserved addresses).
+          schema:
+            type: string
+            format: uri
+            pattern: '^https://'
+      responses:
+        '200':
+          description: Issuer discovery and JWKS resolution succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IssuerHealthResponse'
+        '400':
+          description: Invalid issuer parameter.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '502':
+          description: Issuer discovery or JWKS fetch failed.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+
+  /health:
+    get:
+      operationId: getLiveness
+      tags: [Health]
+      summary: Reference-verifier liveness check
+      responses:
+        '200':
+          description: Reference verifier is live.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ok]
+                properties:
+                  ok:
+                    type: boolean
+                    const: true
 
 components:
   schemas:
     VerifyRequest:
       type: object
-      required:
-        - receipt_jws
+      required: [receipt]
       additionalProperties: false
+      description: |
+        Request body for verification. `receipt` is a compact JWS string
+        whose JOSE header `typ` is `interaction-record+jwt` (Wire 0.2)
+        or `peac-receipt/0.1` (legacy Wire 0.1, verify-only).
       properties:
-        receipt_jws:
+        receipt:
           type: string
-          minLength: 16
-          maxLength: 16384
-          description: JWS compact serialization of the PEAC receipt
-          example: 'eyJ0eXAiOiJwZWFjLnJlY2VpcHQvMC45IiwiYWxnIjoiRWREU0EiLCJraWQiOiIyMDI1LTAxLTE1VDEwOjMwOjAwWiJ9...'
-
-    VerifyResponseSuccess:
-      type: object
-      required:
-        - ok
-        - header
-        - claims
-      additionalProperties: false
-      properties:
-        ok:
-          type: boolean
-          const: true
-          description: Verification succeeded
-        header:
-          $ref: '#/components/schemas/JWSHeader'
-        claims:
-          $ref: '#/components/schemas/ReceiptClaims'
-        perf:
+          minLength: 1
+          maxLength: 262144
+          description: Compact JWS string. Maximum size 256 KiB (262 144 bytes).
+          example: eyJ0eXAiOiJpbnRlcmFjdGlvbi1yZWNvcmQrand0IiwiYWxnIjoiRWREU0EiLCJraWQiOiIyMDI2LTA0LTE4In0...
+        public_key:
+          type: string
+          minLength: 1
+          description: |
+            Optional base64url-encoded Ed25519 public key (32 bytes). When
+            supplied, skips issuer discovery and JWKS resolution.
+        policy:
           type: object
+          additionalProperties: false
+          description: Optional policy expectation. Used for `policy_binding` check.
           properties:
-            verify_ms:
-              type: number
-              description: Time spent verifying signature (milliseconds)
-            jwks_fetch_ms:
-              type: number
-              description: Time spent fetching JWKS (milliseconds, if not cached)
+            uri:
+              type: string
+              format: uri
+            version:
+              type: string
+        options:
+          type: object
+          additionalProperties: false
+          properties:
+            issuer:
+              type: string
+              format: uri
+              description: Expected issuer URI for binding check.
+            max_clock_skew:
+              type: integer
+              minimum: 1
+              maximum: 3600
+              description: Clock-skew tolerance in seconds (default 300).
+            strictness:
+              type: string
+              enum: [strict, interop]
+              description: Verification strictness mode. Default `strict`.
 
-    VerifyResponseFailure:
+    VerifySuccessResponse:
       type: object
       required:
-        - ok
-        - reason
-      additionalProperties: false
-      properties:
-        ok:
-          type: boolean
-          const: false
-          description: Verification failed
-        reason:
-          type: string
-          enum:
-            - invalid_signature
-            - expired
-            - invalid_claims
-            - unknown_issuer
-            - jwks_fetch_failed
-            - malformed_jws
-          description: Machine-readable failure reason
-        details:
-          type: string
-          description: Human-readable error details
-
-    JWSHeader:
-      type: object
-      required:
-        - typ
-        - alg
+        - verified
+        - receipt_ref
+        - claims
+        - warnings
+        - policy_binding
+        - issuer
         - kid
+        - wire_version
       additionalProperties: false
+      description: DD-210 deterministic verification report (byte-identical across runs).
       properties:
-        typ:
+        verified:
+          type: boolean
+          description: Whether the receipt passed all verification checks.
+        receipt_ref:
           type: string
-          const: 'peac.receipt/0.9'
-          description: Wire format version (frozen at 0.9 until GA)
-        alg:
+          pattern: '^sha256:[a-f0-9]{64}$'
+          description: SHA-256 of the compact JWS bytes (`sha256:<hex>`).
+        claims:
+          type: object
+          description: Validated interaction-record claims.
+        warnings:
+          type: array
+          items:
+            $ref: '#/components/schemas/VerificationWarning'
+          description: Non-fatal verification warnings (W_* codes).
+        policy_binding:
           type: string
-          const: 'EdDSA'
-          description: Signature algorithm (Ed25519)
+          enum: [unavailable, verified, failed]
+          description: Three-state policy-binding result.
+        issuer:
+          type: string
+          description: Issuer URI from the receipt.
         kid:
           type: string
-          minLength: 8
-          description: Key ID (ISO 8601 timestamp)
-          example: '2025-01-15T10:30:00Z'
+          description: Key ID from the JWS header.
+        wire_version:
+          type: string
+          description: Wire format version (for example "0.2").
 
-    ReceiptClaims:
+    VerificationWarning:
       type: object
-      required:
-        - iss
-        - aud
-        - iat
-        - rid
-        - amt
-        - cur
-        - payment
+      required: [code, message]
       additionalProperties: false
       properties:
-        iss:
+        code:
           type: string
-          format: uri
-          pattern: '^https://'
-          description: Issuer URL (must be https://)
-          example: 'https://api.example.com'
-        aud:
+          description: Warning code (for example `W_UNREGISTERED_TYPE`).
+        message:
           type: string
-          format: uri
-          pattern: '^https://'
-          description: Audience / resource URL
-          example: 'https://app.example.com'
-        iat:
-          type: integer
-          minimum: 0
-          description: Issued at timestamp (Unix seconds)
-          example: 1736934600
-        exp:
-          type: integer
-          minimum: 0
-          description: Expiry timestamp (Unix seconds, optional)
-        rid:
+          description: Human-readable warning message.
+        pointer:
           type: string
-          pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
-          description: Receipt ID (UUIDv7)
-          example: '0193c4d0-0000-7000-8000-000000000000'
-        amt:
-          type: integer
-          minimum: 0
-          description: Amount in smallest currency unit
-          example: 9999
-        cur:
-          type: string
-          pattern: '^[A-Z]{3}$'
-          description: ISO 4217 currency code (uppercase)
-          example: 'USD'
-        payment:
-          $ref: '#/components/schemas/NormalizedPayment'
-        subject:
-          $ref: '#/components/schemas/Subject'
-        ext:
-          $ref: '#/components/schemas/Extensions'
+          description: RFC 6901 JSON Pointer to the problematic field.
 
-    NormalizedPayment:
+    FailureReason:
       type: object
-      required:
-        - scheme
-        - reference
-        - amount
-        - currency
+      required: [code, detail]
       additionalProperties: false
       properties:
-        scheme:
+        code:
           type: string
-          minLength: 1
-          description: Payment rail identifier
-          example: 'stripe'
-        reference:
+          description: Kernel error code (for example `E_INVALID_SIGNATURE`).
+        detail:
           type: string
-          minLength: 1
-          description: Rail-specific payment ID
-          example: 'cs_123456'
-        amount:
-          type: integer
-          minimum: 0
-          description: Amount in smallest currency unit
-          example: 9999
-        currency:
+          description: Human-readable failure reason.
+
+    ExtendedVerifyReport:
+      type: object
+      required:
+        - report_id
+        - verified
+        - verified_at
+        - duration_ms
+        - receipt_ref
+        - key_resolution
+        - failure_reasons
+      additionalProperties: false
+      description: |
+        Extended verification report with timing, report ID, key-resolution
+        method, and failure reasons. Returned when `Accept` contains
+        `application/peac-report+json`.
+      properties:
+        report_id:
           type: string
-          pattern: '^[A-Z]{3}$'
-          description: ISO 4217 currency code
-          example: 'USD'
-        idempotency_key:
+          format: uuid
+        verified:
+          type: boolean
+        verified_at:
           type: string
-          description: Idempotency key for deduplication
-        metadata:
+          format: date-time
+        duration_ms:
+          type: number
+        receipt_ref:
+          type: string
+          pattern: '^sha256:[a-f0-9]{64}$'
+        claims:
           type: object
-          description: Rail-specific metadata (non-normative)
+        warnings:
+          type: array
+          items:
+            $ref: '#/components/schemas/VerificationWarning'
+        policy_binding:
+          type: string
+          enum: [unavailable, verified, failed]
+        issuer:
+          type: string
+        kid:
+          type: string
+        wire_version:
+          type: string
+        key_resolution:
+          type: string
+          enum: [provided, allowlist, discovery]
+        failure_reasons:
+          type: array
+          items:
+            $ref: '#/components/schemas/FailureReason'
 
-    Subject:
+    IssueRequest:
       type: object
-      required:
-        - uri
+      required: [claims, signing_key]
       additionalProperties: false
       properties:
-        uri:
+        claims:
+          type: object
+          description: Interaction-record claims object (Wire 0.2).
+        signing_key:
           type: string
-          format: uri
-          pattern: '^https://'
-          description: URI of the resource being paid for
-          example: 'https://app.example.com/api/resource/123'
+          description: Base64url-encoded Ed25519 private key (32 bytes). Caller-custody only.
+        kid:
+          type: string
+          description: Key identifier to embed in the JWS header.
 
-    Extensions:
+    IssueSuccessResponse:
       type: object
-      properties:
-        aipref_snapshot:
-          $ref: '#/components/schemas/AIPREFSnapshot'
-      description: Extension fields (additive-only, PEIP-defined)
-
-    AIPREFSnapshot:
-      type: object
-      required:
-        - url
-        - hash
+      required: [receipt, receipt_ref, kid, wire_version]
       additionalProperties: false
       properties:
-        url:
+        receipt:
+          type: string
+          description: Signed compact JWS (JOSE header `typ` is `interaction-record+jwt`).
+        receipt_ref:
+          type: string
+          pattern: '^sha256:[a-f0-9]{64}$'
+        kid:
+          type: string
+        wire_version:
+          type: string
+
+    IssuerHealthResponse:
+      type: object
+      required: [issuer, discovery_ok, jwks_ok, duration_ms]
+      additionalProperties: false
+      properties:
+        issuer:
           type: string
           format: uri
-          pattern: '^https://'
-          description: URL of the AIPREF document
-          example: 'https://api.example.com/.well-known/aipref.json'
-        hash:
+        discovery_ok:
+          type: boolean
+          description: Whether `/.well-known/peac-issuer.json` resolved.
+        jwks_ok:
+          type: boolean
+          description: Whether the referenced `jwks_uri` resolved and parsed.
+        jwks_uri:
           type: string
-          minLength: 8
-          description: JCS+SHA-256 hash of the AIPREF document
-          example: 'a1b2c3d4e5f67890'
+          format: uri
+        duration_ms:
+          type: number
+        warnings:
+          type: array
+          items:
+            type: string
 
     ProblemDetails:
       type: object
-      required:
-        - type
-        - title
-        - status
+      required: [type, title, status, detail, peac_error_code]
+      additionalProperties: true
+      description: |
+        RFC 9457 Problem Details with PEAC extensions. Returned with
+        `Content-Type: application/problem+json` on any error response.
       properties:
         type:
           type: string
           format: uri
-          description: URI reference identifying the problem type (RFC 9457)
-          example: 'https://www.peacprotocol.org/errors/rate-limit'
+          description: Problem-type URI under `https://www.peacprotocol.org/problems/`.
         title:
           type: string
-          description: Short, human-readable summary
-          example: 'Rate Limit Exceeded'
+          description: Short human-readable summary of the problem type.
         status:
           type: integer
-          description: HTTP status code
-          example: 429
+          description: HTTP status code for this occurrence.
         detail:
           type: string
-          description: Human-readable explanation specific to this occurrence
-          example: 'IP-based rate limit: 100 requests per second'
+          description: Human-readable explanation specific to this occurrence.
         instance:
           type: string
-          format: uri
-          description: URI reference identifying the specific occurrence
-          example: '/verify'
-      description: RFC 9457 Problem Details for HTTP APIs
+          description: URI reference identifying the specific occurrence.
+        peac_error_code:
+          type: string
+          description: Kernel-canonical error code (for example `E_INVALID_FORMAT`).
+        peac_trace_id:
+          type: string
+          description: Request trace identifier.
+        errors:
+          type: array
+          description: Multi-error details for validation failures.
+          items:
+            type: object
+            required: [pointer, detail]
+            additionalProperties: false
+            properties:
+              pointer:
+                type: string
+                description: RFC 6901 JSON Pointer.
+              detail:
+                type: string
+                description: Field-level error detail.

--- a/scripts/check-public-artifacts.mjs
+++ b/scripts/check-public-artifacts.mjs
@@ -34,6 +34,8 @@ const BUILTIN_PATTERNS = [
   /reference\/.*_LOCAL\./i,
   /[\u200B-\u200F\u2028-\u202F\u2060-\u206F\uFEFF]/, // hidden/bidi Unicode
   /MEMORY\.md/,
+  // Retired category tagline; never valid on any tracked artifact.
+  /cryptographic receipts for agentic commerce/i,
 ];
 
 /**

--- a/scripts/generate-surface-status.mjs
+++ b/scripts/generate-surface-status.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
 /**
- * Generate docs/PACKAGE_STATUS.md and docs/SURFACE_STATUS.md
- * from REPO_SURFACE_STATUS.json.
+ * Builds docs/PACKAGE_STATUS.md and docs/SURFACE_STATUS.md from
+ * REPO_SURFACE_STATUS.json. These two docs are projections of the
+ * machine-readable source; edit the JSON and rebuild.
  *
  * Usage: node scripts/generate-surface-status.mjs
  *        node scripts/generate-surface-status.mjs --check  (verify, no write)
@@ -33,8 +34,7 @@ function generatePackageStatus() {
   const lines = [
     '# Package and Surface Status',
     '',
-    'Generated from `REPO_SURFACE_STATUS.json` by `scripts/generate-surface-status.mjs`.',
-    'Do not edit manually.',
+    'Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scripts/generate-surface-status.mjs`.',
     '',
   ];
 
@@ -120,8 +120,7 @@ function generateSurfaceStatus() {
   const lines = [
     '# Surface Status by Layer',
     '',
-    'Generated from `REPO_SURFACE_STATUS.json` by `scripts/generate-surface-status.mjs`.',
-    'Do not edit manually.',
+    'Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scripts/generate-surface-status.mjs`.',
     '',
     `**Version:** ${status.version} | **Updated:** ${status.updated}`,
     '',
@@ -202,5 +201,5 @@ if (checkMode) {
 
 writeFileSync(packageStatusPath, packageStatusContent);
 writeFileSync(surfaceStatusPath, surfaceStatusContent);
-console.log('Generated docs/PACKAGE_STATUS.md');
-console.log('Generated docs/SURFACE_STATUS.md');
+console.log('Wrote docs/PACKAGE_STATUS.md');
+console.log('Wrote docs/SURFACE_STATUS.md');

--- a/scripts/verify-openapi-drift.mjs
+++ b/scripts/verify-openapi-drift.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+
+/**
+ * OpenAPI drift check for the PEAC reference verifier contract.
+ *
+ * Two OpenAPI documents describe the same HTTP service:
+ *   - `packages/schema/openapi/verify.yaml` (canonical package-level spec,
+ *     covering every route).
+ *   - `apps/api/openapi.yaml` (app-level spec; covers `/v1/verify` only,
+ *     consumed by the app's sync test).
+ *
+ * This script enforces that where the two overlap, they agree:
+ *   - `openapi` version strings match.
+ *   - `info.version` strings match.
+ *   - The `/v1/verify` POST definition is structurally identical
+ *     (operationId, request-body schema name, response status codes,
+ *     response media types, and response schema names).
+ *   - Shared component schemas referenced from `/v1/verify` have the
+ *     same required-field sets and property names.
+ *
+ * Deliberately does NOT insist on byte-for-byte equality; descriptions
+ * and examples are free to vary. The contract is on the wire-facing
+ * shape, not on the prose.
+ *
+ * Exit codes:
+ *   0  No drift.
+ *   1  Drift detected; prints a human-readable diff report.
+ *   2  Script error (unable to parse one of the files).
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+const PKG_SPEC = resolve(ROOT, 'packages/schema/openapi/verify.yaml');
+const APP_SPEC = resolve(ROOT, 'apps/api/openapi.yaml');
+
+function loadSpec(path) {
+  try {
+    return parseYaml(readFileSync(path, 'utf8'));
+  } catch (err) {
+    console.error(`ERROR: cannot parse ${relative(ROOT, path)}: ${err.message}`);
+    process.exit(2);
+  }
+}
+
+const pkg = loadSpec(PKG_SPEC);
+const app = loadSpec(APP_SPEC);
+
+const violations = [];
+
+function compare(label, pkgVal, appVal) {
+  if (pkgVal !== appVal) {
+    violations.push(`${label}: pkg=${JSON.stringify(pkgVal)} app=${JSON.stringify(appVal)}`);
+  }
+}
+
+function compareSets(label, pkgList, appList) {
+  const a = new Set(pkgList || []);
+  const b = new Set(appList || []);
+  const missingInApp = [...a].filter((x) => !b.has(x));
+  const missingInPkg = [...b].filter((x) => !a.has(x));
+  if (missingInApp.length > 0) {
+    violations.push(`${label}: missing in app spec: ${missingInApp.join(', ')}`);
+  }
+  if (missingInPkg.length > 0) {
+    violations.push(`${label}: missing in package spec: ${missingInPkg.join(', ')}`);
+  }
+}
+
+function refName(ref) {
+  if (!ref) return null;
+  if (typeof ref === 'string') return ref.split('/').pop();
+  if (ref.$ref) return ref.$ref.split('/').pop();
+  return null;
+}
+
+compare('openapi', pkg.openapi, app.openapi);
+compare('info.version', pkg.info?.version, app.info?.version);
+
+const pkgPath = pkg.paths?.['/v1/verify']?.post;
+const appPath = app.paths?.['/v1/verify']?.post;
+
+if (!pkgPath) {
+  violations.push('package spec is missing POST /v1/verify');
+}
+if (!appPath) {
+  violations.push('app spec is missing POST /v1/verify');
+}
+
+if (pkgPath && appPath) {
+  compare('/v1/verify operationId', pkgPath.operationId, appPath.operationId);
+
+  const pkgReqSchema = pkgPath.requestBody?.content?.['application/json']?.schema;
+  const appReqSchema = appPath.requestBody?.content?.['application/json']?.schema;
+  compare('/v1/verify request-body schema name', refName(pkgReqSchema), refName(appReqSchema));
+
+  const pkgStatuses = Object.keys(pkgPath.responses || {}).sort();
+  const appStatuses = Object.keys(appPath.responses || {}).sort();
+  compareSets('/v1/verify response status codes', pkgStatuses, appStatuses);
+
+  for (const status of pkgStatuses.filter((s) => appStatuses.includes(s))) {
+    const pkgContent = Object.keys(pkgPath.responses[status].content || {}).sort();
+    const appContent = Object.keys(appPath.responses[status].content || {}).sort();
+    compareSets(`/v1/verify ${status} response media types`, pkgContent, appContent);
+    for (const mediaType of pkgContent.filter((m) => appContent.includes(m))) {
+      const pkgSchema = pkgPath.responses[status].content[mediaType]?.schema;
+      const appSchema = appPath.responses[status].content[mediaType]?.schema;
+      compare(
+        `/v1/verify ${status} ${mediaType} schema name`,
+        refName(pkgSchema),
+        refName(appSchema)
+      );
+    }
+  }
+}
+
+// Component-schema shape agreement for schemas referenced by /v1/verify.
+const sharedSchemaNames = [];
+if (pkgPath && appPath) {
+  const reqName = refName(pkgPath.requestBody?.content?.['application/json']?.schema);
+  if (reqName) sharedSchemaNames.push(reqName);
+  for (const status of Object.keys(pkgPath.responses || {})) {
+    for (const mt of Object.keys(pkgPath.responses[status].content || {})) {
+      const n = refName(pkgPath.responses[status].content[mt]?.schema);
+      if (n) sharedSchemaNames.push(n);
+    }
+  }
+}
+for (const name of [...new Set(sharedSchemaNames)]) {
+  const pkgS = pkg.components?.schemas?.[name];
+  const appS = app.components?.schemas?.[name];
+  if (!pkgS || !appS) continue; // Not present in both specs; nothing to compare.
+  compareSets(
+    `components.schemas.${name}.required`,
+    pkgS.required,
+    appS.required
+  );
+  compareSets(
+    `components.schemas.${name} property names`,
+    Object.keys(pkgS.properties || {}),
+    Object.keys(appS.properties || {})
+  );
+}
+
+if (violations.length > 0) {
+  console.error(`FAIL: OpenAPI drift between package spec and app spec (${violations.length} issue(s)):`);
+  for (const v of violations) console.error(`  - ${v}`);
+  console.error(`\nPackage spec: ${relative(ROOT, PKG_SPEC)}`);
+  console.error(`App spec:     ${relative(ROOT, APP_SPEC)}`);
+  process.exit(1);
+}
+
+console.log('OK: OpenAPI specs agree on shared /v1/verify contract.');


### PR DESCRIPTION
## Summary

Refreshes the machine-readable status surfaces, exported public API
contracts, and the reference-verifier OpenAPI contract to v0.12.12 and
the current Wire 0.2 default. Adds three drift-verification CI gates
so this class of artifact skew cannot accumulate again. No wire format,
schema, kernel, crypto, protocol public API, registries, or errors
taxonomy changes. No runtime behavior change.

## Scope

In scope:

- `REPO_SURFACE_STATUS.json` bumped to v0.12.12; present-state fields
  only (state, wire, layer, published, note).
- `docs/SURFACE_STATUS.md` and `docs/PACKAGE_STATUS.md` rebuilt from
  the JSON source.
- `docs/COMPATIBILITY_MATRIX.md` refreshed; new Adapter Readiness
  column covering 27 Layer-4 surfaces, scored against a five-state
  rubric that biases toward the weaker claim under ambiguity. Every
  row carries an evidence tag that resolves to a specific conformance
  fixture directory or package test suite.
- `contracts/api/{crypto,kernel,protocol,schema}.json` re-extracted
  via the existing extraction pipeline. 832 public exports across 4
  packages; no public-API drift.
- Root `package.json.description` set to the canonical short phrase.
  New pnpm aliases: `verify:contracts:drift`, `verify:surface-status`,
  `verify:openapi:drift`.
- `llms.txt` review stamp refreshed.
- `packages/schema/openapi/verify.yaml` rewritten at OpenAPI 3.1.1,
  `info.version: 0.12.12`. The request and response bodies are
  `application/json`; the `receipt` field is a compact JWS whose JOSE
  header `typ` is `interaction-record+jwt` (the prose spells this
  distinction out explicitly). Legacy `POST /verify` is marked
  `deprecated: true` with RFC 9745 `Deprecation`, RFC 8594 `Sunset`,
  and RFC 8288 `Link` headers. Error responses use RFC 9457 Problem
  Details with PEAC extensions (`peac_error_code`, `peac_trace_id`).
  Receipt and extension-group size caps are documented.
- `apps/api/openapi.yaml` aligned to 3.1.1 and `info.version: 0.12.12`.
- `apps/api/src/openapi-sync.test.js` asserts OpenAPI 3.1.1.
- `scripts/verify-openapi-drift.mjs` added as a tracked drift check
  that compares the package-level and app-level OpenAPI specs on the
  shared `POST /v1/verify` surface (openapi and info versions,
  request/response schema names, status codes, media types, and
  component-schema property sets). Strict on wire-facing shape;
  permissive on prose and examples.
- `scripts/check-public-artifacts.mjs` extended with the retired
  category tagline as a built-in forbidden exact-match.
- `.github/workflows/ci.yml` wires three new drift-verification steps
  (surface-status, API-contract, OpenAPI) into the Fast Guards lane.

Out of scope:

- Any code behavior change.
- Any wire / schema / kernel / crypto / registries / errors mutation.
- README, Start Here, examples rewrite.
- New trust artifacts (SLO, stability contract, threat model, trust
  center). These are tracked separately.

## Changes

- 17 files changed across 2 commits.
- Generated machine-readable artifacts rebuilt from the JSON source;
  no hand-editing of those artifacts.
- Compatibility Matrix Adapter Readiness rubric: `paused <
experimental < types-only < conformance-fixture-only <
live-upstream-tested`. No Layer-4 surface is currently
  `live-upstream-tested`; promotion requires a recorded round-trip
  fixture stamped with the upstream release.

## Validation

- `pnpm api-contract:check` clean (832 exports; no drift).
- `pnpm verify:surface-status` clean.
- `pnpm verify:openapi:drift` clean.
- `pnpm format:check` clean across all touched artifacts.
- `pnpm lint` clean.
- `pnpm --filter @peac/app-api test` green (openapi-sync suite
  updated for 3.1.1).
- `node scripts/check-public-artifacts.mjs` clean.
- `bash scripts/guard.sh` clean.

## Audit outcomes (summary)

- Every network-bearing code path under `@peac/protocol` enforces an
  explicit timeout (`AbortSignal.timeout(N)` with a literal N, or
  `signal: controller.signal` with a `setTimeout`-driven `abort()`,
  or routes through `ssrfSafeFetch`, whose timeout is bounded by
  `VERIFIER_LIMITS.fetchTimeoutMs`). 13 of 13 call sites enforce
  bounded timeouts.
- The current `@peac/protocol` public export surface was reviewed
  against the re-extracted contract. No removals in this change.
