### PR TITLE
docs: SLO, threat model, stability contract, and trust artifacts

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,127 +1,38 @@
 # Security Policy
 
-## Supported Versions
+This file mirrors the GitHub-facing entry points for security disclosure.
+The canonical security policy lives at [`SECURITY.md`](../SECURITY.md) in
+the repository root.
 
-Currently supported versions for security updates:
+## Reporting a vulnerability
 
-| Version   | Supported          |
-| --------- | ------------------ |
-| >= 0.12.7 | :white_check_mark: |
-| < 0.12.7  | :x:                |
+1. Do not open a public issue.
+2. Email [security@peacprotocol.org](mailto:security@peacprotocol.org) or
+   open a private advisory at
+   <https://github.com/peacprotocol/peac/security/advisories>.
+3. Include affected versions, reproducer, observed versus expected
+   behavior, and your impact assessment.
 
-## Reporting a Vulnerability
+Acknowledgement targets:
 
-We take security vulnerabilities seriously. If you discover a security issue, please follow these steps:
+- Critical: 48 hours.
+- High: 72 hours.
+- Medium: 7 days.
+- Low: 14 days.
 
-1. **DO NOT** open a public issue
-2. Email security@peacprotocol.org with:
-   - Description of the vulnerability
-   - Steps to reproduce
-   - Potential impact
-   - Suggested fix (if available)
+Patch-and-disclosure timelines, supply-chain attestations, and the full
+trust-artifact index are documented in the canonical
+[`SECURITY.md`](../SECURITY.md).
 
-3. We will acknowledge receipt within 48 hours
-4. We will investigate and provide updates within 7 days
-5. We will coordinate disclosure timing with you
+## Supported versions
 
-## Security Measures
+See [`SECURITY.md` — Supported versions](../SECURITY.md#supported-versions)
+for the authoritative list.
 
-### Cryptographic Security
+## Trust artifacts
 
-- EdDSA (Ed25519) signatures (RFC 8032)
-- JWS Compact Serialization
-- Key rotation support via JWKS `kid` matching
-- Hardware security module support
-
-### Input Validation
-
-- Strict JSON schema validation
-- SSRF protection on all external calls
-- Rate limiting with token buckets
-- Request size limits enforced
-
-### Operational Security
-
-- No secrets in code or commits
-- Environment-based configuration
-- Audit logging for security events
-- Automated vulnerability scanning
-
-## Security Checklist for Contributors
-
-Before submitting code:
-
-- [ ] No hardcoded secrets or credentials
-- [ ] All user input validated
-- [ ] External URLs validated against SSRF
-- [ ] Rate limiting considered
-- [ ] Error messages don't leak sensitive info
-- [ ] Dependencies audited (`pnpm audit`)
-- [ ] Security tests written for new features
-
-## Dependency Audit Policy
-
-CI runs `scripts/audit-gate.mjs` which enforces a two-tier policy:
-
-- **Critical** vulnerabilities always block merges
-- **High** vulnerabilities warn by default; block in strict mode (`AUDIT_STRICT=1`)
-- **Moderate/Low** are logged but never block
-
-### Advisory Allowlist
-
-Temporary exceptions are tracked in `security/audit-allowlist.json`. Each entry requires:
-
-| Field         | Required | Description                                        |
-| ------------- | -------- | -------------------------------------------------- |
-| `advisory_id` | Yes      | GHSA or advisory identifier                        |
-| `reason`      | Yes      | Why this is temporarily acceptable                 |
-| `expires_at`  | Yes      | ISO 8601 date (YYYY-MM-DD), max 90 days from today |
-| `remediation` | Yes      | Planned fix (version bump, patch, replacement)     |
-| `issue_url`   | Yes      | Link to tracking issue                             |
-
-**Rules:**
-
-- Maximum allowlist expiry window: **90 days**
-- Expired entries are ignored (advisory becomes blocking again)
-- Malformed or incomplete entries fail closed (not allowlisted)
-- Every allowlist entry MUST have a tracking issue with a remediation plan
-- In strict mode (`AUDIT_STRICT=1`): expired or invalid entries cause build failure (prevents allowlist fossilization)
-
-## Known Security Considerations
-
-### SSRF Protection
-
-All crawler and verification endpoints implement SSRF guards:
-
-- Private IP range blocking
-- DNS rebinding protection
-- Redirect limit enforcement
-- Timeout controls
-
-### DoS Prevention
-
-- Token bucket rate limiting
-- Request size limits
-- Computation timeouts
-- Circuit breakers for external services
-
-### Data Privacy
-
-- No PII in logs
-- Structured telemetry with privacy controls
-- GDPR-compliant data handling
-- Configurable retention policies
-
-## Compliance
-
-The PEAC Protocol aims to comply with:
-
-- OWASP API Security Top 10
-- NIST Cybersecurity Framework
-- EU GDPR requirements
-- California CCPA requirements
-
-## Contact
-
-- Security issues: security@peacprotocol.org
-- General inquiries: contact@peacprotocol.org
+- [Threat model](../docs/THREAT_MODEL.md).
+- [Stability contract](../docs/STABILITY-CONTRACT.md).
+- [SLO](../docs/SLO.md).
+- [Security operations](../docs/SECURITY-OPERATIONS.md).
+- [Trust artifacts](../docs/TRUST-ARTIFACTS.md).

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -26,7 +26,7 @@ trust-artifact index are documented in the canonical
 
 ## Supported versions
 
-See [`SECURITY.md` — Supported versions](../SECURITY.md#supported-versions)
+See [`SECURITY.md`: Supported versions](../SECURITY.md#supported-versions)
 for the authoritative list.
 
 ## Trust artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,12 @@ jobs:
       - name: OpenAPI drift verification (package spec vs app spec)
         run: pnpm verify:openapi:drift
 
+      - name: Trust-artifact integrity (threat-model links, stability-contract rows)
+        run: pnpm verify:trust-artifacts
+
+      - name: Public surface-name verification (retired filenames and paths)
+        run: pnpm verify:public-surface-names
+
       - name: Release facts verification
         run: pnpm verify:release
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ PEAC is the records layer beneath runtime governance. PEAC records what another 
 - No silent network fallback for offline verification.
 - Errors mapped to RFC 9457 Problem Details.
 
-See [`SECURITY.md`](.github/SECURITY.md), [`docs/specs/PROTOCOL-BEHAVIOR.md`](docs/specs/PROTOCOL-BEHAVIOR.md), [`docs/COMPATIBILITY_MATRIX.md`](docs/COMPATIBILITY_MATRIX.md), and [`docs/specs/VERSIONING.md`](docs/specs/VERSIONING.md).
+See [`SECURITY.md`](SECURITY.md), [`docs/TRUST-ARTIFACTS.md`](docs/TRUST-ARTIFACTS.md), [`docs/specs/PROTOCOL-BEHAVIOR.md`](docs/specs/PROTOCOL-BEHAVIOR.md), [`docs/COMPATIBILITY_MATRIX.md`](docs/COMPATIBILITY_MATRIX.md), and [`docs/specs/VERSIONING.md`](docs/specs/VERSIONING.md).
 
 ## Versioning
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -106,13 +106,13 @@ scan is clean; the scan is the authoritative check.
 Full trust documentation is organized in
 [Trust artifacts](docs/TRUST-ARTIFACTS.md). Pointers:
 
-- [Threat model](docs/THREAT_MODEL.md) — consolidated threat catalog with
+- [Threat model](docs/THREAT_MODEL.md): consolidated threat catalog with
   per-threat test-coverage links.
-- [Stability contract](docs/STABILITY-CONTRACT.md) — classification of
+- [Stability contract](docs/STABILITY-CONTRACT.md): classification of
   every public surface.
 - [SLO](docs/SLO.md) and [Benchmark methodology](docs/BENCHMARK-METHODOLOGY.md).
-- [Security operations](docs/SECURITY-OPERATIONS.md) — operational detail.
-- [Key custody and tenancy](docs/KEY-CUSTODY-AND-TENANCY.md) — key
+- [Security operations](docs/SECURITY-OPERATIONS.md): operational detail.
+- [Key custody and tenancy](docs/KEY-CUSTODY-AND-TENANCY.md): key
   custody, tenancy, procurement.
 - [Security considerations spec](docs/specs/SECURITY-CONSIDERATIONS.md).
 - [Verifier security model spec](docs/specs/VERIFIER-SECURITY-MODEL.md).
@@ -141,7 +141,7 @@ one:
 
 Each rule above becomes a named threat ID with a concrete test file when
 the corresponding surface is implemented. Details in
-[Threat model — future carrier surfaces](docs/THREAT_MODEL.md#future-carrier-surfaces-pre-doctrine).
+[Threat model: future carrier surfaces](docs/THREAT_MODEL.md#future-carrier-surfaces-pre-doctrine).
 
 ## Contacts
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,57 +1,150 @@
 # Security Policy
 
-Last reviewed: 2026-04-01
+Last reviewed: 2026-04-19
 
-For vulnerability reporting, supported versions, and security practices, see the full security policy:
+This is the canonical security policy for the PEAC Protocol. It describes
+how to report a vulnerability, which versions receive security fixes, what
+supply-chain attestations the project ships, and where the broader
+security and stability model is documented.
 
-[`.github/SECURITY.md`](.github/SECURITY.md)
+## Reporting a vulnerability
 
-## Reporting a Vulnerability
+- Email: [security@peacprotocol.org](mailto:security@peacprotocol.org).
+- GitHub security advisories may be opened privately at
+  <https://github.com/peacprotocol/peac/security/advisories>.
+- Do not open a public issue for a suspected vulnerability.
+- Coordinated disclosure is preferred; details below.
 
-Email: security@peacprotocol.org
+Please include:
 
-Do not open a public issue for security vulnerabilities.
+- Affected version(s), package(s), and reproducer.
+- Expected versus observed behavior.
+- Your assessment of impact and severity, if any.
 
-## Trojan Source Protection
+### Coordinated disclosure timeline
 
-This repository runs a fail-closed invisible/bidi Unicode scan (`scripts/find-invisible-unicode.mjs`)
-on every CI run and local `guard.sh` invocation. The scanner rejects all dangerous Unicode categories
-(bidi overrides, zero-width characters, invisible formatters) in tracked source files.
+| Severity | Acknowledgement | Patch target | Public disclosure              |
+| -------- | --------------- | ------------ | ------------------------------ |
+| Critical | 48 hours        | 30 days      | After a fix is available       |
+| High     | 72 hours        | 60 days      | After a fix is available       |
+| Medium   | 7 days          | 90 days      | After a fix is available       |
+| Low      | 14 days         | Next release | With the corresponding release |
 
-GitHub's diff view may show a "This file contains bidirectional Unicode text" banner on some files.
-This is a heuristic warning and does not indicate a vulnerability when the repo's Trojan Source scan
-passes. The scanner is the authoritative check.
+Timelines are targets and may flex for exceptional cases; the reporter is
+kept in the loop and the disclosure calendar is coordinated.
 
-## Dependency Audit Policy
+## Supported versions
 
-Production dependency audit is clean (zero findings). The audit gate runs
-in CI on every PR and enforces time-bounded, structured allowlist entries
-for dev-only exceptions.
+| Line                             | Status                            | Wire format                         | Security-fix window            |
+| -------------------------------- | --------------------------------- | ----------------------------------- | ------------------------------ |
+| `v0.12.x`                        | Active                            | Wire 0.2 (`interaction-record+jwt`) | Through the `v0.13.x` line     |
+| `v0.11.x`                        | Maintenance (security fixes only) | Wire 0.1 (`peac-receipt/0.1`)       | 6 months after `v0.13.0` ships |
+| `v0.10.x` and earlier            | End of life                       | Wire 0.1 and earlier                | No further updates             |
+| `peac.receipt/0.9` archival path | Verify-only through `@peac/core`  | `peac.receipt/0.9`                  | Frozen; removal at `v0.13.0`   |
 
-### Environment Variables
+See [Compatibility matrix](docs/COMPATIBILITY_MATRIX.md) for full runtime
+and wire-format compatibility, and [Security operations](docs/SECURITY-OPERATIONS.md)
+for support-window definitions.
 
-| Variable              | Effect                                                                 |
-| --------------------- | ---------------------------------------------------------------------- |
-| _(default)_           | Prod: block HIGH/CRITICAL. Full: block CRITICAL, warn HIGH.            |
-| `AUDIT_STRICT=1`      | Block HIGH in full audit. Reject stale/invalid allowlist entries.      |
-| `PEAC_AUDIT_STRICT=1` | Zero tolerance: block ANY prod vulnerability (LOW+). Enterprise CI.    |
-| `PEAC_PERF_UPDATE=1`  | Opt-in: write perf baseline file (`tests/perf/baseline-results.json`). |
+## Supply chain
 
-### Recommended CI Configuration
+- All published packages ship npm provenance attestations via GitHub
+  Actions OIDC trusted publishing. Consumers can verify with
+  `npm audit signatures @peac/protocol`.
+- Build provenance follows SLSA v1.2; build inputs are attested per
+  in-toto v1.0.
+- SHA-pinned GitHub Actions; CodeQL and dependency review run on every
+  pull request.
+- Production-dependency audit must be clean on every release; the gate
+  and allowlist quality bar are documented below.
+- Full supply-chain controls: [Security operations](docs/SECURITY-OPERATIONS.md).
 
-- **Default CI (PRs):** `node scripts/audit-gate.mjs`: prod must be clean, dev exceptions allowed.
-- **Release/tag CI:** `AUDIT_STRICT=1 node scripts/audit-gate.mjs`: no known HIGHs anywhere.
-- **Enterprise CI:** `PEAC_AUDIT_STRICT=1 node scripts/audit-gate.mjs`: zero prod findings.
+## Dependency audit policy
 
-### Allowlist Quality Bar
+CI runs `scripts/audit-gate.mjs`, which enforces the following:
 
-Every entry in `security/audit-allowlist.json` must include:
+| Variable              | Effect                                                                    |
+| --------------------- | ------------------------------------------------------------------------- |
+| _(default)_           | Prod clean; full audit blocks CRITICAL, warns HIGH                        |
+| `AUDIT_STRICT=1`      | Blocks HIGH in the full audit; rejects stale or invalid allowlist entries |
+| `PEAC_AUDIT_STRICT=1` | Zero tolerance: blocks any production vulnerability (LOW or higher)       |
 
-- `advisory_id`, `package`, `reason`, `why_not_exploitable`, `where_used`
-- `expires_at` (max 90 days dev, 30 days prod), `remediation`, `issue_url`
-- `scope` (`dev`/`examples`/`prod`), `dependency_chain`, `verified_by`
-- `owner`, `added_at`
-- `reviewed_at` (optional, recommended for renewals)
+Recommended CI configuration:
 
-Entries missing required fields are rejected (fail-closed). Expired entries
-reactivate the finding. Prod-scope entries may never allowlist HIGH/CRITICAL.
+- Default CI (pull requests): `node scripts/audit-gate.mjs`.
+- Release CI: `AUDIT_STRICT=1 node scripts/audit-gate.mjs`.
+- Enterprise CI: `PEAC_AUDIT_STRICT=1 node scripts/audit-gate.mjs`.
+
+Allowlist quality bar (`security/audit-allowlist.json`): each entry
+requires `advisory_id`, `package`, `reason`, `why_not_exploitable`,
+`where_used`, `expires_at` (max 90 days dev, 30 days prod), `remediation`,
+`issue_url`, `scope`, `dependency_chain`, `verified_by`, `owner`,
+`added_at`. Entries missing required fields fail closed. Production-scope
+entries may never allowlist HIGH or CRITICAL.
+
+## Trojan Source protection
+
+The repository runs a fail-closed invisible / bidi Unicode scan
+(`scripts/find-invisible-unicode.mjs`) on every CI run and local
+`guard.sh` invocation. The scanner rejects dangerous Unicode categories
+(bidi overrides, zero-width characters, invisible formatters) in tracked
+source files. GitHub's diff view may show a bidi banner even when the
+scan is clean; the scan is the authoritative check.
+
+## External review
+
+- CodeQL `javascript-typescript` and `security-extended` queries run on
+  pull requests, pushes to main, and weekly.
+- Dependency review blocks CRITICAL advisories and denies GPL-3.0 /
+  AGPL-3.0 introductions.
+- External security review cadence: scope and artifact list are planned
+  for a future release; execution is coordinated with an independent
+  reviewer.
+
+## Trust artifacts
+
+Full trust documentation is organized in
+[Trust artifacts](docs/TRUST-ARTIFACTS.md). Pointers:
+
+- [Threat model](docs/THREAT_MODEL.md) — consolidated threat catalog with
+  per-threat test-coverage links.
+- [Stability contract](docs/STABILITY-CONTRACT.md) — classification of
+  every public surface.
+- [SLO](docs/SLO.md) and [Benchmark methodology](docs/BENCHMARK-METHODOLOGY.md).
+- [Security operations](docs/SECURITY-OPERATIONS.md) — operational detail.
+- [Key custody and tenancy](docs/KEY-CUSTODY-AND-TENANCY.md) — key
+  custody, tenancy, procurement.
+- [Security considerations spec](docs/specs/SECURITY-CONSIDERATIONS.md).
+- [Verifier security model spec](docs/specs/VERIFIER-SECURITY-MODEL.md).
+- [HTTP transport security](docs/security/HTTP-TRANSPORT-SECURITY.md).
+- [OWASP ASI mapping](docs/security/OWASP-ASI-MAPPING.md).
+
+## Future carrier security controls (pre-doctrine)
+
+Future execution-surface carriers (CLI execution evidence; observational
+lifecycle records) are not shipped. Their security contract is
+pre-declared so that future implementation MUST honor the rules on day
+one:
+
+- No raw secret capture by default; redaction or hashing defaults for
+  `argv`, `stdin`, `stdout`, `stderr`.
+- Hash-only default for stream captures unless a documented
+  `capture_policy` enables raw capture.
+- Environment-variable allowlist plus value hashing; no blanket
+  environment dump.
+- Explicit `argv_mode` for shell-string invocations; no hidden shell
+  expansion.
+- Bounded byte ceilings on command capture; truncation or hashing
+  replaces silent drops.
+- Lifecycle records observational-only; no implied PEAC decision, trust
+  score, policy enforcement, or payment finality.
+
+Each rule above becomes a named threat ID with a concrete test file when
+the corresponding surface is implemented. Details in
+[Threat model — future carrier surfaces](docs/THREAT_MODEL.md#future-carrier-surfaces-pre-doctrine).
+
+## Contacts
+
+- Security: [security@peacprotocol.org](mailto:security@peacprotocol.org).
+- General: [contact@peacprotocol.org](mailto:contact@peacprotocol.org).
+- GitHub Security Advisories: <https://github.com/peacprotocol/peac/security/advisories>.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -313,27 +313,11 @@ interface PaymentEvidence {
 
 ## Security Model
 
-### Signature
+Signature envelope: Ed25519 (RFC 8032) over JWS Compact Serialization (RFC 7515). Key discovery follows `/.well-known/peac-issuer.json` → `jwks_uri` → JWKS.
 
-- Algorithm: Ed25519 (EdDSA with Curve25519)
-- Format: JWS Compact Serialization (RFC 7515)
-- Key discovery: `/.well-known/peac-issuer.json` -> `jwks_uri` -> JWKS
+Verification: parse JWS, resolve the issuer's JWKS via SSRF-safe fetch, verify the signature against the public key identified by `kid`, validate claims and kernel constraints, and evaluate extension-group structure.
 
-### Verification
-
-1. Parse JWS and extract header/payload
-2. Fetch issuer's `peac-issuer.json`, resolve `jwks_uri`, fetch JWKS (all SSRF-safe)
-3. Verify signature against public key identified by `kid`
-4. Validate claims (iss, aud, exp, iat)
-5. Validate payment evidence structure
-
-### Defense in Depth
-
-- SSRF protection on all URL fetches (v0.9.16)
-- DPoP proof-of-possession binding (v0.9.16)
-- JWKS rotation with 90-day key lifecycle
-- Rate limiting on verification endpoints
-- RFC 9457 Problem Details for all errors
+Full threat catalog, mitigations, and per-threat test links live in [Threat model](THREAT_MODEL.md). Cryptographic and JOSE-hardening detail lives in [Security considerations](specs/SECURITY-CONSIDERATIONS.md). Verifier modes, size limits, and error categories live in [Verifier security model](specs/VERIFIER-SECURITY-MODEL.md). Operational controls and supply-chain detail live in [Security operations](SECURITY-OPERATIONS.md) and [SECURITY.md](../SECURITY.md). The full index is [Trust artifacts](TRUST-ARTIFACTS.md).
 
 ---
 

--- a/docs/BENCHMARK-METHODOLOGY.md
+++ b/docs/BENCHMARK-METHODOLOGY.md
@@ -1,0 +1,127 @@
+# Benchmark methodology
+
+This document describes how the numbers published in [SLO.md](SLO.md) are
+produced, what they measure, and how to reproduce them. It is the reference
+companion to the in-repo benchmark infrastructure.
+
+## Scope
+
+- `@peac/crypto` primitives (Ed25519 sign / verify, JCS, hashing).
+- `@peac/schema` validation and byte-budget checks.
+- `@peac/protocol` `issue()` and `verifyLocal()`.
+- `apps/api` `/v1/verify` round-trip (loopback; with and without JWKS
+  resolution).
+- `@peac/mcp-server` `tools/call` round-trip emitting a PEAC receipt.
+
+Out of scope: Hosted Verify performance (operated separately) and any future
+execution-surface carrier (tracked for v0.14.1).
+
+## Machine profile (baseline capture target)
+
+Baseline captures run on the PEAC reference machine profile. Production
+performance varies with hardware, network, workload, and receipt size.
+
+| Field      | Value                                                          |
+| ---------- | -------------------------------------------------------------- |
+| CPU        | Documented at capture time in `reference/bench/<package>.json` |
+| Memory     | Documented at capture time                                     |
+| OS         | Documented at capture time (macOS or Linux)                    |
+| Node.js    | v24.14.1 (current Active LTS; canonical per `.node-version`)   |
+| pnpm       | Pinned via `packageManager` in root `package.json`             |
+| Filesystem | Local APFS or ext4; loopback HTTP for `/v1/verify` runs        |
+
+`PEAC_BENCH_JSON=<path>` emits a structured record including `platform` and
+`node_version` alongside per-operation metrics.
+
+## Fixture set
+
+- Class A: ~1 KB Wire 0.2 record (typical agent observation).
+- Class B: ~8 KB record (commerce evidence with attached upstream artifact).
+- Class C: ~64 KB record (per-extension-group kernel constraint ceiling per
+  [Kernel constraints spec](specs/KERNEL-CONSTRAINTS.md)).
+
+Unless a result row states otherwise, published numbers reflect Class A.
+
+## Measurement protocol
+
+| Phase       | Iterations (default) | Notes                                     |
+| ----------- | -------------------- | ----------------------------------------- |
+| Warmup      | 50                   | Discarded; amortizes JIT and cache warmup |
+| Measured    | 300                  | Retained; feeds percentile aggregation    |
+| Aggregation | n/a                  | p50 (median), p95, p99, min, max, mean    |
+
+Target thresholds and iteration counts are codified in
+[`specs/benchmarks/slo.json`](../specs/benchmarks/slo.json) (machine-readable
+SLO spec). The in-repo regression gate
+[`scripts/benchmarks/verify-slo.mjs`](../scripts/benchmarks/verify-slo.mjs)
+compares captured results against
+[`specs/benchmarks/baseline.json`](../specs/benchmarks/baseline.json) and
+fails when `p95 > max_ratio * baseline` (default `max_ratio = 2.0`).
+
+## Reproduction
+
+```bash
+# Clone at the baseline commit stamped in docs/SLO.md.
+git fetch --tags origin
+git checkout v0.12.12
+pnpm install --frozen-lockfile
+pnpm build
+
+# vitest bench across crypto / schema / protocol packages;
+# outputs JSON into reference/bench/<package>.json.
+node scripts/bench-capture.mjs
+
+# Wire 0.2 SLO gate (verifyLocal p95 <= 10 ms; issue() soft target):
+pnpm --filter @peac/protocol exec vitest run tests/perf/wire02-slo.test.ts
+# Optional: emit structured metrics.
+PEAC_BENCH_JSON=/tmp/wire02-slo.json \
+  pnpm --filter @peac/protocol exec vitest run tests/perf/wire02-slo.test.ts
+
+# Repeated-run aggregation (default N=5) across the Wire 0.2 gate:
+bash scripts/bench-repeated.sh --runs 5 --output tests/perf/repeated-results.json
+
+# Regression gate (exits 1 if p95 exceeds 2x baseline):
+node scripts/benchmarks/verify-slo.mjs
+```
+
+To reproduce the reference verifier `/v1/verify` row, start the loopback
+server (see [Reference verifier recipes](../surfaces/reference-verifier/)) and
+replay a fixture using the fetch-based client of your choice; record `p50`,
+`p95`, and `p99` on a clean run after one warmup request.
+
+## Output artifacts
+
+| Artifact                           | Source                                                 | Purpose                                           |
+| ---------------------------------- | ------------------------------------------------------ | ------------------------------------------------- |
+| `reference/bench/<package>.json`   | `scripts/bench-capture.mjs`                            | Per-package vitest bench JSON                     |
+| `tests/perf/wire02-slo.json`       | `tests/perf/wire02-slo.test.ts` (with env var)         | Wire 0.2 SLO run metrics                          |
+| `tests/perf/repeated-results.json` | `scripts/bench-repeated.sh`                            | Cross-run p95 aggregation                         |
+| `specs/benchmarks/baseline.json`   | Human-maintained; refreshed on intended baseline drift | Regression-gate reference                         |
+| `specs/benchmarks/slo.json`        | Human-maintained                                       | Machine-readable SLO targets and iteration counts |
+
+## Regression gate (CI)
+
+`scripts/benchmarks/verify-slo.mjs` runs as part of the performance lane in
+CI. It fails the build when any captured p95 exceeds `max_ratio *
+baseline.p95`. Absolute CI-target breaches warn but do not fail, because CI
+runners are shared; the repeated-run aggregation in
+`scripts/bench-repeated.sh` is the primary guard against shared-runner
+noise.
+
+## Limitations
+
+- Loopback measurement does not capture wide-area latency; the published
+  reference-verifier numbers are loopback by design.
+- JWKS-resolution numbers assume a warm cache. Cold-cache numbers depend on
+  upstream issuer latency and are not published here.
+- Go parity numbers are tracked separately in
+  [`sdks/go`](../sdks/go) with its own benchmark suite; cross-language parity
+  fixtures live under
+  [`specs/conformance/fixtures/go-interaction-record/`](../specs/conformance/fixtures/go-interaction-record/).
+
+## Related documents
+
+- [SLO.md](SLO.md)
+- [Stability contract](STABILITY-CONTRACT.md)
+- [Threat model](THREAT_MODEL.md)
+- [Trust artifacts](TRUST-ARTIFACTS.md)

--- a/docs/KEY-CUSTODY-AND-TENANCY.md
+++ b/docs/KEY-CUSTODY-AND-TENANCY.md
@@ -1,8 +1,10 @@
-# Enterprise Trust Posture
+# Key custody and tenancy
 
-> Version: 0.12.7 | Status: Current
+> Version: 0.12.12 | Status: Current
 
-This document describes the trust model, key custody architecture, tenancy guarantees, and procurement posture for organizations evaluating or deploying the PEAC Protocol.
+This document describes the key custody architecture, tenancy guarantees, and procurement model for organizations evaluating or deploying the PEAC Protocol.
+
+For the full index of trust artifacts (SLO, stability contract, threat model, security operations), see [Trust artifacts](TRUST-ARTIFACTS.md).
 
 ## Key Custody Model
 
@@ -41,7 +43,7 @@ The Hosted Verify API uses per-API-key tenant isolation:
 
 Cross-tenant data leakage is prevented by design: each API key resolves to an isolated verification context with no shared mutable state. See [Hosted Verify Contract](HOSTED_VERIFY_CONTRACT.md) for the full API design.
 
-## Procurement Posture
+## Procurement
 
 ### License
 
@@ -74,6 +76,12 @@ Core packages (`@peac/kernel`, `@peac/schema`, `@peac/crypto`, `@peac/protocol`)
 
 ## Related Documents
 
+- [Trust artifacts](TRUST-ARTIFACTS.md): Single index over every trust artifact
+- [SECURITY.md](../SECURITY.md): Vulnerability reporting, supported versions, supply chain
+- [Security operations](SECURITY-OPERATIONS.md): Support windows, incident handling, logging, data residency
+- [Threat model](THREAT_MODEL.md): Consolidated threat catalog with per-threat test coverage
+- [Stability contract](STABILITY-CONTRACT.md): Classification of every public surface
+- [SLO](SLO.md) and [Benchmark methodology](BENCHMARK-METHODOLOGY.md)
 - [Architecture](ARCHITECTURE.md): Package layering, dependency DAG, wire formats
 - [Security Considerations](specs/SECURITY-CONSIDERATIONS.md): Signing model, JOSE hardening, key lifecycle
 - [Hosted Verify Contract](HOSTED_VERIFY_CONTRACT.md): API design, tenant isolation, threat mitigations

--- a/docs/README_LONG.md
+++ b/docs/README_LONG.md
@@ -455,7 +455,7 @@ Normative spec: [WORKFLOW-CORRELATION.md](specs/WORKFLOW-CORRELATION.md). Exampl
 - Kernel constraints enforced at issuance and verification (fail-closed)
 - No silent network fallback for offline verification
 
-See [SECURITY.md](../.github/SECURITY.md), [PROTOCOL-BEHAVIOR.md](specs/PROTOCOL-BEHAVIOR.md), and [HTTP-TRANSPORT-SECURITY.md](security/HTTP-TRANSPORT-SECURITY.md).
+See [SECURITY.md](../SECURITY.md), [Trust artifacts](TRUST-ARTIFACTS.md), [PROTOCOL-BEHAVIOR.md](specs/PROTOCOL-BEHAVIOR.md), and [HTTP-TRANSPORT-SECURITY.md](security/HTTP-TRANSPORT-SECURITY.md).
 
 ---
 

--- a/docs/REFERENCE_ARCHITECTURES.md
+++ b/docs/REFERENCE_ARCHITECTURES.md
@@ -160,5 +160,5 @@ All three patterns support fully offline verification. Once a verifier has the i
 - [Architecture](ARCHITECTURE.md): Package layering, dependency DAG
 - [Protocol Behavior](specs/PROTOCOL-BEHAVIOR.md): Normative issuance and verification flows
 - [Evidence Carrier Contract](specs/EVIDENCE-CARRIER-CONTRACT.md): Transport-neutral carrier interface
-- [Enterprise Trust Posture](ENTERPRISE_TRUST_POSTURE.md): Key custody, tenancy, procurement
-- [Security Posture](SECURITY_POSTURE.md): Support windows, provenance, logging
+- [Key custody and tenancy](KEY-CUSTODY-AND-TENANCY.md): Key custody, tenancy, procurement
+- [Security operations](SECURITY-OPERATIONS.md): Support windows, provenance, logging

--- a/docs/SECURITY-OPERATIONS.md
+++ b/docs/SECURITY-OPERATIONS.md
@@ -1,16 +1,16 @@
-# Security Posture
+# Security operations
 
-> Version: 0.12.7 | Status: Current
+> Version: 0.12.12 | Status: Current
 
-This document describes the operational security posture of the PEAC Protocol: support windows, incident handling, supply chain provenance, logging boundaries, tenant isolation, and data residency.
+This document describes the operational security model of the PEAC Protocol: support windows, incident handling, supply chain provenance, logging boundaries, tenant isolation, and data residency.
 
-For cryptographic design, JOSE hardening, and SSRF prevention, see [Security Considerations](specs/SECURITY-CONSIDERATIONS.md). For vulnerability reporting, see [SECURITY.md](../.github/SECURITY.md).
+For cryptographic design, JOSE hardening, and SSRF prevention, see [Security Considerations](specs/SECURITY-CONSIDERATIONS.md). For the canonical vulnerability-reporting policy and supported versions, see the root [SECURITY.md](../SECURITY.md). The full trust-artifact index lives in [Trust artifacts](TRUST-ARTIFACTS.md).
 
 ## Support Windows
 
 | Surface state           | Fix policy                               | Minimum window                                   |
 | ----------------------- | ---------------------------------------- | ------------------------------------------------ |
-| `default` / `supported` | Security, correctness, and feature fixes | Current release train                            |
+| `default` / `supported` | Security, correctness, and feature fixes | Current minor-release line                       |
 | `compat-only`           | Security and correctness fixes only      | Until next major or deprecation notice           |
 | `deprecated`            | Security fixes only                      | 2 minor releases or 60 days, whichever is longer |
 | `archived`              | No fixes                                 | May be removed in any future minor               |
@@ -29,14 +29,14 @@ The current deprecation schedule is in [Deprecation Policy](DEPRECATION_POLICY.m
 
 ## Incident Disclosure
 
-Vulnerability reports follow the process defined in [SECURITY.md](../.github/SECURITY.md):
+Vulnerability reports follow the process defined in [SECURITY.md](../SECURITY.md):
 
-| Step                                | SLA                                   |
-| ----------------------------------- | ------------------------------------- |
-| Report to security@peacprotocol.org | Anytime                               |
-| Acknowledgment                      | 48 hours                              |
-| Investigation and triage            | 7 days                                |
-| Fix and coordinated disclosure      | Per severity; critical within 30 days |
+| Step                                                                | SLA                                   |
+| ------------------------------------------------------------------- | ------------------------------------- |
+| Report to `security@peacprotocol.org` or GitHub Security Advisories | Anytime                               |
+| Acknowledgment                                                      | 48 hours                              |
+| Investigation and triage                                            | 7 days                                |
+| Fix and coordinated disclosure                                      | Per severity; critical within 30 days |
 
 PEAC does not currently operate a bug bounty program.
 
@@ -117,9 +117,13 @@ See [Deprecation Policy](DEPRECATION_POLICY.md) for the full lifecycle.
 
 ## Related Documents
 
-- [SECURITY.md](../.github/SECURITY.md): Vulnerability reporting, dependency audit policy
+- [Trust artifacts](TRUST-ARTIFACTS.md): Single index over every trust artifact
+- [SECURITY.md](../SECURITY.md): Vulnerability reporting, supported versions, supply chain
+- [Threat model](THREAT_MODEL.md): Consolidated threat catalog with per-threat test coverage
+- [Stability contract](STABILITY-CONTRACT.md): Classification of every public surface
+- [SLO](SLO.md) and [Benchmark methodology](BENCHMARK-METHODOLOGY.md)
 - [Security Considerations](specs/SECURITY-CONSIDERATIONS.md): Signing model, JOSE hardening, SSRF prevention, key lifecycle
 - [Verifier Security Model](specs/VERIFIER-SECURITY-MODEL.md): Verification modes, security limits, error codes
 - [HTTP Transport Security](security/HTTP-TRANSPORT-SECURITY.md): MCP server deployment checklist
-- [Enterprise Trust Posture](ENTERPRISE_TRUST_POSTURE.md): Key custody, tenancy, procurement
+- [Key custody and tenancy](KEY-CUSTODY-AND-TENANCY.md): Key custody, tenancy, procurement
 - [Hosted Verify Contract](HOSTED_VERIFY_CONTRACT.md): API design, threat mitigations, privacy defaults

--- a/docs/SLO.md
+++ b/docs/SLO.md
@@ -1,0 +1,103 @@
+# PEAC Protocol SLO
+
+> **Status:** Operator-facing service-level objectives for the open-source
+> reference verifier and the published `@peac/protocol` package. Numbers are
+> baseline measurements against a documented machine profile; see
+> [Benchmark methodology](BENCHMARK-METHODOLOGY.md). These are SLOs, not
+> SLAs. The open-source reference verifier carries no contractual SLA. The
+> managed Hosted Verify instance is operated separately under its own
+> contract and is not part of this repository.
+
+## Baseline metadata
+
+| Field                      | Value                                                                                           |
+| -------------------------- | ----------------------------------------------------------------------------------------------- |
+| `baseline_commit`          | `release-prep` (final value stamped on the v0.12.12 release-prep commit)                        |
+| `baseline_date`            | `release-prep` (final value stamped on the v0.12.12 release-prep commit)                        |
+| `baseline_machine_profile` | See [Benchmark methodology](BENCHMARK-METHODOLOGY.md)                                           |
+| Capture method             | `pnpm test --filter @peac/protocol tests/perf/wire02-slo.test.ts` with `PEAC_BENCH_JSON=<path>` |
+
+All rows below carry `baseline_commit: release-prep` until the release-prep
+commit replaces the placeholders with captured numbers. The captured numbers
+are the measurement against the `baseline_commit` on the documented machine
+profile; real-world performance varies with hardware, network, workload, and
+receipt size.
+
+## Local protocol operations (`@peac/protocol` v0.12.12)
+
+| Operation                               | Median (p50)   | p95            | p99            | Notes                        |
+| --------------------------------------- | -------------- | -------------- | -------------- | ---------------------------- |
+| `issue()` (Ed25519, ~1 KB record)       | `release-prep` | `release-prep` | `release-prep` | Loopback; Ed25519 only       |
+| `verifyLocal()` (Ed25519, ~1 KB record) | `release-prep` | `release-prep` | `release-prep` | Local validation; no network |
+
+The existing SLO gate in [tests/perf/wire02-slo.test.ts](../tests/perf/wire02-slo.test.ts)
+asserts `verifyLocal` p95 MUST be ≤ 10 ms. That gate runs in CI on every PR.
+
+## Reference verifier (`apps/api` `/v1/verify`)
+
+| Operation                                                     | Median (p50)   | p95            | p99            | Notes                                        |
+| ------------------------------------------------------------- | -------------- | -------------- | -------------- | -------------------------------------------- |
+| `/v1/verify` (Ed25519, ~1 KB record)                          | `release-prep` | `release-prep` | `release-prep` | Loopback; no JWKS resolution                 |
+| `/v1/verify` with JWKS resolution (single issuer, warm cache) | `release-prep` | `release-prep` | `release-prep` | Measured after first request; JWKS cache hot |
+
+## MCP tool-call round-trip with receipt issuance
+
+| Operation                                                                 | Median (p50)   | p95            | p99            | Notes                 |
+| ------------------------------------------------------------------------- | -------------- | -------------- | -------------- | --------------------- |
+| MCP `tools/call` round-trip emitting `_meta.org.peacprotocol/receipt_jws` | `release-prep` | `release-prep` | `release-prep` | Local stdio transport |
+
+## Receipt size classes used in the table
+
+- Class A: ~1 KB record (typical agent observation; used in the rows above).
+- Class B: ~8 KB record (commerce evidence with attached upstream artifact).
+- Class C: ~64 KB record (per-extension-group kernel constraint ceiling; see
+  [Kernel constraints spec](specs/KERNEL-CONSTRAINTS.md)).
+
+The published numbers reflect Class A unless a row explicitly states otherwise.
+
+## What these SLOs do not promise
+
+- The open-source reference verifier carries no uptime SLA. Self-hosters
+  operate the verifier under their own availability commitments.
+- Hosted Verify (managed, multi-tenant, SLA) is a separate offering
+  operated outside this repository. See
+  [Hosted Verify contract](HOSTED_VERIFY_CONTRACT.md).
+- Baseline numbers describe loopback measurement on the documented machine
+  profile. Production performance varies with hardware, network, workload,
+  and receipt size.
+- SLO numbers are not available for future execution-surface carriers (CLI
+  execution evidence; observational lifecycle records). Those carriers
+  enter the SLO document at v0.14.1; see the forward-looking subsection
+  below.
+
+## Regression policy
+
+- `verifyLocal()` p95 is gated by the existing CI benchmark regression
+  check in [tests/perf/wire02-slo.test.ts](../tests/perf/wire02-slo.test.ts).
+- `issue()` baseline is published here and becomes a regression-gate
+  candidate alongside the broader mutation-testing baseline work tracked
+  for a future release.
+- Reference verifier `/v1/verify` baseline is published here. Regression
+  gating is scheduled to evolve alongside the existing Go middleware
+  benchmark discipline.
+
+## Future execution-surface carriers (pre-doctrine)
+
+This subsection is forward-looking. It documents the expected SLO
+commitments for future public carriers that have not yet shipped. These
+rules apply when, and only when, the corresponding carriers land.
+
+- CLI execution-evidence carrier: SLO rows publish at v0.14.1 against the
+  same machine profile. Until v0.14.1 ships, no CLI execution-evidence
+  SLO is claimed.
+- Observational lifecycle-record carrier: SLO rows publish at v0.14.1.
+  Lifecycle records are observational-only; SLO measures record-emission
+  time on the PEAC side, not the upstream producing system.
+
+## Related documents
+
+- [Benchmark methodology](BENCHMARK-METHODOLOGY.md)
+- [Stability contract](STABILITY-CONTRACT.md)
+- [Threat model](THREAT_MODEL.md)
+- [Trust artifacts](TRUST-ARTIFACTS.md)
+- [SECURITY.md](../SECURITY.md)

--- a/docs/SOLUTIONS/regulatory-audit-trail.md
+++ b/docs/SOLUTIONS/regulatory-audit-trail.md
@@ -168,5 +168,5 @@ The `@peac/protocol` test suite covers the three-state policy-binding result; th
 - [`docs/governance/`](../governance/) — mapping from PEAC record fields to EU AI Act Annex IV, NIST AI RMF, and ISO 42001 Clause 8 controls. Formal mapping docs publish in a near-term release; the directory is the forward link.
 - [`docs/specs/EVIDENCE-CARRIER-CONTRACT.md`](../specs/EVIDENCE-CARRIER-CONTRACT.md) — bundle format and carrier contracts.
 - [`docs/specs/PROTOCOL-BEHAVIOR.md`](../specs/PROTOCOL-BEHAVIOR.md) — normative policy-binding three-state result.
-- [`docs/KEY-CUSTODY-AND-TENANCY.md`](../KEY-CUSTODY-AND-TENANCY.md) — key custody, tenancy, and procurement detail.
+- [`docs/KEY-CUSTODY-AND-TENANCY.md`](../KEY-CUSTODY-AND-TENANCY.md): key custody, tenancy, and procurement detail.
 - [`packages/cli/`](../../packages/cli/) — `peac reconcile`, `peac policy`, `peac conformance run`.

--- a/docs/SOLUTIONS/regulatory-audit-trail.md
+++ b/docs/SOLUTIONS/regulatory-audit-trail.md
@@ -168,5 +168,5 @@ The `@peac/protocol` test suite covers the three-state policy-binding result; th
 - [`docs/governance/`](../governance/) — mapping from PEAC record fields to EU AI Act Annex IV, NIST AI RMF, and ISO 42001 Clause 8 controls. Formal mapping docs publish in a near-term release; the directory is the forward link.
 - [`docs/specs/EVIDENCE-CARRIER-CONTRACT.md`](../specs/EVIDENCE-CARRIER-CONTRACT.md) — bundle format and carrier contracts.
 - [`docs/specs/PROTOCOL-BEHAVIOR.md`](../specs/PROTOCOL-BEHAVIOR.md) — normative policy-binding three-state result.
-- [`docs/ENTERPRISE_TRUST_POSTURE.md`](../ENTERPRISE_TRUST_POSTURE.md) — key custody, tenancy, and procurement-facing posture.
+- [`docs/KEY-CUSTODY-AND-TENANCY.md`](../KEY-CUSTODY-AND-TENANCY.md) — key custody, tenancy, and procurement detail.
 - [`packages/cli/`](../../packages/cli/) — `peac reconcile`, `peac policy`, `peac conformance run`.

--- a/docs/STABILITY-CONTRACT.md
+++ b/docs/STABILITY-CONTRACT.md
@@ -1,0 +1,201 @@
+# Stability contract
+
+This document classifies every public surface PEAC publishes. The
+classification is binding for the declared release line. Each row names the
+exact surface path, package, header, API, or artifact so consumers can pin
+expectations to concrete, reviewable entries.
+
+## Classifications
+
+| Classification  | Commitment                                                                                                                    |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `stable`        | Public commitment. Breaking changes at a declared major-version boundary. Wire constants in this class are frozen until v1.0. |
+| `experimental`  | Public but explicitly subject to change. Breaking changes may land in any release with a CHANGELOG note. Flagged in source.   |
+| `deprecated`    | Public and supported within its declared window; scheduled for removal at a named release.                                    |
+| `internal-only` | Not part of the public surface. Not documented on README, `docs/START_HERE.md`, examples, listings, or marketing prose.       |
+
+These classifications describe behavioral stability, not package-level
+maintenance (security and correctness fixes apply to every active line per
+[Security operations](SECURITY-OPERATIONS.md)).
+
+## Wire formats
+
+| Surface                    | Concrete identifier                                       | Classification | Notes                                                          |
+| -------------------------- | --------------------------------------------------------- | -------------- | -------------------------------------------------------------- |
+| Current interaction record | `typ: interaction-record+jwt` (JWS JOSE header; Wire 0.2) | `stable`       | Frozen wire identifiers until v1.0                             |
+| Legacy receipt format      | `peac-receipt/0.1` (Wire 0.1)                             | `stable`       | Verify-only path frozen; no new-feature extensions             |
+| Archival receipt format    | `peac.receipt/0.9`                                        | `deprecated`   | Verify-only via `@peac/core` archival path; removal at v0.13.0 |
+| Cryptographic envelope     | JWS Compact Serialization (RFC 7515), Ed25519 (RFC 8032)  | `stable`       | Algorithm negotiation is not supported                         |
+| Canonical JSON             | JCS (RFC 8785)                                            | `stable`       | Cross-language parity fixtures in `specs/conformance/`         |
+| Verifier response bodies   | `application/json` (RFC 8259)                             | `stable`       | Error bodies: `application/problem+json` (RFC 9457)            |
+
+## Public TypeScript APIs
+
+| Surface (package)                                                                           | Classification  | Notes                                                                                                                      |
+| ------------------------------------------------------------------------------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| [`@peac/protocol`](../packages/protocol) `issue()`                                          | `stable`        | Wire 0.2 issuance entry point                                                                                              |
+| [`@peac/protocol`](../packages/protocol) `verifyLocal()`                                    | `stable`        | Offline verification                                                                                                       |
+| [`@peac/protocol`](../packages/protocol) `verify()`                                         | `stable`        | Verification with optional hosted report assembly                                                                          |
+| `@peac/protocol` discovery / JWKS resolver helpers                                          | `internal-only` | Use via `verifyLocal()` / `verify()`; see [protocol-behavior](specs/PROTOCOL-BEHAVIOR.md)                                  |
+| [`@peac/crypto`](../packages/crypto) Ed25519 sign / verify                                  | `stable`        | RFC 8032 primitives                                                                                                        |
+| [`@peac/crypto`](../packages/crypto) JCS                                                    | `stable`        | RFC 8785 serialization                                                                                                     |
+| [`@peac/schema`](../packages/schema) record + extension-group exports                       | `stable`        | Zod v4 schemas                                                                                                             |
+| [`@peac/kernel`](../packages/kernel) type URIs and constants                                | `stable`        | Some constants relocate in a later release with a compat barrel; announced via [deprecation policy](DEPRECATION_POLICY.md) |
+| `@peac/control` high-level APIs                                                             | `stable`        | Compose `@peac/protocol` with higher-level flows                                                                           |
+| `@peac/middleware-core`, `@peac/middleware-express`                                         | `stable`        | HTTP middleware                                                                                                            |
+| `@peac/disc` issuer-config resolution                                                       | `stable`        | `/.well-known/peac-issuer.json` → `jwks_uri`                                                                               |
+| `@peac/jwks-cache`                                                                          | `stable`        | Bounded LRU JWKS cache with kid-reuse detection                                                                            |
+| `@peac/audit` bundle exports                                                                | `stable`        | Offline dispute-bundle composition                                                                                         |
+| [`@peac/adapter-core`](../packages/adapters/core) `assertExplicitFinality`                  | `stable`        | Commerce mapper-boundary guard                                                                                             |
+| `@peac/mappings-{mcp,a2a,acp,paymentauth,ucp,content-signals,intoto,slsa}`                  | `stable`        | Observation mappers                                                                                                        |
+| `@peac/adapter-{x402,openclaw,eat,did,managed-agents,runtime-governance,openai-compatible}` | `stable`        | Layer 4 adapters                                                                                                           |
+| `@peac/rails-x402`, `@peac/rails-card`, `@peac/rails-razorpay`, `@peac/rails-stripe`        | `stable`        | Commerce rails                                                                                                             |
+| `@peac/http-signatures`                                                                     | `stable`        | RFC 9421 helpers                                                                                                           |
+| `@peac/net-node` SSRF-safe fetch                                                            | `stable`        | Used by resolver paths; see [security considerations](specs/SECURITY-CONSIDERATIONS.md)                                    |
+| `@peac/transport-grpc`                                                                      | `stable`        | A2A gRPC carrier                                                                                                           |
+| `@peac/policy-kit`                                                                          | `stable`        | Policy authoring helpers (non-enforcement)                                                                                 |
+| `@peac/capture-core`, `@peac/capture-node`                                                  | `stable`        | Local capture utilities                                                                                                    |
+| `@peac/telemetry`, `@peac/telemetry-otel`                                                   | `stable`        | OpenTelemetry signals (opt-in)                                                                                             |
+| `@peac/contracts`                                                                           | `stable`        | Machine-readable contract exports                                                                                          |
+| `@peac/pay402`, `@peac/pref`, `@peac/attribution`, `@peac/receipts`                         | `stable`        | Supporting packages on Layer 4                                                                                             |
+| `@peac/worker-core`                                                                         | `stable`        | Worker-oriented helpers                                                                                                    |
+| `@peac/core`                                                                                | `deprecated`    | Archival; Wire 0.9 verify-only path; removal at v0.13.0                                                                    |
+| `@peac/sdk`                                                                                 | `deprecated`    | Workspace stub; removal at v0.13.0                                                                                         |
+
+Consumers: import only from the package's documented public entry points.
+Subpath imports into internal modules are not a stable surface even when
+`package.json` `exports` permits them; such imports may break without a
+breaking-version bump on the package.
+
+## Machine-readable contracts
+
+| Surface                       | Path                                                                                                                  | Classification           |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `@peac/crypto` API contract   | [`contracts/api/crypto.json`](../contracts/api/crypto.json)                                                           | `stable`                 |
+| `@peac/kernel` API contract   | [`contracts/api/kernel.json`](../contracts/api/kernel.json)                                                           | `stable`                 |
+| `@peac/protocol` API contract | [`contracts/api/protocol.json`](../contracts/api/protocol.json)                                                       | `stable`                 |
+| `@peac/schema` API contract   | [`contracts/api/schema.json`](../contracts/api/schema.json)                                                           | `stable`                 |
+| Reference verifier OpenAPI    | [`packages/schema/openapi/verify.yaml`](../packages/schema/openapi/verify.yaml)                                       | `stable` (OpenAPI 3.1.1) |
+| Conformance fixtures          | [`specs/conformance/`](../specs/conformance/)                                                                         | `stable`                 |
+| Registries spec               | [`docs/specs/REGISTRIES.md`](specs/REGISTRIES.md) + [`specs/kernel/registries.json`](../specs/kernel/registries.json) | `stable`                 |
+| Error taxonomy                | [`docs/specs/ERRORS.md`](specs/ERRORS.md) + [`specs/kernel/errors.json`](../specs/kernel/errors.json)                 | `stable`                 |
+
+## CLI commands
+
+Package: [`@peac/cli`](../packages/cli).
+
+| Command                               | Classification |
+| ------------------------------------- | -------------- |
+| `peac verify`                         | `stable`       |
+| `peac issue`                          | `stable`       |
+| `peac doctor`                         | `stable`       |
+| `peac conformance run`                | `stable`       |
+| `peac samples list`/`show`/`generate` | `stable`       |
+| `peac reconcile`                      | `stable`       |
+| `peac policy`                         | `stable`       |
+
+## Reference verifier (`apps/api`)
+
+| Surface               | Path                                                                             | Classification                                                  |
+| --------------------- | -------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `POST /v1/verify`     | [`apps/api`](../apps/api)                                                        | `stable`                                                        |
+| `POST /v1/issue`      | `apps/api` (provisional; see [Hosted issue contract](HOSTED_VERIFY_CONTRACT.md)) | `experimental`                                                  |
+| Legacy `POST /verify` | `apps/api`                                                                       | `deprecated` (Deprecation + Sunset headers; removal at v0.13.0) |
+
+Response shapes:
+
+| Media type                                    | Classification |
+| --------------------------------------------- | -------------- |
+| `application/json` (default)                  | `stable`       |
+| `application/peac-report+json`                | `stable`       |
+| `application/problem+json` (errors; RFC 9457) | `stable`       |
+| `text/plain` (human-readable)                 | `stable`       |
+
+## MCP server surfaces
+
+Package: [`@peac/mcp-server`](../packages/mcp-server).
+
+| Surface                                                                                                          | Classification |
+| ---------------------------------------------------------------------------------------------------------------- | -------------- |
+| MCP tool-call `_meta.org.peacprotocol/receipt_jws` + `receipt_ref`                                               | `stable`       |
+| `stdio` transport                                                                                                | `stable`       |
+| Streamable HTTP transport (unprotected mode; see [HTTP transport security](security/HTTP-TRANSPORT-SECURITY.md)) | `stable`       |
+| Registry manifest ([`packages/mcp-server/server.json`](../packages/mcp-server/server.json))                      | `stable`       |
+| Smithery config ([`packages/mcp-server/smithery.yaml`](../packages/mcp-server/smithery.yaml))                    | `stable`       |
+
+## IDE plugin packs
+
+Path: [`surfaces/plugin-pack/`](../surfaces/plugin-pack/).
+
+| Surface                                                                 | Classification |
+| ----------------------------------------------------------------------- | -------------- |
+| `surfaces/plugin-pack/cursor/`                                          | `stable`       |
+| `surfaces/plugin-pack/codex/`                                           | `stable`       |
+| `surfaces/plugin-pack/claude-code/`                                     | `stable`       |
+| `surfaces/plugin-pack/vscode/`                                          | `stable`       |
+| `surfaces/plugin-pack/continue/`, `opencode/`, `smithery/`, `windsurf/` | `experimental` |
+
+## HTTP headers and identifiers
+
+| Identifier                                               | Classification | Notes                                                            |
+| -------------------------------------------------------- | -------------- | ---------------------------------------------------------------- |
+| `PEAC-Receipt` header                                    | `stable`       | Compact JWS; see [PROTOCOL-BEHAVIOR](specs/PROTOCOL-BEHAVIOR.md) |
+| `receipt_ref` (MCP `_meta.org.peacprotocol/receipt_ref`) | `stable`       | `sha256(receipt_jws)`                                            |
+| `Deprecation` response header                            | `stable`       | RFC 9745 on deprecated routes                                    |
+| `Sunset` response header                                 | `stable`       | RFC 8594 on removed routes                                       |
+
+## Archived surfaces
+
+| Surface                   | Path                                                                                                         | Classification  |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------ | --------------- |
+| Historical bridge app     | [`apps/bridge`](../apps/bridge)                                                                              | `internal-only` |
+| Sandbox issuer            | [`apps/sandbox-issuer`](../apps/sandbox-issuer)                                                              | `internal-only` |
+| Experimental EAS adapter  | [`packages/adapters/eas`](../packages/adapters/eas)                                                          | `experimental`  |
+| Experimental transports   | [`packages/transport/http`](../packages/transport/http), [`packages/transport/ws`](../packages/transport/ws) | `experimental`  |
+| Nextjs middleware preview | [`surfaces/nextjs/middleware`](../surfaces/nextjs/middleware)                                                | `experimental`  |
+
+## Deprecation schedule
+
+| Surface                                                   | Deprecated since | Removal target |
+| --------------------------------------------------------- | ---------------- | -------------- |
+| `ProofMethodSchema` (compat alias)                        | v0.12.2          | v0.13.0        |
+| A2A v0.3.0 compatibility path                             | v0.12.3          | v0.13.0        |
+| Legacy `POST /verify` endpoint (in favor of `/v1/verify`) | v0.12.x          | v0.13.0        |
+| `packages/sdk-js/` workspace stub                         | v0.12.x          | v0.13.0        |
+| `peac.receipt/0.9` archival format                        | Legacy frozen    | v0.13.0        |
+| `@peac/core` archival verify-only path                    | Legacy frozen    | v0.13.0        |
+
+All status transitions are tracked in
+[`REPO_SURFACE_STATUS.json`](../REPO_SURFACE_STATUS.json) and mirrored in
+[`docs/SURFACE_STATUS.md`](SURFACE_STATUS.md) and
+[`docs/PACKAGE_STATUS.md`](PACKAGE_STATUS.md). Support windows and fix
+policy live in [Security operations](SECURITY-OPERATIONS.md) and
+[Deprecation policy](DEPRECATION_POLICY.md).
+
+## Forthcoming surfaces (pre-doctrine)
+
+The following surfaces are not yet shipped. They enter the stability
+contract only when the corresponding code lands. Classifications here are
+forward-looking and binding for the future public code, not for any
+current behavior.
+
+| Surface                                               | Status      | Target                                                             |
+| ----------------------------------------------------- | ----------- | ------------------------------------------------------------------ |
+| CLI execution-evidence carrier profile                | Not shipped | v0.14.1                                                            |
+| Observational lifecycle-record carrier profile        | Not shipped | v0.14.1                                                            |
+| COSE/CBOR codec flag (`PEAC_EXPERIMENTAL_CODEC=cose`) | Not shipped | `experimental` once shipped; gated by an explicit roadmap decision |
+
+Security and semantic constraints pre-declared for these surfaces live in
+the [Threat model](THREAT_MODEL.md) forward-looking subsection.
+
+## Related documents
+
+- [SECURITY.md](../SECURITY.md)
+- [Security operations](SECURITY-OPERATIONS.md)
+- [Deprecation policy](DEPRECATION_POLICY.md)
+- [Compatibility matrix](COMPATIBILITY_MATRIX.md)
+- [Surface status](SURFACE_STATUS.md)
+- [Package status](PACKAGE_STATUS.md)
+- [Threat model](THREAT_MODEL.md)
+- [SLO](SLO.md)
+- [Trust artifacts](TRUST-ARTIFACTS.md)

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -1,0 +1,163 @@
+# PEAC Protocol threat model
+
+Consolidated threat model for the wire format, the open-source reference
+verifier, the MCP server, and the published Layer 4 adapters. Each threat
+below lists the mitigation and a test path that exercises it; the
+companion verifier [`scripts/verify-trust-artifacts.mjs`](../scripts/verify-trust-artifacts.mjs)
+fails CI if any referenced test path does not exist or if any threat row
+lacks a test link.
+
+## Scope
+
+In scope:
+
+- Wire format (`typ: interaction-record+jwt`, Wire 0.2; `peac-receipt/0.1`,
+  Wire 0.1; archival `peac.receipt/0.9`).
+- Signature verification (Ed25519, JWS Compact Serialization, JCS).
+- Issuer-config and JWKS resolution.
+- Reference verifier ([`apps/api`](../apps/api)).
+- MCP server ([`@peac/mcp-server`](../packages/mcp-server)) stdio and
+  Streamable HTTP transports.
+- Layer 4 commerce mapper boundary
+  ([`@peac/adapter-core`](../packages/adapters/core)
+  `assertExplicitFinality`).
+- Cross-language parity (`packages/schema` and `sdks/go`).
+
+Out of scope:
+
+- Managed Hosted Verify (operated separately under its own threat model).
+- Customer-side key custody (bring-your-own-key; see [Key custody and
+  tenancy](KEY-CUSTODY-AND-TENANCY.md)).
+- Transport-level confidentiality beyond what TLS and RFC 9421 provide.
+- Application-level business logic layered on top of PEAC records.
+
+## Trust boundaries
+
+| Boundary                             | Assumption                                                                     |
+| ------------------------------------ | ------------------------------------------------------------------------------ |
+| Record issuer ↔ record verifier      | Untrusted over the wire; trust is established by the issuer's JWKS binding     |
+| Reference verifier ↔ upstream JWKS   | Untrusted network; SSRF-safe fetch + private-range block                       |
+| Caller ↔ `@peac/protocol` public API | Trusted process boundary; caller supplies keys and fixtures                    |
+| MCP client ↔ MCP server              | Session-isolated per client; no shared mutable state between clients           |
+| Layer 4 mapper ↔ upstream artifact   | Upstream state is never synthesized into finality; see commerce-finality guard |
+
+## Threat catalog
+
+Each row links to a test file that exercises the mitigation. CI enforces
+that every link resolves to a tracked path.
+
+### Wire format and signature
+
+| ID        | Threat                                                      | Mitigation                                                                      | Test coverage                                                                                                                                                                  |
+| --------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| T-WIRE-01 | Forged signature                                            | Ed25519 verify (RFC 8032); JWS Compact Serialization (RFC 7515)                 | [`packages/crypto/tests/jws.test.ts`](../packages/crypto/tests/jws.test.ts)                                                                                                    |
+| T-WIRE-02 | JOSE header abuse (`jwk`/`x5c`/`x5u`/`jku`)                 | Embedded-key forms rejected on verify                                           | [`packages/crypto/__tests__/jws-wire-02.test.ts`](../packages/crypto/__tests__/jws-wire-02.test.ts)                                                                            |
+| T-WIRE-03 | Critical-extension abuse (`crit` / `b64:false` / `zip`)     | Disallowed at the JWS layer                                                     | [`packages/crypto/__tests__/jws.property.test.ts`](../packages/crypto/__tests__/jws.property.test.ts)                                                                          |
+| T-WIRE-04 | Wire-version confusion (0.1 ↔ 0.2 cross-claim)              | `typ` header drives dispatch; coherence enforced at verify                      | [`packages/protocol/__tests__/strictness.property.test.ts`](../packages/protocol/__tests__/strictness.property.test.ts)                                                        |
+| T-WIRE-05 | Receipt-ref tampering                                       | `receipt_ref = sha256(receipt_jws)` verified at extraction                      | [`packages/schema/__tests__/carrier.test.ts`](../packages/schema/__tests__/carrier.test.ts)                                                                                    |
+| T-WIRE-06 | Replay attack                                               | `jti` uniqueness; `iat` / `nbf` / `exp` time bounds; verifier-side replay cache | [`packages/protocol/__tests__/verify-local-order.test.ts`](../packages/protocol/__tests__/verify-local-order.test.ts)                                                          |
+| T-WIRE-07 | Canonical-JSON divergence (JCS RFC 8785)                    | Golden vectors; property tests; cross-language parity                           | [`packages/crypto/tests/jcs.test.ts`](../packages/crypto/tests/jcs.test.ts), [`packages/net/node/tests/jcs-property.test.ts`](../packages/net/node/tests/jcs-property.test.ts) |
+| T-WIRE-08 | Algorithm confusion / downgrade                             | Ed25519 only; no alg negotiation                                                | [`packages/crypto/tests/golden-vectors.test.ts`](../packages/crypto/tests/golden-vectors.test.ts)                                                                              |
+| T-WIRE-09 | Policy-binding forgery (policy claim not bound to issuance) | JCS-based policy digest + three-state policy-binding result                     | [`packages/protocol/__tests__/policy-binding.test.ts`](../packages/protocol/__tests__/policy-binding.test.ts)                                                                  |
+
+### Issuer and JWKS resolution
+
+| ID       | Threat                                                         | Mitigation                                                                                               | Test coverage                                                                                                                                                                                            |
+| -------- | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T-RES-01 | SSRF via issuer-config / JWKS fetch                            | HTTPS only; private, loopback, and reserved-range block; IDNA / bracket / IPv4-in-IPv6 expansion blocked | [`packages/net/node/tests/safe-fetch.test.ts`](../packages/net/node/tests/safe-fetch.test.ts), [`packages/net/node/tests/ssrf-expansion.test.ts`](../packages/net/node/tests/ssrf-expansion.test.ts)     |
+| T-RES-02 | Slowloris / unbounded fetch time                               | Explicit timeout cap on every network-bearing path                                                       | [`packages/jwks-cache/tests/resolver.test.ts`](../packages/jwks-cache/tests/resolver.test.ts)                                                                                                            |
+| T-RES-03 | JWKS cache poisoning / kid substitution                        | Bounded LRU keyed per issuer; `kid` retention with reuse detection                                       | [`packages/jwks-cache/tests/security.test.ts`](../packages/jwks-cache/tests/security.test.ts), [`packages/jwks-cache/tests/cache.test.ts`](../packages/jwks-cache/tests/cache.test.ts)                   |
+| T-RES-04 | Redirect-chain attack (cross-origin redirect to private range) | Redirect policy bounded; redirects to blocked ranges rejected                                            | [`packages/net/node/tests/safe-fetch.test.ts`](../packages/net/node/tests/safe-fetch.test.ts)                                                                                                            |
+| T-RES-05 | `receipt_url` fetch amplification                              | Semaphore, per-tenant quota, fetch timeout, SSRF-safe                                                    | [`packages/net/node/tests/receipt-url-middleware.test.ts`](../packages/net/node/tests/receipt-url-middleware.test.ts)                                                                                    |
+| T-RES-06 | Reference-verifier discovery ambient fetch                     | Discovery constrained to verified resolver paths; no ambient pointer fetch                               | [`packages/protocol/tests/pointer-fetch.test.ts`](../packages/protocol/tests/pointer-fetch.test.ts), [`packages/protocol/tests/jwks-resolver.test.ts`](../packages/protocol/tests/jwks-resolver.test.ts) |
+
+### Verifier resource control
+
+| ID        | Threat                                             | Mitigation                                                                                   | Test coverage                                                                                                                                                                                                                    |
+| --------- | -------------------------------------------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T-VRFY-01 | Oversized record DoS                               | Receipt, per-extension-group, total-extension, nesting-depth, and member-count caps enforced | [`packages/schema/__tests__/constraints.test.ts`](../packages/schema/__tests__/constraints.test.ts), [`packages/schema/__tests__/byte-budget-enforcement.test.ts`](../packages/schema/__tests__/byte-budget-enforcement.test.ts) |
+| T-VRFY-02 | Kernel-constraint bypass (pre-signing path)        | `validateKernelConstraints()` enforced in `issue()` before signing and on verify             | [`packages/protocol/tests/issue-constraints.test.ts`](../packages/protocol/tests/issue-constraints.test.ts), [`packages/protocol/tests/verify-constraints.test.ts`](../packages/protocol/tests/verify-constraints.test.ts)       |
+| T-VRFY-03 | Issuance path calls network (no-network invariant) | Issuance MUST NOT perform any network I/O                                                    | [`tests/security/no-fetch-audit.test.ts`](../tests/security/no-fetch-audit.test.ts)                                                                                                                                              |
+| T-VRFY-04 | Wire 0.2 issuance byte-identity drift              | Property test over canonical JCS + JWS construction                                          | [`packages/protocol/__tests__/issue-wire-02.test.ts`](../packages/protocol/__tests__/issue-wire-02.test.ts)                                                                                                                      |
+
+### MCP server
+
+| ID       | Threat                                         | Mitigation                                                   | Test coverage                                                                                                                                                                                                                              |
+| -------- | ---------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| T-MCP-01 | Cross-client state leak (Streamable HTTP)      | Session-isolated `McpServer` + transport per client          | [`packages/mcp-server/tests/http/session-manager.test.ts`](../packages/mcp-server/tests/http/session-manager.test.ts), [`packages/mcp-server/tests/http/http-transport.test.ts`](../packages/mcp-server/tests/http/http-transport.test.ts) |
+| T-MCP-02 | Static-policy bypass (runtime policy mutation) | Static policy loaded at startup; immutable at runtime        | [`packages/mcp-server/tests/infra/policy.test.ts`](../packages/mcp-server/tests/infra/policy.test.ts)                                                                                                                                      |
+| T-MCP-03 | Path-traversal via handler input               | Path-safety validation on every file-bearing handler input   | [`packages/mcp-server/tests/infra/path-safety.test.ts`](../packages/mcp-server/tests/infra/path-safety.test.ts)                                                                                                                            |
+| T-MCP-04 | Stdout framing bypass (stdio transport)        | Line-buffered stdout fence                                   | [`packages/mcp-server/tests/security/stdout-fence.test.ts`](../packages/mcp-server/tests/security/stdout-fence.test.ts)                                                                                                                    |
+| T-MCP-05 | Evidence-carrier size overflow in `_meta`      | Transport-binding size caps; 64 KB embed for MCP / A2A / UCP | [`packages/mcp-server/tests/integration/e2e-smoke.test.ts`](../packages/mcp-server/tests/integration/e2e-smoke.test.ts)                                                                                                                    |
+
+### Commerce mapper boundary
+
+| ID        | Threat                                                 | Mitigation                                                                                 | Test coverage                                                                                                                                                                                                              |
+| --------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T-CMRC-01 | Mapper synthesizes finality from non-payment artifacts | `assertExplicitFinality` boundary guard; stable code `commerce.finality_synthesis_blocked` | [`packages/adapters/core/tests/finality.test.ts`](../packages/adapters/core/tests/finality.test.ts), [`packages/adapters/core/tests/finality-fixtures.test.ts`](../packages/adapters/core/tests/finality-fixtures.test.ts) |
+
+### Cross-language parity
+
+| ID          | Threat                         | Mitigation                                             | Test coverage                                                                                                                                                                                                                        |
+| ----------- | ------------------------------ | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| T-PARITY-01 | TS / Go wire-output divergence | Shared JCS golden vectors; claim parity property tests | [`tests/parity/core-claims.test.ts`](../tests/parity/core-claims.test.ts), [`specs/conformance/fixtures/go-interaction-record/jcs-golden-vectors.json`](../specs/conformance/fixtures/go-interaction-record/jcs-golden-vectors.json) |
+
+## Mitigation gaps (acknowledged)
+
+These mitigations are in effect but have scheduled follow-ups for a future
+release. The stability contract and security operations describe the current
+behavior; the scheduled work is planning scope, not a current gap in
+shipped behavior.
+
+- Mutation-testing baseline (Stryker for TypeScript; `go-mutesting` for Go).
+- Error-code emission audit (classify unused codes in
+  [`specs/kernel/errors.json`](../specs/kernel/errors.json)).
+- Verifier-policy extraction from `@peac/kernel` into a verifier-owned
+  surface.
+- Resource-limit invariant table with per-row implementation, test, and
+  baseline references.
+
+## Future carrier surfaces (pre-doctrine)
+
+The forthcoming public surfaces listed in the
+[Stability contract](STABILITY-CONTRACT.md) pre-doctrine section have not
+shipped. Their security contract is pre-declared here so that future
+implementation MUST honor the rules on day one.
+
+- **No raw secret capture by default.** Any future CLI or lifecycle record
+  carrier defaults to redaction or hashing for `argv`, `stdin`, `stdout`,
+  and `stderr`. Raw capture is opt-in and declared by a documented
+  `capture_policy` entry.
+- **Hash-only default for stream captures.** `stdin` / `stdout` / `stderr`
+  are hashed, not stored verbatim, unless the caller explicitly enables
+  raw capture under a documented policy.
+- **Environment-variable allowlist plus value hashing.** No blanket
+  environment dump. Only explicitly-listed variables enter the record,
+  and even those are hashed by default.
+- **Explicit `argv_mode`.** A shell-string invocation must be recorded as
+  such. Hidden shell-expansion ambiguity is rejected.
+- **Bounded byte ceilings on command capture.** `argv` bytes, stream
+  bytes, and environment-variable reference counts all carry documented
+  upper bounds. Exceeding a bound truncates or hashes; it never silently
+  drops.
+- **Lifecycle records are observational-only.** Approval, evaluation,
+  experiment, and workflow records describe what another system
+  attested. They never imply PEAC made the decision, scored the runtime,
+  enforced the policy, or determined payment finality.
+
+Each rule above becomes a named threat ID with a concrete test file at the
+time the corresponding surface is implemented. No public CLI or lifecycle
+code ships ahead of this contract.
+
+## Related documents
+
+- [Security considerations](specs/SECURITY-CONSIDERATIONS.md)
+- [Verifier security model](specs/VERIFIER-SECURITY-MODEL.md)
+- [HTTP transport security](security/HTTP-TRANSPORT-SECURITY.md)
+- [OWASP ASI mapping](security/OWASP-ASI-MAPPING.md)
+- [SECURITY.md](../SECURITY.md)
+- [Security operations](SECURITY-OPERATIONS.md)
+- [Key custody and tenancy](KEY-CUSTODY-AND-TENANCY.md)
+- [Stability contract](STABILITY-CONTRACT.md)
+- [SLO](SLO.md)
+- [Trust artifacts](TRUST-ARTIFACTS.md)

--- a/docs/TRUST-ARTIFACTS.md
+++ b/docs/TRUST-ARTIFACTS.md
@@ -1,0 +1,93 @@
+# Trust artifacts
+
+The single index over PEAC's trust artifacts. Each artifact below has one
+canonical home; this page points at all of them and normalizes the
+reference-verifier versus Hosted Verify distinction once so the rest of
+the documentation can link here.
+
+## Engineering trust
+
+- [SLO](SLO.md) — operator-facing service-level objectives with
+  versioned baseline stamps.
+- [Benchmark methodology](BENCHMARK-METHODOLOGY.md) — machine profile,
+  fixture set, measurement protocol, and reproduction commands.
+- [Stability contract](STABILITY-CONTRACT.md) — every public surface
+  classified `stable`, `experimental`, `deprecated`, or `internal-only`.
+- [Threat model](THREAT_MODEL.md) — consolidated threat catalog with
+  per-threat test-coverage links.
+
+## Disclosure and supply chain
+
+- [SECURITY.md](../SECURITY.md) — coordinated disclosure contact,
+  supported versions, supply-chain controls, external review cadence.
+- [Security operations](SECURITY-OPERATIONS.md) — support windows, runtime
+  support, incident handling SLAs, supply-chain provenance, logging
+  boundaries, tenant isolation, data residency.
+- [Key custody and tenancy](KEY-CUSTODY-AND-TENANCY.md) — key
+  custody, tenancy, procurement, stewardship.
+
+## Architecture and deep detail
+
+- [Architecture](ARCHITECTURE.md) — package layering and dependency
+  direction.
+- [Reference architectures](REFERENCE_ARCHITECTURES.md) — topology and
+  integration-flow patterns.
+- [Security considerations spec](specs/SECURITY-CONSIDERATIONS.md) —
+  signing model, JOSE hardening, SSRF prevention, key lifecycle.
+- [Verifier security model spec](specs/VERIFIER-SECURITY-MODEL.md) —
+  verification modes, size limits, error categories.
+- [HTTP transport security](security/HTTP-TRANSPORT-SECURITY.md) — MCP
+  server deployment checklist.
+- [OWASP ASI mapping](security/OWASP-ASI-MAPPING.md).
+
+## Reference verifier versus Hosted Verify
+
+PEAC ships two distinct verification surfaces. The stability contract,
+SLO, threat model, and security operations apply to the **reference
+verifier** unless a row is explicitly scoped to Hosted Verify.
+
+| Aspect             | Reference verifier                                                              | Hosted Verify                                       |
+| ------------------ | ------------------------------------------------------------------------------- | --------------------------------------------------- |
+| Location           | [`apps/api`](../apps/api) in this repository                                    | Operated separately; not part of this repository    |
+| Hosting model      | Self-hostable, tenantless                                                       | Managed, multi-tenant                               |
+| Deployment recipes | [`surfaces/reference-verifier/`](../surfaces/reference-verifier/)               | Not published here                                  |
+| SLA                | None (operator-managed availability)                                            | Per-contract                                        |
+| Contract           | [`packages/schema/openapi/verify.yaml`](../packages/schema/openapi/verify.yaml) | [Hosted Verify contract](HOSTED_VERIFY_CONTRACT.md) |
+| Threat model       | [`docs/THREAT_MODEL.md`](THREAT_MODEL.md)                                       | Operated under its own threat model                 |
+| SLO scope          | [`docs/SLO.md`](SLO.md)                                                         | Published by the Hosted Verify operator             |
+
+## Machine-readable and conformance artifacts
+
+- [Public API contracts](../contracts/api/) for `@peac/crypto`,
+  `@peac/kernel`, `@peac/protocol`, `@peac/schema`.
+- [Reference-verifier OpenAPI](../packages/schema/openapi/verify.yaml).
+- [Conformance fixtures](../specs/conformance/).
+- [Registries spec](specs/REGISTRIES.md) +
+  [`specs/kernel/registries.json`](../specs/kernel/registries.json).
+- [Error taxonomy](specs/ERRORS.md) +
+  [`specs/kernel/errors.json`](../specs/kernel/errors.json).
+- [Benchmark SLO spec](../specs/benchmarks/slo.json) and
+  [baseline](../specs/benchmarks/baseline.json).
+- [Repo surface status](../REPO_SURFACE_STATUS.json) →
+  [Surface status view](SURFACE_STATUS.md).
+- [Package status](PACKAGE_STATUS.md).
+
+## Compatibility
+
+- [Compatibility matrix](COMPATIBILITY_MATRIX.md) — runtime,
+  wire-format, and deprecation compatibility.
+- [Deprecation policy](DEPRECATION_POLICY.md) — support windows and
+  archive protocol.
+- [Compatibility docs by protocol](compatibility/) — commerce,
+  runtime, A2A, MCP, Copilot, Go middleware.
+
+## Forward-looking
+
+- Compliance mappings (ISO 42001 Clause 8; EU AI Act Annex IV transparency
+  applicability context) are scheduled for a later release and will land
+  under `docs/compliance/`.
+- Execution-surface carriers (CLI execution evidence; observational
+  lifecycle records) are scheduled for v0.14.1; their pre-doctrine
+  security controls are declared in the
+  [Threat model forward-looking subsection](THREAT_MODEL.md#future-carrier-surfaces-pre-doctrine)
+  and [Stability contract forthcoming subsection](STABILITY-CONTRACT.md#forthcoming-surfaces-pre-doctrine).

--- a/docs/TRUST-ARTIFACTS.md
+++ b/docs/TRUST-ARTIFACTS.md
@@ -7,36 +7,36 @@ the documentation can link here.
 
 ## Engineering trust
 
-- [SLO](SLO.md) — operator-facing service-level objectives with
+- [SLO](SLO.md): operator-facing service-level objectives with
   versioned baseline stamps.
-- [Benchmark methodology](BENCHMARK-METHODOLOGY.md) — machine profile,
+- [Benchmark methodology](BENCHMARK-METHODOLOGY.md): machine profile,
   fixture set, measurement protocol, and reproduction commands.
-- [Stability contract](STABILITY-CONTRACT.md) — every public surface
+- [Stability contract](STABILITY-CONTRACT.md): every public surface
   classified `stable`, `experimental`, `deprecated`, or `internal-only`.
-- [Threat model](THREAT_MODEL.md) — consolidated threat catalog with
+- [Threat model](THREAT_MODEL.md): consolidated threat catalog with
   per-threat test-coverage links.
 
 ## Disclosure and supply chain
 
-- [SECURITY.md](../SECURITY.md) — coordinated disclosure contact,
+- [SECURITY.md](../SECURITY.md): coordinated disclosure contact,
   supported versions, supply-chain controls, external review cadence.
-- [Security operations](SECURITY-OPERATIONS.md) — support windows, runtime
+- [Security operations](SECURITY-OPERATIONS.md): support windows, runtime
   support, incident handling SLAs, supply-chain provenance, logging
   boundaries, tenant isolation, data residency.
-- [Key custody and tenancy](KEY-CUSTODY-AND-TENANCY.md) — key
+- [Key custody and tenancy](KEY-CUSTODY-AND-TENANCY.md): key
   custody, tenancy, procurement, stewardship.
 
 ## Architecture and deep detail
 
-- [Architecture](ARCHITECTURE.md) — package layering and dependency
+- [Architecture](ARCHITECTURE.md): package layering and dependency
   direction.
-- [Reference architectures](REFERENCE_ARCHITECTURES.md) — topology and
+- [Reference architectures](REFERENCE_ARCHITECTURES.md): topology and
   integration-flow patterns.
-- [Security considerations spec](specs/SECURITY-CONSIDERATIONS.md) —
+- [Security considerations spec](specs/SECURITY-CONSIDERATIONS.md):
   signing model, JOSE hardening, SSRF prevention, key lifecycle.
-- [Verifier security model spec](specs/VERIFIER-SECURITY-MODEL.md) —
+- [Verifier security model spec](specs/VERIFIER-SECURITY-MODEL.md):
   verification modes, size limits, error categories.
-- [HTTP transport security](security/HTTP-TRANSPORT-SECURITY.md) — MCP
+- [HTTP transport security](security/HTTP-TRANSPORT-SECURITY.md): MCP
   server deployment checklist.
 - [OWASP ASI mapping](security/OWASP-ASI-MAPPING.md).
 
@@ -74,11 +74,11 @@ verifier** unless a row is explicitly scoped to Hosted Verify.
 
 ## Compatibility
 
-- [Compatibility matrix](COMPATIBILITY_MATRIX.md) — runtime,
+- [Compatibility matrix](COMPATIBILITY_MATRIX.md): runtime,
   wire-format, and deprecation compatibility.
-- [Deprecation policy](DEPRECATION_POLICY.md) — support windows and
+- [Deprecation policy](DEPRECATION_POLICY.md): support windows and
   archive protocol.
-- [Compatibility docs by protocol](compatibility/) — commerce,
+- [Compatibility docs by protocol](compatibility/): commerce,
   runtime, A2A, MCP, Copilot, Go middleware.
 
 ## Forward-looking

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -1,8 +1,8 @@
 # PEAC Security
 
-The top-level security posture is documented in
-[`docs/SECURITY_POSTURE.md`](../SECURITY_POSTURE.md) and the security policy in
-[`SECURITY.md`](../../.github/SECURITY.md).
+The top-level security operations are documented in
+[`docs/SECURITY-OPERATIONS.md`](../SECURITY-OPERATIONS.md) and the security policy in
+[`SECURITY.md`](../../SECURITY.md).
 
 This directory contains transport- and surface-specific security notes:
 

--- a/docs/specs/SECURITY-CONSIDERATIONS.md
+++ b/docs/specs/SECURITY-CONSIDERATIONS.md
@@ -156,21 +156,8 @@ PEAC receipts follow a hash-first design (DD-138):
 
 ## 9. Threat Model Summary
 
-The MCP server threat model (`reference/THREAT_MODEL_MCP.md`) identifies 10
-threats (T1-T10) with 9 security invariants:
-
-| Threat                   | Control                             | Design Decision |
-| ------------------------ | ----------------------------------- | --------------- |
-| T1: Key exfiltration     | No ambient key discovery            | DD-52           |
-| T2: Policy tampering     | Static policy, immutable at runtime | DD-53           |
-| T3: SSRF via receipt URL | No implicit fetch                   | DD-55           |
-| T4: Transport confusion  | Handler-transport separation        | DD-51           |
-| T5: Replay attack        | Unique jti, cache guidance          | Spec sec. 20    |
-| T6: Algorithm confusion  | Ed25519 only, no negotiation        | DD-156          |
-| T7: Key injection        | Reject embedded keys in JWS         | DD-156          |
-| T8: Oversized payload    | JWS size cap, transport limits      | DD-124-131      |
-| T9: Session confusion    | Per-client McpServer isolation      | DD-119          |
-| T10: Stdin/stdout leak   | Line-buffered stdout fence          | DD-58           |
-
-For the complete threat model, mitigations, and test references, see
-`reference/THREAT_MODEL_MCP.md`.
+For the consolidated threat catalog covering the wire format, signature
+verification, JWKS resolution, the reference verifier, the MCP server, the
+commerce mapper boundary, and cross-language parity, with per-threat
+mitigations and test-coverage links, see the
+[Threat model](../THREAT_MODEL.md).

--- a/docs/specs/ZERO-TRUST-PROFILE-PACK.md
+++ b/docs/specs/ZERO-TRUST-PROFILE-PACK.md
@@ -16,7 +16,7 @@
 
 This specification defines the **Zero Trust Profile Pack**: a collection of seven documentation overlays that constrain which PEAC receipt fields are REQUIRED, RECOMMENDED, or PROHIBITED for specific zero trust use cases.
 
-Profiles do NOT add new wire format fields. All zero trust data flows through existing `ext[]` extension slots using reverse-DNS keys per [PROFILE_RULES.md](../../reference/PROFILE_RULES.md). New fields belong in schemas (`@peac/schema`); profiles constrain their usage for specific deployment patterns.
+Profiles do NOT add new wire format fields. All zero trust data flows through existing `ext[]` extension slots using reverse-DNS keys; see the profile rules in the [profiles index](../profiles/README.md) and the normative extension group specification in [WIRE-0.2](WIRE-0.2.md) section 12. New fields belong in schemas (`@peac/schema`); profiles constrain their usage for specific deployment patterns.
 
 ### 1.2 Scope
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
     "verify:contracts:drift": "tsx scripts/extract-api-contract.ts --check",
     "verify:surface-status": "node scripts/generate-surface-status.mjs --check",
     "verify:openapi:drift": "node scripts/verify-openapi-drift.mjs",
+    "verify:trust-artifacts": "node scripts/verify-trust-artifacts.mjs",
+    "verify:public-surface-names": "node scripts/verify-public-surface-names.mjs",
     "fixtures:new": "node scripts/fixtures-new.mjs",
     "conformance:regen:bundle": "tsx scripts/generate-bundle-vectors.ts",
     "bench": "pnpm --filter @peac/crypto bench && pnpm --filter @peac/schema bench && pnpm --filter @peac/protocol bench",

--- a/scripts/guard.sh
+++ b/scripts/guard.sh
@@ -183,8 +183,8 @@ echo "== forbid legacy wire format IDs (v0.10.0 break) =="
 # peac.receipt/0.9 -> peac-receipt/0.1
 # peac.dispute-bundle/0.1 -> peac-bundle/0.1
 # wire/0.9/ -> wire/0.1/
-# Allow in: CHANGELOG, guard script, migration docs, versioning doctrine (historical), deprecated packages, tests pending migration, Go SDK
-LEGACY_WIRE_ALLOW='^(CHANGELOG\.md|scripts/(guard\.sh|lint-schemas\.mjs)|docs/(migration/|specs/VERSIONING\.md)|packages/(core|sdk-js)/|packages/(crypto|protocol|schema)/(tests|openapi|src/(index|types|envelope))|tests/(golden|vectors)/|specs/(kernel/README|conformance/fixtures/bundle/invalid)|sdks/go/|examples/x402-node-server/)'
+# Allow in: CHANGELOG, guard script, migration docs, versioning doctrine (historical), deprecated packages, tests pending migration, Go SDK, security / stability / threat docs that must name the legacy identifier to describe its deprecated state
+LEGACY_WIRE_ALLOW='^(CHANGELOG\.md|SECURITY\.md|scripts/(guard\.sh|lint-schemas\.mjs|verify-trust-artifacts\.mjs)|docs/(migration/|specs/VERSIONING\.md|STABILITY-CONTRACT\.md|THREAT_MODEL\.md)|packages/(core|sdk-js)/|packages/(crypto|protocol|schema)/(tests|openapi|src/(index|types|envelope))|tests/(golden|vectors)/|specs/(kernel/README|conformance/fixtures/bundle/invalid)|sdks/go/|examples/x402-node-server/)'
 if git grep -nE 'peac\.receipt/0\.9|peac\.dispute-bundle|wire/0\.9/|PEAC-RECEIPT-SCHEMA-v0\.9' -- ':!node_modules' ':!archive/**' \
   | grep -vE "$LEGACY_WIRE_ALLOW" | grep .; then
   echo "FAIL: Found legacy wire format IDs - use normalized 0.1 versions"

--- a/scripts/verify-public-surface-names.mjs
+++ b/scripts/verify-public-surface-names.mjs
@@ -71,6 +71,22 @@ const RULES = [
     message:
       'retired boundary heading "What PEAC owns" - use "What PEAC standardizes"',
   },
+  {
+    id: 'retired-label-enterprise-trust-posture',
+    pattern: /\bEnterprise\s+Trust\s+Posture\b/,
+    message:
+      'retired label "Enterprise Trust Posture" - use "Key custody and tenancy"',
+  },
+  {
+    id: 'retired-label-security-posture',
+    pattern: /\bSecurity\s+Posture\b/,
+    message: 'retired label "Security Posture" - use "Security operations"',
+  },
+  {
+    id: 'retired-label-trust-center',
+    pattern: /\bTrust\s+center\b/,
+    message: 'retired label "Trust center" - use "Trust artifacts"',
+  },
 ];
 
 // ---------------------------------------------------------------------------

--- a/scripts/verify-public-surface-names.mjs
+++ b/scripts/verify-public-surface-names.mjs
@@ -52,24 +52,24 @@ const RULES = [
     id: 'retired-filename-enterprise-trust-posture',
     pattern: /ENTERPRISE_TRUST_POSTURE/,
     message:
-      'retired filename "ENTERPRISE_TRUST_POSTURE" — use docs/KEY-CUSTODY-AND-TENANCY.md',
+      'retired filename "ENTERPRISE_TRUST_POSTURE" - use docs/KEY-CUSTODY-AND-TENANCY.md',
   },
   {
     id: 'retired-filename-security-posture',
     pattern: /SECURITY_POSTURE\.md/,
     message:
-      'retired filename "SECURITY_POSTURE.md" — use docs/SECURITY-OPERATIONS.md',
+      'retired filename "SECURITY_POSTURE.md" - use docs/SECURITY-OPERATIONS.md',
   },
   {
     id: 'retired-path-trust-center',
     pattern: /trust-center\//,
-    message: 'retired path "trust-center/" — use docs/TRUST-ARTIFACTS.md',
+    message: 'retired path "trust-center/" - use docs/TRUST-ARTIFACTS.md',
   },
   {
     id: 'retired-boundary-what-peac-owns',
     pattern: /\bWhat\s+PEAC\s+owns\b/,
     message:
-      'retired boundary heading "What PEAC owns" — use "What PEAC standardizes"',
+      'retired boundary heading "What PEAC owns" - use "What PEAC standardizes"',
   },
 ];
 

--- a/scripts/verify-public-surface-names.mjs
+++ b/scripts/verify-public-surface-names.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * Public surface-name verifier.
+ *
+ * Fails CI if tracked/public artifacts reference retired filenames,
+ * retired directory paths, or retired public boundary-doc headings that
+ * have been consolidated under new canonical names.
+ *
+ * Scope (tracked files plus untracked-but-not-ignored):
+ *   README.md
+ *   SECURITY.md
+ *   .github/SECURITY.md
+ *   docs/**\/*.md
+ *   examples/**\/*.md
+ *   surfaces/**\/*.md
+ *   packages/*\/README.md
+ *
+ * Excluded:
+ *   CHANGELOG.md (historical)
+ *   docs/maintainers/** (maintainer-facing; not public-product surface)
+ *   archive/**, paper/**, node_modules/**
+ *   verifier scripts themselves (would match their own pattern strings)
+ *
+ * Usage:
+ *   node scripts/verify-public-surface-names.mjs           # human-readable
+ *   node scripts/verify-public-surface-names.mjs --json    # machine-readable
+ *
+ * Exit codes:
+ *   0  No violations
+ *   1  One or more violations
+ *   2  Internal script error
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+
+const args = process.argv.slice(2);
+const JSON_MODE = args.includes('--json');
+
+// ---------------------------------------------------------------------------
+// Objective rules. Every rule names a retired public-surface identifier and
+// points consumers at the canonical replacement.
+// ---------------------------------------------------------------------------
+
+const RULES = [
+  {
+    id: 'retired-filename-enterprise-trust-posture',
+    pattern: /ENTERPRISE_TRUST_POSTURE/,
+    message:
+      'retired filename "ENTERPRISE_TRUST_POSTURE" — use docs/KEY-CUSTODY-AND-TENANCY.md',
+  },
+  {
+    id: 'retired-filename-security-posture',
+    pattern: /SECURITY_POSTURE\.md/,
+    message:
+      'retired filename "SECURITY_POSTURE.md" — use docs/SECURITY-OPERATIONS.md',
+  },
+  {
+    id: 'retired-path-trust-center',
+    pattern: /trust-center\//,
+    message: 'retired path "trust-center/" — use docs/TRUST-ARTIFACTS.md',
+  },
+  {
+    id: 'retired-boundary-what-peac-owns',
+    pattern: /\bWhat\s+PEAC\s+owns\b/,
+    message:
+      'retired boundary heading "What PEAC owns" — use "What PEAC standardizes"',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Scope resolution.
+// ---------------------------------------------------------------------------
+
+const PATH_INCLUDES = [
+  /^README\.md$/,
+  /^SECURITY\.md$/,
+  /^\.github\/SECURITY\.md$/,
+  /^docs\/.*\.md$/,
+  /^examples\/.*\.md$/,
+  /^surfaces\/.*\.md$/,
+  /^packages\/[^/]+\/README\.md$/,
+];
+
+const PATH_EXCLUDES = [
+  /^CHANGELOG\.md$/,
+  /^docs\/maintainers\//,
+  /^archive\//,
+  /^paper\//,
+  /^node_modules\//,
+  // Verifier sources contain rule patterns as strings; skip to avoid
+  // self-match on the retired names this very file documents.
+  /^scripts\/verify-public-surface-names\.mjs$/,
+  /^scripts\/verify-trust-artifacts\.mjs$/,
+  /^scripts\/check-public-artifacts\.mjs$/,
+];
+
+function listFiles() {
+  try {
+    const out = execSync(
+      'git ls-files -z --cached --others --exclude-standard',
+      { cwd: REPO_ROOT, encoding: 'buffer' }
+    );
+    return out
+      .toString('utf8')
+      .split('\0')
+      .filter(Boolean)
+      .filter((p) => PATH_INCLUDES.some((re) => re.test(p)))
+      .filter((p) => !PATH_EXCLUDES.some((re) => re.test(p)))
+      .map((p) => resolve(REPO_ROOT, p));
+  } catch (err) {
+    throw new Error(`git ls-files failed: ${err?.message ?? err}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scan.
+// ---------------------------------------------------------------------------
+
+const violations = [];
+
+function scanFile(absPath) {
+  const rel = relative(REPO_ROOT, absPath);
+  const text = readFileSync(absPath, 'utf8');
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    for (const rule of RULES) {
+      if (rule.pattern.test(line)) {
+        violations.push({
+          rule: rule.id,
+          file: rel,
+          line: i + 1,
+          excerpt: line.trim().slice(0, 160),
+          message: rule.message,
+        });
+      }
+    }
+  }
+}
+
+try {
+  const files = listFiles();
+  for (const f of files) scanFile(f);
+} catch (err) {
+  if (JSON_MODE) {
+    process.stdout.write(JSON.stringify({ error: String(err) }, null, 2) + '\n');
+  } else {
+    process.stderr.write(`Internal error: ${err?.stack || err}\n`);
+  }
+  process.exit(2);
+}
+
+if (JSON_MODE) {
+  process.stdout.write(
+    JSON.stringify({ ok: violations.length === 0, violations }, null, 2) + '\n'
+  );
+} else {
+  if (violations.length === 0) {
+    process.stdout.write('verify-public-surface-names: OK\n');
+    process.stdout.write(`  scanned ${listFiles().length} tracked files\n`);
+    process.stdout.write(`  enforced ${RULES.length} rules\n`);
+  } else {
+    process.stderr.write(
+      `verify-public-surface-names: ${violations.length} violation(s)\n\n`
+    );
+    for (const v of violations) {
+      process.stderr.write(`  [${v.rule}] ${v.file}:${v.line}\n`);
+      process.stderr.write(`    ${v.message}\n`);
+      process.stderr.write(`    ${v.excerpt}\n\n`);
+    }
+  }
+}
+
+process.exit(violations.length === 0 ? 0 : 1);

--- a/scripts/verify-trust-artifacts.mjs
+++ b/scripts/verify-trust-artifacts.mjs
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+/**
+ * Trust-artifact integrity verifier.
+ *
+ * Three checks, all fail-closed:
+ *
+ *   1. docs/THREAT_MODEL.md table rows: every threat-ID row must carry at
+ *      least one markdown link in its Test-coverage column, and every
+ *      linked repository-relative path MUST resolve to a tracked file.
+ *   2. docs/STABILITY-CONTRACT.md table rows: every row must name a
+ *      concrete public surface (path, package, or identifier). Empty or
+ *      placeholder rows fail.
+ *   3. Public docs (everything under docs/, SECURITY.md, .github/SECURITY.md,
+ *      README.md) MUST NOT link to gitignored reference/ paths. The
+ *      reference/ tree is local-only; external contributors cannot
+ *      resolve those links.
+ *
+ * Usage:
+ *   node scripts/verify-trust-artifacts.mjs        # human-readable
+ *   node scripts/verify-trust-artifacts.mjs --json # machine-readable
+ *
+ * Exit codes:
+ *   0  All checks passed
+ *   1  One or more violations found
+ *   2  Internal script error
+ */
+
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import { resolve, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+
+const THREAT_MODEL = resolve(REPO_ROOT, 'docs/THREAT_MODEL.md');
+const STABILITY_CONTRACT = resolve(REPO_ROOT, 'docs/STABILITY-CONTRACT.md');
+
+const args = process.argv.slice(2);
+const JSON_MODE = args.includes('--json');
+
+const violations = [];
+
+function addViolation(check, file, line, message) {
+  violations.push({ check, file: relative(REPO_ROOT, file), line, message });
+}
+
+function readLines(path) {
+  return readFileSync(path, 'utf8').split('\n');
+}
+
+function resolveRepoPath(docPath, linkTarget) {
+  // linkTarget is relative to docPath's directory; fragment stripped.
+  const noFragment = linkTarget.split('#')[0];
+  if (!noFragment) return null; // pure anchor
+  return resolve(dirname(docPath), noFragment);
+}
+
+function isTrackedPath(absPath) {
+  if (!existsSync(absPath)) return false;
+  // Directory targets count as tracked if the directory exists.
+  try {
+    statSync(absPath);
+  } catch {
+    return false;
+  }
+  return true;
+}
+
+// Markdown link regex: [text](url) -- excludes image syntax.
+// Captures the link target.
+const MD_LINK_RE = /(?<!\!)\[[^\]]+\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+
+// ---------- Check 1: THREAT_MODEL.md per-row test coverage ----------
+
+function checkThreatModel() {
+  if (!existsSync(THREAT_MODEL)) {
+    addViolation('threat-model-exists', THREAT_MODEL, 0, 'docs/THREAT_MODEL.md is missing');
+    return;
+  }
+
+  const lines = readLines(THREAT_MODEL);
+
+  // Threat ID pattern: T-<CATEGORY>-<NN> at the start of a table row.
+  // Example row: "| T-WIRE-01 | Forged signature | ... | [path](link) |"
+  const THREAT_ROW_RE = /^\|\s*(T-[A-Z]+-\d+)\s*\|(.+)\|\s*$/;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const m = line.match(THREAT_ROW_RE);
+    if (!m) continue;
+
+    const threatId = m[1];
+    // Split columns. Row begins with "| T-..." so cells[0] = "" (empty prefix).
+    const cells = line.split('|').map((c) => c.trim());
+    // Expected layout: [empty, threatId, threat, mitigation, testCoverage, ...empty]
+    if (cells.length < 5) {
+      addViolation('threat-model-row-shape', THREAT_MODEL, i + 1, `${threatId}: row has too few columns`);
+      continue;
+    }
+
+    const testCell = cells[cells.length - 2]; // last non-empty cell
+    if (!testCell) {
+      addViolation(
+        'threat-model-missing-link',
+        THREAT_MODEL,
+        i + 1,
+        `${threatId}: Test-coverage column is empty`
+      );
+      continue;
+    }
+
+    // Extract every markdown link from the test-coverage cell.
+    const links = [...testCell.matchAll(MD_LINK_RE)].map((x) => x[1]);
+    if (links.length === 0) {
+      addViolation(
+        'threat-model-missing-link',
+        THREAT_MODEL,
+        i + 1,
+        `${threatId}: Test-coverage column has no markdown link`
+      );
+      continue;
+    }
+
+    for (const link of links) {
+      if (link.startsWith('http://') || link.startsWith('https://')) continue;
+      if (link.startsWith('mailto:')) continue;
+      const abs = resolveRepoPath(THREAT_MODEL, link);
+      if (!abs) continue; // fragment-only; ignore
+      if (!isTrackedPath(abs)) {
+        addViolation(
+          'threat-model-broken-link',
+          THREAT_MODEL,
+          i + 1,
+          `${threatId}: test link does not resolve: ${link}`
+        );
+      }
+    }
+  }
+}
+
+// ---------- Check 2: STABILITY-CONTRACT.md per-row surface concreteness ----------
+
+function checkStabilityContract() {
+  if (!existsSync(STABILITY_CONTRACT)) {
+    addViolation(
+      'stability-contract-exists',
+      STABILITY_CONTRACT,
+      0,
+      'docs/STABILITY-CONTRACT.md is missing'
+    );
+    return;
+  }
+
+  const lines = readLines(STABILITY_CONTRACT);
+
+  // Stability-classification regex: a cell that is one of the four known
+  // classifications surrounded by backticks. We only assert on rows that
+  // actually carry a classification.
+  const CLASS_RE = /`(stable|experimental|deprecated|internal-only)`/;
+
+  // A surface cell is "concrete" if it contains any of:
+  //   - a backticked identifier: `@peac/...`, `POST /v1/...`, `typ: ...`,
+  //     `PEAC-Receipt`, `surfaces/plugin-pack/...`, `RFC NNNN`
+  //   - a markdown link with a path-like target
+  //   - a human-readable surface noun with explicit identifier
+  // We reject rows whose surface cell is empty, whitespace, "-", "n/a",
+  // "TBD", or similar placeholder.
+  const PLACEHOLDER_RE = /^(-|n\/a|na|tbd|todo|placeholder)$/i;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.startsWith('|')) continue;
+    if (!CLASS_RE.test(line)) continue;
+
+    const cells = line.split('|').map((c) => c.trim());
+    // Drop leading / trailing empties from the table-row split.
+    while (cells.length && cells[0] === '') cells.shift();
+    while (cells.length && cells[cells.length - 1] === '') cells.pop();
+    if (cells.length === 0) continue;
+
+    // Surface column is the first cell. It must be non-empty and not a
+    // placeholder.
+    const surface = cells[0];
+    if (!surface || PLACEHOLDER_RE.test(surface)) {
+      addViolation(
+        'stability-contract-empty-surface',
+        STABILITY_CONTRACT,
+        i + 1,
+        `row has classification but no surface identifier: ${line.trim()}`
+      );
+      continue;
+    }
+  }
+}
+
+// ---------- Check 3: no gitignored reference/ links in public docs ----------
+
+function listPublicDocs() {
+  try {
+    const stdout = execSync(
+      'git ls-files -- "docs/**/*.md" "*.md" ".github/SECURITY.md" ".github/**/*.md" "examples/**/*.md" "surfaces/**/*.md" "integrator-kits/**/*.md"',
+      { cwd: REPO_ROOT, encoding: 'utf8' }
+    );
+    return stdout
+      .split('\n')
+      .filter(Boolean)
+      .map((p) => resolve(REPO_ROOT, p));
+  } catch {
+    return [];
+  }
+}
+
+function checkNoReferenceLinks() {
+  const docs = listPublicDocs();
+  // A link to "reference/foo" is a gitignored-target leak EXCEPT when it's
+  // the explicit reference/ directory at the repository root that happens
+  // to be tracked. In this repo, reference/ is gitignored (CLAUDE.md). So
+  // any markdown link into reference/ from a tracked public doc is a leak.
+
+  for (const doc of docs) {
+    // Skip this script file itself (it discusses reference/ in prose).
+    if (doc.endsWith('scripts/verify-trust-artifacts.mjs')) continue;
+    // Skip the OPERATING_MODEL / TRUTH_MATRIX etc which are local-only
+    // anyway (they're under reference/ so wouldn't match). listPublicDocs
+    // only matches docs/ and tracked surfaces. Safe.
+
+    const text = readFileSync(doc, 'utf8');
+    const lines = text.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      // Look for markdown links whose target begins with reference/ or
+      // contains /reference/ as a path component (after any ../ prefix).
+      for (const match of line.matchAll(MD_LINK_RE)) {
+        const target = match[1];
+        const noFragment = target.split('#')[0];
+        if (!noFragment) continue;
+        if (noFragment.startsWith('http://') || noFragment.startsWith('https://')) continue;
+
+        // Normalize: strip leading ../
+        const norm = noFragment.replace(/^(\.\.\/)+/, '');
+        if (norm.startsWith('reference/') || norm === 'reference') {
+          addViolation(
+            'public-doc-references-gitignored-reference-tree',
+            doc,
+            i + 1,
+            `markdown link to gitignored reference/ path: ${target}`
+          );
+        }
+      }
+    }
+  }
+}
+
+// ---------- Run ----------
+
+try {
+  checkThreatModel();
+  checkStabilityContract();
+  checkNoReferenceLinks();
+} catch (err) {
+  if (JSON_MODE) {
+    process.stdout.write(JSON.stringify({ error: String(err) }, null, 2) + '\n');
+  } else {
+    process.stderr.write(`Internal error: ${err?.stack || err}\n`);
+  }
+  process.exit(2);
+}
+
+if (JSON_MODE) {
+  process.stdout.write(
+    JSON.stringify({ ok: violations.length === 0, violations }, null, 2) + '\n'
+  );
+} else {
+  if (violations.length === 0) {
+    process.stdout.write('verify-trust-artifacts: OK\n');
+    process.stdout.write('  threat-model rows: per-row test links resolve\n');
+    process.stdout.write('  stability-contract rows: surface identifiers present\n');
+    process.stdout.write('  public docs: no links to gitignored reference/ tree\n');
+  } else {
+    process.stderr.write(`verify-trust-artifacts: ${violations.length} violation(s)\n\n`);
+    for (const v of violations) {
+      process.stderr.write(`  [${v.check}] ${v.file}:${v.line}\n`);
+      process.stderr.write(`    ${v.message}\n`);
+    }
+  }
+}
+
+process.exit(violations.length === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Publishes SLO, benchmark methodology, stability contract, threat model, and trust-artifact index docs. Expands `SECURITY.md`, aligns `.github/SECURITY.md`, and renames two docs for clearer naming.

No wire format, schema, kernel, crypto, protocol public API, or normative behavior changes.

## Scope

- add `docs/SLO.md` with release-prep baseline stamps
- add `docs/BENCHMARK-METHODOLOGY.md`
- add `docs/STABILITY-CONTRACT.md`
- add `docs/THREAT_MODEL.md` with per-threat test links
- add `docs/TRUST-ARTIFACTS.md`
- rename two existing security/trust docs to clearer names
- add CI checks:
  - `scripts/verify-trust-artifacts.mjs`
  - `scripts/verify-public-surface-names.mjs`
- replace local-only path references with public equivalents
- fix `specs/registries.json` links to `specs/kernel/registries.json`