### PR TITLE
chore: stamp v0.12.12 release

### DIFF
--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable surface classification for PEAC Protocol workspace. CI fails if any workspace member is missing. See docs/PACKAGE_STATUS.md for human-readable view.",
   "version": "0.12.12",
-  "updated": "2026-04-18",
+  "updated": "2026-04-19",
   "states": {
     "default": "Current recommended path. Actively maintained, Wire 0.2 native.",
     "supported": "Actively maintained, published, production-ready. May not be on default quickstart path.",

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -2,7 +2,7 @@
 
 Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scripts/generate-surface-status.mjs`.
 
-**Version:** 0.12.12 | **Updated:** 2026-04-18
+**Version:** 0.12.12 | **Updated:** 2026-04-19
 
 ## Layer 1
 

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -4,7 +4,7 @@
   "version": "0.12.12",
   "wire_format_version": "0.2",
   "dist_tag": "next",
-  "release_date": "2026-04-15",
+  "release_date": "2026-04-19",
   "metrics": {
     "tests": 7392,
     "test_files": 296,


### PR DESCRIPTION
## Summary

Stamps the real `release_date` for v0.12.12 post-publish, and refreshes `REPO_SURFACE_STATUS.updated` and the derived status docs.
