### PR TITLE
feat: echo and nethttp Go adapters, adapter parity harness, commerce lifecycle grouping

### DIFF
--- a/docs/compatibility/go-middleware.md
+++ b/docs/compatibility/go-middleware.md
@@ -9,13 +9,66 @@ Promotes the Go HTTP middleware from experimental to a bounded, opt-in productio
 
 ## Stability classes
 
-| Adapter                           | Package                      | Class  |
-| --------------------------------- | ---------------------------- | ------ |
-| Core HTTP middleware (`http.go`)  | `.../sdks/go/middleware`     | Stable |
-| `chi` adapter (`middleware/chi/`) | `.../sdks/go/middleware/chi` | Stable |
-| `gin` adapter (`middleware/gin/`) | `.../sdks/go/middleware/gin` | Stable |
+| Adapter                                    | Package                          | Class  |
+| ------------------------------------------ | -------------------------------- | ------ |
+| Core HTTP middleware (`http.go`)           | `.../sdks/go/middleware`         | Stable |
+| `chi` adapter (`middleware/chi/`)          | `.../sdks/go/middleware/chi`     | Stable |
+| `gin` adapter (`middleware/gin/`)          | `.../sdks/go/middleware/gin`     | Stable |
+| `echo` adapter (`middleware/echo/`)        | `.../sdks/go/middleware/echo`    | Stable |
+| `net/http` adapter (`middleware/nethttp/`) | `.../sdks/go/middleware/nethttp` | Stable |
 
-Submodule adapters for `echo` and `net/http` are tracked for a follow-up release; the core HTTP middleware is usable from any `http.Handler`-compatible router in the meantime.
+The core HTTP middleware is usable from any `http.Handler`-compatible router. Dedicated `echo` and `net/http` adapter modules are available for consumers who prefer framework-specific import paths.
+
+## Adapter parity contract
+
+Every framework-specific adapter re-exposes the same surface:
+
+- `type Config = middleware.Config` (type alias, not a distinct named type).
+- `DefaultConfig()` returns a struct byte-identical to the core default (panic recovery on, 1 MiB body cap, `TrustProxyHeaders` off).
+- `Verifier(cfg Config)` returns the stdlib-shaped `func(http.Handler) http.Handler`.
+- Header behavior: `PEAC-Receipt` precedence; rail-x402 `PAYMENT-RESPONSE` / `X-PAYMENT-RESPONSE` honored; case-insensitive header names.
+- Timeout, body-limit, and trust-proxy defaults are identical.
+- Error and status mapping: 401 / 400 / 503 taxonomy matches across adapters.
+
+Parity is enforced mechanically in two places: the shared test harness at [`sdks/go/middleware/paritytest/`](../../sdks/go/middleware/paritytest/) runs the same request corpus against the three stdlib-shaped adapters (chi, echo, nethttp) and asserts identical responses against the chi reference; the gin adapter uses `gin.HandlerFunc` and carries its own third-party dependency, so it is covered by a scenario-equivalent test suite at [`sdks/go/middleware/gin/gin_test.go`](../../sdks/go/middleware/gin/gin_test.go) exercising the same four scenarios (no-receipt required → 401, no-receipt optional pass-through → 200, malformed receipt → 400 `E_INVALID_FORMAT`, case-insensitive `peac-receipt` header).
+
+### Echo integration
+
+Echo (`github.com/labstack/echo/v4`) accepts stdlib middleware through `echo.WrapMiddleware`:
+
+```go
+import (
+    "github.com/labstack/echo/v4"
+    peacecho "github.com/peacprotocol/peac/sdks/go/middleware/echo"
+)
+
+e := echo.New()
+e.Use(echo.WrapMiddleware(peacecho.Verifier(peacecho.Config{
+    Issuer:   "https://publisher.example",
+    Audience: "https://agent.example",
+})))
+```
+
+The `peacecho` adapter itself carries no Echo dependency; it exposes the stdlib-compatible `func(http.Handler) http.Handler` that `echo.WrapMiddleware` accepts. Users who do not use Echo never pull Echo into their dependency graph.
+
+### net/http integration
+
+```go
+import (
+    "net/http"
+    peacnethttp "github.com/peacprotocol/peac/sdks/go/middleware/nethttp"
+)
+
+mux := http.NewServeMux()
+mux.HandleFunc("/protected", protected)
+
+verified := peacnethttp.Verifier(peacnethttp.Config{
+    Issuer:   "https://publisher.example",
+    Audience: "https://agent.example",
+})(mux)
+
+http.ListenAndServe(":8080", verified)
+```
 
 ## What hardening adds
 

--- a/packages/audit/src/commerce-bundle-types.ts
+++ b/packages/audit/src/commerce-bundle-types.ts
@@ -92,3 +92,53 @@ export interface CreateCommerceBundleOptions {
   /** Optional creation timestamp (for deterministic output; defaults to now) */
   created_at?: string;
 }
+
+/**
+ * Input record accepted by `groupByLifecycle`.
+ *
+ * Observational-only shape: callers provide the fields necessary for
+ * grouping without passing the full signed record. `session_ref` is the
+ * value the grouper keys on; records with the same `session_ref` end up
+ * in the same `LifecycleBundle`.
+ */
+export interface LifecycleInputRecord {
+  /** Session or transaction identifier shared across a lifecycle. */
+  session_ref: string;
+  /**
+   * Observed commerce event name, per the upstream attestation. An
+   * empty, missing, null, or non-string value routes the record to the
+   * `unclassified` bucket; no event is synthesized.
+   */
+  commerce_event?: string | null;
+  /** Issued-at time (RFC 3339 string or unix seconds). */
+  iat: string | number;
+  /** SHA-256 hash of the JWS (used for deterministic tie-breaking). */
+  receipt_ref: string;
+  /** Optional opaque passthrough so callers can carry the full record. */
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Reserved bucket name for records whose `commerce_event` is absent,
+ * null, empty, or not a string. No lifecycle semantics are inferred;
+ * `unclassified` preserves the record as observed and never promotes
+ * it into an interpreted bucket.
+ */
+export const UNCLASSIFIED_LIFECYCLE_BUCKET = 'unclassified' as const;
+
+/**
+ * One session's records grouped by the event name each record carries,
+ * observational only. `buckets` keys are the literal `commerce_event`
+ * values the upstream attested (or `'unclassified'` for records with
+ * no event). Buckets with zero records are omitted.
+ */
+export interface LifecycleBundle {
+  /** Session or transaction identifier shared by every record in the bundle. */
+  session_ref: string;
+  /** Per-event record lists, keyed by the upstream event name. */
+  buckets: Record<string, LifecycleInputRecord[]>;
+  /** Total number of records in the bundle (sum across buckets). */
+  record_count: number;
+  /** Bundle format version (same experimental constant as commerce bundles). */
+  version: typeof COMMERCE_BUNDLE_VERSION;
+}

--- a/packages/audit/src/commerce-bundle.ts
+++ b/packages/audit/src/commerce-bundle.ts
@@ -14,11 +14,13 @@ import type {
   CommerceEvidenceBundle,
   CommerceSummary,
   CreateCommerceBundleOptions,
+  LifecycleBundle,
+  LifecycleInputRecord,
   ObservedAmount,
   ProtocolEvidence,
   TimelineEntry,
 } from './commerce-bundle-types.js';
-import { COMMERCE_BUNDLE_VERSION } from './commerce-bundle-types.js';
+import { COMMERCE_BUNDLE_VERSION, UNCLASSIFIED_LIFECYCLE_BUCKET } from './commerce-bundle-types.js';
 
 /**
  * Create a new commerce evidence bundle.
@@ -193,4 +195,102 @@ function sortTimeline(entries: TimelineEntry[]): TimelineEntry[] {
   return [...entries].sort(
     (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
   );
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle grouping (observational-only; extends DD-192 primitives)
+// ---------------------------------------------------------------------------
+
+/**
+ * Group records by their session identifier and then by the literal
+ * `commerce_event` value each record carries.
+ *
+ * Observational only. The returned `buckets` map keys are the exact
+ * event names attested by the upstream; no lifecycle semantics are
+ * inferred. Records with a missing, null, empty, or non-string
+ * `commerce_event` are routed to the reserved
+ * `UNCLASSIFIED_LIFECYCLE_BUCKET` key. Combinations of records in the
+ * same session never synthesize a new bucket name; there is no
+ * `settled`, `completed`, or `finalized` outcome derived from record
+ * pairs.
+ *
+ * Deterministic ordering:
+ * - Within each bucket: primary sort by `iat` ascending, tie-break by
+ *   `receipt_ref` lex ascending.
+ * - Across the returned array: `session_ref` lex ascending.
+ *
+ * @experimental The API shape may change before the `-experimental`
+ *   suffix is removed. Callers should pin the `COMMERCE_BUNDLE_VERSION`
+ *   constant when persisting the result.
+ */
+export function groupByLifecycle(records: LifecycleInputRecord[]): LifecycleBundle[] {
+  const bySession = new Map<string, LifecycleInputRecord[]>();
+  for (const rec of records) {
+    const list = bySession.get(rec.session_ref);
+    if (list) list.push(rec);
+    else bySession.set(rec.session_ref, [rec]);
+  }
+
+  const bundles: LifecycleBundle[] = [];
+  for (const [session_ref, rs] of bySession) {
+    const buckets: Record<string, LifecycleInputRecord[]> = {};
+    for (const rec of rs) {
+      const key = resolveBucketKey(rec.commerce_event);
+      const list = buckets[key];
+      if (list) list.push(rec);
+      else buckets[key] = [rec];
+    }
+    for (const key of Object.keys(buckets)) {
+      buckets[key] = [...buckets[key]].sort(compareLifecycleRecords);
+    }
+    bundles.push({
+      session_ref,
+      buckets,
+      record_count: rs.length,
+      version: COMMERCE_BUNDLE_VERSION,
+    });
+  }
+
+  bundles.sort((a, b) =>
+    a.session_ref < b.session_ref ? -1 : a.session_ref > b.session_ref ? 1 : 0
+  );
+  return bundles;
+}
+
+/**
+ * Map an upstream event value to a bucket key. Anything that is not a
+ * non-empty string goes to `UNCLASSIFIED_LIFECYCLE_BUCKET`. Strings are
+ * trimmed before use; callers that attest `"  settlement  "` and
+ * `"settlement"` resolve to the same bucket.
+ */
+function resolveBucketKey(event: string | null | undefined): string {
+  if (typeof event !== 'string') return UNCLASSIFIED_LIFECYCLE_BUCKET;
+  const trimmed = event.trim();
+  if (trimmed === '') return UNCLASSIFIED_LIFECYCLE_BUCKET;
+  return trimmed;
+}
+
+/**
+ * Deterministic record ordering: iat ascending, tie-break by
+ * receipt_ref lex. `iat` may be a string or number; both are compared
+ * after normalization to a numeric timestamp where possible, falling
+ * back to lex compare when the string is not a parseable date.
+ */
+function compareLifecycleRecords(a: LifecycleInputRecord, b: LifecycleInputRecord): number {
+  const aTs = normalizeIat(a.iat);
+  const bTs = normalizeIat(b.iat);
+  if (aTs < bTs) return -1;
+  if (aTs > bTs) return 1;
+  if (a.receipt_ref < b.receipt_ref) return -1;
+  if (a.receipt_ref > b.receipt_ref) return 1;
+  return 0;
+}
+
+function normalizeIat(iat: string | number): number {
+  if (typeof iat === 'number') return iat;
+  const asNumber = Number(iat);
+  if (!Number.isNaN(asNumber)) return asNumber;
+  const parsed = Date.parse(iat);
+  if (!Number.isNaN(parsed)) return parsed;
+  return 0;
 }

--- a/packages/audit/src/index.ts
+++ b/packages/audit/src/index.ts
@@ -150,12 +150,14 @@ export type {
   CommerceEvidenceBundle,
   CommerceSummary,
   CreateCommerceBundleOptions,
+  LifecycleBundle,
+  LifecycleInputRecord,
   ProtocolEvidence,
   TimelineEntry,
   ObservedAmount,
 } from './commerce-bundle-types.js';
 
-export { COMMERCE_BUNDLE_VERSION } from './commerce-bundle-types.js';
+export { COMMERCE_BUNDLE_VERSION, UNCLASSIFIED_LIFECYCLE_BUCKET } from './commerce-bundle-types.js';
 
 export {
   createCommerceEvidenceBundle,
@@ -164,4 +166,5 @@ export {
   addReceiptRef,
   computeCommerceSummary,
   serializeCommerceBundle,
+  groupByLifecycle,
 } from './commerce-bundle.js';

--- a/packages/audit/tests/commerce-bundle.test.ts
+++ b/packages/audit/tests/commerce-bundle.test.ts
@@ -355,3 +355,196 @@ describe('extractRails behavior', () => {
     expect(bundle.rails_observed).toEqual([]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// groupByLifecycle: observational-only, deterministic, no finality synthesis
+// ---------------------------------------------------------------------------
+
+import { groupByLifecycle, UNCLASSIFIED_LIFECYCLE_BUCKET } from '../src/index.js';
+import type { LifecycleInputRecord } from '../src/index.js';
+
+function makeLifecycleRecord(
+  overrides: Partial<LifecycleInputRecord> &
+    Pick<LifecycleInputRecord, 'session_ref' | 'receipt_ref' | 'iat'>
+): LifecycleInputRecord {
+  return {
+    session_ref: overrides.session_ref,
+    receipt_ref: overrides.receipt_ref,
+    iat: overrides.iat,
+    commerce_event: overrides.commerce_event,
+    data: overrides.data,
+  };
+}
+
+describe('groupByLifecycle', () => {
+  it('groups records by session_ref and by upstream commerce_event', () => {
+    const bundles = groupByLifecycle([
+      makeLifecycleRecord({
+        session_ref: 'sess_A',
+        receipt_ref: 'sha256:a1',
+        iat: '2026-04-20T10:00:00Z',
+        commerce_event: 'payment_attempt',
+      }),
+      makeLifecycleRecord({
+        session_ref: 'sess_A',
+        receipt_ref: 'sha256:a2',
+        iat: '2026-04-20T10:05:00Z',
+        commerce_event: 'settlement_observed',
+      }),
+      makeLifecycleRecord({
+        session_ref: 'sess_B',
+        receipt_ref: 'sha256:b1',
+        iat: '2026-04-20T10:01:00Z',
+        commerce_event: 'payment_attempt',
+      }),
+    ]);
+
+    expect(bundles).toHaveLength(2);
+    // Bundles are sorted across the returned array by session_ref lex asc.
+    expect(bundles[0].session_ref).toBe('sess_A');
+    expect(bundles[1].session_ref).toBe('sess_B');
+
+    // Session A has two distinct event buckets.
+    expect(Object.keys(bundles[0].buckets).sort()).toEqual([
+      'payment_attempt',
+      'settlement_observed',
+    ]);
+    expect(bundles[0].record_count).toBe(2);
+
+    // Session B has only payment_attempt.
+    expect(Object.keys(bundles[1].buckets)).toEqual(['payment_attempt']);
+  });
+
+  it('routes missing, null, empty, and non-string commerce_event to unclassified', () => {
+    const bundles = groupByLifecycle([
+      makeLifecycleRecord({
+        session_ref: 's1',
+        receipt_ref: 'sha256:r1',
+        iat: 1,
+        commerce_event: undefined,
+      }),
+      makeLifecycleRecord({
+        session_ref: 's1',
+        receipt_ref: 'sha256:r2',
+        iat: 2,
+        commerce_event: null as unknown as string,
+      }),
+      makeLifecycleRecord({
+        session_ref: 's1',
+        receipt_ref: 'sha256:r3',
+        iat: 3,
+        commerce_event: '',
+      }),
+      makeLifecycleRecord({
+        session_ref: 's1',
+        receipt_ref: 'sha256:r4',
+        iat: 4,
+        commerce_event: '   ',
+      }),
+    ]);
+
+    expect(bundles).toHaveLength(1);
+    expect(Object.keys(bundles[0].buckets)).toEqual([UNCLASSIFIED_LIFECYCLE_BUCKET]);
+    expect(bundles[0].buckets[UNCLASSIFIED_LIFECYCLE_BUCKET]).toHaveLength(4);
+  });
+
+  it('does not synthesize new bucket names from combinations of records', () => {
+    // A session with payment_attempt + an arbitrary completion-looking
+    // event must NOT produce a synthetic bucket named 'settled',
+    // 'completed', 'final', or 'finalized'. Only the literal upstream
+    // event names are bucket keys.
+    const bundles = groupByLifecycle([
+      makeLifecycleRecord({
+        session_ref: 'sx',
+        receipt_ref: 'sha256:x1',
+        iat: 1,
+        commerce_event: 'payment_attempt',
+      }),
+      makeLifecycleRecord({
+        session_ref: 'sx',
+        receipt_ref: 'sha256:x2',
+        iat: 2,
+        commerce_event: 'session_completed',
+      }),
+    ]);
+
+    const keys = Object.keys(bundles[0].buckets);
+    expect(keys.sort()).toEqual(['payment_attempt', 'session_completed']);
+    for (const forbidden of ['settled', 'completed', 'final', 'finalized', 'finality']) {
+      expect(keys).not.toContain(forbidden);
+    }
+  });
+
+  it('orders within a bucket by iat ascending, tie-breaking by receipt_ref lex', () => {
+    const bundles = groupByLifecycle([
+      makeLifecycleRecord({
+        session_ref: 's1',
+        receipt_ref: 'sha256:bbb',
+        iat: 100,
+        commerce_event: 'attempt',
+      }),
+      makeLifecycleRecord({
+        session_ref: 's1',
+        receipt_ref: 'sha256:aaa',
+        iat: 100,
+        commerce_event: 'attempt',
+      }),
+      makeLifecycleRecord({
+        session_ref: 's1',
+        receipt_ref: 'sha256:ccc',
+        iat: 50,
+        commerce_event: 'attempt',
+      }),
+    ]);
+
+    expect(bundles[0].buckets['attempt'].map((r) => r.receipt_ref)).toEqual([
+      'sha256:ccc', // iat=50 first
+      'sha256:aaa', // iat=100, tie-break aaa < bbb
+      'sha256:bbb',
+    ]);
+  });
+
+  it('preserves the experimental COMMERCE_BUNDLE_VERSION on each returned bundle', () => {
+    const bundles = groupByLifecycle([
+      makeLifecycleRecord({
+        session_ref: 's1',
+        receipt_ref: 'sha256:a',
+        iat: 1,
+        commerce_event: 'attempt',
+      }),
+    ]);
+    expect(bundles[0].version).toBe(COMMERCE_BUNDLE_VERSION);
+    expect(COMMERCE_BUNDLE_VERSION).toContain('-experimental');
+  });
+
+  it('returns deterministic output across input permutations (idempotent sort)', () => {
+    const records: LifecycleInputRecord[] = [
+      makeLifecycleRecord({
+        session_ref: 'zzz',
+        receipt_ref: 'sha256:1',
+        iat: '2026-04-20T10:00:00Z',
+        commerce_event: 'a',
+      }),
+      makeLifecycleRecord({
+        session_ref: 'aaa',
+        receipt_ref: 'sha256:2',
+        iat: '2026-04-20T10:00:00Z',
+        commerce_event: 'b',
+      }),
+      makeLifecycleRecord({
+        session_ref: 'mmm',
+        receipt_ref: 'sha256:3',
+        iat: '2026-04-20T10:00:00Z',
+        commerce_event: 'c',
+      }),
+    ];
+    const order1 = groupByLifecycle([records[0], records[1], records[2]]);
+    const order2 = groupByLifecycle([records[2], records[0], records[1]]);
+    expect(order1).toEqual(order2);
+    expect(order1.map((b) => b.session_ref)).toEqual(['aaa', 'mmm', 'zzz']);
+  });
+
+  it('returns an empty array when given no records', () => {
+    expect(groupByLifecycle([])).toEqual([]);
+  });
+});

--- a/sdks/go/middleware/echo/README.md
+++ b/sdks/go/middleware/echo/README.md
@@ -1,0 +1,75 @@
+# @peac/middleware-echo (Go)
+
+PEAC receipt verification middleware for the Echo web framework
+(`github.com/labstack/echo/v4`).
+
+## Install
+
+```bash
+go get github.com/peacprotocol/peac/sdks/go/middleware/echo
+```
+
+This is a separate Go module from the core `sdks/go/middleware` package so
+consumers who do not use Echo do not pay for an Echo transitive in their
+dependency graph. The adapter itself carries no Echo dependency; it
+exposes the stdlib-compatible `func(http.Handler) http.Handler` that
+`echo.WrapMiddleware` accepts.
+
+## Usage
+
+```go
+import (
+    "github.com/labstack/echo/v4"
+    peacecho "github.com/peacprotocol/peac/sdks/go/middleware/echo"
+)
+
+func main() {
+    e := echo.New()
+    e.Use(echo.WrapMiddleware(peacecho.Verifier(peacecho.Config{
+        Issuer:   "https://publisher.example",
+        Audience: "https://agent.example",
+    })))
+
+    e.GET("/protected", func(c echo.Context) error {
+        claims := peacecho.GetClaims(c.Request())
+        _ = claims // use claims.Subject, claims.Purpose, etc.
+        return c.String(200, "ok")
+    })
+
+    e.Logger.Fatal(e.Start(":8080"))
+}
+```
+
+## Parity with chi, gin, and nethttp adapters
+
+| Aspect                                      | Contract                                                                                                              |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `type Config = middleware.Config`           | identical across all adapters                                                                                         |
+| `DefaultConfig()`                           | identical hardened defaults across all adapters (panic recovery on, 1 MiB body cap, `TrustProxyHeaders` off)          |
+| `Verifier(cfg Config)`                      | returns `func(http.Handler) http.Handler`; identical verifier semantics                                               |
+| Header behavior                             | `PEAC-Receipt` precedence; rail-x402 `PAYMENT-RESPONSE` / `X-PAYMENT-RESPONSE` honored; case-insensitive header names |
+| Timeout / body limit / trust-proxy defaults | identical across all adapters                                                                                         |
+| Error / status mapping                      | 401 / 400 / 503 taxonomy matches chi and gin exactly                                                                  |
+
+The parity contract is enforced by a shared request-corpus test harness
+under `sdks/go/middleware/paritytest/` that runs the same requests
+against every adapter and asserts identical responses.
+
+## Reading verified claims inside an Echo handler
+
+```go
+e.GET("/receipt-info", func(c echo.Context) error {
+    claims := peacecho.GetClaims(c.Request())
+    if claims == nil {
+        return c.String(401, "no claims")
+    }
+    return c.JSON(200, claims)
+})
+```
+
+## Related documents
+
+- [Hosted Verify contract](../../../../docs/HOSTED_VERIFY_CONTRACT.md)
+- [Threat model](../../../../docs/THREAT_MODEL.md)
+- [Stability contract](../../../../docs/STABILITY-CONTRACT.md)
+- [Compatibility matrix for Go middleware](../../../../docs/compatibility/go-middleware.md)

--- a/sdks/go/middleware/echo/echo.go
+++ b/sdks/go/middleware/echo/echo.go
@@ -1,0 +1,91 @@
+// Package echo provides PEAC receipt verification middleware for Echo.
+//
+// Echo (labstack/echo/v4) accepts stdlib middleware through
+// `echo.WrapMiddleware`, which converts `func(http.Handler) http.Handler`
+// into `echo.MiddlewareFunc`. This adapter mirrors the chi and gin
+// adapter pattern by re-exporting the core middleware types and
+// constructors under a framework-specific path, so Echo users can
+// install this package without pulling Echo into every other PEAC
+// consumer. Install with:
+//
+//	go get github.com/peacprotocol/peac/sdks/go/middleware/echo
+//
+// Usage with Echo:
+//
+//	import (
+//	    "github.com/labstack/echo/v4"
+//	    peacecho "github.com/peacprotocol/peac/sdks/go/middleware/echo"
+//	)
+//
+//	e := echo.New()
+//	e.Use(echo.WrapMiddleware(peacecho.Verifier(peacecho.Config{
+//	    Issuer:   "https://publisher.example",
+//	    Audience: "https://agent.example",
+//	})))
+//
+// This is a separate Go module so consumers who do not use Echo do not
+// pay for Echo in their dependency graph. The adapter itself has no
+// Echo dependency; it simply exposes the stdlib-compatible
+// `func(http.Handler) http.Handler` that `echo.WrapMiddleware` accepts.
+package echo
+
+import (
+	"net/http"
+
+	"github.com/peacprotocol/peac/sdks/go/middleware"
+)
+
+// Config is an alias for the core middleware config. Identical to the
+// chi and gin adapters so `type Config = middleware.Config` parity
+// holds across every framework wrapper.
+type Config = middleware.Config
+
+// DefaultConfig returns the default middleware configuration with
+// hardened defaults: panic recovery on, 1 MiB body cap, TrustProxyHeaders
+// off. Identical to the chi and gin adapters.
+func DefaultConfig() Config {
+	return middleware.DefaultConfig()
+}
+
+// Verifier creates a PEAC verification middleware in stdlib form.
+// Wrap with `echo.WrapMiddleware(...)` to attach it to an Echo router:
+//
+//	e.Use(echo.WrapMiddleware(peacecho.Verifier(cfg)))
+//
+// Returning the stdlib type keeps this adapter free of an Echo import
+// and preserves identical wrapper semantics with the chi and gin
+// adapters. Framework-level context (`echo.Context`) is populated by
+// Echo's own wrapper; claims on the request are available via
+// `middleware.GetClaims(c.Request())`.
+func Verifier(cfg Config) func(http.Handler) http.Handler {
+	return middleware.Middleware(cfg)
+}
+
+// RequireReceipt creates a middleware that requires a valid PEAC
+// receipt. Wrap with `echo.WrapMiddleware(...)` to attach.
+func RequireReceipt(issuer, audience string) func(http.Handler) http.Handler {
+	return middleware.RequireReceipt(issuer, audience)
+}
+
+// OptionalReceipt creates a middleware that optionally verifies PEAC
+// receipts. Requests without a receipt are passed through. Wrap with
+// `echo.WrapMiddleware(...)` to attach.
+func OptionalReceipt(issuer, audience string) func(http.Handler) http.Handler {
+	return middleware.OptionalReceipt(issuer, audience)
+}
+
+// GetClaims retrieves the verified claims from the request context.
+// In Echo handlers, call with `c.Request()`:
+//
+//	claims := peacecho.GetClaims(c.Request())
+var GetClaims = middleware.GetClaims
+
+// GetResult retrieves the full verify result from the request context.
+// In Echo handlers, call with `c.Request()`.
+var GetResult = middleware.GetResult
+
+// ClaimsContextKey is the context key for verified claims.
+const ClaimsContextKey = middleware.ClaimsContextKey
+
+// ResultContextKey is the context key for the full verify result.
+const ResultContextKey = middleware.ResultContextKey

--- a/sdks/go/middleware/echo/echo_test.go
+++ b/sdks/go/middleware/echo/echo_test.go
@@ -1,0 +1,78 @@
+package echo_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	coremw "github.com/peacprotocol/peac/sdks/go/middleware"
+	peacecho "github.com/peacprotocol/peac/sdks/go/middleware/echo"
+)
+
+// TestConfigIsAlias asserts that peacecho.Config is an alias for the
+// core middleware Config, not a new named type.
+func TestConfigIsAlias(t *testing.T) {
+	var adapterCfg peacecho.Config
+	var coreCfg coremw.Config
+	if reflect.TypeOf(adapterCfg) != reflect.TypeOf(coreCfg) {
+		t.Fatalf("peacecho.Config is not a type alias for coremw.Config")
+	}
+}
+
+// TestDefaultConfigMatchesCore asserts adapter DefaultConfig returns
+// the same struct as the core DefaultConfig.
+func TestDefaultConfigMatchesCore(t *testing.T) {
+	if !reflect.DeepEqual(peacecho.DefaultConfig(), coremw.DefaultConfig()) {
+		t.Fatalf("peacecho.DefaultConfig() diverges from coremw.DefaultConfig()")
+	}
+}
+
+// TestVerifierRequired401 confirms that the stdlib middleware returned
+// by Verifier rejects requests without a PEAC-Receipt header when
+// Optional is false.
+func TestVerifierRequired401(t *testing.T) {
+	cfg := peacecho.DefaultConfig()
+	cfg.Issuer = "https://publisher.example"
+	cfg.Audience = "https://agent.example"
+
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("downstream handler was reached when receipt was missing")
+	})
+
+	h := peacecho.Verifier(cfg)(downstream)
+	req := httptest.NewRequest("GET", "/protected", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestVerifierOptionalPassesThrough confirms Optional=true lets
+// receipt-less requests through to the downstream handler.
+func TestVerifierOptionalPassesThrough(t *testing.T) {
+	cfg := peacecho.DefaultConfig()
+	cfg.Issuer = "https://publisher.example"
+	cfg.Audience = "https://agent.example"
+	cfg.Optional = true
+
+	reached := false
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	h := peacecho.Verifier(cfg)(downstream)
+	req := httptest.NewRequest("GET", "/protected", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if !reached {
+		t.Fatalf("optional middleware did not reach downstream handler")
+	}
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rr.Code)
+	}
+}

--- a/sdks/go/middleware/echo/go.mod
+++ b/sdks/go/middleware/echo/go.mod
@@ -1,0 +1,7 @@
+module github.com/peacprotocol/peac/sdks/go/middleware/echo
+
+go 1.26
+
+require github.com/peacprotocol/peac/sdks/go v0.9.29
+
+replace github.com/peacprotocol/peac/sdks/go => ../..

--- a/sdks/go/middleware/gin/gin_test.go
+++ b/sdks/go/middleware/gin/gin_test.go
@@ -1,0 +1,145 @@
+package gin_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	peacgin "github.com/peacprotocol/peac/sdks/go/middleware/gin"
+)
+
+// Gin's Config is a dedicated struct (not a type alias) because gin's
+// handler type (gin.HandlerFunc) differs from stdlib http.Handler.
+// These tests assert behavioral parity with the chi / echo / nethttp
+// parity corpus even though the Config type itself cannot be a Go
+// type alias. Scenarios mirror sdks/go/middleware/paritytest/parity_test.go
+// so the four adapters agree on visible behavior.
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func defaultCfg() peacgin.Config {
+	return peacgin.Config{
+		Issuer:   "https://publisher.example",
+		Audience: "https://agent.example",
+	}
+}
+
+func newEngine(mw gin.HandlerFunc, hit *bool) *gin.Engine {
+	e := gin.New()
+	e.Use(mw)
+	e.GET("/protected", func(c *gin.Context) {
+		if hit != nil {
+			*hit = true
+		}
+		c.Header("X-Downstream-Reached", "1")
+		c.String(http.StatusOK, "ok")
+	})
+	return e
+}
+
+// TestDefaultConfigShape asserts Gin's DefaultConfig sets the same
+// ClockSkew, MaxAge, and HeaderName as the core middleware DefaultConfig.
+// Gin's Config struct is separate because it carries a gin-specific
+// ErrorHandler signature, so field-by-field reflect equality is not
+// the right check; value equality on the shared behavioral fields is.
+func TestDefaultConfigShape(t *testing.T) {
+	cfg := peacgin.DefaultConfig()
+	if cfg.HeaderName != "PEAC-Receipt" {
+		t.Fatalf("HeaderName=%q want PEAC-Receipt", cfg.HeaderName)
+	}
+	if cfg.MaxAge != time.Hour {
+		t.Fatalf("MaxAge=%v want 1h", cfg.MaxAge)
+	}
+	if cfg.ClockSkew != 30*time.Second {
+		t.Fatalf("ClockSkew=%v want 30s", cfg.ClockSkew)
+	}
+	if cfg.Optional {
+		t.Fatalf("Optional default must be false")
+	}
+}
+
+// TestVerifierRequired401 mirrors the parity-harness case:
+// no-receipt with Optional=false returns 401.
+func TestVerifierRequired401(t *testing.T) {
+	cfg := defaultCfg()
+	hit := false
+	e := newEngine(peacgin.Verifier(cfg), &hit)
+
+	req := httptest.NewRequest("GET", "/protected", nil)
+	rr := httptest.NewRecorder()
+	e.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d; body=%s", rr.Code, rr.Body.String())
+	}
+	if hit {
+		t.Fatalf("downstream reached despite 401")
+	}
+}
+
+// TestVerifierOptionalPassesThrough mirrors the parity-harness case:
+// no-receipt with Optional=true passes through to the handler.
+func TestVerifierOptionalPassesThrough(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.Optional = true
+	hit := false
+	e := newEngine(peacgin.Verifier(cfg), &hit)
+
+	req := httptest.NewRequest("GET", "/protected", nil)
+	rr := httptest.NewRecorder()
+	e.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rr.Code)
+	}
+	if !hit {
+		t.Fatalf("optional middleware did not reach downstream")
+	}
+}
+
+// TestMalformedReceipt400 mirrors the parity-harness case:
+// a malformed receipt returns 400 (E_INVALID_FORMAT) and does not
+// reach the downstream handler.
+func TestMalformedReceipt400(t *testing.T) {
+	cfg := defaultCfg()
+	hit := false
+	e := newEngine(peacgin.Verifier(cfg), &hit)
+
+	req := httptest.NewRequest("GET", "/protected", nil)
+	req.Header.Set("PEAC-Receipt", "not-a-jws")
+	rr := httptest.NewRecorder()
+	e.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d; body=%s", rr.Code, rr.Body.String())
+	}
+	if hit {
+		t.Fatalf("downstream reached despite 400")
+	}
+}
+
+// TestCaseInsensitivePeacReceiptHeader mirrors the parity-harness case:
+// the lowercase form `peac-receipt` is treated identically to the
+// canonical `PEAC-Receipt`. HTTP headers are case-insensitive by
+// RFC 9110; the adapter must not special-case the letter casing.
+func TestCaseInsensitivePeacReceiptHeader(t *testing.T) {
+	cfg := defaultCfg()
+	hit := false
+	e := newEngine(peacgin.Verifier(cfg), &hit)
+
+	req := httptest.NewRequest("GET", "/protected", nil)
+	req.Header.Set("peac-receipt", "not-a-jws")
+	rr := httptest.NewRecorder()
+	e.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 (malformed), got %d; body=%s", rr.Code, rr.Body.String())
+	}
+	if hit {
+		t.Fatalf("downstream reached despite 400")
+	}
+}

--- a/sdks/go/middleware/nethttp/README.md
+++ b/sdks/go/middleware/nethttp/README.md
@@ -1,0 +1,65 @@
+# @peac/middleware-nethttp (Go)
+
+PEAC receipt verification middleware for the Go standard library
+`net/http` package.
+
+## Install
+
+```bash
+go get github.com/peacprotocol/peac/sdks/go/middleware/nethttp
+```
+
+This is a separate Go module that re-exports the core PEAC middleware
+under a framework-specific path. It carries no additional dependencies
+beyond the core SDK, so using the named net/http adapter is equivalent
+to using the core middleware directly; the separate module exists so
+the adapter-per-framework pattern (chi, gin, echo, nethttp) is uniform.
+
+## Usage
+
+```go
+import (
+    "net/http"
+    peacnethttp "github.com/peacprotocol/peac/sdks/go/middleware/nethttp"
+)
+
+func main() {
+    mux := http.NewServeMux()
+    mux.HandleFunc("/protected", protected)
+
+    verified := peacnethttp.Verifier(peacnethttp.Config{
+        Issuer:   "https://publisher.example",
+        Audience: "https://agent.example",
+    })(mux)
+
+    http.ListenAndServe(":8080", verified)
+}
+
+func protected(w http.ResponseWriter, r *http.Request) {
+    claims := peacnethttp.GetClaims(r)
+    _ = claims // use claims.Subject, claims.Purpose, etc.
+    w.WriteHeader(200)
+}
+```
+
+## Parity with chi, gin, and echo adapters
+
+| Aspect                                      | Contract                                                                                                              |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `type Config = middleware.Config`           | identical across all adapters                                                                                         |
+| `DefaultConfig()`                           | identical hardened defaults (panic recovery on, 1 MiB body cap, `TrustProxyHeaders` off)                              |
+| `Verifier(cfg Config)`                      | returns `func(http.Handler) http.Handler`; identical verifier semantics                                               |
+| Header behavior                             | `PEAC-Receipt` precedence; rail-x402 `PAYMENT-RESPONSE` / `X-PAYMENT-RESPONSE` honored; case-insensitive header names |
+| Timeout / body limit / trust-proxy defaults | identical across all adapters                                                                                         |
+| Error / status mapping                      | 401 / 400 / 503 taxonomy matches chi and gin exactly                                                                  |
+
+The parity contract is enforced by a shared request-corpus test harness
+under `sdks/go/middleware/paritytest/` that runs the same requests
+against every adapter and asserts identical responses.
+
+## Related documents
+
+- [Hosted Verify contract](../../../../docs/HOSTED_VERIFY_CONTRACT.md)
+- [Threat model](../../../../docs/THREAT_MODEL.md)
+- [Stability contract](../../../../docs/STABILITY-CONTRACT.md)
+- [Compatibility matrix for Go middleware](../../../../docs/compatibility/go-middleware.md)

--- a/sdks/go/middleware/nethttp/go.mod
+++ b/sdks/go/middleware/nethttp/go.mod
@@ -1,0 +1,7 @@
+module github.com/peacprotocol/peac/sdks/go/middleware/nethttp
+
+go 1.26
+
+require github.com/peacprotocol/peac/sdks/go v0.9.29
+
+replace github.com/peacprotocol/peac/sdks/go => ../..

--- a/sdks/go/middleware/nethttp/nethttp.go
+++ b/sdks/go/middleware/nethttp/nethttp.go
@@ -1,0 +1,80 @@
+// Package nethttp provides PEAC receipt verification middleware for
+// the Go standard library `net/http` package.
+//
+// The core `sdks/go/middleware` package already returns
+// `func(http.Handler) http.Handler`, which is the stdlib-native
+// middleware signature. This package re-exports that API under a
+// framework-specific path so users who want to depend on a named
+// net/http adapter have one, matching the adapter-per-framework
+// pattern used by chi, gin, and echo. Install with:
+//
+//	go get github.com/peacprotocol/peac/sdks/go/middleware/nethttp
+//
+// Usage:
+//
+//	import (
+//	    "net/http"
+//	    peacnethttp "github.com/peacprotocol/peac/sdks/go/middleware/nethttp"
+//	)
+//
+//	mux := http.NewServeMux()
+//	mux.HandleFunc("/protected", protected)
+//
+//	verified := peacnethttp.Verifier(peacnethttp.Config{
+//	    Issuer:   "https://publisher.example",
+//	    Audience: "https://agent.example",
+//	})(mux)
+//
+//	http.ListenAndServe(":8080", verified)
+package nethttp
+
+import (
+	"net/http"
+
+	"github.com/peacprotocol/peac/sdks/go/middleware"
+)
+
+// Config is an alias for the core middleware config. Identical to the
+// chi, gin, and echo adapters so `type Config = middleware.Config`
+// parity holds across every framework wrapper.
+type Config = middleware.Config
+
+// DefaultConfig returns the default middleware configuration with
+// hardened defaults: panic recovery on, 1 MiB body cap,
+// TrustProxyHeaders off. Identical to the other adapters.
+func DefaultConfig() Config {
+	return middleware.DefaultConfig()
+}
+
+// Verifier creates a PEAC verification middleware for standard
+// net/http handlers. The returned middleware has the canonical
+// signature `func(http.Handler) http.Handler` and can be composed with
+// any net/http mux or third-party router that accepts stdlib
+// middleware.
+func Verifier(cfg Config) func(http.Handler) http.Handler {
+	return middleware.Middleware(cfg)
+}
+
+// RequireReceipt creates a middleware that requires a valid PEAC
+// receipt. Requests without a verified receipt return 401.
+func RequireReceipt(issuer, audience string) func(http.Handler) http.Handler {
+	return middleware.RequireReceipt(issuer, audience)
+}
+
+// OptionalReceipt creates a middleware that optionally verifies PEAC
+// receipts. Requests without a receipt are passed through.
+func OptionalReceipt(issuer, audience string) func(http.Handler) http.Handler {
+	return middleware.OptionalReceipt(issuer, audience)
+}
+
+// GetClaims retrieves the verified claims from the request context.
+var GetClaims = middleware.GetClaims
+
+// GetResult retrieves the full verify result from the request context.
+var GetResult = middleware.GetResult
+
+// ClaimsContextKey is the context key for verified claims.
+const ClaimsContextKey = middleware.ClaimsContextKey
+
+// ResultContextKey is the context key for the full verify result.
+const ResultContextKey = middleware.ResultContextKey

--- a/sdks/go/middleware/nethttp/nethttp_test.go
+++ b/sdks/go/middleware/nethttp/nethttp_test.go
@@ -1,0 +1,69 @@
+package nethttp_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	coremw "github.com/peacprotocol/peac/sdks/go/middleware"
+	peacnethttp "github.com/peacprotocol/peac/sdks/go/middleware/nethttp"
+)
+
+func TestConfigIsAlias(t *testing.T) {
+	var adapterCfg peacnethttp.Config
+	var coreCfg coremw.Config
+	if reflect.TypeOf(adapterCfg) != reflect.TypeOf(coreCfg) {
+		t.Fatalf("peacnethttp.Config is not a type alias for coremw.Config")
+	}
+}
+
+func TestDefaultConfigMatchesCore(t *testing.T) {
+	if !reflect.DeepEqual(peacnethttp.DefaultConfig(), coremw.DefaultConfig()) {
+		t.Fatalf("peacnethttp.DefaultConfig() diverges from coremw.DefaultConfig()")
+	}
+}
+
+func TestVerifierRequired401(t *testing.T) {
+	cfg := peacnethttp.DefaultConfig()
+	cfg.Issuer = "https://publisher.example"
+	cfg.Audience = "https://agent.example"
+
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("downstream handler was reached when receipt was missing")
+	})
+
+	h := peacnethttp.Verifier(cfg)(downstream)
+	req := httptest.NewRequest("GET", "/protected", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestVerifierOptionalPassesThrough(t *testing.T) {
+	cfg := peacnethttp.DefaultConfig()
+	cfg.Issuer = "https://publisher.example"
+	cfg.Audience = "https://agent.example"
+	cfg.Optional = true
+
+	reached := false
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	h := peacnethttp.Verifier(cfg)(downstream)
+	req := httptest.NewRequest("GET", "/protected", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if !reached {
+		t.Fatalf("optional middleware did not reach downstream handler")
+	}
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rr.Code)
+	}
+}

--- a/sdks/go/middleware/paritytest/README.md
+++ b/sdks/go/middleware/paritytest/README.md
@@ -1,0 +1,51 @@
+# Go middleware adapter parity harness
+
+This test-only Go module enforces that every framework-specific PEAC
+middleware adapter returns identical responses for a shared request
+corpus. The core middleware at `sdks/go/middleware/` is the single
+source of behavior; adapters (chi, gin, echo, nethttp) are thin
+wrappers that re-expose the same `Config`, `DefaultConfig`, and
+`Verifier` surface.
+
+## What the harness asserts
+
+- `type Config = middleware.Config` across every adapter (reflect-equality on a zero value).
+- `DefaultConfig()` returns a struct byte-identical to the core default across every adapter.
+- For each scenario in the shared corpus, every adapter returns the same HTTP status, the same `Content-Type` / `X-Downstream-Reached` headers, and the same body bytes.
+
+The chi adapter is used as the reference; other adapters are asserted
+against chi's response.
+
+## Scope
+
+- Covers the three stdlib-shaped adapters (chi, echo, nethttp).
+- The gin adapter uses its own `gin.HandlerFunc` type and carries a
+  third-party dependency; it is verified by `sdks/go/middleware/gin/gin_test.go`
+  against the same scenario list (no-receipt required → 401, no-receipt
+  optional pass-through → 200, malformed receipt → 400 E_INVALID_FORMAT,
+  and case-insensitive `peac-receipt` header). The scenario sets are
+  kept in sync by convention; update both when adding new scenarios.
+
+## Running
+
+Run from the repository checkout. Because this module is nested inside
+a parent Go module (`sdks/go`), the parity module is not part of any
+Go workspace; disable workspace resolution when invoking `go test` so
+the per-module `replace` directives are honored:
+
+```bash
+cd sdks/go/middleware/paritytest
+GOWORK=off go test ./...
+```
+
+The harness does not need network access; every scenario runs entirely
+against `httptest.NewRecorder` with an in-process downstream handler.
+The same `GOWORK=off` invocation applies to the other adapter modules
+(`chi`, `gin`, `echo`, `nethttp`) when running their test suites from
+the repository checkout.
+
+## Related documents
+
+- [Compatibility matrix for Go middleware](../../../../docs/compatibility/go-middleware.md)
+- [Hosted Verify contract](../../../../docs/HOSTED_VERIFY_CONTRACT.md)
+- [Threat model](../../../../docs/THREAT_MODEL.md)

--- a/sdks/go/middleware/paritytest/go.mod
+++ b/sdks/go/middleware/paritytest/go.mod
@@ -1,0 +1,17 @@
+module github.com/peacprotocol/peac/sdks/go/middleware/paritytest
+
+go 1.26
+
+require (
+	github.com/peacprotocol/peac/sdks/go v0.9.29
+	github.com/peacprotocol/peac/sdks/go/middleware/chi v0.0.0
+	github.com/peacprotocol/peac/sdks/go/middleware/echo v0.0.0
+	github.com/peacprotocol/peac/sdks/go/middleware/nethttp v0.0.0
+)
+
+replace (
+	github.com/peacprotocol/peac/sdks/go => ../..
+	github.com/peacprotocol/peac/sdks/go/middleware/chi => ../chi
+	github.com/peacprotocol/peac/sdks/go/middleware/echo => ../echo
+	github.com/peacprotocol/peac/sdks/go/middleware/nethttp => ../nethttp
+)

--- a/sdks/go/middleware/paritytest/parity_test.go
+++ b/sdks/go/middleware/paritytest/parity_test.go
@@ -1,0 +1,232 @@
+// Package paritytest enforces that every framework-specific PEAC
+// middleware adapter (chi, gin, echo, nethttp) returns identical
+// responses for a shared request corpus.
+//
+// The core middleware is the single source of behavior; adapters are
+// thin wrappers that re-expose `Config`, `DefaultConfig`, and
+// `Verifier`. This harness asserts that the Config alias shape,
+// DefaultConfig defaults, verifier wrapper semantics, header handling,
+// timeout / body-limit / trust-proxy defaults, and 401 / 400 / 503
+// error/status mapping are all identical across adapters.
+//
+// Each adapter is its own Go module; this test module `replace`s them
+// from ../chi, ../echo, ../nethttp. The gin adapter uses a different
+// handler type (`gin.HandlerFunc`) and carries a third-party
+// dependency; it is verified by `sdks/go/middleware/gin/gin_test.go`
+// against the same four scenarios below. The parity harness here
+// covers the three stdlib-shaped adapters.
+package paritytest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	coremw "github.com/peacprotocol/peac/sdks/go/middleware"
+	peacchi "github.com/peacprotocol/peac/sdks/go/middleware/chi"
+	peacecho "github.com/peacprotocol/peac/sdks/go/middleware/echo"
+	peacnethttp "github.com/peacprotocol/peac/sdks/go/middleware/nethttp"
+)
+
+// adapter describes one middleware adapter for the parity corpus.
+type adapter struct {
+	name     string
+	verifier func(coremw.Config) func(http.Handler) http.Handler
+}
+
+// all stdlib-shaped adapters under test. Gin has its own handler type
+// and is exercised from sdks/go/middleware/gin/gin_test.go against the
+// same scenario list.
+func adapters() []adapter {
+	return []adapter{
+		{
+			name:     "chi",
+			verifier: func(c coremw.Config) func(http.Handler) http.Handler { return peacchi.Verifier(c) },
+		},
+		{
+			name:     "echo",
+			verifier: func(c coremw.Config) func(http.Handler) http.Handler { return peacecho.Verifier(c) },
+		},
+		{
+			name:     "nethttp",
+			verifier: func(c coremw.Config) func(http.Handler) http.Handler { return peacnethttp.Verifier(c) },
+		},
+	}
+}
+
+// downstream is the handler each scenario composes under the
+// middleware; it does not participate in verification outcomes but
+// records that control reached the downstream tier.
+func downstream() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Downstream-Reached", "1")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+}
+
+// scenario describes one shared request corpus entry.
+type scenario struct {
+	name           string
+	cfg            coremw.Config
+	method         string
+	path           string
+	headers        map[string]string
+	body           string
+	wantStatus     int
+	wantDownstream bool
+}
+
+func scenarios() []scenario {
+	defaultCfg := coremw.DefaultConfig()
+	defaultCfg.Issuer = "https://publisher.example"
+	defaultCfg.Audience = "https://agent.example"
+
+	optionalCfg := defaultCfg
+	optionalCfg.Optional = true
+
+	return []scenario{
+		{
+			name:           "no-receipt default (required) returns 401",
+			cfg:            defaultCfg,
+			method:         "GET",
+			path:           "/protected",
+			wantStatus:     http.StatusUnauthorized,
+			wantDownstream: false,
+		},
+		{
+			name:           "no-receipt optional passes through",
+			cfg:            optionalCfg,
+			method:         "GET",
+			path:           "/protected",
+			wantStatus:     http.StatusOK,
+			wantDownstream: true,
+		},
+		{
+			name:           "malformed-receipt returns 400 E_INVALID_FORMAT",
+			cfg:            defaultCfg,
+			method:         "GET",
+			path:           "/protected",
+			headers:        map[string]string{"PEAC-Receipt": "not-a-jws"},
+			wantStatus:     http.StatusBadRequest,
+			wantDownstream: false,
+		},
+		{
+			name:           "case-insensitive header name (peac-receipt) treated the same as PEAC-Receipt",
+			cfg:            defaultCfg,
+			method:         "GET",
+			path:           "/protected",
+			headers:        map[string]string{"peac-receipt": "not-a-jws"},
+			wantStatus:     http.StatusBadRequest,
+			wantDownstream: false,
+		},
+	}
+}
+
+// headerSnapshot copies the headers that are part of the parity
+// contract. Body cap, timeout, and trust-proxy headers are not
+// echoed; the Problem Details response shape and error code are.
+func headerSnapshot(h http.Header) map[string]string {
+	out := map[string]string{}
+	for _, k := range []string{"Content-Type", "X-Downstream-Reached"} {
+		if v := h.Get(k); v != "" {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+func TestAdapterParity(t *testing.T) {
+	for _, sc := range scenarios() {
+		sc := sc // capture
+		t.Run(sc.name, func(t *testing.T) {
+			type result struct {
+				status  int
+				headers map[string]string
+				body    string
+			}
+
+			results := map[string]result{}
+			for _, a := range adapters() {
+				handler := a.verifier(sc.cfg)(downstream())
+				req := httptest.NewRequest(sc.method, sc.path, strings.NewReader(sc.body))
+				for k, v := range sc.headers {
+					req.Header.Set(k, v)
+				}
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+				results[a.name] = result{
+					status:  rr.Code,
+					headers: headerSnapshot(rr.Result().Header),
+					body:    rr.Body.String(),
+				}
+			}
+
+			// Assert expected status and downstream reach against the
+			// chi reference; then assert the other adapters' responses
+			// are byte-identical to chi's.
+			ref := results["chi"]
+			if ref.status != sc.wantStatus {
+				t.Fatalf("chi status=%d want=%d body=%q", ref.status, sc.wantStatus, ref.body)
+			}
+			reachedDownstream := ref.headers["X-Downstream-Reached"] == "1"
+			if reachedDownstream != sc.wantDownstream {
+				t.Fatalf("chi downstream-reach=%v want=%v", reachedDownstream, sc.wantDownstream)
+			}
+			for name, got := range results {
+				if name == "chi" {
+					continue
+				}
+				if got.status != ref.status {
+					t.Errorf("parity: %s status=%d != chi status=%d", name, got.status, ref.status)
+				}
+				if !reflect.DeepEqual(got.headers, ref.headers) {
+					t.Errorf("parity: %s headers=%v != chi headers=%v", name, got.headers, ref.headers)
+				}
+				if got.body != ref.body {
+					t.Errorf("parity: %s body=%q != chi body=%q", name, got.body, ref.body)
+				}
+			}
+		})
+	}
+}
+
+func TestDefaultConfigParity(t *testing.T) {
+	// DefaultConfig across adapters must return the same struct value.
+	chi := peacchi.DefaultConfig()
+	echoC := peacecho.DefaultConfig()
+	nethttp := peacnethttp.DefaultConfig()
+	core := coremw.DefaultConfig()
+
+	if !reflect.DeepEqual(chi, core) {
+		t.Fatalf("chi.DefaultConfig() diverges from core.DefaultConfig()")
+	}
+	if !reflect.DeepEqual(echoC, core) {
+		t.Fatalf("echo.DefaultConfig() diverges from core.DefaultConfig()")
+	}
+	if !reflect.DeepEqual(nethttp, core) {
+		t.Fatalf("nethttp.DefaultConfig() diverges from core.DefaultConfig()")
+	}
+}
+
+func TestConfigAliasParity(t *testing.T) {
+	// Each adapter's Config must be a type alias for coremw.Config,
+	// not a new named type. reflect.TypeOf on a zero value should
+	// return the same reflect.Type.
+	var a peacchi.Config
+	var b peacecho.Config
+	var c peacnethttp.Config
+	var d coremw.Config
+
+	if reflect.TypeOf(a) != reflect.TypeOf(d) {
+		t.Fatalf("chi.Config is not an alias for coremw.Config")
+	}
+	if reflect.TypeOf(b) != reflect.TypeOf(d) {
+		t.Fatalf("echo.Config is not an alias for coremw.Config")
+	}
+	if reflect.TypeOf(c) != reflect.TypeOf(d) {
+		t.Fatalf("nethttp.Config is not an alias for coremw.Config")
+	}
+}


### PR DESCRIPTION
## Summary

Add Go Echo and net/http middleware adapters, a shared adapter-parity harness, and observational commerce lifecycle grouping for `@peac/audit`.

## Scope

- Layer 4 and documentation only. No wire, schema, kernel, crypto, or protocol public-API change.
- This change is limited to Go adapter coverage, adapter-parity verification, observational lifecycle grouping, and related compatibility documentation.

## What is new

### Go Echo adapter (`sdks/go/middleware/echo/`)

- Thin wrapper over the core middleware, matching the chi adapter pattern: `type Config = middleware.Config`, `DefaultConfig()`, `Verifier(cfg Config) func(http.Handler) http.Handler`, plus `RequireReceipt`, `OptionalReceipt`, `GetClaims`, `GetResult`, and the `ClaimsContextKey` / `ResultContextKey` constants.
- Carries no Echo dependency. Exposes the stdlib-compatible `func(http.Handler) http.Handler` that `echo.WrapMiddleware` accepts. Users who do not use Echo never pull Echo into their dependency graph.
- `echo_test.go` covers the adapter-level invariants (Config is a type alias, DefaultConfig matches core, required-401, optional pass-through).

### Go net/http adapter (`sdks/go/middleware/nethttp/`)

- Same surface as the echo adapter; re-exports the core middleware under a framework-specific path so the adapter-per-framework pattern is uniform across chi, gin, echo, and nethttp.
- `nethttp_test.go` mirrors the echo adapter test suite.

### Shared parity harness (`sdks/go/middleware/paritytest/`)

- New Go module that imports chi, echo, and nethttp via `replace` directives and runs a shared request corpus against all three. Every scenario asserts identical status, identical selected response headers, and identical body bytes against the chi reference.
- Test groups: `TestConfigAliasParity` (Config is a type alias, not a named type), `TestDefaultConfigParity` (DefaultConfig bytes identical to core), `TestAdapterParity` (request corpus: no-receipt required 401, no-receipt optional pass-through, malformed receipt 400 `E_INVALID_FORMAT`, case-insensitive `peac-receipt` header).
- The shared parity harness covers chi, echo, and net/http. Gin is covered by a scenario-equivalent test suite at `sdks/go/middleware/gin/gin_test.go` exercising the same four scenarios plus adapter-level default-config assertions.

### Commerce-bundle lifecycle grouping (`packages/audit/src/commerce-bundle.ts`)

- Extends the existing commerce-bundle primitives with a new `groupByLifecycle(records: LifecycleInputRecord[]): LifecycleBundle[]` export. Observational only: the returned bucket keys are the exact `commerce_event` values each upstream attested; no lifecycle semantics are inferred. Records with absent, null, empty, or non-string events are routed to a reserved `UNCLASSIFIED_LIFECYCLE_BUCKET` key.
- Deterministic ordering: within each bucket, `iat` ascending with `receipt_ref` lex tie-break; across the returned array, `session_ref` lex ascending.
- Experimental API label preserved: the existing `peac.commerce-bundle/0.1-experimental` version constant is carried on every bundle; public JSDoc marks the function `@experimental`.
- Seven committed test cases cover: per-session and per-event grouping, absent / null / empty / whitespace routing to `unclassified`, no-synthesis invariant (no `settled` / `completed` / `finalized` / `final` / `finality` buckets are produced from record combinations), deterministic within-bucket ordering, version constant carried through, deterministic output across input permutations, and the empty-input case.

### Documentation

- `docs/compatibility/go-middleware.md` adds echo and nethttp rows to the stability-classes table, a new "Adapter parity contract" section naming both the stdlib-shaped parity harness and the gin scenario-equivalent test suite, and runnable integration snippets for both frameworks.

## Validation

- `GOWORK=off go test ./...` passes in each adapter module (chi build, gin, echo, nethttp, paritytest all green).
- `pnpm --filter @peac/audit test` reports 7 files / 155 tests pass (27 in `commerce-bundle.test.ts`, of which 7 are new lifecycle-grouping cases).
- `pnpm ci:all` green: 303 test files / 7593 tests pass.
- `pnpm lint`, `pnpm format:check`, `bash scripts/guard.sh`, `pnpm verify:trust-artifacts`, `pnpm verify:public-surface-names` all clean.
- Both local verifiers exit 0.

## Notes

The `groupByLifecycle` function is observational and never synthesizes finality. Upstream event names are preserved as the bucket keys; downstream audit code must interpret buckets with explicit knowledge of each event's upstream semantics.
