### PR TITLE
chore: stamp v0.12.13 release_date

### DIFF
--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable surface classification for PEAC Protocol workspace. CI fails if any workspace member is missing. See docs/PACKAGE_STATUS.md for human-readable view.",
   "version": "0.12.13",
-  "updated": "2026-04-19",
+  "updated": "2026-04-20",
   "states": {
     "default": "Current recommended path. Actively maintained, Wire 0.2 native.",
     "supported": "Actively maintained, published, production-ready. May not be on default quickstart path.",

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -2,7 +2,7 @@
 
 Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scripts/generate-surface-status.mjs`.
 
-**Version:** 0.12.13 | **Updated:** 2026-04-19
+**Version:** 0.12.13 | **Updated:** 2026-04-20
 
 ## Layer 1
 

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -4,7 +4,7 @@
   "version": "0.12.13",
   "wire_format_version": "0.2",
   "dist_tag": "next",
-  "release_date": "2026-04-19",
+  "release_date": "2026-04-20",
   "metrics": {
     "tests": 7600,
     "test_files": 304,


### PR DESCRIPTION
## Summary

Post-publish release-state stamp for v0.12.13. Run via `node scripts/stamp-release-state.mjs --publish 2026-04-20` per `docs/RELEASING.md` Mode 2 post-publish step.

## Scope

- Stamp-only PR: two lines total. `docs/releases/facts.json` `release_date` and `REPO_SURFACE_STATUS.json` `updated` both move to `2026-04-20`.
- CI stamp-only-guard confirms every changed path is in the allowlist.

## Validation

- `node scripts/stamp-release-state.mjs --check --mode publish 2026-04-20` passes locally.
- v0.12.13 is live on npm dist-tag `next` across the publish manifest; `latest` remains 0.12.12 until promote.
