### PR TITLE
chore: stamp v0.12.12 dist_tag latest

### DIFF
--- a/docs/releases/current.json
+++ b/docs/releases/current.json
@@ -2,7 +2,7 @@
   "description": "PEAC release manifest: CI-enforceable source of truth for release state",
   "version": "0.12.12",
   "wire_format_version": "0.2",
-  "dist_tag": "next",
+  "dist_tag": "latest",
   "registries_version": "0.6.0",
   "errors_version": "0.12.12"
 }

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -3,7 +3,7 @@
   "schema_version": "1.0.0",
   "version": "0.12.12",
   "wire_format_version": "0.2",
-  "dist_tag": "next",
+  "dist_tag": "latest",
   "release_date": "2026-04-19",
   "metrics": {
     "tests": 7392,


### PR DESCRIPTION
## Summary

Stamps `dist_tag: latest` in `docs/releases/facts.json` and `docs/releases/current.json` after `promote-latest.yml` completed successfully for v0.12.12.

## Scope

- `docs/releases/facts.json`: `dist_tag` stamped to `latest`
- `docs/releases/current.json`: `dist_tag` stamped to `latest`