### PR TITLE
chore: stamp v0.12.13 dist_tag latest

### DIFF
--- a/docs/releases/current.json
+++ b/docs/releases/current.json
@@ -2,7 +2,7 @@
   "description": "PEAC release manifest: CI-enforceable source of truth for release state",
   "version": "0.12.13",
   "wire_format_version": "0.2",
-  "dist_tag": "next",
+  "dist_tag": "latest",
   "registries_version": "0.6.0",
   "errors_version": "0.12.13"
 }

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -3,7 +3,7 @@
   "schema_version": "1.0.0",
   "version": "0.12.13",
   "wire_format_version": "0.2",
-  "dist_tag": "next",
+  "dist_tag": "latest",
   "release_date": "2026-04-20",
   "metrics": {
     "tests": 7600,


### PR DESCRIPTION
## Summary

Post-promote release-state stamp for v0.12.13. Run via `node scripts/stamp-release-state.mjs --promote latest` per `docs/RELEASING.md` Mode 2 post-promote step.