### PR TITLE
fix: release tooling polish for stamp regen and promote closeout

### DIFF
--- a/.github/workflows/promote-latest.yml
+++ b/.github/workflows/promote-latest.yml
@@ -230,10 +230,21 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
+          # The checkout step above does a shallow fetch by default and
+          # does not pull tag refs. The closeout reconciler needs the
+          # release tag locally to verify it is reachable from origin/main.
+          git fetch --tags --force origin "refs/tags/v${VERSION}:refs/tags/v${VERSION}" || true
+          git fetch origin main || true
           echo "Running scripts/verify-release-closeout.mjs --version $VERSION --stage promote ..."
+          # --allow-stamp-pending: when this step runs inline the
+          # post-promote stamp PR has not landed yet, so facts.json
+          # still carries dist_tag=next. Accept that in this narrow
+          # window. A strict local run after the stamp PR merges does
+          # not pass this flag and gets the full dist_tag=latest check.
           node scripts/verify-release-closeout.mjs \
             --version "$VERSION" \
             --stage promote \
+            --allow-stamp-pending \
             --max-updated-age-hours 72
 
       - name: Summary

--- a/scripts/stamp-release-state.mjs
+++ b/scripts/stamp-release-state.mjs
@@ -41,6 +41,7 @@
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_ROOT = join(__dirname, '..');
@@ -283,6 +284,26 @@ if (check) {
 }
 
 const changed = runApply(ops);
+
+// --publish mutates REPO_SURFACE_STATUS.json.updated. The derived docs
+// (docs/SURFACE_STATUS.md, docs/PACKAGE_STATUS.md) are regenerated from
+// that JSON by scripts/generate-surface-status.mjs. Re-run the generator
+// here so a stamp-only PR does not trip the Generated Status Doc Drift
+// guard in CI. Skipped on dry-run and on --promote (promote does not
+// touch REPO_SURFACE_STATUS.json).
+if (!dryRun && !check && mode === 'publish' && changed > 0) {
+  const generator = join(ROOT, 'scripts/generate-surface-status.mjs');
+  if (existsSync(generator)) {
+    const result = spawnSync('node', [generator], {
+      cwd: ROOT,
+      stdio: 'inherit',
+    });
+    if (result.status !== 0) {
+      console.error('ERROR: generate-surface-status.mjs failed');
+      process.exit(2);
+    }
+  }
+}
 
 console.log('');
 if (dryRun) {

--- a/scripts/verify-release-closeout.mjs
+++ b/scripts/verify-release-closeout.mjs
@@ -53,6 +53,7 @@ let stage = null;
 let skipRemote = false;
 let strict = false;
 let jsonOutput = false;
+let allowStampPending = false;
 let maxUpdatedAgeHours = 24;
 const targetedPackages = [];
 
@@ -80,6 +81,8 @@ for (let i = 0; i < args.length; i++) {
     strict = true;
   } else if (a === '--json') {
     jsonOutput = true;
+  } else if (a === '--allow-stamp-pending') {
+    allowStampPending = true;
   } else {
     process.stderr.write(`unknown argument: ${a}\n`);
     process.exit(2);
@@ -269,8 +272,16 @@ if (facts.__error) {
   if (!releaseDate || releaseDate === '') problems.push('release_date is empty');
   if (facts_version && facts_version !== version) problems.push(`version=${facts_version} (expected ${version})`);
   const expectedDistTag = stage === 'publish' ? 'next' : 'latest';
+  // --allow-stamp-pending: at stage=promote the post-promote stamp PR has
+  // not landed yet when this runs inline in promote-latest.yml, so
+  // facts.json.dist_tag is still `next`. Accept either `next` or `latest`
+  // in that narrow window. Local strict runs after the stamp PR merges do
+  // not pass this flag and get the full strict check.
   if (distTag && distTag !== expectedDistTag) {
-    problems.push(`dist_tag=${distTag} (expected ${expectedDistTag})`);
+    const allowed = allowStampPending && stage === 'promote' && distTag === 'next';
+    if (!allowed) {
+      problems.push(`dist_tag=${distTag} (expected ${expectedDistTag})`);
+    }
   }
   row(
     'facts.json',

--- a/scripts/verify-release-closeout.test.mjs
+++ b/scripts/verify-release-closeout.test.mjs
@@ -7,7 +7,7 @@
  * offline skip-remote path using the live repository artifacts (the live
  * `docs/releases/facts.json`, `docs/releases/current.json`, and
  * `REPO_SURFACE_STATUS.json` are read against the current shipped version
- * 0.12.12 which is known GREEN). Remote npm / gh paths are not exercised
+ * 0.12.13 which is known GREEN). Remote npm / gh paths are not exercised
  * here so tests stay deterministic.
  *
  * Cases:
@@ -15,9 +15,10 @@
  *   2. invalid --stage: exit 2 with stage-message error
  *   3. unknown argument: exit 2
  *   4. "--" sentinel accepted
- *   5. --skip-remote --stage promote on v0.12.12: exit 0 with 0 RED
+ *   5. --skip-remote --stage promote on v0.12.13: exit 0 with 0 RED
  *   6. --json emits parseable JSON with rows and counts
  *   7. --strict flips exit code to 1 when any YELLOW row is present
+ *   8. --allow-stamp-pending is accepted and keeps a GREEN facts.json GREEN
  */
 
 import { execFileSync } from 'node:child_process';
@@ -64,7 +65,7 @@ try {
   );
 
   // Case 2: invalid stage.
-  const badStage = run(['--version', '0.12.12', '--stage', 'nope']);
+  const badStage = run(['--version', '0.12.13', '--stage', 'nope']);
   expect(
     'invalid --stage exits 2',
     badStage.exitCode === 2 && badStage.stderr.includes('--stage must be one of'),
@@ -72,7 +73,7 @@ try {
   );
 
   // Case 3: unknown argument.
-  const unknown = run(['--version', '0.12.12', '--stage', 'promote', '--what']);
+  const unknown = run(['--version', '0.12.13', '--stage', 'promote', '--what']);
   expect(
     'unknown argument exits 2',
     unknown.exitCode === 2 && unknown.stderr.includes('unknown argument'),
@@ -83,7 +84,7 @@ try {
   const sentinel = run([
     '--',
     '--version',
-    '0.12.12',
+    '0.12.13',
     '--stage',
     'promote',
     '--skip-remote',
@@ -92,14 +93,14 @@ try {
   ]);
   expect(
     '"--" sentinel is accepted',
-    sentinel.exitCode === 0 && sentinel.stdout.includes('version=0.12.12 stage=promote'),
+    sentinel.exitCode === 0 && sentinel.stdout.includes('version=0.12.13 stage=promote'),
     `exit=${sentinel.exitCode} stdout=${JSON.stringify(sentinel.stdout.slice(0, 200))}`
   );
 
-  // Case 5: --skip-remote --stage promote on v0.12.12: exit 0, zero RED.
+  // Case 5: --skip-remote --stage promote on v0.12.13: exit 0, zero RED.
   const offline = run([
     '--version',
-    '0.12.12',
+    '0.12.13',
     '--stage',
     'promote',
     '--skip-remote',
@@ -107,7 +108,7 @@ try {
     '2000',
   ]);
   expect(
-    '--skip-remote on v0.12.12 exits 0 with zero RED',
+    '--skip-remote on v0.12.13 exits 0 with zero RED',
     offline.exitCode === 0 &&
       offline.stdout.includes('0 RED') &&
       offline.stdout.includes('[GREEN] git-tag'),
@@ -117,7 +118,7 @@ try {
   // Case 6: --json emits valid JSON with rows and counts.
   const jsonRun = run([
     '--version',
-    '0.12.12',
+    '0.12.13',
     '--stage',
     'promote',
     '--skip-remote',
@@ -135,7 +136,7 @@ try {
     '--json emits parseable JSON with rows and counts',
     jsonRun.exitCode === 0 &&
       parsed &&
-      parsed.version === '0.12.12' &&
+      parsed.version === '0.12.13' &&
       parsed.stage === 'promote' &&
       Array.isArray(parsed.rows) &&
       parsed.rows.length >= 4 &&
@@ -149,7 +150,7 @@ try {
   // --strict must produce a nonzero exit.
   const strict = run([
     '--version',
-    '0.12.12',
+    '0.12.13',
     '--stage',
     'promote',
     '--skip-remote',
@@ -161,6 +162,27 @@ try {
     '--strict fails on YELLOW rows',
     strict.exitCode === 1 && strict.stdout.includes('YELLOW'),
     `exit=${strict.exitCode} stdout=${JSON.stringify(strict.stdout)}`
+  );
+
+  // Case 8: --allow-stamp-pending is accepted at stage=promote and does
+  // not regress an already-stamped facts.json. Live facts.json has
+  // dist_tag=latest, so the facts.json row stays GREEN either way.
+  const allowPending = run([
+    '--version',
+    '0.12.13',
+    '--stage',
+    'promote',
+    '--skip-remote',
+    '--max-updated-age-hours',
+    '2000',
+    '--allow-stamp-pending',
+  ]);
+  expect(
+    '--allow-stamp-pending keeps a GREEN facts.json GREEN',
+    allowPending.exitCode === 0 &&
+      allowPending.stdout.includes('[GREEN] facts.json') &&
+      allowPending.stdout.includes('0 RED'),
+    `exit=${allowPending.exitCode} stdout=${JSON.stringify(allowPending.stdout)}`
   );
 } catch (err) {
   failures += 1;


### PR DESCRIPTION
## Summary

Two tooling fixes across the release flow.

1. `scripts/stamp-release-state.mjs --publish` re-runs `scripts/generate-surface-status.mjs` after writing the `REPO_SURFACE_STATUS.json` update so `docs/SURFACE_STATUS.md` and `docs/PACKAGE_STATUS.md` stay in sync with the source JSON. Skipped on `--dry-run`, `--check`, and `--promote`.
2. `scripts/verify-release-closeout.mjs` adds `--allow-stamp-pending`. At `--stage promote` the reconciler accepts `docs/releases/facts.json` `dist_tag=next` only when the flag is set; any other value still RED-fails. `.github/workflows/promote-latest.yml` passes the flag on its inline closeout step and fetches the release tag and `origin/main` first so tag reachability verifies on a shallow-checkout runner.

## Scope

- Scripts, tests, and workflow only. No wire, schema, kernel, crypto, or protocol public-API change.

## Changes

- `scripts/stamp-release-state.mjs`: spawn `scripts/generate-surface-status.mjs` after a successful `--publish` write.
- `scripts/verify-release-closeout.mjs`: `--allow-stamp-pending` flag; at `--stage promote` accept `facts.json.dist_tag=next` when set.
- `.github/workflows/promote-latest.yml`: `git fetch --tags` the release tag and `origin/main` before the step; pass `--allow-stamp-pending` to the inline invocation.
- `scripts/verify-release-closeout.test.mjs`: pinned test version moves from 0.12.12 to 0.12.13; new case 8 covers the flag.