### PR TITLE
feat: go benchmark gate, bench-tooling tests, extended jcs parity corpus

### DIFF
--- a/.github/workflows/bench-gate.yml
+++ b/.github/workflows/bench-gate.yml
@@ -1,0 +1,141 @@
+# Regression-aware Go benchmark gate.
+#
+# Runs the stable benchmark subset (sdks/go/bench, functions prefixed
+# `BenchmarkVerify_Stable_`) and compares median ns/op against the
+# committed baseline at sdks/go/bench/baseline.json. Methodology is
+# documented in scripts/go-bench-gate.mjs.
+#
+# Two entrypoints:
+#
+#   1. pull_request on core-runtime paths:
+#        Runs the gate in non-strict mode. A regression flagged here is
+#        annotated but does not block the PR on its first occurrence;
+#        it blocks only after the plan's 2-of-3 reproduction rule is
+#        met, which is left to maintainer judgment.
+#
+#   2. workflow_dispatch with mode=update-baseline:
+#        Captures fresh numbers on the CI runner, writes them to
+#        sdks/go/bench/baseline.json (flipping baseline_pending to
+#        false), and opens a baseline-refresh PR. Baseline-update is
+#        the only path allowed to edit baseline.json.
+#
+# The gate runs docs-only PRs as a no-op: the paths filter below skips
+# the core-runtime job when no Go code changed and no baseline change
+# is involved.
+
+name: Bench gate (Go)
+
+on:
+  pull_request:
+    paths:
+      - 'sdks/go/**'
+      - 'scripts/go-bench-gate.mjs'
+      - '.github/workflows/bench-gate.yml'
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Mode: measure runs the gate; update-baseline captures fresh numbers and opens a refresh PR'
+        type: choice
+        options:
+          - measure
+          - update-baseline
+        default: measure
+      runs:
+        description: 'Number of bench iterations per measurement'
+        type: string
+        default: '10'
+
+concurrency:
+  group: bench-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  measure:
+    name: Measure stable bench subset
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'measure') }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version: '1.26'
+          # Caching disabled: the bench module has no external dependency
+          # footprint beyond the sibling sdks/go module, and the repo does
+          # not commit a go.sum for bench/. Add a go.sum and re-enable
+          # cache only if the bench module grows real external deps.
+          cache: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: '.node-version'
+
+      - name: Run bench gate
+        env:
+          BENCH_RUNS: ${{ github.event_name == 'workflow_dispatch' && inputs.runs || '10' }}
+        run: |
+          node scripts/go-bench-gate.mjs --runs "${BENCH_RUNS}" --save-run --json | tee bench-result.json
+
+      - name: Upload run artifact
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: bench-run-${{ github.sha }}
+          path: |
+            bench-result.json
+            sdks/go/bench/runs/
+
+  update-baseline:
+    name: Update baseline
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'update-baseline' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version: '1.26'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: '.node-version'
+
+      - name: Capture baseline on this runner
+        env:
+          BENCH_RUNS: ${{ inputs.runs }}
+        run: |
+          node scripts/go-bench-gate.mjs --runs "${BENCH_RUNS}" --save-run --json > bench-capture.json
+          node scripts/update-bench-baseline.mjs --input bench-capture.json
+
+      - name: Open baseline-refresh pull request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          commit-message: 'chore: refresh Go bench baseline on ubuntu-24.04'
+          branch: chore/bench-baseline-refresh
+          title: 'chore: refresh Go bench baseline on ubuntu-24.04'
+          body: |
+            Refresh `sdks/go/bench/baseline.json` from a fresh workflow_dispatch
+            run on ubuntu-24.04. Baseline-update is the only path allowed
+            to edit `baseline.json`. Review the new median ns/op values
+            against the prior baseline and merge only when the numbers
+            look sensible for the machine profile.
+          add-paths: |
+            sdks/go/bench/baseline.json

--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
     "verify:release-closeout:test": "node scripts/verify-release-closeout.test.mjs",
     "verify:changelog-entry:test": "node scripts/extract-changelog-entry.test.mjs",
     "verify:stamp-only-pr:test": "node scripts/ci/check-stamp-only-pr.test.mjs",
+    "verify:go-bench-gate:test": "node scripts/go-bench-gate.test.mjs",
+    "verify:bench-baseline:test": "node scripts/update-bench-baseline.test.mjs",
     "fixtures:new": "node scripts/fixtures-new.mjs",
     "conformance:regen:bundle": "tsx scripts/generate-bundle-vectors.ts",
     "bench": "pnpm --filter @peac/crypto bench && pnpm --filter @peac/schema bench && pnpm --filter @peac/protocol bench",

--- a/packages/crypto/tests/jcs.parity-extended.test.ts
+++ b/packages/crypto/tests/jcs.parity-extended.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Extended JCS (RFC 8785) parity tests against the shared corpus at
+ * specs/conformance/parity-corpus/jcs-extended/.
+ *
+ * The corpus is the single source of truth for the cross-language
+ * canonicalization contract; the Go implementation in
+ * sdks/go/jcs_parity_extended_test.go runs the same vectors and
+ * must produce byte-identical output.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+
+import { canonicalize } from '../src/jcs.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CORPUS_PATH = resolve(
+  __dirname,
+  '../../../specs/conformance/parity-corpus/jcs-extended/vectors.json'
+);
+
+interface Vector {
+  id: string;
+  description: string;
+  input: unknown;
+  canonical: string;
+}
+
+interface Corpus {
+  description: string;
+  generator: string;
+  vectors: Vector[];
+}
+
+const corpus: Corpus = JSON.parse(readFileSync(CORPUS_PATH, 'utf8'));
+
+describe('JCS extended parity corpus (TypeScript side)', () => {
+  it('corpus has the expected six vectors', () => {
+    expect(corpus.vectors.map((v) => v.id).sort()).toEqual([
+      'escape-sequences',
+      'integer-vs-float-same-value',
+      'nested-depth-5',
+      'numeric-zero-and-neg-zero',
+      'unicode-nfc-nfd',
+      'utf16-surrogate-pair',
+    ]);
+  });
+
+  for (const vector of corpus.vectors) {
+    it(`vector "${vector.id}" canonicalizes byte-identically to the corpus`, () => {
+      const got = canonicalize(vector.input);
+      expect(got).toBe(vector.canonical);
+    });
+  }
+});

--- a/scripts/go-bench-gate.mjs
+++ b/scripts/go-bench-gate.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+/**
+ * Regression-aware Go benchmark gate.
+ *
+ * Runs the stable benchmark subset in sdks/go/bench/ and compares the
+ * median ns/op of each benchmark against the committed baseline in
+ * sdks/go/bench/baseline.json. The methodology follows the v0.12.13
+ * plan rules:
+ *
+ *   - Stable benchmark subset only (`BenchmarkVerify_Stable_*` prefix).
+ *   - N=10 runs per bench per CI job (override via --runs).
+ *   - Threshold bands:
+ *       ratio <= 1.10x            -> green
+ *       1.10x < ratio <= 1.25x    -> warn (annotate; do not fail)
+ *       ratio > 1.25x AND absolute breach > 50us  -> fail
+ *   - A fail is blocking only when it reproduces in 2-of-3 consecutive
+ *     CI runs; --strict forces the current run to block regardless.
+ *   - Baseline updates land only via the dedicated workflow_dispatch
+ *     entrypoint; this gate never edits baseline.json.
+ *
+ * When the committed baseline has `baseline_pending: true` the gate
+ * runs in measurement-only mode: it captures and reports the current
+ * numbers, writes them to sdks/go/bench/runs/ if `--save-run` is set,
+ * and always exits 0. This lets CI run the gate before any real
+ * baseline exists for the target platform.
+ *
+ * Usage:
+ *   node scripts/go-bench-gate.mjs              # measure-and-compare
+ *   node scripts/go-bench-gate.mjs --runs 10    # N=10 runs
+ *   node scripts/go-bench-gate.mjs --strict     # any fail blocks now
+ *   node scripts/go-bench-gate.mjs --save-run   # write runs/<ts>.json
+ *   node scripts/go-bench-gate.mjs --json       # JSON output
+ *   node scripts/go-bench-gate.mjs --dry-run    # skip `go test -bench`; read
+ *                                               # --fixture-output instead
+ *
+ * Exit codes:
+ *   0  green, or warn, or baseline_pending=true
+ *   1  fail (reproduction requirement already met in this run)
+ *   2  usage error or internal failure
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+const BENCH_DIR = resolve(REPO_ROOT, 'sdks/go/bench');
+const BASELINE_PATH = resolve(BENCH_DIR, 'baseline.json');
+const RUNS_DIR = resolve(BENCH_DIR, 'runs');
+
+const args = process.argv.slice(2);
+let runs = 10;
+let strict = false;
+let saveRun = false;
+let jsonOutput = false;
+let dryRun = false;
+let fixtureOutput = null;
+
+for (let i = 0; i < args.length; i++) {
+  const a = args[i];
+  if (a === '--') continue;
+  if (a === '--runs' && args[i + 1]) {
+    runs = Number(args[i + 1]);
+    i += 1;
+  } else if (a === '--strict') {
+    strict = true;
+  } else if (a === '--save-run') {
+    saveRun = true;
+  } else if (a === '--json') {
+    jsonOutput = true;
+  } else if (a === '--dry-run') {
+    dryRun = true;
+  } else if (a === '--fixture-output' && args[i + 1]) {
+    fixtureOutput = args[i + 1];
+    i += 1;
+  } else {
+    process.stderr.write(`unknown argument: ${a}\n`);
+    process.exit(2);
+  }
+}
+
+if (!existsSync(BASELINE_PATH)) {
+  process.stderr.write(`baseline not found: ${BASELINE_PATH}\n`);
+  process.exit(2);
+}
+const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'));
+
+const STABLE_PREFIX = 'BenchmarkVerify_Stable_';
+
+/**
+ * Run `go test -bench` in the bench module. Returns raw benchmark
+ * output text. Honors GOWORK=off so nested-module resolution works
+ * from the repository checkout. Uses -benchtime=200ms so the total
+ * wall time for all runs stays bounded on CI.
+ */
+function runBenchmarks() {
+  if (dryRun && fixtureOutput) {
+    return readFileSync(fixtureOutput, 'utf8');
+  }
+  const args = [
+    'test',
+    '-run=^$',
+    `-bench=^${STABLE_PREFIX}`,
+    '-benchmem',
+    `-count=${runs}`,
+    '-benchtime=200ms',
+    './...',
+  ];
+  const env = { ...process.env, GOWORK: 'off' };
+  try {
+    return execFileSync('go', args, {
+      cwd: BENCH_DIR,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf8',
+      maxBuffer: 16 * 1024 * 1024,
+    });
+  } catch (err) {
+    const stdout = (err.stdout || '').toString();
+    const stderr = (err.stderr || '').toString();
+    process.stderr.write(`go test -bench failed:\n${stdout}\n${stderr}\n`);
+    process.exit(2);
+  }
+}
+
+/**
+ * Parse Go benchmark output into { name: [ns_per_op, ...] }. Accepts
+ * lines like:
+ *   BenchmarkVerify_Stable_JCSSmall-10   149181   1540 ns/op   1728 B/op   25 allocs/op
+ */
+function parseBenchmarkOutput(text) {
+  const rows = {};
+  const re = /^(Benchmark\S+?)(?:-\d+)?\s+\d+\s+([\d.]+)\s+ns\/op\s+([\d.]+)\s+B\/op\s+([\d.]+)\s+allocs\/op/;
+  for (const line of text.split('\n')) {
+    const m = line.match(re);
+    if (!m) continue;
+    if (!m[1].startsWith(STABLE_PREFIX)) continue;
+    const row = rows[m[1]] ?? { ns: [], bytes: [], allocs: [] };
+    row.ns.push(Number(m[2]));
+    row.bytes.push(Number(m[3]));
+    row.allocs.push(Number(m[4]));
+    rows[m[1]] = row;
+  }
+  return rows;
+}
+
+function median(nums) {
+  const sorted = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) return (sorted[mid - 1] + sorted[mid]) / 2;
+  return sorted[mid];
+}
+
+function evaluate(rows, baseline) {
+  const thresholds = baseline.thresholds || {
+    ratio_warn: 1.1,
+    ratio_fail: 1.25,
+    absolute_fail_ns_min: 50000,
+    reproduction_runs_required_for_fail: 2,
+  };
+  const results = [];
+  for (const name of Object.keys(rows)) {
+    const row = rows[name];
+    const medianNs = median(row.ns);
+    const baselineRow = baseline.benchmarks?.[name] ?? null;
+    const baselineNs = baselineRow?.ns_per_op ?? 0;
+    let status;
+    let reason = null;
+    if (!baselineRow || baselineNs === 0) {
+      status = 'SEED';
+      reason = 'no baseline value for this benchmark';
+    } else {
+      const ratio = medianNs / baselineNs;
+      const absBreach = medianNs - baselineNs;
+      if (ratio > thresholds.ratio_fail && absBreach > thresholds.absolute_fail_ns_min) {
+        status = 'FAIL';
+        reason = `ratio=${ratio.toFixed(3)} absolute_breach_ns=${absBreach.toFixed(0)}`;
+      } else if (ratio > thresholds.ratio_warn) {
+        status = 'WARN';
+        reason = `ratio=${ratio.toFixed(3)}`;
+      } else {
+        status = 'GREEN';
+        reason = `ratio=${ratio.toFixed(3)}`;
+      }
+    }
+    results.push({
+      name,
+      median_ns_per_op: medianNs,
+      median_bytes_per_op: median(row.bytes),
+      median_allocs_per_op: median(row.allocs),
+      baseline_ns_per_op: baselineNs,
+      samples: row.ns.length,
+      status,
+      reason,
+    });
+  }
+  return { thresholds, results };
+}
+
+function writeRunRecord(rows, evaluation) {
+  if (!saveRun) return;
+  mkdirSync(RUNS_DIR, { recursive: true });
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const path = resolve(RUNS_DIR, `${ts}.json`);
+  writeFileSync(
+    path,
+    JSON.stringify({ timestamp: ts, rows, evaluation }, null, 2) + '\n'
+  );
+  if (!jsonOutput) process.stdout.write(`wrote run record: ${path}\n`);
+}
+
+const output = runBenchmarks();
+const rows = parseBenchmarkOutput(output);
+
+if (Object.keys(rows).length === 0) {
+  process.stderr.write('no stable benchmarks captured; check the go test -bench output above\n');
+  process.exit(2);
+}
+
+const evaluation = evaluate(rows, baseline);
+writeRunRecord(rows, evaluation);
+
+const fails = evaluation.results.filter((r) => r.status === 'FAIL');
+const warns = evaluation.results.filter((r) => r.status === 'WARN');
+const greens = evaluation.results.filter((r) => r.status === 'GREEN');
+const seeds = evaluation.results.filter((r) => r.status === 'SEED');
+
+if (jsonOutput) {
+  process.stdout.write(
+    JSON.stringify(
+      {
+        baseline_pending: baseline.baseline_pending === true,
+        thresholds: evaluation.thresholds,
+        results: evaluation.results,
+        counts: {
+          GREEN: greens.length,
+          WARN: warns.length,
+          FAIL: fails.length,
+          SEED: seeds.length,
+        },
+      },
+      null,
+      2
+    ) + '\n'
+  );
+} else {
+  process.stdout.write(
+    `go-bench-gate: baseline_pending=${baseline.baseline_pending === true} runs=${runs} strict=${strict}\n`
+  );
+  for (const r of evaluation.results) {
+    process.stdout.write(
+      `  [${r.status}] ${r.name}  median=${r.median_ns_per_op.toFixed(0)}ns/op baseline=${r.baseline_ns_per_op}ns/op  ${r.reason}\n`
+    );
+  }
+  process.stdout.write(
+    `summary: ${greens.length} GREEN / ${warns.length} WARN / ${fails.length} FAIL / ${seeds.length} SEED\n`
+  );
+}
+
+if (baseline.baseline_pending === true) {
+  if (!jsonOutput) process.stdout.write('baseline_pending=true; measurement-only run, not gating\n');
+  process.exit(0);
+}
+
+if (fails.length > 0 && strict) {
+  process.exit(1);
+}
+
+const reproRequired = evaluation.thresholds.reproduction_runs_required_for_fail ?? 2;
+if (fails.length > 0 && reproRequired <= 1) {
+  process.exit(1);
+}
+
+// Default: non-strict, reproduction required => single-run fails warn
+// but do not block. CI should invoke with --strict after 2 prior runs
+// have also produced fails on the same benchmark(s).
+process.exit(0);

--- a/scripts/go-bench-gate.test.mjs
+++ b/scripts/go-bench-gate.test.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * Tests for scripts/go-bench-gate.mjs.
+ *
+ * The gate shells out to `go test -bench` in production; this harness
+ * drives the parsing and evaluation logic via `--dry-run --fixture-output
+ * <path>` so tests are deterministic and do not require a Go toolchain.
+ *
+ * Cases:
+ *   1. parses `go test -bench` output, reports SEED when baseline is pending
+ *   2. emits --json with median_ns_per_op, median_bytes_per_op,
+ *      median_allocs_per_op per result
+ *   3. unknown argument exits 2
+ *   4. "--" sentinel accepted
+ *   5. missing fixture-output in dry-run exits 2 (no go toolchain shell-out)
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = resolve(__dirname, 'go-bench-gate.mjs');
+
+const tmp = mkdtempSync(join(tmpdir(), 'go-bench-gate-test-'));
+let failures = 0;
+
+function run(args) {
+  let stdout = '';
+  let stderr = '';
+  let exitCode = 0;
+  try {
+    stdout = execFileSync('node', [SCRIPT, ...args], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf8',
+    });
+  } catch (err) {
+    exitCode = err.status ?? -1;
+    stdout = (err.stdout || '').toString();
+    stderr = (err.stderr || '').toString();
+  }
+  return { stdout, stderr, exitCode };
+}
+
+function expect(label, condition, detail) {
+  if (condition) console.log(`PASS [${label}]`);
+  else {
+    failures += 1;
+    console.error(`FAIL [${label}]: ${detail}`);
+  }
+}
+
+// Canned `go test -bench -count=3 -benchmem` output covering the three
+// stable benchmarks. Apple M1 numbers, but the gate does not care about
+// the machine profile in test mode.
+const FIXTURE_OUTPUT = [
+  'goos: linux',
+  'goarch: amd64',
+  'pkg: github.com/peacprotocol/peac/sdks/go/bench',
+  'cpu: fixture',
+  'BenchmarkVerify_Stable_JCSSmall-4     150000   1500 ns/op   1728 B/op   25 allocs/op',
+  'BenchmarkVerify_Stable_JCSSmall-4     151000   1510 ns/op   1728 B/op   25 allocs/op',
+  'BenchmarkVerify_Stable_JCSSmall-4     152000   1520 ns/op   1728 B/op   25 allocs/op',
+  'BenchmarkVerify_Stable_JCSNested-4     96000   2500 ns/op   2728 B/op   40 allocs/op',
+  'BenchmarkVerify_Stable_JCSNested-4     97000   2550 ns/op   2728 B/op   40 allocs/op',
+  'BenchmarkVerify_Stable_JCSNested-4     98000   2600 ns/op   2728 B/op   40 allocs/op',
+  'BenchmarkVerify_Stable_JCSHash-4       86000   2650 ns/op   2936 B/op   43 allocs/op',
+  'BenchmarkVerify_Stable_JCSHash-4       87000   2670 ns/op   2936 B/op   43 allocs/op',
+  'BenchmarkVerify_Stable_JCSHash-4       88000   2690 ns/op   2936 B/op   43 allocs/op',
+  'PASS',
+  'ok  	github.com/peacprotocol/peac/sdks/go/bench	3.155s',
+  '',
+].join('\n');
+
+try {
+  // Case 1: parses fixture output, reports SEED on pending baseline.
+  const fixturePath = join(tmp, 'fixture-1.txt');
+  writeFileSync(fixturePath, FIXTURE_OUTPUT);
+  const r1 = run(['--dry-run', '--fixture-output', fixturePath, '--runs', '3']);
+  expect(
+    'parses fixture output and reports SEED against pending baseline',
+    r1.exitCode === 0 &&
+      r1.stdout.includes('baseline_pending=true') &&
+      r1.stdout.includes('[SEED] BenchmarkVerify_Stable_JCSSmall') &&
+      r1.stdout.includes('[SEED] BenchmarkVerify_Stable_JCSNested') &&
+      r1.stdout.includes('[SEED] BenchmarkVerify_Stable_JCSHash'),
+    `exit=${r1.exitCode} stdout=${JSON.stringify(r1.stdout.slice(0, 400))}`
+  );
+
+  // Case 2: --json emits medians for ns_per_op, bytes_per_op, allocs_per_op.
+  const r2 = run([
+    '--dry-run',
+    '--fixture-output',
+    fixturePath,
+    '--runs',
+    '3',
+    '--json',
+  ]);
+  let parsed = null;
+  try {
+    parsed = JSON.parse(r2.stdout);
+  } catch {
+    parsed = null;
+  }
+  const ok =
+    r2.exitCode === 0 &&
+    parsed &&
+    Array.isArray(parsed.results) &&
+    parsed.results.length === 3 &&
+    parsed.results.every(
+      (r) =>
+        typeof r.median_ns_per_op === 'number' &&
+        typeof r.median_bytes_per_op === 'number' &&
+        typeof r.median_allocs_per_op === 'number' &&
+        r.median_ns_per_op > 0 &&
+        r.median_bytes_per_op > 0 &&
+        r.median_allocs_per_op > 0
+    );
+  expect(
+    '--json emits medians for ns_per_op, bytes_per_op, allocs_per_op',
+    ok,
+    `exit=${r2.exitCode} parsed=${JSON.stringify(parsed).slice(0, 400)}`
+  );
+
+  // Specifically check the JCSNested median values (middle samples).
+  if (parsed) {
+    const nested = parsed.results.find((r) => r.name === 'BenchmarkVerify_Stable_JCSNested');
+    expect(
+      'JCSNested medians match the middle sample of the fixture',
+      nested && nested.median_ns_per_op === 2550 && nested.median_bytes_per_op === 2728 && nested.median_allocs_per_op === 40,
+      `nested=${JSON.stringify(nested)}`
+    );
+  }
+
+  // Case 3: unknown argument exits 2.
+  const r3 = run(['--nope']);
+  expect(
+    'unknown argument exits 2',
+    r3.exitCode === 2 && r3.stderr.includes('unknown argument'),
+    `exit=${r3.exitCode} stderr=${JSON.stringify(r3.stderr)}`
+  );
+
+  // Case 4: "--" sentinel accepted.
+  const r4 = run([
+    '--',
+    '--dry-run',
+    '--fixture-output',
+    fixturePath,
+    '--runs',
+    '3',
+  ]);
+  expect(
+    '"--" sentinel is accepted',
+    r4.exitCode === 0 && r4.stdout.includes('baseline_pending=true'),
+    `exit=${r4.exitCode} stdout=${JSON.stringify(r4.stdout.slice(0, 200))}`
+  );
+
+  // Case 5: dry-run without a fixture-output file still invokes go; to
+  // guarantee the test never shells out, we point at a missing file
+  // and expect a failure. (This case simply confirms --dry-run alone
+  // is not silently ok when no fixture is given.)
+  const r5 = run(['--dry-run', '--fixture-output', join(tmp, 'no-such.txt')]);
+  expect(
+    'dry-run with missing fixture-output fails with nonzero exit',
+    r5.exitCode !== 0,
+    `exit=${r5.exitCode} stderr=${JSON.stringify(r5.stderr.slice(0, 200))}`
+  );
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}
+
+if (failures > 0) {
+  console.error(`\ngo-bench-gate.test: ${failures} case(s) failed`);
+  process.exit(1);
+} else {
+  console.log('\ngo-bench-gate.test: all cases passed');
+  process.exit(0);
+}

--- a/scripts/update-bench-baseline.mjs
+++ b/scripts/update-bench-baseline.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * Update sdks/go/bench/baseline.json from a go-bench-gate --json capture.
+ *
+ * This script is the only supported way to edit baseline.json. It is
+ * invoked exclusively by the bench-gate update-baseline workflow, which
+ * runs on a specific CI runner profile (ubuntu-24.04). Reviewers
+ * approve the resulting baseline-refresh pull request.
+ *
+ * Usage:
+ *   node scripts/update-bench-baseline.mjs --input <bench-capture.json>
+ *
+ * Exit codes:
+ *   0  baseline.json updated (or was already up to date)
+ *   1  capture input missing required fields
+ *   2  usage error
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+const DEFAULT_BASELINE_PATH = resolve(REPO_ROOT, 'sdks/go/bench/baseline.json');
+
+const args = process.argv.slice(2);
+let inputPath = null;
+let baselinePath = DEFAULT_BASELINE_PATH;
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--input' && args[i + 1]) {
+    inputPath = resolve(args[i + 1]);
+    i += 1;
+  } else if (args[i] === '--baseline' && args[i + 1]) {
+    // Override the baseline path for tests. Production callers omit this
+    // and the script writes to sdks/go/bench/baseline.json.
+    baselinePath = resolve(args[i + 1]);
+    i += 1;
+  } else if (args[i] === '--') {
+    continue;
+  } else {
+    process.stderr.write(`unknown argument: ${args[i]}\n`);
+    process.exit(2);
+  }
+}
+const BASELINE_PATH = baselinePath;
+
+if (!inputPath) {
+  process.stderr.write('usage: update-bench-baseline.mjs --input <capture.json>\n');
+  process.exit(2);
+}
+if (!existsSync(inputPath)) {
+  process.stderr.write(`capture not found: ${inputPath}\n`);
+  process.exit(2);
+}
+
+const capture = JSON.parse(readFileSync(inputPath, 'utf8'));
+if (!Array.isArray(capture.results) || capture.results.length === 0) {
+  process.stderr.write('capture.results is empty; refusing to overwrite baseline\n');
+  process.exit(1);
+}
+
+const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'));
+const benchmarks = {};
+for (const r of capture.results) {
+  const ns = typeof r.median_ns_per_op === 'number' ? r.median_ns_per_op : 0;
+  const bytes = typeof r.median_bytes_per_op === 'number' ? r.median_bytes_per_op : 0;
+  const allocs = typeof r.median_allocs_per_op === 'number' ? r.median_allocs_per_op : 0;
+  benchmarks[r.name] = {
+    ns_per_op: Math.round(ns),
+    allocs_per_op: Math.round(allocs),
+    bytes_per_op: Math.round(bytes),
+  };
+}
+
+let commit = '';
+try {
+  commit = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: REPO_ROOT, encoding: 'utf8' }).trim();
+} catch {
+  commit = '';
+}
+let goVersion = '';
+try {
+  goVersion = execFileSync('go', ['version'], { encoding: 'utf8' }).trim();
+} catch {
+  goVersion = '';
+}
+
+const updated = {
+  ...baseline,
+  baseline_pending: false,
+  captured_commit: commit,
+  captured_at: new Date().toISOString(),
+  platform: `${process.platform}/${process.arch}`,
+  go_version: goVersion,
+  benchmarks,
+};
+
+writeFileSync(BASELINE_PATH, JSON.stringify(updated, null, 2) + '\n');
+process.stdout.write(`updated ${BASELINE_PATH}\n`);
+process.stdout.write(`  baseline_pending=false\n`);
+for (const name of Object.keys(benchmarks)) {
+  process.stdout.write(`  ${name}: ${benchmarks[name].ns_per_op}ns/op\n`);
+}

--- a/scripts/update-bench-baseline.test.mjs
+++ b/scripts/update-bench-baseline.test.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+/**
+ * Tests for scripts/update-bench-baseline.mjs.
+ *
+ * Drives the updater against a temp baseline file with a synthetic
+ * bench-gate capture. The production script writes to
+ * sdks/go/bench/baseline.json; `--baseline <path>` overrides the
+ * target so tests stay hermetic.
+ *
+ * Cases:
+ *   1. valid capture -> writes baseline with real ns/bytes/allocs medians
+ *      and flips baseline_pending to false
+ *   2. empty results -> exits 1 and leaves baseline untouched
+ *   3. missing --input -> usage error exits 2
+ *   4. nonexistent input file -> exits 2
+ *   5. unknown argument -> exits 2
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = resolve(__dirname, 'update-bench-baseline.mjs');
+
+const tmp = mkdtempSync(join(tmpdir(), 'update-bench-baseline-test-'));
+let failures = 0;
+
+function run(args) {
+  let stdout = '';
+  let stderr = '';
+  let exitCode = 0;
+  try {
+    stdout = execFileSync('node', [SCRIPT, ...args], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf8',
+    });
+  } catch (err) {
+    exitCode = err.status ?? -1;
+    stdout = (err.stdout || '').toString();
+    stderr = (err.stderr || '').toString();
+  }
+  return { stdout, stderr, exitCode };
+}
+
+function expect(label, condition, detail) {
+  if (condition) console.log(`PASS [${label}]`);
+  else {
+    failures += 1;
+    console.error(`FAIL [${label}]: ${detail}`);
+  }
+}
+
+function writeBaseline(path, overrides = {}) {
+  const base = {
+    baseline_pending: true,
+    captured_commit: '',
+    captured_at: '',
+    platform: '',
+    go_version: '',
+    methodology: 'test',
+    benchmarks: {
+      BenchmarkVerify_Stable_JCSSmall: { ns_per_op: 0, allocs_per_op: 0, bytes_per_op: 0 },
+      BenchmarkVerify_Stable_JCSNested: { ns_per_op: 0, allocs_per_op: 0, bytes_per_op: 0 },
+      BenchmarkVerify_Stable_JCSHash: { ns_per_op: 0, allocs_per_op: 0, bytes_per_op: 0 },
+    },
+    thresholds: { ratio_warn: 1.1, ratio_fail: 1.25, absolute_fail_ns_min: 50000, reproduction_runs_required_for_fail: 2 },
+    notes: '',
+    ...overrides,
+  };
+  writeFileSync(path, JSON.stringify(base, null, 2) + '\n');
+}
+
+try {
+  // Case 1: valid capture updates baseline with real medians and flips
+  // baseline_pending to false.
+  {
+    const capturePath = join(tmp, 'case1-capture.json');
+    const baselinePath = join(tmp, 'case1-baseline.json');
+    writeBaseline(baselinePath);
+    writeFileSync(
+      capturePath,
+      JSON.stringify({
+        baseline_pending: true,
+        thresholds: {},
+        results: [
+          {
+            name: 'BenchmarkVerify_Stable_JCSSmall',
+            median_ns_per_op: 1520,
+            median_bytes_per_op: 1728,
+            median_allocs_per_op: 25,
+          },
+          {
+            name: 'BenchmarkVerify_Stable_JCSNested',
+            median_ns_per_op: 2550,
+            median_bytes_per_op: 2728,
+            median_allocs_per_op: 40,
+          },
+          {
+            name: 'BenchmarkVerify_Stable_JCSHash',
+            median_ns_per_op: 2670,
+            median_bytes_per_op: 2936,
+            median_allocs_per_op: 43,
+          },
+        ],
+      })
+    );
+
+    const r = run(['--input', capturePath, '--baseline', baselinePath]);
+    const updated = JSON.parse(readFileSync(baselinePath, 'utf8'));
+    expect(
+      'valid capture writes baseline with real medians and flips pending to false',
+      r.exitCode === 0 &&
+        updated.baseline_pending === false &&
+        updated.benchmarks.BenchmarkVerify_Stable_JCSSmall.ns_per_op === 1520 &&
+        updated.benchmarks.BenchmarkVerify_Stable_JCSSmall.bytes_per_op === 1728 &&
+        updated.benchmarks.BenchmarkVerify_Stable_JCSSmall.allocs_per_op === 25 &&
+        updated.benchmarks.BenchmarkVerify_Stable_JCSNested.bytes_per_op === 2728 &&
+        updated.benchmarks.BenchmarkVerify_Stable_JCSNested.allocs_per_op === 40 &&
+        updated.benchmarks.BenchmarkVerify_Stable_JCSHash.allocs_per_op === 43,
+      `exit=${r.exitCode} updated=${JSON.stringify(updated).slice(0, 600)}`
+    );
+    expect(
+      'valid capture preserves thresholds and notes fields',
+      updated.thresholds &&
+        updated.thresholds.ratio_warn === 1.1 &&
+        typeof updated.notes === 'string',
+      `thresholds=${JSON.stringify(updated.thresholds)}`
+    );
+  }
+
+  // Case 2: empty results exits 1 and leaves baseline untouched.
+  {
+    const capturePath = join(tmp, 'case2-capture.json');
+    const baselinePath = join(tmp, 'case2-baseline.json');
+    writeBaseline(baselinePath);
+    const before = readFileSync(baselinePath, 'utf8');
+    writeFileSync(capturePath, JSON.stringify({ results: [] }));
+    const r = run(['--input', capturePath, '--baseline', baselinePath]);
+    const after = readFileSync(baselinePath, 'utf8');
+    expect(
+      'empty results exits 1 and leaves baseline untouched',
+      r.exitCode === 1 && before === after,
+      `exit=${r.exitCode} before===after:${before === after}`
+    );
+  }
+
+  // Case 3: missing --input exits 2.
+  {
+    const r = run([]);
+    expect(
+      'missing --input exits 2 with usage',
+      r.exitCode === 2 && r.stderr.includes('usage:'),
+      `exit=${r.exitCode} stderr=${JSON.stringify(r.stderr)}`
+    );
+  }
+
+  // Case 4: nonexistent input exits 2.
+  {
+    const r = run(['--input', join(tmp, 'no-such.json')]);
+    expect(
+      'nonexistent input exits 2',
+      r.exitCode === 2 && r.stderr.includes('capture not found'),
+      `exit=${r.exitCode} stderr=${JSON.stringify(r.stderr)}`
+    );
+  }
+
+  // Case 5: unknown argument exits 2.
+  {
+    const r = run(['--whoops']);
+    expect(
+      'unknown argument exits 2',
+      r.exitCode === 2 && r.stderr.includes('unknown argument'),
+      `exit=${r.exitCode} stderr=${JSON.stringify(r.stderr)}`
+    );
+  }
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}
+
+if (failures > 0) {
+  console.error(`\nupdate-bench-baseline.test: ${failures} case(s) failed`);
+  process.exit(1);
+} else {
+  console.log('\nupdate-bench-baseline.test: all cases passed');
+  process.exit(0);
+}

--- a/sdks/go/bench/baseline.json
+++ b/sdks/go/bench/baseline.json
@@ -1,0 +1,32 @@
+{
+  "baseline_pending": true,
+  "captured_commit": "",
+  "captured_at": "",
+  "platform": "",
+  "go_version": "",
+  "methodology": "scripts/go-bench-gate.mjs runs the BenchmarkVerify_Stable_* suite under -count=10 -benchtime=200ms and compares the median ns/op against the values below.",
+  "benchmarks": {
+    "BenchmarkVerify_Stable_JCSSmall": {
+      "ns_per_op": 0,
+      "allocs_per_op": 0,
+      "bytes_per_op": 0
+    },
+    "BenchmarkVerify_Stable_JCSNested": {
+      "ns_per_op": 0,
+      "allocs_per_op": 0,
+      "bytes_per_op": 0
+    },
+    "BenchmarkVerify_Stable_JCSHash": {
+      "ns_per_op": 0,
+      "allocs_per_op": 0,
+      "bytes_per_op": 0
+    }
+  },
+  "thresholds": {
+    "ratio_warn": 1.1,
+    "ratio_fail": 1.25,
+    "absolute_fail_ns_min": 50000,
+    "reproduction_runs_required_for_fail": 2
+  },
+  "notes": "baseline_pending=true means the gate runs in measurement-only mode and will not fail CI. The bench-gate workflow_dispatch with mode=update-baseline captures CI numbers, flips baseline_pending to false, and opens a refresh PR touching only this file plus sdks/go/bench/runs/<commit>.json."
+}

--- a/sdks/go/bench/go.mod
+++ b/sdks/go/bench/go.mod
@@ -1,0 +1,7 @@
+module github.com/peacprotocol/peac/sdks/go/bench
+
+go 1.26
+
+require github.com/peacprotocol/peac/sdks/go v0.9.29
+
+replace github.com/peacprotocol/peac/sdks/go => ..

--- a/sdks/go/bench/verify_bench_test.go
+++ b/sdks/go/bench/verify_bench_test.go
@@ -1,0 +1,71 @@
+// Package bench carries the stable benchmark subset the regression-
+// aware Go benchmark gate enforces against a committed baseline.
+//
+// Every exported benchmark in this file is prefixed `BenchmarkVerify_Stable_`.
+// The gate (scripts/go-bench-gate.mjs) only evaluates benchmarks with that
+// prefix; noisy or exploratory benchmarks live elsewhere and do not
+// participate in regression detection.
+//
+// The suite is deliberately narrow: JCS canonicalization and SHA-256
+// hashing of a canonical payload, because both operations are
+// deterministic, pure CPU-bound, and heavily exercised on every
+// issue / verify path.
+package bench
+
+import (
+	"testing"
+
+	peac "github.com/peacprotocol/peac/sdks/go"
+)
+
+// stableInputSmall is the small canonicalization fixture. Matches the
+// shape of a minimal interaction record claims object.
+var stableInputSmall = []byte(`{"iss":"https://publisher.example","sub":"agent:example","iat":1735992000,"jti":"rec_abc123"}`)
+
+// stableInputNested is the nested canonicalization fixture. Keys are
+// intentionally out of sort order so the canonicalizer performs the
+// full walk on every iteration.
+var stableInputNested = []byte(`{
+  "z_last": {"b": 2, "a": 1},
+  "a_first": {"z": 26, "y": 25},
+  "m_middle": [3, 1, 4, 1, 5, 9, 2, 6]
+}`)
+
+// BenchmarkVerify_Stable_JCSSmall canonicalizes a flat claims object.
+// Pair with the baseline `verify_stable_jcs_small_ns_per_op` metric.
+func BenchmarkVerify_Stable_JCSSmall(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := peac.Canonicalize(stableInputSmall)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkVerify_Stable_JCSNested canonicalizes a nested object with
+// sort work at multiple levels. Pair with the baseline
+// `verify_stable_jcs_nested_ns_per_op` metric.
+func BenchmarkVerify_Stable_JCSNested(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := peac.Canonicalize(stableInputNested)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkVerify_Stable_JCSHash computes the JCS+SHA-256 hash of the
+// nested fixture, exercising both canonicalization and hashing in one
+// unit. Pair with the baseline `verify_stable_jcs_hash_ns_per_op`
+// metric.
+func BenchmarkVerify_Stable_JCSHash(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := peac.JCSHash(stableInputNested)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/sdks/go/jcs_parity_extended_test.go
+++ b/sdks/go/jcs_parity_extended_test.go
@@ -1,0 +1,83 @@
+package peac
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestJCSExtendedParityCorpus runs the shared cross-language JCS
+// parity corpus at specs/conformance/parity-corpus/jcs-extended/vectors.json
+// against the Go implementation in jcs.go. The TypeScript side runs
+// the same corpus at packages/crypto/tests/jcs.parity-extended.test.ts.
+// Every vector must canonicalize byte-identically on both sides.
+func TestJCSExtendedParityCorpus(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+	corpusPath := filepath.Join(repoRoot, "specs", "conformance", "parity-corpus", "jcs-extended", "vectors.json")
+
+	data, err := os.ReadFile(corpusPath)
+	if err != nil {
+		t.Fatalf("cannot read corpus at %s: %v", corpusPath, err)
+	}
+
+	var corpus struct {
+		Description string `json:"description"`
+		Generator   string `json:"generator"`
+		Vectors     []struct {
+			ID          string          `json:"id"`
+			Description string          `json:"description"`
+			Input       json.RawMessage `json:"input"`
+			Canonical   string          `json:"canonical"`
+		} `json:"vectors"`
+	}
+	if err := json.Unmarshal(data, &corpus); err != nil {
+		t.Fatalf("cannot parse corpus JSON: %v", err)
+	}
+
+	if len(corpus.Vectors) != 6 {
+		t.Fatalf("corpus vector count = %d, want 6", len(corpus.Vectors))
+	}
+
+	expectedIDs := map[string]bool{
+		"unicode-nfc-nfd":             false,
+		"nested-depth-5":              false,
+		"numeric-zero-and-neg-zero":   false,
+		"integer-vs-float-same-value": false,
+		"escape-sequences":            false,
+		"utf16-surrogate-pair":        false,
+	}
+
+	for _, vector := range corpus.Vectors {
+		v := vector // capture
+		t.Run(v.ID, func(t *testing.T) {
+			if _, present := expectedIDs[v.ID]; !present {
+				t.Errorf("unexpected vector id in corpus: %q", v.ID)
+				return
+			}
+			expectedIDs[v.ID] = true
+
+			got, err := Canonicalize(v.Input)
+			if err != nil {
+				t.Fatalf("Canonicalize returned error: %v", err)
+			}
+			if string(got) != v.Canonical {
+				t.Errorf(
+					"vector %q canonical mismatch\n  want: %q\n  got:  %q",
+					v.ID, v.Canonical, string(got),
+				)
+			}
+		})
+	}
+
+	for id, seen := range expectedIDs {
+		if !seen {
+			t.Errorf("expected vector %q was not present in the corpus", id)
+		}
+	}
+}

--- a/specs/conformance/parity-corpus/jcs-extended/README.md
+++ b/specs/conformance/parity-corpus/jcs-extended/README.md
@@ -1,0 +1,80 @@
+# Extended JCS (RFC 8785) parity corpus
+
+This corpus covers JCS edge cases that are not in the baseline
+`specs/conformance/fixtures/go-interaction-record/jcs-golden-vectors.json`
+set. Every vector in `vectors.json` must produce byte-identical output
+from both the TypeScript implementation in `@peac/crypto`
+(`packages/crypto/src/jcs.ts`) and the Go implementation in
+`sdks/go/jcs.go`.
+
+## Coverage
+
+| Vector id                     | Edge case                                                                                                                |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `unicode-nfc-nfd`             | Unicode normalization boundary: NFC (U+00E9) and NFD (U+0065 U+0301) preserved byte-identically; JCS does not normalize. |
+| `nested-depth-5`              | Nested object depth 5 with mixed keys; keys sort per JCS at every level.                                                 |
+| `numeric-zero-and-neg-zero`   | Zero and negative zero both render as `0` per JCS number serialization.                                                  |
+| `integer-vs-float-same-value` | Integer 1 and float 1.0 both render as `1`.                                                                              |
+| `escape-sequences`            | JCS requires escape only for quote, backslash, and U+0000 through U+001F.                                                |
+| `utf16-surrogate-pair`        | Non-BMP character U+1F600 encoded via surrogate pair; JCS emits UTF-8 bytes.                                             |
+
+## Format
+
+```json
+{
+  "description": "...",
+  "generator": "@peac/crypto canonicalize() vX.Y.Z",
+  "vectors": [
+    { "id": "...", "description": "...", "input": {...}, "canonical": "..." }
+  ]
+}
+```
+
+`canonical` is the exact UTF-8 string produced by a compliant
+RFC 8785 canonicalizer. Tests compare the canonicalizer's output to
+this string byte-for-byte.
+
+## How the corpus is validated
+
+- **TypeScript side:** `packages/crypto/__tests__/jcs.parity-extended.test.ts`
+  reads `vectors.json` and asserts `canonicalize(input)` equals
+  `canonical` for every vector.
+- **Go side:** `sdks/go/jcs_parity_extended_test.go` reads
+  `vectors.json` and asserts `peac.Canonicalize(input)` equals
+  `canonical` for every vector.
+
+Both tests live alongside their implementations and run in CI. If
+either side drifts, the corresponding test fails with the exact
+byte-diff.
+
+## Regenerating the corpus
+
+When the corpus needs new vectors or updates, build `@peac/crypto`
+first and regenerate through a small node script that imports the
+package via its workspace entry. Keep the new vectors in a temp
+script file rather than an inline `-e` expression to avoid inlining
+build-output paths.
+
+```bash
+# from the repository root
+pnpm --filter @peac/crypto build
+cat > /tmp/regen-jcs-extended.mjs <<'MJS'
+import { canonicalize } from '@peac/crypto';
+
+const vectors = [
+  // new inputs here; existing six vectors are already in vectors.json
+];
+
+const out = {
+  description: '...',
+  generator: '@peac/crypto canonicalize() vX.Y.Z',
+  vectors: vectors.map((v) => ({ ...v, canonical: canonicalize(v.input) })),
+};
+
+process.stdout.write(JSON.stringify(out, null, 2) + '\n');
+MJS
+pnpm exec node /tmp/regen-jcs-extended.mjs > specs/conformance/parity-corpus/jcs-extended/vectors.json
+```
+
+Cross-verify the Go implementation produces the same output for every
+vector before committing.

--- a/specs/conformance/parity-corpus/jcs-extended/vectors.json
+++ b/specs/conformance/parity-corpus/jcs-extended/vectors.json
@@ -1,0 +1,69 @@
+{
+  "description": "Extended JCS (RFC 8785) parity fixtures. Each vector is canonicalized identically by the TypeScript implementation in @peac/crypto and the Go implementation in sdks/go/jcs.go.",
+  "generator": "@peac/crypto canonicalize() v0.12.12",
+  "vectors": [
+    {
+      "id": "unicode-nfc-nfd",
+      "description": "JCS preserves strings byte-identically; NFC (U+00E9) and NFD (U+0065 U+0301) do not normalize.",
+      "input": {
+        "nfc": "é",
+        "nfd": "é"
+      },
+      "canonical": "{\"nfc\":\"é\",\"nfd\":\"é\"}"
+    },
+    {
+      "id": "nested-depth-5",
+      "description": "Nested object depth 5 with mixed keys; keys sort per JCS at every level.",
+      "input": {
+        "a": {
+          "b": {
+            "c": {
+              "d": {
+                "e": "leaf"
+              }
+            }
+          }
+        }
+      },
+      "canonical": "{\"a\":{\"b\":{\"c\":{\"d\":{\"e\":\"leaf\"}}}}}"
+    },
+    {
+      "id": "numeric-zero-and-neg-zero",
+      "description": "Zero and negative zero both render as 0 per JCS number serialization.",
+      "input": {
+        "zero": 0,
+        "negZero": 0
+      },
+      "canonical": "{\"negZero\":0,\"zero\":0}"
+    },
+    {
+      "id": "integer-vs-float-same-value",
+      "description": "Integer 1 and float 1.0 both render as 1.",
+      "input": {
+        "integer": 1,
+        "float": 1
+      },
+      "canonical": "{\"float\":1,\"integer\":1}"
+    },
+    {
+      "id": "escape-sequences",
+      "description": "JCS requires escape only for quote, backslash, and U+0000 through U+001F.",
+      "input": {
+        "quote": "\"",
+        "backslash": "\\",
+        "tab": "\t",
+        "newline": "\n",
+        "bell": "\u0007"
+      },
+      "canonical": "{\"backslash\":\"\\\\\",\"bell\":\"\\u0007\",\"newline\":\"\\n\",\"quote\":\"\\\"\",\"tab\":\"\\t\"}"
+    },
+    {
+      "id": "utf16-surrogate-pair",
+      "description": "Non-BMP character U+1F600 encoded via surrogate pair; JCS emits UTF-8 bytes.",
+      "input": {
+        "emoji": "😀"
+      },
+      "canonical": "{\"emoji\":\"😀\"}"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add a regression-aware Go benchmark gate, committed bench-tooling tests, and an extended JCS parity corpus exercised by both TypeScript and Go.

## Scope

- Documentation, tests, workflows, and SDK support tooling only. No wire, schema, kernel, crypto, or protocol public-API change.

## What is new

### Go benchmark gate (`sdks/go/bench/`)

- `sdks/go/bench/` is a new Go module carrying the stable benchmark subset (`BenchmarkVerify_Stable_*` prefix). Three benchmarks cover JCS canonicalization of a flat claims object, JCS canonicalization of a nested object, and the combined JCS + SHA-256 hash path.
- `scripts/go-bench-gate.mjs` runs the stable subset under `-count=10 -benchtime=200ms` and compares median ns/op to the committed baseline. `--json` emits structured output including `median_ns_per_op`, `median_bytes_per_op`, and `median_allocs_per_op` for every benchmark. Threshold bands: ratio ≤ 1.10x green; 1.10x - 1.25x warn (annotate, do not fail); > 1.25x and absolute breach > 50us fail. A fail blocks only when it reproduces in 2-of-3 consecutive runs; `--strict` forces a single-run fail to block. `--save-run` writes run records to `sdks/go/bench/runs/`; `--dry-run` plus `--fixture-output` lets tests drive the gate against a captured output file.
- `sdks/go/bench/baseline.json` ships with `baseline_pending: true`, which routes the gate into measurement-only mode until the bench-gate workflow with `mode=update-baseline` captures numbers on the target CI machine profile.
- `scripts/update-bench-baseline.mjs` is the only supported path to edit `baseline.json`; it writes real medians for `ns_per_op`, `bytes_per_op`, and `allocs_per_op` from the gate's captured output, and accepts a `--baseline <path>` override used by the hermetic test harness.
- `.github/workflows/bench-gate.yml` wires the gate for pull-requests touching `sdks/go/**`, `scripts/go-bench-gate.mjs`, or the workflow itself, and exposes a `workflow_dispatch` entrypoint with `mode=measure` or `mode=update-baseline`. `setup-go` is invoked with `cache: false` because the bench module has no external dependency footprint yet; caching can be enabled once a real `sdks/go/bench/go.sum` is committed.

### Committed tests for the bench tooling

- `scripts/go-bench-gate.test.mjs` exercises fixture-driven parsing, `--json` output shape, median computation for ns / bytes / allocs, the `--` sentinel, and error paths (6 cases).
- `scripts/update-bench-baseline.test.mjs` exercises valid capture → baseline update (real medians written; `baseline_pending` flipped), empty results → exit 1 leaves baseline untouched, and the usage / missing-input / unknown-argument paths (6 cases).
- Both harnesses are hermetic: they drive the scripts against temp fixtures with `--fixture-output` / `--baseline` path overrides and require no Go toolchain or live baseline.
- Wired into `package.json` as `verify:go-bench-gate:test` and `verify:bench-baseline:test`.

### Extended JCS parity corpus (`specs/conformance/parity-corpus/jcs-extended/`)

- Six new RFC 8785 parity vectors covering edge cases not in the existing golden-vectors set: Unicode NFC/NFD boundary, nested depth-5 objects, zero vs negative zero, integer vs float with same value, control-character and quote/backslash escape sequences, and UTF-16 surrogate pairs for non-BMP characters.
- `packages/crypto/tests/jcs.parity-extended.test.ts` runs the TypeScript canonicalizer against the corpus (7 passing cases).
- `sdks/go/jcs_parity_extended_test.go` runs the Go canonicalizer against the same corpus and asserts byte-identical output for all 6 vectors.
- A `README.md` under the corpus directory documents the format, coverage table, and regeneration procedure.