### PR TITLE
docs: solutions library, reference-verifier recipes, and operator entry docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # PEAC Protocol
 
+**Govern locally. Prove across boundaries.**
+
+When logs aren't enough, PEAC gives you portable signed records anyone can verify offline.
+
 Portable signed records for agent, API, MCP, and cross-runtime interactions.
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-brightgreen.svg)](LICENSE)
@@ -7,31 +11,16 @@ Portable signed records for agent, API, MCP, and cross-runtime interactions.
 [![npm downloads](https://img.shields.io/npm/dm/@peac/protocol?style=flat&color=brightgreen)](https://www.npmjs.com/package/@peac/protocol)
 [![CI Status](https://img.shields.io/github/actions/workflow/status/peacprotocol/peac/ci.yml?branch=main&label=CI&color=brightgreen)](https://github.com/peacprotocol/peac/actions/workflows/ci.yml)
 
-PEAC is the open standard for verifiable interaction records across APIs, MCP servers, x402-powered payment flows, paymentauth / MPP, ACP, A2A workflows, runtime governance, and other cross-runtime systems.
+## What you can do
 
-Use PEAC when local logs are not enough and another party needs a signed, portable record of what happened. Do not use PEAC when local logs inside one system are sufficient and no external party needs to verify those records. PEAC does not replace auth, payment rails, observability, or transport protocols; it adds portable signed records across them.
+- **I run an API or HTTP service.** Issue signed receipts on every response. [API Provider Quickstart](docs/guides/quickstart-api-provider.md).
+- **I run an MCP server.** Attach signed records to tool calls. [MCP Integration Kit](integrator-kits/mcp/README.md) or `npx -y @peac/mcp-server`.
+- **I want to verify a receipt.** Verify offline with the issuer's public key. [Agent Operator Quickstart](docs/guides/quickstart-agent-operator.md).
+- **I want to prove my runtime decisions.** Record governance observations from managed runtimes. [`@peac/adapter-runtime-governance`](packages/adapters/runtime-governance/).
 
-> **Keep auth, keep payments, keep observability.** Add `/.well-known/peac.txt`, return `PEAC-Receipt`, and verify records offline across organizational boundaries.
+Full path-by-role tree: [`docs/START_HERE.md`](docs/START_HERE.md).
 
-## The PEAC loop
-
-```text
-1. Publish terms at /.well-known/peac.txt
-2. Return PEAC-Receipt with a signed interaction record
-3. Verify offline with the issuer's public key
-```
-
-## Why PEAC
-
-- Logs are local. PEAC records are portable.
-- Traces correlate systems. PEAC records survive organizational boundaries.
-- Auth and payments authorize actions. PEAC records prove what happened.
-
-## Quick start
-
-**In under a minute, you can verify a PEAC receipt offline.**
-
-**Requirements:** Node 24 tested, Node 22+ compatible. Go middleware and examples are supported (Go 1.26+). Python is available through API-first examples and OpenAPI-driven flows.
+## Verify a PEAC receipt in 60 seconds
 
 ```bash
 pnpm add @peac/protocol @peac/crypto
@@ -50,43 +39,42 @@ if (result.valid) {
 }
 ```
 
-A governed HTTP response looks like:
+Node 24 tested, Node 22+ compatible. Go middleware and examples supported (Go 1.26+). Python via API-first examples and OpenAPI-driven flows.
+
+## How it works
 
 ```text
-HTTP/1.1 200 OK
-PEAC-Receipt: eyJhbGciOiJFZERTQSIsInR5cCI6ImludGVyYWN0aW9uLXJlY29yZCtqd3QifQ...
-Link: </.well-known/peac-issuer.json>; rel="issuer"
+1. Publish terms at /.well-known/peac.txt
+2. Return PEAC-Receipt with a signed interaction record
+3. Verify offline with the issuer's public key
 ```
 
-## Try PEAC in 5 minutes
+Full loop: [`docs/HOW-IT-WORKS.md`](docs/HOW-IT-WORKS.md). Artifact vocabulary (record, receipt, bundle, report): [`docs/ARTIFACTS.md`](docs/ARTIFACTS.md). Where PEAC sits next to other systems: [`docs/WHERE-IT-FITS.md`](docs/WHERE-IT-FITS.md). Protocol scope: [`docs/WHAT-PEAC-STANDARDIZES.md`](docs/WHAT-PEAC-STANDARDIZES.md).
+
+## Solutions
+
+Outcome-led recipes under [`docs/SOLUTIONS/`](docs/SOLUTIONS/):
+
+- [Runtime evidence export](docs/SOLUTIONS/runtime-evidence-export.md)
+- [API receipt issuance](docs/SOLUTIONS/api-receipt-issuance.md)
+- [MCP tool-call receipts](docs/SOLUTIONS/mcp-tool-call-receipts.md)
+- [Commerce evidence bundle](docs/SOLUTIONS/commerce-evidence-bundle.md)
+- [Regulatory audit trail](docs/SOLUTIONS/regulatory-audit-trail.md)
+
+## Why PEAC
+
+- Logs are local. PEAC records are portable.
+- Traces correlate systems. PEAC records survive organizational boundaries.
+- Auth and payments authorize actions. PEAC records prove what happened.
+
+## Try it in 5 minutes
 
 - Verify a receipt locally with `verifyLocal()` or `pnpm dlx @peac/cli verify`.
 - Start the MCP server: `npx -y @peac/mcp-server`.
 - Run the x402 settlement mapping demo: `pnpm install && pnpm build && pnpm --filter @peac/example-x402-upto-evidence demo`.
-- Open an editor plugin-pack surface under [`surfaces/plugin-pack/`](surfaces/plugin-pack/) (Cursor, Codex, Claude Code, VS Code, Continue, Windsurf, OpenCode).
+- Open an editor plugin-pack under [`surfaces/plugin-pack/`](surfaces/plugin-pack/) (Cursor, Codex, Claude Code, VS Code, Continue, Windsurf, OpenCode).
 - Run the minimal example: `pnpm --filter @peac/example-minimal demo`.
-- Follow the [API Provider Quickstart](docs/guides/quickstart-api-provider.md) or [Agent Operator Quickstart](docs/guides/quickstart-agent-operator.md).
-
-## Choose your path
-
-- **I run an API.** [API Provider Quickstart](docs/guides/quickstart-api-provider.md) with Express middleware.
-- **I run an MCP server.** [MCP Integration Kit](integrator-kits/mcp/README.md) or `npx -y @peac/mcp-server`; editor surfaces under [`surfaces/plugin-pack/`](surfaces/plugin-pack/).
-- **I verify receipts.** [Agent Operator Quickstart](docs/guides/quickstart-agent-operator.md).
-- **I build A2A agents.** [A2A Integration Kit](integrator-kits/a2a/README.md).
-- **I build x402, paymentauth / MPP, ACP, or metered API flows.** [x402](integrator-kits/x402/README.md), [paymentauth](integrator-kits/paymentauth/README.md), [ACP](integrator-kits/acp/README.md); coverage at [`docs/compatibility/commerce-protocol-coverage.md`](docs/compatibility/commerce-protocol-coverage.md).
-- **I operate governed runtimes.** [`@peac/adapter-runtime-governance`](packages/adapters/runtime-governance/) records decisions from managed runtimes (for example Microsoft Agent Governance Toolkit).
-- **I need portable audit evidence.** [Core use-case coverage](docs/compatibility/core-use-case-coverage.md) and [governance mappings](docs/governance/).
-- **I want editor or plugin integration.** Cursor, Codex, Claude Code, VS Code, Continue, Windsurf, and OpenCode under [`surfaces/plugin-pack/`](surfaces/plugin-pack/); canonical [Smithery deployment config](packages/mcp-server/smithery.yaml).
-
-See [`docs/START_HERE.md`](docs/START_HERE.md) for the full decision tree.
-
-## Where PEAC fits
-
-- **Attach signed records to metered or paid API responses** so consumers can verify what was offered, measured, charged, or delivered.
-- **Carry verifiable receipts across MCP and agent workflows** instead of relying on local execution logs.
-- **Preserve evidence for audit, dispute, and reconciliation** across system and organizational boundaries.
-- **Record governance and control-plane decisions** from managed runtimes such as Microsoft Agent Governance Toolkit.
-- **Map commerce and payment events into verifiable records** across x402, paymentauth ([`draft-ryan-httpauth-payment-01`](https://datatracker.ietf.org/doc/draft-ryan-httpauth-payment-01/); MPP), Agentic Commerce Protocol (ACP), and Stripe SPT.
+- Self-host the reference verifier: [`surfaces/reference-verifier/`](surfaces/reference-verifier/).
 
 ## Implementations and surfaces
 
@@ -96,8 +84,9 @@ See [`docs/START_HERE.md`](docs/START_HERE.md) for the full decision tree.
 - **Editor and plugin-pack surfaces** — Cursor, Codex, Claude Code, VS Code, Continue, Windsurf, OpenCode under [`surfaces/plugin-pack/`](surfaces/plugin-pack/); canonical [Smithery config](packages/mcp-server/smithery.yaml).
 - **Express middleware** — [`packages/middleware-express/`](packages/middleware-express/).
 - **Commerce mappings** — [`packages/adapters/x402/`](packages/adapters/x402/) (v1 + v2), [`packages/mappings/paymentauth/`](packages/mappings/paymentauth/) (paymentauth and MPP), [`packages/mappings/acp/`](packages/mappings/acp/) (ACP delegated payment).
-- **Runtime governance** — [`packages/adapters/runtime-governance/`](packages/adapters/runtime-governance/) records from Microsoft Agent Governance Toolkit and other managed runtimes.
+- **Runtime governance** — [`packages/adapters/runtime-governance/`](packages/adapters/runtime-governance/) records observations from managed runtimes including Microsoft Agent Governance Toolkit.
 - **Supply-chain mappings** — [`packages/mappings/intoto/`](packages/mappings/intoto/) and [`packages/mappings/slsa/`](packages/mappings/slsa/).
+- **Reference verifier (self-hostable)** — [`apps/api/`](apps/api/) with deployment recipes under [`surfaces/reference-verifier/`](surfaces/reference-verifier/).
 
 Long tail (A2A, gRPC, DID, managed agents, and more): [`docs/README_LONG.md`](docs/README_LONG.md).
 
@@ -108,11 +97,9 @@ Long tail (A2A, gRPC, DID, managed agents, and more): [`docs/README_LONG.md`](do
 | `/.well-known/peac.txt` | Machine-readable terms                              |
 | `PEAC-Receipt`          | Signed interaction record on governed responses     |
 | `verifyLocal()`         | Offline verification once issuer keys are available |
-| `peac-bundle/0.1`       | Portable audit/dispute package                      |
+| `peac-bundle/0.1`       | Portable audit and dispute package                  |
 
 ## CLI
-
-Use the CLI to verify receipts, run conformance checks, reconcile bundles, validate policy artifacts, and run installability diagnostics without writing integration code first.
 
 ```bash
 # One-off
@@ -121,12 +108,13 @@ pnpm dlx @peac/cli verify 'eyJhbGc...'
 # Installed in your workspace
 pnpm add -D @peac/cli
 pnpm exec peac verify 'eyJhbGc...'
-
-# From this repo
-pnpm --filter @peac/cli exec peac verify 'eyJhbGc...'
 ```
 
-Other commands: `peac conformance run`, `peac reconcile a.bundle b.bundle`, `peac policy init|validate|generate`, `peac doctor`. Full reference: [`packages/cli/README.md`](packages/cli/README.md).
+Other commands: `peac conformance run`, `peac reconcile a.bundle b.bundle`, `peac policy init|validate|generate`, `peac doctor`. Reference: [`packages/cli/README.md`](packages/cli/README.md).
+
+## Protocol boundary
+
+PEAC is the records layer beneath runtime governance. PEAC records what another system attested; it is not a governance toolkit, policy engine, runtime control plane, payment protocol, identity protocol, trust-score system, observability dashboard, or hosted runtime. Full boundary: [`docs/WHERE-IT-FITS.md`](docs/WHERE-IT-FITS.md).
 
 ## Security
 
@@ -140,21 +128,22 @@ See [`SECURITY.md`](.github/SECURITY.md), [`docs/specs/PROTOCOL-BEHAVIOR.md`](do
 
 ## Versioning
 
-- **Current default format:** `interaction-record+jwt`.
-- **Legacy:** `peac-receipt/0.1` is frozen and legacy-only; `verifyLocal()` returns `E_UNSUPPORTED_WIRE_VERSION` on legacy input.
+- **Current default format:** `interaction-record+jwt` (Wire 0.2).
+- **Legacy:** `peac-receipt/0.1` (Wire 0.1) is frozen and legacy-only; `verifyLocal()` returns `E_UNSUPPORTED_WIRE_VERSION` on legacy input.
 
 Full doctrine: [`docs/specs/VERSIONING.md`](docs/specs/VERSIONING.md).
 
 ## Documentation
 
+- [Start Here](docs/START_HERE.md) — path by role.
+- [How it works](docs/HOW-IT-WORKS.md), [Artifacts](docs/ARTIFACTS.md), [Where it fits](docs/WHERE-IT-FITS.md), [What PEAC standardizes](docs/WHAT-PEAC-STANDARDIZES.md).
+- [Solutions](docs/SOLUTIONS/) — five outcome-led recipes.
 - [Spec Index](docs/SPEC_INDEX.md) — normative specifications.
-- [Interaction Record Spec](docs/specs/WIRE-0.2.md) — envelope, kinds, extensions.
-- [Architecture](docs/ARCHITECTURE.md) — kernel-first design.
-- [Developer Guide](docs/README_LONG.md) — package catalog, extended examples.
+- [Developer Guide](docs/README_LONG.md) — package catalog and extended examples.
 
 ## Contributing and license
 
-Contributions are welcome. For substantial changes, please open an issue first. See [`docs/SPEC_INDEX.md`](docs/SPEC_INDEX.md) for normative specifications.
+Contributions are welcome. For substantial changes, please open an issue first.
 
 Apache-2.0. See [`LICENSE`](LICENSE).
 

--- a/docs/ARTIFACTS.md
+++ b/docs/ARTIFACTS.md
@@ -1,0 +1,119 @@
+# PEAC artifacts
+
+PEAC uses several different nouns for related-but-distinct things. This page fixes the vocabulary.
+
+## The short version
+
+| Noun         | Scope                                          | Example                                                         |
+| ------------ | ---------------------------------------------- | --------------------------------------------------------------- |
+| **Record**   | Top-level category term                        | "PEAC is the records layer."                                    |
+| **Receipt**  | Per-action / per-transaction artifact          | The `PEAC-Receipt` header value; one signed interaction.        |
+| **Evidence** | What a record carries (deep architecture)      | "The extension group carries the evidence the issuer attested." |
+| **Bundle**   | A portable collection of records plus metadata | A `peac-bundle/0.1` audit package.                              |
+| **Report**   | Output of verification                         | The DD-210 JSON the reference verifier returns.                 |
+
+Front-door copy leads with **records** as the category term and **receipts** as the per-action noun. Deeper architecture and compliance prose sometimes calls the same substrate the "evidence plane" or "evidence floor"; this is deep-architecture vocabulary, not the top-line category term.
+
+## Record
+
+A **record** is any signed interaction artifact PEAC produces or verifies. It is always a compact JWS with `typ: interaction-record+jwt` in the JOSE header. It is the category noun: "PEAC is the records layer," "portable signed records anyone can verify offline."
+
+A record has a fixed structural shape:
+
+- `iss` — issuer URI (`https://` or `did:`).
+- `iat`, optional `nbf`, optional `exp` — timing.
+- `jti` — record identifier, UUIDv7.
+- `kind` — `evidence` or `challenge`. Two fixed structural kinds.
+- `type` — reverse-DNS or URI (open set). Identifies what the record represents.
+- `pillars` — subset of the ten-pillar closed taxonomy (access, attribution, commerce, consent, compliance, privacy, provenance, safety, identity, purpose).
+- `peac_version` — `"0.2"` for the current default (Wire 0.2).
+- `schema` — `"interaction-record+jwt"`.
+- `ext` — optional typed extension groups keyed by pillar.
+
+Normative shape: [`docs/specs/WIRE-0.2.md`](specs/WIRE-0.2.md).
+
+## Receipt
+
+A **receipt** is a record carried in a specific per-action context. The term is correct in three places:
+
+- The HTTP header name **`PEAC-Receipt`** (and the `PEAC-Receipt-Ref` variant for oversized payloads).
+- Per-interaction artifact examples: a receipt for a single MCP tool call, a receipt for a single API response, a receipt for a single payment observation.
+- Commerce-specific surfaces, where "payment receipt" is the idiomatic term.
+
+Do not globally rename "receipt" to "record." The artifact noun stays.
+
+## Evidence
+
+A **record carries evidence**. The extension group data inside a record is the evidence — the specific claims the issuer attested about what happened.
+
+- **Front-door copy:** lead with "records" (category) and "receipts" (per-action). Only use "evidence" when the sentence subject is the claim the record carries.
+- **Compliance / audit prose:** "portable audit records," "audit trail," "signed audit evidence" are all acceptable translations for regulator-facing material.
+- **Deep architecture / threat model / compliance doctrine:** the same substrate is sometimes called the **evidence plane** or **evidence floor**. This is a deep-architecture term, not the top-line category term. It does not appear on the README, Start Here, examples, listings, or package descriptions.
+
+## Bundle
+
+A **bundle** is a portable collection of records plus the metadata needed to verify them offline at a later time. The current format is `peac-bundle/0.1`.
+
+A bundle typically contains:
+
+- One or more compact JWS records.
+- A JWKS snapshot (the public keys that were current when the records were issued).
+- Optional policy artifacts (the `peac.txt` / `peac-issuer.json` documents that were current).
+- Optional pointer targets fetched and attached by value.
+- A manifest describing the bundle contents.
+
+Use bundles for audit and dispute workflows where a third party needs to verify records days, months, or years after issuance without live access to the issuer's key rotation history.
+
+Spec: [`docs/specs/EVIDENCE-CARRIER-CONTRACT.md`](specs/EVIDENCE-CARRIER-CONTRACT.md).
+
+## Report
+
+A **report** is the deterministic JSON output of a verification call. The reference verifier (`POST /v1/verify`) returns the DD-210 report shape:
+
+```json
+{
+  "verified": true,
+  "receipt_ref": "sha256:abcd...",
+  "claims": { "iss": "...", "kind": "evidence", "type": "...", "pillars": ["..."] },
+  "warnings": [],
+  "policy_binding": "verified",
+  "issuer": "https://...",
+  "kid": "...",
+  "wire_version": "0.2"
+}
+```
+
+Content negotiation on the `Accept` header selects between:
+
+- `application/json` — byte-identical DD-210 report (default).
+- `application/peac-report+json` — extended report with `report_id`, `verified_at`, `duration_ms`, `key_resolution`, and `failure_reasons`.
+- `text/plain` — human-readable summary.
+
+On error the reference verifier returns RFC 9457 Problem Details (`application/problem+json`) with PEAC extensions (`peac_error_code`, `peac_trace_id`).
+
+Contract: [`packages/schema/openapi/verify.yaml`](../packages/schema/openapi/verify.yaml).
+
+## Lifecycle example
+
+A single API call produces one record, which travels as a receipt, which can later be collected into a bundle, which a third party verifies and receives a report about:
+
+```text
+ HTTP request to /api/v1/resource
+     |
+     v
+ issue()                      --> record (compact JWS, typ: interaction-record+jwt)
+     |
+     v
+ PEAC-Receipt response header --> receipt (carried per-action)
+     |
+     v
+ accumulate many receipts
+     |
+     v
+ peac-bundle/0.1              --> bundle (portable audit package)
+     |
+     v
+ POST /v1/verify              --> report (DD-210 JSON, per record)
+```
+
+Each of those four words has one specific meaning. Mixing them up loses information.

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -89,11 +89,11 @@ No Layer 4 surface in v0.12.12 is `live-upstream-tested`: no CI step exercises a
 
 Each tag below points at the conformance vectors and test paths that justify the classification in the row above.
 
-- **[e1]** Per-mapper conformance vectors under [`specs/conformance/`](../specs/conformance/) and package `__tests__` suites. Exercised under `pnpm test`; no network.
-- **[e2]** [`specs/conformance/runtime-governance/`](../specs/conformance/runtime-governance/) (RTGOV-001..RTGOV-007, Section 27) plus `packages/adapters/runtime-governance/__tests__/`.
-- **[e3]** [`specs/conformance/managed-agents/`](../specs/conformance/managed-agents/) event-family vectors plus `packages/adapters/managed-agents/__tests__/`.
-- **[e4]** Commerce evidence vectors for ACP / MPP / x402 under [`specs/conformance/commerce/`](../specs/conformance/commerce/) (Section 26) plus per-mapper `__tests__/` suites; the `assertExplicitFinality` boundary is asserted in `packages/adapters/core/__tests__/`.
-- **[e5]** Type-definition coverage only: TypeScript declaration file(s) in the package `src/` compile under the workspace typecheck. No runtime assertion exists beyond the declaration shape.
+- **[e1]** Conformance fixtures under [`specs/conformance/fixtures/`](../specs/conformance/fixtures/) (per-surface subdirectories: `interaction/`, `carrier/`, `carrier-boundary/`, `content-usage/`, `discovery/`, `x402/`, `paymentauth/`, `acp/`, `ucp/`, `stripe/`, `attribution/`, `purpose/`, `obligations/`, `policy/`, `workflow/`) plus each package's `tests/` suite. Exercised under `pnpm test`; no network.
+- **[e2]** RTGOV-001..RTGOV-007 requirement IDs declared in [`specs/conformance/requirement-ids.json`](../specs/conformance/requirement-ids.json) (Section 27) plus [`packages/adapters/runtime-governance/tests/`](../packages/adapters/runtime-governance/tests/) (families, fixtures, guards, issue, mappers).
+- **[e3]** [`packages/adapters/managed-agents/tests/`](../packages/adapters/managed-agents/tests/) covering event families, issue-event, and session-summary, built on upstream-event fixtures checked into that package's test tree.
+- **[e4]** Commerce evidence vectors C-001..C-010 under [`specs/conformance/commerce/`](../specs/conformance/commerce/) plus per-mapper test suites at [`packages/adapters/x402/tests/`](../packages/adapters/x402/tests/), [`packages/mappings/acp/tests/`](../packages/mappings/acp/tests/), and [`packages/mappings/paymentauth/tests/`](../packages/mappings/paymentauth/tests/). The `assertExplicitFinality` boundary is asserted in [`packages/adapters/core/tests/finality.test.ts`](../packages/adapters/core/tests/finality.test.ts) and [`packages/adapters/core/tests/finality-fixtures.test.ts`](../packages/adapters/core/tests/finality-fixtures.test.ts).
+- **[e5]** Type-definition coverage only: TypeScript declaration file(s) in the package `src/` compile under the workspace typecheck (`pnpm typecheck:core`). No runtime assertion exists beyond the declaration shape.
 
 ## Performance Targets
 

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -1,0 +1,128 @@
+# How PEAC works
+
+PEAC is a records layer. You **publish** terms, you **issue** signed records when something happens, another party **verifies** them offline, and the records **travel** across boundaries as portable proof.
+
+The whole protocol is a four-step loop. Most integrations only touch one or two steps directly.
+
+```text
+                               +---------------------------+
+                               |    1. Publish             |
+                               |    /.well-known/peac.txt  |
+                               |    peac-issuer.json       |
+                               |    JWKS (jwks.json)       |
+                               +---------------------------+
+                                            |
+                                            v
+                               +---------------------------+
+                               |    2. Issue               |
+                               |    issue()                |
+                               |    returns compact JWS    |
+                               |    typ: interaction-      |
+                               |         record+jwt        |
+                               +---------------------------+
+                                            |
+                                            v
+                               +---------------------------+
+                               |    3. Verify              |
+                               |    verifyLocal()          |
+                               |    offline                |
+                               |    (or /v1/verify)        |
+                               +---------------------------+
+                                            |
+                                            v
+                               +---------------------------+
+                               |    4. Export / share      |
+                               |    PEAC-Receipt header    |
+                               |    MCP _meta carrier      |
+                               |    A2A metadata carrier   |
+                               |    peac-bundle/0.1        |
+                               +---------------------------+
+```
+
+## 1. Publish
+
+An issuer publishes three machine-readable documents:
+
+- **`/.well-known/peac.txt`** — the policy discovery surface. Human-readable terms, pointer to the issuer config, supported payment rails.
+- **`/.well-known/peac-issuer.json`** — the issuer config. Points at the issuer's JWKS URI (for example `jwks_uri: https://issuer.example.com/.well-known/jwks.json`) and declares supported algorithms.
+- **JWKS (`jwks.json`)** — the public keys used to sign receipts. Rotated over time with `kid` identifiers.
+
+Specs: [`docs/specs/PEAC-TXT.md`](specs/PEAC-TXT.md), [`docs/specs/PEAC-ISSUER.md`](specs/PEAC-ISSUER.md). The well-known URLs follow RFC 8615.
+
+## 2. Issue
+
+When something happens that another party will need to verify, the issuer creates a signed record:
+
+```typescript
+import { issue } from '@peac/protocol';
+
+const jws = await issue(
+  {
+    iss: 'https://api.example.com',
+    kind: 'evidence',
+    type: 'org.peacprotocol/api-receipt',
+    pillars: ['access'],
+    ext: { access: { path: '/api/v1/resource', method: 'GET', status: 200 } },
+  },
+  privateKey
+);
+```
+
+The output is a compact JWS string (three base64url parts separated by dots). The JOSE header carries `typ: interaction-record+jwt`, `alg: EdDSA`, and `kid` pointing at the key in the issuer's JWKS. The payload carries the claims: `iss`, `kind`, `type`, `pillars`, `iat`, `jti`, optional extensions, optional policy binding.
+
+**Key point:** the `receipt` is a compact JWS. The JOSE `typ` is `interaction-record+jwt`. The HTTP body that carries the receipt is `application/json` (or the `PEAC-Receipt` HTTP header). Do not confuse the JWS `typ` with an HTTP media type.
+
+## 3. Verify
+
+Any party with the issuer's public key can verify the record offline — no call back to the issuer required.
+
+```typescript
+import { verifyLocal } from '@peac/protocol';
+
+const result = await verifyLocal(jws, publicKey, {
+  issuer: 'https://api.example.com',
+});
+
+if (result.valid) {
+  console.log(result.claims.type, result.claims.ext);
+}
+```
+
+Under the hood, `verifyLocal()` checks:
+
+1. JOSE header hardening (no embedded keys, no `crit`, no `zip`, algorithm is Ed25519).
+2. Signature validity against the provided public key.
+3. Kernel constraints (size caps, pointer depth, canonical form).
+4. Schema validity (Wire 0.2 claims shape, extension groups, pillar taxonomy).
+5. Policy binding (if `peac.policy` is present, three-state: `verified` / `failed` / `unavailable`).
+6. Timing bounds (`iat` / `nbf` / `exp` within configured clock skew).
+
+For the hosted path, `POST /v1/verify` on the reference verifier returns the same deterministic report (DD-210 shape). See [`packages/schema/openapi/verify.yaml`](../packages/schema/openapi/verify.yaml).
+
+## 4. Export and share
+
+Records travel in several carriers depending on the surface:
+
+- **HTTP**: the `PEAC-Receipt` response header carries a compact JWS (up to 8 KiB in the header; larger records use `PEAC-Receipt-Ref` pointing at a fetchable resource).
+- **MCP**: the tool-call response `_meta` field carries `org.peacprotocol/receipt_jws` and `org.peacprotocol/receipt_ref` (up to 64 KiB embed).
+- **A2A**: the `metadata[extensionURI].carriers[]` array carries receipt records across Agent-to-Agent flows.
+- **Bundles**: `peac-bundle/0.1` packages multiple receipts, JWKS snapshots, and policy artifacts into a portable audit file. See [`docs/specs/EVIDENCE-CARRIER-CONTRACT.md`](specs/EVIDENCE-CARRIER-CONTRACT.md).
+- **Reports**: the reference verifier returns the deterministic DD-210 verification report; the extended `application/peac-report+json` shape adds timing, report ID, and failure reasons.
+
+## Kinds and types
+
+A record's `kind` is one of two fixed structural values — `evidence` (records what happened) or `challenge` (requests proof from a peer). A record's `type` is an open reverse-DNS or URI identifier for **what** the record represents (for example `org.peacprotocol/payment`, `org.peacprotocol/mcp-tool-call`, `org.peacprotocol/api-receipt`). Extensions are typed data groups organized by pillar (access, attribution, commerce, consent, compliance, privacy, provenance, safety, identity, purpose).
+
+Normative detail: [`docs/specs/WIRE-0.2.md`](specs/WIRE-0.2.md) and [`docs/specs/PROTOCOL-BEHAVIOR.md`](specs/PROTOCOL-BEHAVIOR.md).
+
+## What PEAC does not do in this loop
+
+PEAC records what another system attested. It does not:
+
+- Decide whether an action is allowed or denied.
+- Orchestrate agents, workflows, or commands.
+- Settle payments or custody funds.
+- Issue identity credentials or manage keys beyond the signing path.
+- Host dashboards or telemetry backends.
+
+See [`docs/WHERE-IT-FITS.md`](WHERE-IT-FITS.md) for the boundary next to adjacent systems and [`docs/WHAT-PEAC-STANDARDIZES.md`](WHAT-PEAC-STANDARDIZES.md) for what the protocol defines.

--- a/docs/MIGRATION_CURRENT.md
+++ b/docs/MIGRATION_CURRENT.md
@@ -2,6 +2,20 @@
 
 This guide covers migration paths for current PEAC Protocol surfaces.
 
+## Documentation reorganization (v0.12.12)
+
+The documentation surface has been reorganized around five new operator-facing docs and a curated solutions library. If you previously linked to sections of the monolithic developer guide, the following map applies:
+
+- The **role-based entry point** is now [`docs/START_HERE.md`](START_HERE.md). It is the single top-level job selector; the README points to it first.
+- **How PEAC works** (the publish / issue / verify / share loop and the distinction between the compact JWS `receipt`, the JOSE `typ`, and the HTTP body) is now at [`docs/HOW-IT-WORKS.md`](HOW-IT-WORKS.md).
+- **The artifact taxonomy** (record, receipt, evidence, bundle, report) is now at [`docs/ARTIFACTS.md`](ARTIFACTS.md). These nouns each have one specific meaning; mixing them up loses information.
+- **Where PEAC sits next to adjacent systems** (logs / traces / OpenTelemetry, runtime governance, payment rails, identity, native runtime attestations) is now at [`docs/WHERE-IT-FITS.md`](WHERE-IT-FITS.md).
+- **Protocol scope and boundary** are summarized at [`docs/WHAT-PEAC-STANDARDIZES.md`](WHAT-PEAC-STANDARDIZES.md).
+- **Outcome-led recipes** live under [`docs/SOLUTIONS/`](SOLUTIONS/): runtime evidence export, API receipt issuance, MCP tool-call receipts, commerce evidence bundle, and regulatory audit trail.
+- **Self-host deployment recipes** for the reference verifier live under [`surfaces/reference-verifier/`](../surfaces/reference-verifier/): Dockerfile, docker-compose, a Cloudflare Worker variant, and a smoke script.
+
+The long-form developer guide at [`docs/README_LONG.md`](README_LONG.md) is retained as the deep package catalog for contributors. It is no longer the recommended starting point for first-time readers.
+
 ## From Wire 0.1 to Wire 0.2
 
 Wire 0.1 (`peac-receipt/0.1`) is frozen legacy. Wire 0.2 (`interaction-record+jwt`) is the current stable format.

--- a/docs/README_LONG.md
+++ b/docs/README_LONG.md
@@ -1,5 +1,7 @@
 # PEAC Protocol Developer Guide
 
+> **Deep reference for package authors and integrators.** If you are new to PEAC, start at [`docs/START_HERE.md`](START_HERE.md) for the role-based job selector, then see [`docs/HOW-IT-WORKS.md`](HOW-IT-WORKS.md), [`docs/ARTIFACTS.md`](ARTIFACTS.md), [`docs/WHERE-IT-FITS.md`](WHERE-IT-FITS.md), and [`docs/WHAT-PEAC-STANDARDIZES.md`](WHAT-PEAC-STANDARDIZES.md) for the operator mental model. Outcome-led recipes under [`docs/SOLUTIONS/`](SOLUTIONS/). This document is a full package catalog and protocol-surface tour for contributors who need the long-tail detail.
+
 Integration examples, package catalog, protocol surfaces, and repo navigation. For a concise overview, see the [main README](../README.md).
 
 ---

--- a/docs/SOLUTIONS/README.md
+++ b/docs/SOLUTIONS/README.md
@@ -1,0 +1,21 @@
+# Solutions
+
+Outcome-led recipes. Each one states the real-world problem, the PEAC pieces you'll use, and a step-by-step path from a clean clone to a verified record.
+
+| Recipe                                                  | Outcome                                                                                                | Audience                    |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | --------------------------- |
+| [Runtime evidence export](runtime-evidence-export.md)   | Export portable evidence from a managed agent runtime for compliance and audit.                        | Runtime / platform operator |
+| [API receipt issuance](api-receipt-issuance.md)         | Issue signed receipts on every HTTP response with Express middleware.                                  | API provider                |
+| [MCP tool-call receipts](mcp-tool-call-receipts.md)     | Attach signed records to MCP tool-call responses.                                                      | MCP server operator         |
+| [Commerce evidence bundle](commerce-evidence-bundle.md) | Bundle observational evidence across x402, ACP, and paymentauth without synthesizing payment finality. | Agentic commerce operator   |
+| [Regulatory audit trail](regulatory-audit-trail.md)     | Build a portable, signed audit trail for EU AI Act, NIST AI RMF, and ISO 42001 review.                 | Compliance / audit lead     |
+
+Each recipe follows the same structure:
+
+1. **The problem** — what real situation this addresses, in plain language.
+2. **What you'll use** — packages, optional adjacent systems, prerequisites.
+3. **Step-by-step** — numbered commands and code.
+4. **Evidence of output** — what the receipt or report looks like.
+5. **Where to go from here** — deeper specs, compatibility rows, integrator kits.
+
+Every recipe preserves PEAC's boundary: PEAC carries signed records of what another system attested. It does not execute, orchestrate, evaluate, approve, enforce, or determine payment finality. Future releases will add carrier breadth for CLI execution evidence and observational lifecycle records emitted by other systems; that carrier work does not change the boundary.

--- a/docs/SOLUTIONS/api-receipt-issuance.md
+++ b/docs/SOLUTIONS/api-receipt-issuance.md
@@ -1,0 +1,138 @@
+# API receipt issuance
+
+> **Outcome:** Your HTTP API emits signed receipts on every response so consumers can verify what terms applied and what happened — offline, with just your public key.
+>
+> **Audience:** API provider.
+>
+> **Time:** About 5 minutes from a clean clone.
+
+## The problem
+
+An API operator wants to add portable proof to every response. Consumers may be paying partners, downstream services, auditors, or agents acting on behalf of users. Local logs are not enough — the other party needs a signed record that survives your log retention and can be checked without calling back to your service.
+
+PEAC issues a compact JWS on every response, carried in the `PEAC-Receipt` HTTP header. The signature lets anyone with your public key verify offline.
+
+## What you'll use
+
+PEAC packages:
+
+- `@peac/middleware-express` — Express middleware that issues records on each response.
+- `@peac/protocol` — issuance and offline verification.
+- `@peac/crypto` — Ed25519 signing.
+
+Optional adjacent systems: any HTTP server (Express shown; Hono / Koa / Fastify adapters exist). Any signing-key custody option (in-process key, KMS, HSM) works as long as it implements the signing callback.
+
+Prerequisites: Node 22+, pnpm 8+, Express.
+
+## Step-by-step
+
+1. Install dependencies:
+
+   ```bash
+   pnpm add @peac/middleware-express @peac/protocol @peac/crypto
+   ```
+
+2. Create an Ed25519 keypair and publish the public key at `/.well-known/peac-issuer.json` + JWKS (`/.well-known/jwks.json`). A minimal harness:
+
+   ```typescript
+   import { generateKeypair } from '@peac/crypto';
+
+   const { privateKey, publicKey, kid } = await generateKeypair();
+   ```
+
+3. Wire the middleware into your Express app:
+
+   ```typescript
+   import express from 'express';
+   import { peacIssue } from '@peac/middleware-express';
+
+   const app = express();
+
+   app.use(
+     peacIssue({
+       issuer: 'https://api.example.com',
+       privateKey,
+       kid,
+       // Map each response into a claim payload.
+       claimsFromResponse: (req, res) => ({
+         kind: 'evidence',
+         type: 'org.peacprotocol/api-receipt',
+         pillars: ['access'],
+         ext: {
+           access: {
+             path: req.path,
+             method: req.method,
+             status: res.statusCode,
+           },
+         },
+       }),
+     })
+   );
+
+   app.get('/api/v1/resource', (req, res) => {
+     res.json({ ok: true });
+   });
+   ```
+
+4. Inspect a response:
+
+   ```bash
+   curl -i https://api.example.com/api/v1/resource
+   # ...
+   # PEAC-Receipt: eyJhbGciOiJFZERTQSIsInR5cCI6ImludGVyYWN0aW9uLXJlY29yZCtqd3QifQ...
+   # Link: </.well-known/peac-issuer.json>; rel="issuer"
+   ```
+
+5. Verify the record offline from any consumer:
+
+   ```typescript
+   import { verifyLocal } from '@peac/protocol';
+
+   const result = await verifyLocal(receiptHeader, publicKey, {
+     issuer: 'https://api.example.com',
+   });
+   console.log(result.valid, result.claims.type, result.claims.ext.access);
+   ```
+
+## Evidence of output
+
+A decoded record payload for an authorized GET looks like this:
+
+```json
+{
+  "iss": "https://api.example.com",
+  "iat": 1781609600,
+  "jti": "019676d0-0000-7000-8000-000000000000",
+  "kind": "evidence",
+  "type": "org.peacprotocol/api-receipt",
+  "pillars": ["access"],
+  "peac_version": "0.2",
+  "schema": "interaction-record+jwt",
+  "ext": {
+    "access": {
+      "path": "/api/v1/resource",
+      "method": "GET",
+      "status": 200
+    }
+  }
+}
+```
+
+The JOSE header carries `typ: interaction-record+jwt`, `alg: EdDSA`, and `kid` for the signing key. The HTTP response body remains whatever your handler returned; the `receipt` is additive on the response.
+
+## Validated with
+
+```bash
+pnpm install && pnpm build
+pnpm --filter @peac/middleware-express test
+pnpm --filter @peac/example-hello-world demo
+```
+
+The `@peac/middleware-express` test suite exercises the issue-on-response path; `examples/hello-world` issues a record and verifies it offline in the same script.
+
+## Where to go from here
+
+- [API Provider Quickstart](../guides/quickstart-api-provider.md) — the five-minute walkthrough with full source.
+- [`packages/middleware-express/`](../../packages/middleware-express/) — middleware reference.
+- [`docs/specs/PROTOCOL-BEHAVIOR.md`](../specs/PROTOCOL-BEHAVIOR.md) — normative issuance and verification behavior.
+- [`docs/compatibility/COMPATIBILITY_MATRIX.md`](../COMPATIBILITY_MATRIX.md) — Adapter Readiness for `@peac/middleware-express` and `@peac/protocol`.

--- a/docs/SOLUTIONS/commerce-evidence-bundle.md
+++ b/docs/SOLUTIONS/commerce-evidence-bundle.md
@@ -1,0 +1,154 @@
+# Commerce evidence bundle
+
+> **Outcome:** Build a portable, signed bundle of commerce observations across x402, ACP, and paymentauth / MPP so auditors, counterparties, or downstream settlement systems can verify what each rail attested — without PEAC synthesizing payment finality.
+>
+> **Audience:** Agentic commerce operator.
+>
+> **Time:** About 10 minutes from a clean clone.
+
+## The problem
+
+A single agentic commerce flow may cross several systems: an x402 offer and settlement proof, an ACP delegated-payment session, a paymentauth / MPP payment-attempt and settlement, maybe a Stripe SPT observation. Each system emits its own attestation. An auditor, counterparty, or downstream reconciler needs the **observations** in a portable, signed, verifiable form — and specifically does **not** want a PEAC record that claims finality the upstream never attested.
+
+PEAC adapters carry each rail's attestations verbatim. A bundle composes the observations into a portable audit package. A mapper-boundary guard (`assertExplicitFinality`) refuses to emit commerce records that would synthesize payment finality from non-payment artifacts.
+
+## What you'll use
+
+PEAC packages:
+
+- `@peac/adapter-core` — mapper-boundary finality guard (`assertExplicitFinality`, `MapperBoundaryError`).
+- `@peac/adapter-x402` — x402 v1 and v2 settlement-proof extractor (dual-header precedence `PEAC-Receipt` > `PAYMENT-RESPONSE` > `X-PAYMENT-RESPONSE`).
+- `@peac/mappings-acp` — ACP delegated-payment observation mapper (`artifact_kind` discriminator).
+- `@peac/mappings-paymentauth` — paymentauth / MPP payment-attempt and settlement mappers.
+- `@peac/protocol` — issuance and offline verification.
+- `@peac/audit` — bundle builder.
+
+Prerequisites: Node 22+, pnpm 8+. The shipped conformance fixtures cover positive and negative vectors for each rail; no external rail is required to exercise this recipe.
+
+## Step-by-step
+
+1. Install dependencies:
+
+   ```bash
+   pnpm add @peac/adapter-core @peac/adapter-x402 @peac/mappings-acp @peac/mappings-paymentauth @peac/protocol @peac/audit
+   ```
+
+2. Map each rail's observation into a PEAC record. Each mapper preserves the upstream artifact verbatim under `upstream_artifact` and labels the observed state with the rail's own closed enum:
+
+   ```typescript
+   import { fromX402SettlementObservation } from '@peac/adapter-x402';
+   import { fromACPDelegatedPaymentObservation } from '@peac/mappings-acp';
+   import { fromMPPSettlement } from '@peac/mappings-paymentauth';
+   import { issue } from '@peac/protocol';
+
+   const x402Claims = fromX402SettlementObservation(x402Response, {
+     issuer: 'https://commerce.example.com',
+   });
+   const acpClaims = fromACPDelegatedPaymentObservation(acpEvent, {
+     issuer: 'https://commerce.example.com',
+   });
+   const mppClaims = fromMPPSettlement(mppSettlementArtifact, {
+     issuer: 'https://commerce.example.com',
+   });
+
+   const x402Jws = await issue(x402Claims, privateKey);
+   const acpJws = await issue(acpClaims, privateKey);
+   const mppJws = await issue(mppClaims, privateKey);
+   ```
+
+3. Attempt a finality synthesis and watch the guard refuse it:
+
+   ```typescript
+   import { assertExplicitFinality, MapperBoundaryError } from '@peac/adapter-core';
+
+   try {
+     // Non-payment artifact trying to claim settled state.
+     assertExplicitFinality(acpClaims.ext.commerce, {
+       artifact_kind: 'session_lifecycle',
+       attempted_event: 'settled',
+     });
+   } catch (err) {
+     if (err instanceof MapperBoundaryError) {
+       console.log(err.code); // 'commerce.finality_synthesis_blocked'
+     }
+   }
+   ```
+
+4. Build a bundle from the three records:
+
+   ```typescript
+   import { buildBundle } from '@peac/audit';
+
+   const bundle = await buildBundle({
+     records: [x402Jws, acpJws, mppJws],
+     jwks_snapshot: currentJwksDocument,
+     policy: { uri: 'https://commerce.example.com/policies/default' },
+   });
+
+   // Write the portable audit package.
+   await writeFile('commerce-evidence.peac-bundle', bundle.bytes);
+   ```
+
+5. Verify each record in the bundle offline:
+
+   ```typescript
+   import { verifyLocal } from '@peac/protocol';
+   import { openBundle } from '@peac/audit';
+
+   const open = await openBundle(bundle.bytes);
+   for (const record of open.records) {
+     const result = await verifyLocal(record, open.jwks, {
+       issuer: 'https://commerce.example.com',
+     });
+     console.log(result.valid, result.claims.type, result.claims.ext.commerce?.observed_state);
+   }
+   ```
+
+## Evidence of output
+
+A decoded x402 settlement-observation record carries the upstream artifact verbatim and the observed state from the x402 closed enum (never synthesized):
+
+```json
+{
+  "iss": "https://commerce.example.com",
+  "iat": 1781609600,
+  "kind": "evidence",
+  "type": "org.peacprotocol/x402-settlement",
+  "pillars": ["commerce"],
+  "peac_version": "0.2",
+  "schema": "interaction-record+jwt",
+  "ext": {
+    "commerce": {
+      "rail": "x402",
+      "observed_state": "settled",
+      "upstream_artifact_ref": "sha256:...",
+      "scheme": "...",
+      "settlement_proof": "..."
+    }
+  }
+}
+```
+
+An ACP delegated-payment session record carries `artifact_kind: "session_lifecycle"` and an ACP-scoped `observed_payment_state` from the ACP closed enum. It does NOT say "settled" unless the upstream ACP artifact explicitly attested settlement. An attempted finality synthesis raises `MapperBoundaryError` with code `commerce.finality_synthesis_blocked`.
+
+## Validated with
+
+```bash
+pnpm install && pnpm build
+pnpm verify:examples-commerce
+pnpm --filter @peac/adapter-core test
+pnpm --filter @peac/adapter-x402 test
+pnpm --filter @peac/mappings-acp test
+pnpm --filter @peac/mappings-paymentauth test
+```
+
+The `verify:examples-commerce` workspace script runs the shipped commerce examples (`paymentauth-evidence`, `paymentauth-jsonrpc`, `acp-session-lifecycle`, `stripe-spt-evidence`, `commerce-evidence-bundle`, `x402-dual-header-read`) build-and-demo. The `@peac/adapter-core` test suite exercises `assertExplicitFinality` / `MapperBoundaryError` with representative synthesis-blocking vectors.
+
+## Where to go from here
+
+- [`docs/compatibility/commerce-protocol-coverage.md`](../compatibility/commerce-protocol-coverage.md) — x402 v1 / v2 Stable, MPP Experimental, ACP Beta.
+- [`docs/profiles/acp-delegated-payment.md`](../profiles/acp-delegated-payment.md) — ACP profile.
+- [`docs/profiles/mpp-payment-evidence.md`](../profiles/mpp-payment-evidence.md) — MPP profile.
+- [`docs/specs/X402-V2-PROFILE.md`](../specs/X402-V2-PROFILE.md) — x402 v2 profile (see §8 dual-header precedence).
+- [`docs/WHERE-IT-FITS.md`](../WHERE-IT-FITS.md) — PEAC vs payment rails boundary.
+- [Examples `commerce-evidence-bundle`, `acp-delegated-checkout`, `mpp-payment-attempt`, `x402-upto-evidence`](../../examples/) — runnable per-rail demos.

--- a/docs/SOLUTIONS/mcp-tool-call-receipts.md
+++ b/docs/SOLUTIONS/mcp-tool-call-receipts.md
@@ -1,0 +1,122 @@
+# MCP tool-call receipts
+
+> **Outcome:** Your MCP server emits a signed record for every tool call so downstream agents, auditors, or counterparties can verify what tool ran, what arguments were used, and what the result was — offline, with just your public key.
+>
+> **Audience:** MCP server operator.
+>
+> **Time:** About 5 minutes from a clean clone.
+
+## The problem
+
+An MCP server hosts tools that agents call. When the tool executes, the MCP client has local state for the call; another party in the chain has nothing. For paid tools, audit-relevant tools, or tools that produce durable artifacts, a portable signed record of the call is the only way to carry provenance across boundaries.
+
+PEAC attaches a signed record to the MCP tool-call response via the `_meta` carrier keys `org.peacprotocol/receipt_jws` and `org.peacprotocol/receipt_ref` (up to 64 KiB embed per the Evidence Carrier Contract).
+
+## What you'll use
+
+PEAC packages:
+
+- `@peac/mcp-server` — MCP server with built-in evidence tools (`verify`, `inspect`, `issue`, `bundle`).
+- `@peac/mappings-mcp` — MCP `_meta` carrier mapping.
+- `@peac/protocol` — issuance and offline verification.
+- `@peac/crypto` — Ed25519 signing.
+
+Prerequisites: Node 22+, pnpm 8+. An MCP client to call the server (the shipped examples use the MCP SDK stdio transport).
+
+## Step-by-step
+
+1. Install dependencies:
+
+   ```bash
+   pnpm add @peac/mcp-server @peac/mappings-mcp @peac/protocol @peac/crypto
+   ```
+
+2. Start the server for local exploration:
+
+   ```bash
+   npx -y @peac/mcp-server --help
+   ```
+
+3. Attach a record to a tool response from your own server. The mapping helper writes the record into `_meta` per the Evidence Carrier Contract:
+
+   ```typescript
+   import { issue } from '@peac/protocol';
+   import { toMcpMeta } from '@peac/mappings-mcp';
+
+   async function handleToolCall(toolName, args, ctx) {
+     const result = await runTool(toolName, args);
+
+     const jws = await issue(
+       {
+         iss: 'https://mcp.example.com',
+         kind: 'evidence',
+         type: 'org.peacprotocol/mcp-tool-call',
+         pillars: ['attribution'],
+         ext: {
+           attribution: { tool: toolName, arguments_digest: digestOf(args) },
+         },
+       },
+       ctx.privateKey
+     );
+
+     return {
+       content: result.content,
+       _meta: toMcpMeta({ receipt_jws: jws }),
+     };
+   }
+   ```
+
+4. Verify the record from the MCP client:
+
+   ```typescript
+   import { fromMcpMeta } from '@peac/mappings-mcp';
+   import { verifyLocal } from '@peac/protocol';
+
+   const { receipt_jws } = fromMcpMeta(response._meta);
+   const result = await verifyLocal(receipt_jws, publicKey, {
+     issuer: 'https://mcp.example.com',
+   });
+   console.log(result.valid, result.claims.type, result.claims.ext.attribution);
+   ```
+
+5. Explore a runnable example:
+
+   ```bash
+   pnpm install && pnpm build
+   cd examples/mcp-tool-call && pnpm demo
+   ```
+
+## Evidence of output
+
+A tool-call response carrying a PEAC record looks like this (MCP content + `_meta`):
+
+```json
+{
+  "content": [{ "type": "text", "text": "Tool executed. Result attached." }],
+  "_meta": {
+    "org.peacprotocol/receipt_jws": "eyJhbGciOiJFZERTQSIsInR5cCI6ImludGVyYWN0aW9uLXJlY29yZCtqd3QifQ...",
+    "org.peacprotocol/receipt_ref": "sha256:abcd..."
+  }
+}
+```
+
+Decoded, the record carries the `kind: evidence` / `type: org.peacprotocol/mcp-tool-call` shape with an `attribution` extension group referencing the tool name and a digest of the arguments. The MCP server ran the tool; PEAC recorded what happened.
+
+## Validated with
+
+```bash
+pnpm install && pnpm build
+pnpm --filter @peac/mcp-server test
+pnpm --filter @peac/mappings-mcp test
+pnpm --filter @peac/example-mcp-tool-call demo
+```
+
+The MCP server and mapping test suites cover the `_meta` carrier path; `examples/mcp-tool-call` exercises the paid-tool flow end-to-end.
+
+## Where to go from here
+
+- [MCP Integration Kit](../../integrator-kits/mcp/README.md) — full MCP setup guide.
+- [`packages/mcp-server/`](../../packages/mcp-server/) — server reference (5 evidence tools).
+- [`packages/mappings/mcp/`](../../packages/mappings/mcp/) — `_meta` carrier mapping reference.
+- [`docs/specs/EVIDENCE-CARRIER-CONTRACT.md`](../specs/EVIDENCE-CARRIER-CONTRACT.md) — MCP / A2A / UCP carrier budgets and key names.
+- [`docs/compatibility/COMPATIBILITY_MATRIX.md`](../COMPATIBILITY_MATRIX.md) — Adapter Readiness for `@peac/mcp-server` and `@peac/mappings-mcp`.

--- a/docs/SOLUTIONS/regulatory-audit-trail.md
+++ b/docs/SOLUTIONS/regulatory-audit-trail.md
@@ -1,0 +1,172 @@
+# Regulatory audit trail
+
+> **Outcome:** Build a portable, signed audit trail suitable for EU AI Act Annex IV review, NIST AI RMF mapping, and ISO 42001 Clause 8 interaction logging. Records carry the policy, config, and runtime observations that auditors consistently ask for, and survive organizational boundaries.
+>
+> **Audience:** Compliance / audit lead, or platform operator preparing for audit.
+>
+> **Time:** About 15 minutes from a clean clone.
+
+## The problem
+
+Compliance reviewers under EU AI Act Annex IV, NIST AI RMF, and ISO 42001 Clause 8 ask for evidence that an AI system's interactions were logged, that the policy in force at the time is identifiable, and that the audit trail can be produced later without depending on the original runtime still being online. Local logs do not satisfy those three properties at once.
+
+PEAC records carry policy digests, config digests, and runtime observations in a single signed artifact. A bundle preserves the records plus the JWKS snapshot needed to verify them offline months or years later.
+
+## What you'll use
+
+PEAC packages:
+
+- `@peac/protocol` — issuance and offline verification, with three-state policy binding (`verified` / `failed` / `unavailable`).
+- `@peac/adapter-runtime-governance` — runtime-governance observation mapper.
+- `@peac/audit` — bundle builder and reconciliation tooling.
+- `@peac/cli` — `peac conformance run`, `peac reconcile`.
+
+Optional adjacent systems: a policy store (URI + version + digest), a config store (URI + digest), an identity layer (DID or HTTPS issuer). Any runtime that already emits decision events feeds this trail via the adapter layer.
+
+Prerequisites: Node 22+, pnpm 8+.
+
+## Step-by-step
+
+1. Install dependencies:
+
+   ```bash
+   pnpm add @peac/protocol @peac/adapter-runtime-governance @peac/audit
+   ```
+
+2. Bind every record to the policy and config in force at the time. The policy-binding check returns a three-state result that auditors can trace:
+
+   ```typescript
+   import { issue, computePolicyDigestJcs, checkPolicyBinding } from '@peac/protocol';
+
+   const policyDoc = await fetchPolicyDocument();
+   const policyDigest = computePolicyDigestJcs(policyDoc);
+
+   const jws = await issue(
+     {
+       iss: 'https://runtime.example.com',
+       kind: 'evidence',
+       type: 'org.peacprotocol/runtime-governance/decision',
+       pillars: ['compliance', 'safety'],
+       peac: {
+         policy: {
+           uri: policyDoc.uri,
+           version: policyDoc.version,
+           digest: policyDigest,
+         },
+       },
+       ext: {
+         runtime_governance: {
+           decision: 'allow',
+           policy_ref: policyDoc.uri,
+           config_digest: configDigest,
+           upstream_artifact_ref: 'sha256:...',
+         },
+       },
+     },
+     privateKey
+   );
+   ```
+
+3. Verify a record with policy binding. The verifier reports a three-state policy-binding result auditors can point at:
+
+   ```typescript
+   import { verifyLocal } from '@peac/protocol';
+
+   const result = await verifyLocal(jws, publicKey, {
+     issuer: 'https://runtime.example.com',
+     policy: policyDoc,
+   });
+
+   console.log(result.valid, result.policy_binding);
+   // policy_binding: "verified" | "failed" | "unavailable"
+   ```
+
+4. Build a long-lived audit bundle that includes the JWKS snapshot:
+
+   ```typescript
+   import { buildBundle } from '@peac/audit';
+
+   const bundle = await buildBundle({
+     records: allRecords,
+     jwks_snapshot: currentJwksDocument,
+     policy: { uri: policyDoc.uri, version: policyDoc.version, digest: policyDigest },
+     captured_at: new Date().toISOString(),
+   });
+
+   await writeFile(`audit-${quarter}.peac-bundle`, bundle.bytes);
+   ```
+
+5. Re-verify the bundle months later without needing the runtime online:
+
+   ```typescript
+   import { openBundle } from '@peac/audit';
+   import { verifyLocal } from '@peac/protocol';
+
+   const open = await openBundle(await readFile('audit-Q1.peac-bundle'));
+   for (const record of open.records) {
+     const result = await verifyLocal(record, open.jwks, {
+       issuer: open.manifest.issuer,
+       policy: open.policy,
+     });
+     // Record, policy binding, and issuer JWKS all travel with the bundle.
+   }
+   ```
+
+6. Reconcile two bundles (for example a runtime-side bundle and an auditor-side bundle) to check they carry the same set of records:
+
+   ```bash
+   pnpm exec peac reconcile runtime.peac-bundle auditor.peac-bundle
+   ```
+
+## Evidence of output
+
+A decoded audit-trail record carries the policy binding and the runtime-governance observation in one signed artifact:
+
+```json
+{
+  "iss": "https://runtime.example.com",
+  "iat": 1781609600,
+  "jti": "019676d0-0000-7000-8000-000000000000",
+  "kind": "evidence",
+  "type": "org.peacprotocol/runtime-governance/decision",
+  "pillars": ["compliance", "safety"],
+  "peac_version": "0.2",
+  "schema": "interaction-record+jwt",
+  "peac": {
+    "policy": {
+      "uri": "https://runtime.example.com/policies/enterprise",
+      "version": "2026-04-15",
+      "digest": "sha256:..."
+    }
+  },
+  "ext": {
+    "runtime_governance": {
+      "decision": "allow",
+      "policy_ref": "https://runtime.example.com/policies/enterprise",
+      "config_digest": "sha256:...",
+      "upstream_artifact_ref": "sha256:..."
+    }
+  }
+}
+```
+
+The verifier report (DD-210 shape) carries `policy_binding: "verified"` when the verifier's supplied policy document matches the record's `peac.policy.digest`. That three-state result is what an auditor points at to confirm the record was bound to the expected policy at the time.
+
+## Validated with
+
+```bash
+pnpm install && pnpm build
+pnpm --filter @peac/protocol test
+pnpm --filter @peac/audit test
+pnpm exec peac conformance run
+```
+
+The `@peac/protocol` test suite covers the three-state policy-binding result; the `@peac/audit` test suite covers bundle build and open round-trips; `peac conformance run` exercises the shipped conformance vectors.
+
+## Where to go from here
+
+- [`docs/governance/`](../governance/) — mapping from PEAC record fields to EU AI Act Annex IV, NIST AI RMF, and ISO 42001 Clause 8 controls. Formal mapping docs publish in a near-term release; the directory is the forward link.
+- [`docs/specs/EVIDENCE-CARRIER-CONTRACT.md`](../specs/EVIDENCE-CARRIER-CONTRACT.md) — bundle format and carrier contracts.
+- [`docs/specs/PROTOCOL-BEHAVIOR.md`](../specs/PROTOCOL-BEHAVIOR.md) — normative policy-binding three-state result.
+- [`docs/ENTERPRISE_TRUST_POSTURE.md`](../ENTERPRISE_TRUST_POSTURE.md) — key custody, tenancy, and procurement-facing posture.
+- [`packages/cli/`](../../packages/cli/) — `peac reconcile`, `peac policy`, `peac conformance run`.

--- a/docs/SOLUTIONS/runtime-evidence-export.md
+++ b/docs/SOLUTIONS/runtime-evidence-export.md
@@ -1,0 +1,131 @@
+# Runtime evidence export
+
+> **Outcome:** Your managed agent runtime (Microsoft Agent Governance Toolkit, Claude Managed Agents, OpenAI ACP-backed runtime, or a custom harness) emits decisions. You want those decisions to leave the runtime as portable signed records that an auditor, a counterparty, or another team can verify offline.
+>
+> **Audience:** Runtime / platform operator.
+>
+> **Time:** About 10 minutes from a clean clone, using the runtime-governance example fixtures.
+
+## The problem
+
+Managed agent runtimes make decisions all day — allow this tool call, deny this prompt, modify this output, require this approval, sandbox this session. The runtime has a local record of those decisions. But the decisions are locked inside the runtime: another party has no way to inspect the trail without calling the runtime vendor's API, and the record does not survive the runtime instance going away.
+
+PEAC records the runtime's observations as portable signed records. The runtime still decides and enforces; PEAC just makes the decisions portable.
+
+## What you'll use
+
+PEAC packages:
+
+- `@peac/protocol` — issuance and offline verification.
+- `@peac/crypto` — Ed25519 signing.
+- `@peac/adapter-runtime-governance` — generic runtime-governance observation mapper.
+- `@peac/adapter-managed-agents` — runtime-specific mappings (Claude Managed Agents event families, and similar shapes for other managed runtimes).
+
+Optional adjacent systems: any runtime that already produces a structured decision event. This recipe uses the shipped conformance fixtures, so no external runtime is required to run it.
+
+Prerequisites: Node 22+, pnpm 8+.
+
+## Step-by-step
+
+1. Install dependencies from a clean clone:
+
+   ```bash
+   pnpm install
+   pnpm build
+   ```
+
+2. Inspect the runtime-governance surface. Requirement IDs RTGOV-001..RTGOV-007 (Section 27) are declared in `specs/conformance/requirement-ids.json`; the adapter's own fixtures and test vectors live at `packages/adapters/runtime-governance/tests/`:
+
+   ```bash
+   jq '.sections[] | select(.section=="Runtime Governance Records") | .requirements[].id' specs/conformance/requirement-ids.json
+   ls packages/adapters/runtime-governance/tests/
+   ```
+
+3. Issue a signed record from a managed-runtime observation. The adapter translates the upstream event into Wire 0.2 claims and preserves the upstream attestation verbatim in `upstream_artifact`:
+
+   ```typescript
+   import { issue } from '@peac/protocol';
+   import { fromManagedAgentsEvent } from '@peac/adapter-managed-agents';
+
+   // upstreamEvent is whatever your runtime emits: a governance decision,
+   // a session summary, a policy-reference event, etc. See the adapter's
+   // tests/ directory for representative shapes.
+   const claims = fromManagedAgentsEvent(upstreamEvent, {
+     issuer: 'https://runtime.example.com',
+   });
+
+   const jws = await issue(claims, privateKey);
+   ```
+
+4. Verify the record offline:
+
+   ```typescript
+   import { verifyLocal } from '@peac/protocol';
+
+   const result = await verifyLocal(jws, publicKey, {
+     issuer: 'https://runtime.example.com',
+   });
+
+   console.log(result.valid, result.claims.type, result.claims.pillars);
+   ```
+
+5. Or verify it via the self-hostable reference verifier:
+
+   ```bash
+   cd surfaces/reference-verifier
+   docker compose up -d
+   bash smoke.sh
+   ```
+
+## Evidence of output
+
+A runtime evidence export record looks like this (decoded JWS payload):
+
+```json
+{
+  "iss": "https://runtime.example.com",
+  "iat": 1781609600,
+  "jti": "019676d0-0000-7000-8000-000000000000",
+  "kind": "evidence",
+  "type": "org.peacprotocol/runtime-governance/decision",
+  "pillars": ["safety", "compliance"],
+  "peac_version": "0.2",
+  "schema": "interaction-record+jwt",
+  "ext": {
+    "runtime_governance": {
+      "decision": "allow",
+      "observed_mode": "agent_loop",
+      "policy_ref": "https://runtime.example.com/policies/default",
+      "policy_digest": "sha256:...",
+      "upstream_artifact_ref": "sha256:..."
+    }
+  }
+}
+```
+
+The runtime made the decision (`decision: "allow"`). PEAC carries the decision verbatim, with a digest of the policy that was in force and a reference back to the upstream artifact. An auditor or counterparty verifying the record offline can confirm:
+
+- Which runtime issued the record (signature plus `iss`).
+- What decision was observed (`decision`).
+- What policy was in force (`policy_digest`).
+- What upstream artifact the observation traces back to (`upstream_artifact_ref`).
+
+PEAC did not make the decision. PEAC did not enforce the policy. PEAC carried the signed record of what the runtime attested.
+
+## Validated with
+
+```bash
+pnpm install && pnpm build
+pnpm --filter @peac/adapter-runtime-governance test
+pnpm --filter @peac/adapter-managed-agents test
+```
+
+The conformance vectors used in the step-by-step are under [`specs/conformance/runtime-governance/`](../../specs/conformance/runtime-governance/) (Section 27: RTGOV-001..RTGOV-007); the per-mapper test suites exercise each vector end-to-end.
+
+## Where to go from here
+
+- [`docs/compatibility/COMPATIBILITY_MATRIX.md`](../COMPATIBILITY_MATRIX.md) — Adapter Readiness row for `@peac/adapter-runtime-governance` and `@peac/adapter-managed-agents`.
+- [`docs/profiles/`](../profiles/) — runtime-governance profile doc.
+- [`docs/WHERE-IT-FITS.md`](../WHERE-IT-FITS.md) — PEAC vs runtime governance boundary.
+- [`docs/WHAT-PEAC-STANDARDIZES.md`](../WHAT-PEAC-STANDARDIZES.md) — what the protocol defines and what it stops at.
+- **Future carrier surfaces:** planned releases extend PEAC to carry CLI execution evidence and observational lifecycle records (eval, approval, experiment, or workflow event exports emitted by other systems) as additional carrier surfaces. The protocol boundary does not change.

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -1,28 +1,34 @@
 # Start Here
 
-PEAC is most useful where logs are not enough: payments, cross-boundary verification, audit, dispute review, and multi-agent workflows.
+**Govern locally. Prove across boundaries.**
+
+When logs aren't enough, PEAC gives you portable signed records anyone can verify offline.
+
+Portable signed records for agent, API, MCP, and cross-runtime interactions.
 
 Pick the path that matches what you are building.
 
 ## I run an API or HTTP service
 
-You want to issue signed receipts proving what terms applied and what happened.
+You want to issue signed receipts proving what terms applied and what happened on every response.
 
 1. Install: `pnpm add @peac/middleware-express @peac/crypto @peac/protocol`
 2. Follow the [API Provider Quickstart](guides/quickstart-api-provider.md) (5 minutes)
 3. See [examples/hello-world](../examples/hello-world/) for the minimal standalone version
+4. Outcome-led recipe: [`docs/SOLUTIONS/api-receipt-issuance.md`](SOLUTIONS/api-receipt-issuance.md)
 
-Key packages: `@peac/middleware-express`, `@peac/protocol`, `@peac/crypto`
+Key packages: `@peac/middleware-express`, `@peac/protocol`, `@peac/crypto`.
 
 ## I run an MCP server
 
-You want to add receipt operations (verify, inspect, issue, bundle) to your MCP server, or attach receipts to tool responses.
+You want to add receipt operations (verify, inspect, issue, bundle) to your MCP server, or attach signed records to tool-call responses.
 
 1. Try it now: `npx -y @peac/mcp-server --help`
 2. Read the [MCP Integration Kit](../integrator-kits/mcp/README.md) for full setup
 3. See [examples/mcp-tool-call](../examples/mcp-tool-call/) for a paid-tool example
+4. Outcome-led recipe: [`docs/SOLUTIONS/mcp-tool-call-receipts.md`](SOLUTIONS/mcp-tool-call-receipts.md)
 
-Key packages: `@peac/mcp-server`, `@peac/mappings-mcp`
+Key packages: `@peac/mcp-server`, `@peac/mappings-mcp`.
 
 ## I want to verify a receipt
 
@@ -31,8 +37,19 @@ You have a receipt (JWS string) and want to verify it offline with a public key.
 1. Install: `pnpm add @peac/protocol @peac/crypto`
 2. Follow the [Agent Operator Quickstart](guides/quickstart-agent-operator.md) (5 minutes)
 3. See [examples/minimal](../examples/minimal/) for typed accessor helpers
+4. Self-host the reference verifier: recipes under [`surfaces/reference-verifier/`](../surfaces/reference-verifier/)
 
-Key packages: `@peac/protocol`, `@peac/crypto`
+Key packages: `@peac/protocol`, `@peac/crypto`.
+
+## I want to prove my runtime decisions
+
+You run a managed agent runtime (or an adjacent governance system) and want to export signed records of its observations, decisions, or transitions so other parties can verify them offline.
+
+1. Review the [runtime-governance adapter](../packages/adapters/runtime-governance/) and its conformance fixtures.
+2. Outcome-led recipe: [`docs/SOLUTIONS/runtime-evidence-export.md`](SOLUTIONS/runtime-evidence-export.md)
+3. See [examples/managed-agents-export](../examples/managed-agents-export/) for the Claude Managed Agents mapping.
+
+Key packages: `@peac/adapter-runtime-governance`, `@peac/adapter-managed-agents`, `@peac/protocol`.
 
 ## I build A2A agents
 
@@ -42,40 +59,56 @@ You want to carry receipts across Agent-to-Agent Protocol flows.
 2. Read the [A2A Integration Kit](../integrator-kits/a2a/README.md)
 3. See [examples/a2a-gateway-pattern](../examples/a2a-gateway-pattern/) for the gateway pattern
 
-Key packages: `@peac/mappings-a2a`, `@peac/protocol`
+Key packages: `@peac/mappings-a2a`, `@peac/protocol`.
 
 ## Integration areas
 
 ### Commerce and payment evidence
 
-You want verifiable evidence from commerce and payment flows across paymentauth/MPP, ACP, Stripe SPT, x402, or UCP. Prove what was offered, challenged, paid, or settled across organizational boundaries.
+You want verifiable evidence from commerce and payment flows across paymentauth / MPP, ACP, Stripe SPT, x402, or UCP. Prove what was offered, challenged, paid, or settled across organizational boundaries.
 
 1. Choose your protocol:
-   - **paymentauth/MPP**: [paymentauth Integration Kit](../integrator-kits/paymentauth/README.md)
+   - **paymentauth / MPP**: [paymentauth Integration Kit](../integrator-kits/paymentauth/README.md)
    - **ACP**: [ACP Integration Kit](../integrator-kits/acp/README.md)
    - **x402**: [x402 Integration Kit](../integrator-kits/x402/README.md)
 2. See [Commerce Evidence Spec](specs/COMMERCE-EVIDENCE.md) for boundary rules
 3. See [examples/](../examples/) for runnable demos
+4. Outcome-led recipe: [`docs/SOLUTIONS/commerce-evidence-bundle.md`](SOLUTIONS/commerce-evidence-bundle.md)
 
-Key packages: `@peac/mappings-paymentauth`, `@peac/mappings-acp`, `@peac/rails-stripe`, `@peac/adapter-x402`, `@peac/mappings-ucp`
+Key packages: `@peac/mappings-paymentauth`, `@peac/mappings-acp`, `@peac/rails-stripe`, `@peac/adapter-x402`, `@peac/mappings-ucp`.
 
 ### Audit, dispute, and governance evidence
 
-You need signed evidence for audit, dispute review, or governance workflows. Evidence that survives organizational boundaries, not just local logs.
+You need signed evidence for audit, dispute review, or regulatory alignment. Evidence that survives organizational boundaries, not just local logs.
 
 1. Start with the [API Provider Quickstart](guides/quickstart-api-provider.md) to understand issuance
 2. See [Evidence Bundles](specs/EVIDENCE-CARRIER-CONTRACT.md) for offline verification bundles
 3. Review [Governance Mappings](governance/) for NIST AI RMF, EU AI Act, OWASP ASI alignment
+4. Outcome-led recipe: [`docs/SOLUTIONS/regulatory-audit-trail.md`](SOLUTIONS/regulatory-audit-trail.md)
 
-Key packages: `@peac/protocol`, `@peac/audit`
+Key packages: `@peac/protocol`, `@peac/audit`.
 
 ## Core concepts
 
-- **Receipt:** A signed JWS (`interaction-record+jwt`) proving what terms applied and what happened
-- **Kind:** `evidence` (records what happened) or `challenge` (requests proof from a peer)
-- **Type:** Reverse-DNS identifier for what the receipt represents (e.g., `org.peacprotocol/payment`)
-- **Extensions:** Typed data groups (commerce, access, identity, etc.) carrying domain-specific evidence
-- **Offline verification:** Receipts verify with just the public key; no network calls required
+- **Receipt:** a signed JWS (`interaction-record+jwt`) proving what terms applied and what happened. The JOSE header `typ` is `interaction-record+jwt`; the HTTP request or response body is `application/json` (or the `PEAC-Receipt` HTTP header) carrying the compact JWS string.
+- **Kind:** `evidence` (records what happened) or `challenge` (requests proof from a peer).
+- **Type:** reverse-DNS identifier for what the receipt represents (for example `org.peacprotocol/payment`).
+- **Extensions:** typed data groups (commerce, access, identity, and more) carrying domain-specific content.
+- **Offline verification:** receipts verify with just the public key; no network calls required.
+
+See [`docs/HOW-IT-WORKS.md`](HOW-IT-WORKS.md) for the end-to-end publish / issue / verify / share loop and [`docs/ARTIFACTS.md`](ARTIFACTS.md) for the full artifact taxonomy.
+
+## What PEAC is NOT
+
+PEAC is the records layer beneath runtime governance. It does not try to be the runtime, the control plane, or the decision maker. Explicitly:
+
+- **PEAC is not a governance toolkit, policy engine, or runtime control plane.** Those systems (Microsoft Agent Governance Toolkit, OPA / Cedar / Rego, Claude Managed Agents, OpenAI ACP-backed runtimes, custom harnesses) decide and enforce. PEAC records what they attested.
+- **PEAC is not a payment protocol.** x402, paymentauth / MPP, ACP, and Stripe SPT authorize and settle. PEAC carries verifiable observational evidence across them and never synthesizes payment finality from non-payment artifacts.
+- **PEAC is not an identity protocol or trust-score system.** DIDs, VCs, ERC-8004, and reputation layers own those functions. PEAC accepts `iss` in `https://` or `did:` form and never computes trust.
+- **PEAC is not an observability dashboard.** PEAC records are exportable to any observability system via `receipt_ref` as an OTel span attribute.
+- **PEAC will not become a CLI automation framework, eval platform, approval system, or orchestration / workflow engine.** Future releases extend PEAC to carry CLI execution evidence and observational lifecycle records (eval, approval, experiment, or workflow event exports emitted by other systems). Those are carrier extensions, not new PEAC categories; PEAC records what the upstream system attested and never evaluates, approves, experiments, or orchestrates itself.
+
+Full protocol scope and boundary: [`docs/WHAT-PEAC-STANDARDIZES.md`](WHAT-PEAC-STANDARDIZES.md) and [`docs/WHERE-IT-FITS.md`](WHERE-IT-FITS.md).
 
 ## Package layering
 
@@ -84,7 +117,7 @@ Layer 0: @peac/kernel       (types, constants)
 Layer 1: @peac/schema       (Zod validation)
 Layer 2: @peac/crypto       (Ed25519 signing)
 Layer 3: @peac/protocol     (issue, verifyLocal)
-Layer 4: @peac/mappings-*   (MCP, A2A, x402, etc.)
+Layer 4: @peac/mappings-*   (MCP, A2A, x402, and more)
 Layer 5: @peac/mcp-server   (MCP server)
 ```
 
@@ -92,6 +125,7 @@ Dependencies flow down only. Start at the highest layer you need.
 
 ## Reference
 
-- [Compatibility Matrix](COMPATIBILITY_MATRIX.md): wire format support, runtime environments, deprecation schedule
-- [Migration Guide](MIGRATION_CURRENT.md): upgrade paths from Wire 0.1, `@peac/core`, legacy API
-- [Deprecation Policy](DEPRECATION_POLICY.md): surface lifecycle, removal windows, HTTP deprecation headers
+- [Compatibility Matrix](COMPATIBILITY_MATRIX.md) — wire format support, runtime environments, deprecation schedule, adapter readiness with evidence tags.
+- [Migration Guide](MIGRATION_CURRENT.md) — upgrade paths from Wire 0.1, `@peac/core`, legacy API.
+- [Deprecation Policy](DEPRECATION_POLICY.md) — surface lifecycle, removal windows, HTTP deprecation headers.
+- [Spec Index](SPEC_INDEX.md) — normative specifications.

--- a/docs/SUPPORTED_ENVIRONMENTS.md
+++ b/docs/SUPPORTED_ENVIRONMENTS.md
@@ -43,5 +43,5 @@
 
 - **TypeScript/Node.js** is the canonical OSS implementation path
 - **Go** receives minimum viable Wire 0.2 parity next
-- **Hosted Verify and Hosted Issue** serve as the language-agnostic front door via OpenAPI
+- **Hosted Verify and Hosted Issue** serve as the language-agnostic entry point via OpenAPI
 - **Python** receives API-first support before any full SDK commitment

--- a/docs/WHAT-PEAC-STANDARDIZES.md
+++ b/docs/WHAT-PEAC-STANDARDIZES.md
@@ -1,0 +1,65 @@
+# What PEAC standardizes
+
+PEAC standardizes portable signed interaction records and the verification surfaces around them. It defines how records are issued, carried, verified, and preserved across organizational, vendor, and runtime boundaries. PEAC does not standardize the control plane, business logic, policy engine, payment rail, identity provider, or orchestration layer around those records.
+
+For the boundary next to each adjacent system, see [`docs/WHERE-IT-FITS.md`](WHERE-IT-FITS.md).
+
+---
+
+## 1. Portable, offline-verifiable signed records for agent, API, MCP, and cross-runtime interactions
+
+PEAC defines a compact JWS (JOSE `typ: interaction-record+jwt`) that any party with the issuer's public key can verify offline, without a network round-trip to the issuer. The JWS is Ed25519-signed over JCS-canonicalized claims (RFC 8785), with kernel constraints enforced fail-closed at issue and verify time.
+
+Evidence you can point at:
+
+- The conformance fixture corpus under [`specs/conformance/`](../specs/conformance/) covers positive and negative vectors for the core issue and verify path across Wire 0.2.
+- The hello-world quickstart at [`examples/hello-world/`](../examples/hello-world/) issues a record and verifies it offline in under a minute using `@peac/protocol` and `@peac/crypto`.
+- The JOSE hardening test suite at [`packages/protocol/__tests__/`](../packages/protocol/__tests__/) enforces the stability-contract rules (no embedded keys, no `crit`, no `zip`, Ed25519 only).
+- Cross-language parity: the Go SDK ([`sdks/go/`](../sdks/go/)) emits byte-equivalent JCS output against 22 shared fixtures.
+
+## 2. Cross-protocol record normalization across MCP, A2A, x402, ACP, paymentauth, and runtime-governance ecosystems
+
+PEAC defines a single record shape that composes with every major agent, commerce, and runtime ecosystem PEAC integrates with. The adapter and mapping layer translates each ecosystem's native attestations into a Wire 0.2 record, preserves the upstream artifact verbatim, and never synthesizes semantics the upstream did not claim.
+
+Evidence you can point at:
+
+- The Adapter Readiness column in [`docs/COMPATIBILITY_MATRIX.md`](COMPATIBILITY_MATRIX.md) classifies every Layer-4 surface with a conservative rubric; each row carries an evidence tag pointing at per-mapper conformance fixtures and test suites.
+- Mapper-boundary finality guard: [`@peac/adapter-core.assertExplicitFinality`](../packages/adapters/core/) raises `MapperBoundaryError` (stable code `commerce.finality_synthesis_blocked`) when a commerce mapper would synthesize payment finality from non-payment artifacts.
+- Per-protocol profiles under [`docs/profiles/`](profiles/) and [`docs/compatibility/`](compatibility/) describe the boundary for each ecosystem PEAC integrates with.
+
+## 3. Portable audit records aligned with EU AI Act Annex IV, NIST AI RMF, and ISO 42001 Clause 8
+
+PEAC records double as audit-trail entries suitable for the interaction-logging requirements of current AI governance frameworks. The signed records preserve what the runtime attested, bind policy and config digests, and survive organizational boundaries — the three properties auditors consistently ask for.
+
+Evidence you can point at:
+
+- [`docs/governance/`](governance/) carries the in-progress mapping from PEAC record fields to the relevant clauses and controls. The formal compliance mappings (ISO 42001 Clause 8, EU AI Act Annex IV) publish in a near-term release; the mapping directory is the forward link.
+- The policy-binding three-state result (`verified` / `failed` / `unavailable`) is normatively specified at [`docs/specs/PROTOCOL-BEHAVIOR.md`](specs/PROTOCOL-BEHAVIOR.md) and preserves policy-digest traceability.
+- Records are portable in a bundle format (`peac-bundle/0.1`, spec at [`docs/specs/EVIDENCE-CARRIER-CONTRACT.md`](specs/EVIDENCE-CARRIER-CONTRACT.md)) so audit packages can be verified offline months or years after issuance.
+
+---
+
+## What PEAC does not standardize
+
+PEAC is the records layer. It defines issuance, carriage, verification, and preservation. It does not define:
+
+- **Decision logic.** Auth systems, policy engines, runtime-governance toolkits, and approval systems define the decision. PEAC records what they attested.
+- **Enforcement.** Runtime control planes define enforcement. PEAC records what was enforced.
+- **Execution.** Shell runners, task runners, and orchestration engines define execution. PEAC records what was executed where another system emits that observation; PEAC does not execute commands itself.
+- **Evaluation.** Eval platforms, experiment frameworks, and rubric managers define evaluation. PEAC records eval observations emitted by another system; PEAC does not run evaluations itself.
+- **Approval workflows.** Approval systems and reviewer queues define approval logic. PEAC records approval observations emitted by another system; PEAC does not route or decide approvals itself.
+- **Orchestration.** Workflow engines define orchestration. PEAC records workflow observations emitted by another system; PEAC does not orchestrate workflows itself.
+- **Payment finality.** Payment rails (x402, paymentauth / MPP, ACP, Stripe SPT, card networks) define settlement. PEAC preserves upstream attestations verbatim and blocks finality synthesis at the mapper boundary.
+- **Identity or trust scoring.** Identity protocols (DIDs, VCs, OAuth) and trust-score / reputation systems (ERC-8004 and derivatives) define those. PEAC accepts `iss` in `https://` or `did:` form; PEAC does not compute trust.
+- **Observability presentation.** Observability tooling (Datadog, Grafana, Langfuse, OpenTelemetry collectors) defines visualization. PEAC records are exportable to any observability system via `receipt_ref` as an OTel span attribute.
+- **Managed SaaS operation.** PEAC's reference verifier at [`apps/api/`](../apps/api/) is self-hostable and tenantless. Multi-tenant hosted operation is a separate product concern.
+
+Full boundary with each adjacent category: [`docs/WHERE-IT-FITS.md`](WHERE-IT-FITS.md).
+
+---
+
+## Why this scope
+
+Every adjacent category has strong incumbents and active specification work. PEAC defining decision logic, enforcement, execution, settlement, or identity would duplicate work the adjacent systems already do and would lose PEAC's defining property — neutrality. PEAC composes with those systems rather than competing with them: every one of them can export signed proof into PEAC records without PEAC picking favorites.
+
+The result is a protocol with a narrow definition that composes across a wide surface area.

--- a/docs/WHERE-IT-FITS.md
+++ b/docs/WHERE-IT-FITS.md
@@ -1,0 +1,98 @@
+# Where PEAC fits
+
+PEAC is the records layer beneath runtime governance, next to adjacent systems that define their own functions. This page draws the boundary with each of them.
+
+For every comparison below the same sentence holds: **the other system defines the decision, execution, or settlement; PEAC standardizes the portable signed record that another party can verify offline.**
+
+## PEAC vs logs, traces, and OpenTelemetry
+
+Logs and traces correlate activity inside one organization's systems. They are designed for observability and debugging.
+
+| Property              | Logs / traces / OTel                    | PEAC records                                  |
+| --------------------- | --------------------------------------- | --------------------------------------------- |
+| Scope                 | Local to one system                     | Portable across organizational boundaries     |
+| Verifier              | Needs access to the system's log store  | Any party with the issuer's public key        |
+| Authenticity          | Trust the storage system                | Ed25519 signature over canonical JWS          |
+| Survives org boundary | No (unless exported, and then unsigned) | Yes                                           |
+| Tamper-evident        | No                                      | Yes (signature over JCS-canonicalized claims) |
+
+PEAC is complementary to observability, not a replacement. `receipt_ref` is emitted as an OTel span attribute so traces can point at receipts without carrying the JWS inline. Use your existing OTel / Datadog / Langfuse stack for internal visibility; add PEAC when another party needs proof.
+
+**Boundary:** PEAC is not an observability dashboard. It does not host telemetry backends.
+
+## PEAC vs runtime governance
+
+Runtime governance systems decide and enforce at runtime. They say "allow this call," "deny this tool," "require approval," "sandbox this agent."
+
+| Property          | Runtime governance (AGT, Claude Managed Agents, ACP-backed runtimes, custom harnesses) | PEAC records                                          |
+| ----------------- | -------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| Role              | Decide and enforce                                                                     | Carry portable proof of what was decided              |
+| Where it runs     | Inside the runtime                                                                     | Attached to the output that crosses a boundary        |
+| Survives deletion | No (enforcement state stays with the runtime)                                          | Yes (the signed record outlives the runtime instance) |
+| Replaceable       | Swap one runtime governance product for another                                        | Stays consistent across runtime governance products   |
+
+PEAC carries the output of runtime governance. "AGT decides. PEAC records." `@peac/adapter-runtime-governance` translates governance observations (allow / deny / modify / audit / sandbox transitions / policy reference) into portable signed records.
+
+**Boundary:** PEAC is not a governance toolkit, policy engine, or runtime control plane. Runtime governance products (Microsoft Agent Governance Toolkit, OPA / Cedar / Rego, Claude Managed Agents, OpenAI ACP-backed runtimes, custom agent harnesses) own those functions.
+
+## PEAC vs payment rails
+
+Payment rails authorize, settle, refund, and dispute. They carry the money.
+
+| Property                     | Payment rails (x402, paymentauth / MPP, ACP, Stripe SPT, card networks) | PEAC records                                        |
+| ---------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------- |
+| Role                         | Authorize, settle, custody                                              | Carry portable observational evidence               |
+| What the record says         | "This payment was authorized / captured / settled"                      | "I observed that the rail attested X at time T"     |
+| Custody                      | Holds funds, manages refunds                                            | Never custodies funds                               |
+| Synthesizes payment finality | Yes (the rail is the source of truth)                                   | **No** — PEAC preserves upstream artifacts verbatim |
+
+PEAC's adapter layer (`@peac/adapter-x402`, `@peac/mappings-paymentauth`, `@peac/mappings-acp`, `@peac/rails-stripe`) preserves each rail's attestations verbatim and never synthesizes payment finality from non-payment artifacts. A mapper-boundary guard (`assertExplicitFinality` in `@peac/adapter-core`) blocks commerce records that attempt to imply a settled state the upstream did not claim.
+
+**Boundary:** PEAC is not a payment protocol. It does not authorize, settle, custody, refund, or enforce scheme-specific invariants.
+
+## PEAC vs identity protocols and trust scoring
+
+Identity protocols issue and verify credentials. Trust-score / reputation systems aggregate signals into rankings.
+
+| Property           | Identity / trust systems (DIDs, VCs, ERC-8004, OAuth, Entra, OIDC) | PEAC records                             |
+| ------------------ | ------------------------------------------------------------------ | ---------------------------------------- |
+| Role               | Issue, verify, aggregate                                           | Record what the identity system attested |
+| What PEAC accepts  | `iss` in `https://` or `did:` form                                 | (same)                                   |
+| What PEAC computes | Nothing trust-related                                              | (same)                                   |
+
+PEAC's DID adapter (`@peac/adapter-did`) resolves `did:key` and `did:web` public keys for signature verification. PEAC records can feed into trust-score systems, but PEAC itself never aggregates or displays scores.
+
+**Boundary:** PEAC is not an identity protocol, credential issuer, or trust-score / reputation system.
+
+## PEAC vs native runtime attestations (vendor-specific export)
+
+Some managed runtimes expose their own native attestation or audit export (Microsoft AGT evidence export, Claude Managed Agents audit JSON, OpenAI ACP runtime events).
+
+| Property    | Native runtime attestation  | PEAC records                             |
+| ----------- | --------------------------- | ---------------------------------------- |
+| Scope       | One runtime vendor          | Cross-runtime portable                   |
+| Schema      | Vendor-specific             | Open Wire 0.2 (`interaction-record+jwt`) |
+| Verifier    | Vendor's verifier (or none) | Any party with the issuer public key     |
+| Replaceable | Tied to the runtime         | Stays consistent across vendors          |
+
+Where a native attestation exists, PEAC records its output as portable signed evidence. The adapter layer (`@peac/adapter-managed-agents`, `@peac/adapter-runtime-governance`) carries the vendor's attestation verbatim in `upstream_artifact` fields; PEAC never synthesizes semantics the vendor did not claim.
+
+**Boundary:** PEAC does not replace native attestations. It makes them portable.
+
+## PEAC vs future CLI execution and lifecycle systems (planning context)
+
+Carrier breadth is planned to extend to CLI execution evidence and observational lifecycle records (eval completions, approvals, experiment results, workflow transitions) emitted by other systems. This is carrier breadth, not a new category.
+
+| Property           | CLI / lifecycle systems (Temporal, Airflow, OpenAI Evals, approval queues, shell runners, task runners) | PEAC records (future carrier breadth)                                       |
+| ------------------ | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Role               | Execute, schedule, orchestrate, evaluate, approve                                                       | Carry portable signed records of what the system attested                   |
+| Decision authority | The system                                                                                              | **Never PEAC**                                                              |
+| PEAC response      | Integrate as a future carrier extension                                                                 | Lifecycle records are observational-only; CLI evidence is non-orchestrating |
+
+**Boundary (locked):** PEAC will not become a CLI automation framework, eval platform, approval system, or orchestration / workflow engine. Those categories stay occupied by their existing players. PEAC plans to carry signed records from those surfaces in a future release; the carrier work does not change the boundary.
+
+## Reference
+
+- Protocol scope: [`docs/WHAT-PEAC-STANDARDIZES.md`](WHAT-PEAC-STANDARDIZES.md).
+- Compatibility table with evidence-backed adapter readiness: [`docs/COMPATIBILITY_MATRIX.md`](COMPATIBILITY_MATRIX.md).
+- Normative threat model and security boundaries: [`docs/THREAT_MODEL.md`](THREAT_MODEL.md) once published.

--- a/docs/compatibility/core-use-case-coverage.md
+++ b/docs/compatibility/core-use-case-coverage.md
@@ -1,32 +1,36 @@
 # PEAC Core Use-Case Coverage
 
-**Snapshot date:** v0.12.11 release window.
-**Canonical anti-narrowing reference.** Link here from listings,
-READMEs, quickstart guides, and website copy so PEAC's evidence-plane
-thesis stays intact as outward-facing copy evolves.
+**Snapshot date:** v0.12.12 release window.
+**Canonical scope reference.** Link here from listings, READMEs,
+quickstart guides, and website copy so PEAC's records-layer scope stays
+consistent as external copy evolves.
 
 PEAC is the open standard for verifiable interaction records across
-agent, tool, API, and cross-runtime systems. PEAC records portable
-signed evidence; it does not replace the control planes, policy
-engines, payment rails, or trust systems above it.
+agent, tool, API, and cross-runtime systems. PEAC standardizes how
+portable signed records are issued, carried, verified, and preserved;
+it does not standardize the control planes, policy engines, payment
+rails, or trust systems above it.
 
 ## Coverage matrix
 
-PEAC is designed to cover each of the following interaction surfaces.
-"Records" means PEAC produces portable signed records of observed
-events; it does not enforce invariants inside any of these surfaces.
+PEAC is designed to carry records from each of the following interaction
+surfaces. "Records" means PEAC produces portable signed records of
+observed events; PEAC does not enforce invariants inside any of these
+surfaces.
 
-| Interaction surface           | PEAC records                                                                | Upstream / complement                                  | In-repo reference                                                                      |
-| ----------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| Runtime governance            | Governance decisions, audit entries, authority scope, lifecycle transitions | AGT, Claude Managed Agents, OpenAI ACP-backed runtimes | [`runtime-governance-coverage.md`](runtime-governance-coverage.md)                     |
-| Agentic commerce              | Discovery, authorization, settlement, refund, void, chargeback observations | x402, paymentauth / MPP, ACP, Stripe SPT, UCP          | [`commerce-protocol-coverage.md`](commerce-protocol-coverage.md)                       |
-| MCP tool evidence             | Tool invocation records with `_meta` namespaced under `org.peacprotocol/*`  | Anthropic MCP, GitHub Copilot MCP, Claude Code MCP     | [`../specs/MCP-TOOL-EVIDENCE.md`](../specs/MCP-TOOL-EVIDENCE.md)                       |
-| A2A delegation evidence       | Delegation lifecycle, task submission, outcome evaluation                   | A2A protocol                                           | [`../../packages/mappings/a2a/`](../../packages/mappings/a2a/)                         |
-| API request / response        | Request evidence with PEAC-Receipt header, response evidence via middleware | Host HTTP frameworks (Express, chi, gin, Next.js)      | [`go-middleware.md`](go-middleware.md)                                                 |
-| Automated transactions        | Payment authorization, settlement, refund per external system               | Card rails, crypto rails, UPI, x402 facilitators       | [`commerce-protocol-coverage.md`](commerce-protocol-coverage.md)                       |
-| Cross-boundary interaction    | Portable signed records that cross organizational or process boundaries     | Any two systems that trust PEAC's signature            | [`../specs/EVIDENCE-CARRIER-CONTRACT.md`](../specs/EVIDENCE-CARRIER-CONTRACT.md)       |
-| Supply-chain provenance       | in-toto attestations, SLSA provenance, release evidence                     | in-toto, SLSA, Sigstore, SCITT                         | [`../../packages/mappings/intoto/`](../../packages/mappings/intoto/)                   |
-| Content / attribution signals | robots.txt, tdmrep.json, Content-Usage observations                         | RSL, AIPREF, Content Usage                             | [`../../packages/mappings/content-signals/`](../../packages/mappings/content-signals/) |
+| Interaction surface                 | PEAC records                                                                                  | Upstream / complement                                                    | In-repo reference                                                                      |
+| ----------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| Runtime governance                  | Governance decisions, audit entries, authority scope, lifecycle transitions                   | AGT, Claude Managed Agents, OpenAI ACP-backed runtimes                   | [`runtime-governance-coverage.md`](runtime-governance-coverage.md)                     |
+| Agentic commerce                    | Discovery, authorization, settlement, refund, void, chargeback observations                   | x402, paymentauth / MPP, ACP, Stripe SPT, UCP                            | [`commerce-protocol-coverage.md`](commerce-protocol-coverage.md)                       |
+| MCP tool evidence                   | Tool invocation records with `_meta` namespaced under `org.peacprotocol/*`                    | Anthropic MCP, GitHub Copilot MCP, Claude Code MCP                       | [`../specs/MCP-TOOL-EVIDENCE.md`](../specs/MCP-TOOL-EVIDENCE.md)                       |
+| A2A delegation evidence             | Delegation lifecycle, task submission, outcome evaluation                                     | A2A protocol                                                             | [`../../packages/mappings/a2a/`](../../packages/mappings/a2a/)                         |
+| API request / response              | Request evidence with `PEAC-Receipt` header, response evidence via middleware                 | Host HTTP frameworks (Express, chi, gin, Next.js)                        | [`go-middleware.md`](go-middleware.md)                                                 |
+| Automated transactions              | Payment authorization, settlement, refund per external system                                 | Card rails, crypto rails, UPI, x402 facilitators                         | [`commerce-protocol-coverage.md`](commerce-protocol-coverage.md)                       |
+| Cross-boundary interaction          | Portable signed records that cross organizational or process boundaries                       | Any two systems that trust PEAC's signature                              | [`../specs/EVIDENCE-CARRIER-CONTRACT.md`](../specs/EVIDENCE-CARRIER-CONTRACT.md)       |
+| Supply-chain provenance             | in-toto attestations, SLSA provenance, release evidence                                       | in-toto, SLSA, Sigstore, SCITT                                           | [`../../packages/mappings/intoto/`](../../packages/mappings/intoto/)                   |
+| Content / attribution signals       | `robots.txt`, `tdmrep.json`, Content-Usage observations                                       | RSL, AIPREF, Content Usage                                               | [`../../packages/mappings/content-signals/`](../../packages/mappings/content-signals/) |
+| CLI execution evidence _(planned)_  | Command invocation, binary identity / version, input / output capture policy, outcome, timing | Shell runners, task runners, CI-invoked commands, CLI wrappers           | Planned; future extension of [`@peac/cli`](../../packages/cli/) with a carrier profile |
+| Observational lifecycle _(planned)_ | Approval, evaluation, experiment assignment / result, and workflow transition observations    | External eval platforms, approval systems, experiment / workflow engines | Planned; future extension of existing adapter surfaces                                 |
 
 ## Pillar coverage
 
@@ -36,29 +40,33 @@ Safety, Identity, Purpose). Each pillar has a stable extension group
 under `org.peacprotocol/<pillar>`. See the pillar profiles under
 [`../profiles/`](../profiles/).
 
-## Non-goals (anti-absorption)
+## Boundary
 
-PEAC does not become any of the following. These are tracked here so
-outward copy cannot drift back into surface-area expansion:
+PEAC carries signed records from each of the surfaces above. PEAC does
+not define:
 
-- governance toolkit
-- policy engine (OPA, Cedar, Rego)
-- trust-score / reputation system
-- runtime control plane
-- observability dashboard
-- payment protocol
-- identity protocol
-- enterprise SaaS
-- hosted runtime (the reference verifier is self-hostable and tenantless)
+- Governance toolkits
+- Policy engines (OPA, Cedar, Rego)
+- Trust-score / reputation systems
+- Runtime control planes
+- Observability dashboards
+- Payment protocols
+- Identity protocols
+- Enterprise SaaS
+- Hosted runtimes (the reference verifier is self-hostable and tenantless)
+- CLI automation frameworks, evaluation platforms, approval systems, or
+  orchestration / workflow engines (the planned CLI and lifecycle rows
+  carry records of what those systems attested; they do not define those
+  systems)
 
-PEAC records what each of these systems attested; PEAC does not
-replace them.
+PEAC records what each of these systems attested; PEAC does not replace
+them.
 
 ## How to use this doc
 
 When writing listing copy, a quickstart, or a README, link here instead
 of re-enumerating PEAC's scope. That keeps the scope description
-single-sourced and prevents drift across outward-facing surfaces.
+single-sourced and prevents drift across external-facing surfaces.
 
 ## See also
 
@@ -67,3 +75,5 @@ single-sourced and prevents drift across outward-facing surfaces.
 - [x402 Scheme Coverage](x402-scheme-coverage.md)
 - [Go Middleware](go-middleware.md)
 - [Profiles index](../profiles/README.md)
+- [What PEAC standardizes](../WHAT-PEAC-STANDARDIZES.md)
+- [Where PEAC fits](../WHERE-IT-FITS.md)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,19 +1,54 @@
-# PEAC Flagship Examples
+# Examples
 
-Canonical examples demonstrating PEAC Protocol integration patterns.
+Runnable examples that demonstrate PEAC Protocol integration patterns. Each example has a `pnpm demo` script and is exercised in CI.
 
-## Examples
+## Start here
 
-| Example                                   | Description                                        |
-| ----------------------------------------- | -------------------------------------------------- |
-| [x402-node-server](./x402-node-server/)   | x402 HTTP 402 payment flow with PEAC receipts      |
-| [pay-per-inference](./pay-per-inference/) | Agent handles 402, obtains receipt, retries        |
-| [pay-per-crawl](./pay-per-crawl/)         | Policy evaluation + receipt flow for AI crawlers   |
-| [rsl-collective](./rsl-collective/)       | RSL integration and core claims parity             |
-| [mcp-tool-call](./mcp-tool-call/)         | MCP paid tools with budget enforcement             |
-| [telemetry-otel](./telemetry-otel/)       | OpenTelemetry integration with privacy modes       |
-| [erc8004-feedback](./erc8004-feedback/)   | PEAC records as ERC-8004 reputation evidence       |
-| [openclaw-capture](./openclaw-capture/)   | OpenClaw tool calls as signed interaction evidence |
+If you are new to PEAC, try these five in order:
+
+| #   | Example                                                   | What it shows                                                          |
+| --- | --------------------------------------------------------- | ---------------------------------------------------------------------- |
+| 1   | [`hello-world`](./hello-world/)                           | Minimal issue and offline verify in a single Node script.              |
+| 2   | [`mcp-tool-call`](./mcp-tool-call/)                       | MCP server attaches a signed record to each tool-call response.        |
+| 3   | [`x402-node-server`](./x402-node-server/)                 | HTTP 402 flow with PEAC records carried on the response.               |
+| 4   | [`managed-agents-export`](./managed-agents-export/)       | Export portable evidence from a managed-agent runtime event.           |
+| 5   | [`commerce-evidence-bundle`](./commerce-evidence-bundle/) | Bundle x402, ACP, and paymentauth observations into a portable bundle. |
+
+Outcome-led recipes walk through the full story for each of these: [`docs/SOLUTIONS/`](../docs/SOLUTIONS/).
+
+## Full catalog
+
+Every example below builds and runs end-to-end. The shipped list is the source of truth; new additions arrive alongside their corresponding spec or profile.
+
+| Example                                                           | Description                                                                               |
+| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| [`hello-world`](./hello-world/)                                   | Issue a record, verify it offline.                                                        |
+| [`minimal`](./minimal/)                                           | Minimal issuer with typed accessor helpers.                                               |
+| [`mcp-http-quickstart`](./mcp-http-quickstart/)                   | MCP server with the Streamable HTTP transport.                                            |
+| [`mcp-tool-call`](./mcp-tool-call/)                               | MCP tool-call with budget enforcement and attached records.                               |
+| [`x402-node-server`](./x402-node-server/)                         | x402 payment flow with PEAC records.                                                      |
+| [`x402-upto-evidence`](./x402-upto-evidence/)                     | x402 settlement-proof observational mapping.                                              |
+| [`pay-per-inference`](./pay-per-inference/)                       | Agent handles 402, obtains receipt, retries.                                              |
+| [`pay-per-crawl`](./pay-per-crawl/)                               | Policy evaluation plus record flow for AI crawlers.                                       |
+| [`acp-delegated-checkout`](./acp-delegated-checkout/)             | ACP delegated-payment observation mapping.                                                |
+| [`acp-session-lifecycle`](./acp-session-lifecycle/)               | ACP session-lifecycle observation mapping.                                                |
+| [`mpp-payment-attempt`](./mpp-payment-attempt/)                   | MPP payment-attempt observation mapping.                                                  |
+| [`paymentauth-evidence`](./paymentauth-evidence/)                 | paymentauth / MPP settlement observation mapping.                                         |
+| [`paymentauth-jsonrpc`](./paymentauth-jsonrpc/)                   | paymentauth carried over JSON-RPC transport.                                              |
+| [`stripe-spt-evidence`](./stripe-spt-evidence/)                   | Stripe SPT observation mapping.                                                           |
+| [`stripe-projects-provisioning`](./stripe-projects-provisioning/) | Stripe projects provisioning observation.                                                 |
+| [`x402-dual-header-read`](./x402-dual-header-read/)               | x402 dual-header precedence (`PEAC-Receipt` > `PAYMENT-RESPONSE` > `X-PAYMENT-RESPONSE`). |
+| [`commerce-evidence-bundle`](./commerce-evidence-bundle/)         | Build a portable bundle across multiple commerce rails.                                   |
+| [`managed-agents-export`](./managed-agents-export/)               | Export signed records from a managed-agent runtime.                                       |
+| [`a2a-gateway-pattern`](./a2a-gateway-pattern/)                   | Agent-to-Agent gateway pattern.                                                           |
+| [`agent-identity`](./agent-identity/)                             | Agent identity binding with DIDs and actor proofs.                                        |
+| [`did-verification`](./did-verification/)                         | DID-based issuer verification.                                                            |
+| [`content-signals`](./content-signals/)                           | Content-signals observation mapping.                                                      |
+| [`rsl-collective`](./rsl-collective/)                             | Really Simple Licensing (RSL) integration and core claims parity.                         |
+| [`erc8004-feedback`](./erc8004-feedback/)                         | PEAC records as ERC-8004 reputation evidence.                                             |
+| [`openclaw-capture`](./openclaw-capture/)                         | OpenClaw tool calls as signed interaction records.                                        |
+| [`telemetry-otel`](./telemetry-otel/)                             | OpenTelemetry integration with privacy modes.                                             |
+| [`external-pilot`](./external-pilot/)                             | External pilot integration skeleton.                                                      |
 
 ## Prerequisites
 
@@ -24,36 +59,23 @@ pnpm install
 pnpm build
 ```
 
-## Running Examples
+## Running
 
-Each example has a `demo` script:
+Each example exposes `pnpm demo`:
 
 ```bash
-# x402 payment flow with PEAC receipts
-cd examples/x402-node-server && pnpm demo
-
-# Pay-per-inference flow
-cd examples/pay-per-inference && pnpm demo
-
-# Pay-per-crawl with policy
-cd examples/pay-per-crawl && pnpm demo
-
-# RSL collective integration
-cd examples/rsl-collective && pnpm demo
-
-# MCP tool call with budget
-cd examples/mcp-tool-call && pnpm demo
-
-# OpenTelemetry integration
-cd examples/telemetry-otel && pnpm build && pnpm start
+cd examples/hello-world && pnpm demo
 ```
 
-## CI Harness
+Or run from the workspace root with a filter:
 
-All examples are verified in CI:
+```bash
+pnpm --filter @peac/example-hello-world demo
+```
 
-- `pnpm examples:check` - TypeScript compilation check
-- No `X-`-prefixed PEAC headers allowed (use `PEAC-Receipt` instead)
+## CI
+
+Every example is verified in CI via `pnpm examples:check` (TypeScript compilation) and, for examples with a `demo` target, runtime exercises in the release pipeline. Forbidden patterns (such as `X-`-prefixed PEAC headers) are blocked by the workspace lint configuration.
 
 ## Requirements
 

--- a/surfaces/reference-verifier/Dockerfile
+++ b/surfaces/reference-verifier/Dockerfile
@@ -1,0 +1,53 @@
+# PEAC Reference Verifier — OCI image
+#
+# Multi-stage build. First stage installs and builds the monorepo; second stage
+# copies the built apps/api output plus its workspace dependencies and runs a
+# non-root node process.
+#
+# Build context is the repo root (../..). Tag example:
+#   docker build -f surfaces/reference-verifier/Dockerfile -t peac-reference-verifier:local .
+
+# --- Stage 1: build ---
+FROM node:24.14.1-alpine AS build
+
+RUN apk add --no-cache git python3 make g++
+
+WORKDIR /workspace
+
+# Install pnpm pinned to the repo's declared packageManager version.
+RUN corepack enable && corepack prepare pnpm@8.15.0 --activate
+
+# Copy only the lockfile + workspace manifests first for better cache reuse.
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml turbo.json ./
+COPY apps/api/package.json apps/api/
+COPY packages ./packages
+
+# Install workspace dependencies (dev included; required for build).
+RUN pnpm install --frozen-lockfile --prefer-offline
+
+# Copy the rest of the repo and build the verifier plus its dependencies.
+COPY . .
+RUN pnpm --filter @peac/app-api... build
+
+# Prune dev dependencies for the runtime stage.
+RUN pnpm --filter @peac/app-api... --prod deploy /deploy
+
+# --- Stage 2: runtime ---
+FROM node:24.14.1-alpine AS runtime
+
+RUN addgroup -S peac && adduser -S peac -G peac
+
+WORKDIR /app
+
+COPY --from=build --chown=peac:peac /deploy ./
+
+USER peac
+
+ENV NODE_ENV=production
+ENV PORT=3000
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD wget -qO- http://127.0.0.1:3000/health || exit 1
+
+CMD ["node", "dist/server.js"]

--- a/surfaces/reference-verifier/README.md
+++ b/surfaces/reference-verifier/README.md
@@ -1,0 +1,50 @@
+# Reference verifier — deployment recipes
+
+The OSS reference verifier lives at [`apps/api/`](../../apps/api/). It is self-hostable, tenantless, and carries no managed-service SLA. The contract is documented at [`packages/schema/openapi/verify.yaml`](../../packages/schema/openapi/verify.yaml) and [`docs/HOSTED_VERIFY_CONTRACT.md`](../../docs/HOSTED_VERIFY_CONTRACT.md).
+
+This directory carries lightweight deployment recipes for running the reference verifier yourself.
+
+| Recipe                                     | Use when                                                                  |
+| ------------------------------------------ | ------------------------------------------------------------------------- |
+| [`Dockerfile`](Dockerfile)                 | Build a container image of the reference verifier.                        |
+| [`docker-compose.yml`](docker-compose.yml) | Run the reference verifier locally for development with a single command. |
+| [`cloudflare/`](cloudflare/)               | Deploy the reference verifier as a Cloudflare Worker.                     |
+| [`smoke.sh`](smoke.sh)                     | End-to-end smoke test; brings up the container and hits `/v1/verify`.     |
+
+## Quick start
+
+Build and run with Docker Compose:
+
+```bash
+cd surfaces/reference-verifier
+docker compose up -d
+curl -s http://localhost:3000/health
+```
+
+Run the smoke script:
+
+```bash
+bash smoke.sh
+```
+
+Build a standalone image:
+
+```bash
+docker build -f Dockerfile -t peac-reference-verifier:local ../..
+docker run --rm -p 3000:3000 peac-reference-verifier:local
+```
+
+Deploy as a Cloudflare Worker:
+
+```bash
+cd cloudflare
+npx wrangler deploy
+```
+
+## Scope
+
+The reference verifier is an offline-first verification service. It does not require any database, cache, or persistent state beyond an optional JWKS cache. SSRF-safe fetches bound every outbound request.
+
+The recipes here are sufficient for local evaluation, development, CI smoke tests, and single-tenant self-hosted deployments. Multi-tenant hosted operation (SLA, billing, authenticated access, logging plane, multi-region failover) is out of scope for these recipes.
+
+For the normative runtime contract, see [`packages/schema/openapi/verify.yaml`](../../packages/schema/openapi/verify.yaml). For the security model, see [`apps/api/THREATS.md`](../../apps/api/THREATS.md).

--- a/surfaces/reference-verifier/cloudflare/worker.ts
+++ b/surfaces/reference-verifier/cloudflare/worker.ts
@@ -1,0 +1,160 @@
+/**
+ * PEAC reference-verifier: Cloudflare Worker variant.
+ *
+ * Accepts POST /v1/verify with a JSON body of { receipt, public_key, options? }
+ * and returns the deterministic DD-210 report (shape matches
+ * `packages/schema/openapi/verify.yaml`). On failure, returns RFC 9457
+ * Problem Details with `Content-Type: application/problem+json` and a
+ * canonical `peac_error_code`.
+ *
+ * Callers must supply the verification key in the request body. Live issuer
+ * discovery and JWKS resolution are out of scope for the edge variant;
+ * operators who need live resolution should run the full reference verifier
+ * (see `surfaces/reference-verifier/Dockerfile`).
+ */
+
+import { verifyLocal } from '@peac/protocol';
+import { base64urlDecode } from '@peac/crypto';
+
+interface VerifyRequest {
+  receipt: string;
+  public_key: string;
+  options?: {
+    issuer?: string;
+    max_clock_skew?: number;
+    strictness?: 'strict' | 'interop';
+  };
+}
+
+const securityHeaders: Record<string, string> = {
+  'X-Content-Type-Options': 'nosniff',
+  'Cache-Control': 'no-store',
+  'Referrer-Policy': 'no-referrer',
+  Vary: 'PEAC-Receipt',
+};
+
+function problem(status: number, peacErrorCode: string, title: string, detail: string): Response {
+  const body = {
+    type: `https://www.peacprotocol.org/problems/${peacErrorCode}`,
+    title,
+    status,
+    detail,
+    peac_error_code: peacErrorCode,
+  };
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/problem+json',
+      ...securityHeaders,
+    },
+  });
+}
+
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname === '/health' && request.method === 'GET') {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json', ...securityHeaders },
+      });
+    }
+
+    if (url.pathname !== '/v1/verify' || request.method !== 'POST') {
+      return problem(
+        404,
+        'E_NOT_FOUND',
+        'Not Found',
+        `${request.method} ${url.pathname} is not served by this Worker.`
+      );
+    }
+
+    const contentType = request.headers.get('content-type') ?? '';
+    if (!contentType.startsWith('application/json')) {
+      return problem(
+        415,
+        'E_UNSUPPORTED_MEDIA_TYPE',
+        'Unsupported Media Type',
+        'Request body must be application/json.'
+      );
+    }
+
+    let body: VerifyRequest;
+    try {
+      body = await request.json();
+    } catch {
+      return problem(
+        400,
+        'E_INVALID_FORMAT',
+        'Invalid request body',
+        'Request body is not valid JSON.'
+      );
+    }
+
+    if (typeof body?.receipt !== 'string' || body.receipt.length === 0) {
+      return problem(
+        400,
+        'E_INVALID_FORMAT',
+        'Missing receipt',
+        'Request body must include `receipt` as a non-empty string.'
+      );
+    }
+    if (typeof body?.public_key !== 'string' || body.public_key.length === 0) {
+      return problem(
+        400,
+        'E_INVALID_FORMAT',
+        'Missing public_key',
+        'Request body must include `public_key` as a base64url-encoded Ed25519 public key. Live JWKS resolution is not available in the Worker variant.'
+      );
+    }
+
+    let publicKey: Uint8Array;
+    try {
+      publicKey = base64urlDecode(body.public_key);
+    } catch {
+      return problem(
+        400,
+        'E_INVALID_FORMAT',
+        'Invalid public_key',
+        'public_key is not valid base64url.'
+      );
+    }
+
+    const result = await verifyLocal(body.receipt, publicKey, {
+      issuer: body.options?.issuer,
+      maxClockSkew: body.options?.max_clock_skew,
+      strictness: body.options?.strictness ?? 'strict',
+    });
+
+    if (!result.valid) {
+      return problem(
+        422,
+        result.errorCode ?? 'E_VERIFICATION_FAILED',
+        'Verification failure',
+        result.errorDetail ?? 'Receipt failed verification.'
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        verified: true,
+        receipt_ref: result.receiptRef,
+        claims: result.claims,
+        warnings: result.warnings ?? [],
+        policy_binding: result.policyBinding ?? 'unavailable',
+        issuer: result.claims?.iss,
+        kid: result.kid,
+        wire_version: result.wireVersion ?? '0.2',
+      }),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'PEAC-Report-Id': crypto.randomUUID(),
+          ...securityHeaders,
+        },
+      }
+    );
+  },
+};

--- a/surfaces/reference-verifier/cloudflare/wrangler.toml
+++ b/surfaces/reference-verifier/cloudflare/wrangler.toml
@@ -1,0 +1,28 @@
+# Cloudflare Worker deployment for the PEAC reference verifier.
+#
+# This is a minimal Worker that proxies /v1/verify to an offline verification
+# path using `@peac/protocol.verifyLocal()`. It accepts a compact JWS plus a
+# base64url-encoded Ed25519 public key, verifies offline, and returns the
+# deterministic DD-210 report on success or an RFC 9457 Problem Details
+# response on failure.
+#
+# Deploy:
+#   npx wrangler deploy
+#
+# Notes:
+# - SSRF-safe issuer discovery and JWKS resolution are not exercised in this
+#   Worker path; callers must supply the verification key. For live JWKS
+#   resolution use the full reference-verifier image (Dockerfile / compose).
+# - The Worker relies on the Web Fetch API and the WebCrypto signature
+#   primitives used by `@peac/crypto` on the edge.
+
+name = "peac-reference-verifier"
+main = "worker.ts"
+compatibility_date = "2025-11-01"
+compatibility_flags = ["nodejs_compat"]
+
+[observability]
+enabled = true
+
+[limits]
+cpu_ms = 50

--- a/surfaces/reference-verifier/docker-compose.yml
+++ b/surfaces/reference-verifier/docker-compose.yml
@@ -1,0 +1,43 @@
+# Local development compose file for the PEAC reference verifier.
+#
+# From this directory:
+#   docker compose up -d
+#   curl -s http://localhost:3000/health
+#
+# Bring the stack down:
+#   docker compose down
+
+services:
+  reference-verifier:
+    build:
+      context: ../..
+      dockerfile: surfaces/reference-verifier/Dockerfile
+    image: peac-reference-verifier:local
+    container_name: peac-reference-verifier
+    ports:
+      - '3000:3000'
+    environment:
+      NODE_ENV: production
+      PORT: '3000'
+      # Set to 'false' to harden the local environment by disabling the BYO-key
+      # hosted-issue endpoint. The reference verifier ships with it disabled
+      # by default; this makes the posture explicit for operators who read
+      # this file.
+      PEAC_HOSTED_ISSUE: 'false'
+      # Leave unset to reject private / loopback / reserved network ranges in
+      # issuer discovery and JWKS fetches. Set to 'true' only for local
+      # development where the issuer you are verifying runs on loopback.
+      # PEAC_ALLOW_PRIVATE_NET: 'false'
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://127.0.0.1:3000/health']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL

--- a/surfaces/reference-verifier/smoke.sh
+++ b/surfaces/reference-verifier/smoke.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# PEAC reference-verifier end-to-end smoke test.
+#
+# Builds the Docker image, brings up the compose stack, waits for the health
+# endpoint, posts a known bad payload to /v1/verify (must return an RFC 9457
+# Problem Details response), and brings the stack down.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+log() {
+  printf '[smoke] %s\n' "$1"
+}
+
+cleanup() {
+  log 'bringing stack down'
+  docker compose down --remove-orphans || true
+}
+trap cleanup EXIT
+
+log 'building image'
+docker compose build --quiet
+
+log 'starting stack'
+docker compose up -d
+
+log 'waiting for /health'
+for i in {1..30}; do
+  if curl -fsS http://localhost:3000/health >/dev/null 2>&1; then
+    log 'health OK'
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    log 'health never came up'
+    docker compose logs --no-color
+    exit 1
+  fi
+  sleep 1
+done
+
+log 'POST /v1/verify with a malformed body (must return 400 + application/problem+json)'
+response_body="$(mktemp)"
+http_code="$(curl -s -o "$response_body" -w '%{http_code}' \
+  -X POST http://localhost:3000/v1/verify \
+  -H 'Content-Type: application/json' \
+  --data '{"not_a_receipt":true}')"
+
+content_type="$(curl -s -D - -o /dev/null \
+  -X POST http://localhost:3000/v1/verify \
+  -H 'Content-Type: application/json' \
+  --data '{"not_a_receipt":true}' | tr -d '\r' | awk -F': ' 'tolower($1)=="content-type"{print $2; exit}')"
+
+log "/v1/verify -> HTTP $http_code, Content-Type: $content_type"
+if [ "$http_code" != '400' ]; then
+  log "FAIL: expected 400, got $http_code"
+  cat "$response_body"
+  exit 1
+fi
+if [[ "$content_type" != application/problem+json* ]]; then
+  log "FAIL: expected application/problem+json, got $content_type"
+  exit 1
+fi
+
+log 'smoke passed'


### PR DESCRIPTION
## Summary

Adds `docs/START_HERE.md` as the role-based entry point, four operator mental-model docs (`docs/HOW-IT-WORKS.md`, `docs/ARTIFACTS.md`, `docs/WHERE-IT-FITS.md`, `docs/WHAT-PEAC-STANDARDIZES.md`), five outcome-led recipes under `docs/SOLUTIONS/`, and deployment recipes for the self-hostable reference verifier under `surfaces/reference-verifier/`. Reorganizes `README.md` around a short opening and a role-based selector. Updates `docs/compatibility/core-use-case-coverage.md` with two planned-coverage rows. No wire format, schema, kernel, crypto, protocol API, registries, or errors taxonomy changes.

## Scope

- Documentation only.
- No runtime behavior change.
- No new public package.

## Validation

- `pnpm format:check` clean.
- `bash scripts/ci/forbid-strings.sh` clean.
- Pre-push Tier 1 and Tier 2 gates green.
