### PR TITLE
feat: peac.txt policy-document loader; deprecate @peac/pref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,9 @@ jobs:
       - name: Protocol string verification (forbidden patterns)
         run: pnpm verify:protocol-strings
 
+      - name: No network I/O in content-signal parser packages
+        run: pnpm verify:no-network-in-parsers
+
       - name: Spec drift verification (constants parity)
         run: pnpm verify:spec-drift
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,6 +260,9 @@ jobs:
       - name: No network I/O in content-signal parser packages
         run: pnpm verify:no-network-in-parsers
 
+      - name: No bidi / invisible Unicode in tracked files
+        run: pnpm verify:no-bidi-controls
+
       - name: Spec drift verification (constants parity)
         run: pnpm verify:spec-drift
 

--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -388,10 +388,12 @@
     },
     "packages/aipref": {
       "npm": "@peac/pref",
-      "state": "supported",
+      "state": "deprecated",
+      "removal": "v0.13.0",
       "wire": "0.2",
       "layer": 4,
-      "published": true
+      "published": true,
+      "note": "Thin deprecated facade over @peac/mappings-content-signals (RFC 8941/9651 Structured Fields Content-Usage, RFC 9309 robots.txt, tdmrep). No in-package network I/O. Full RFC 8785 JCS + SHA-256 digest. Emits PEAC_DEPRECATED_PREF DeprecationWarning on instantiation."
     },
     "packages/access": {
       "npm": null,

--- a/apps/api/src/verifier.ts
+++ b/apps/api/src/verifier.ts
@@ -213,7 +213,11 @@ export class VerifierV13 {
       }
     };
 
-    // Discover peac.txt with caching
+    // Discover peac.txt with caching. peac.txt is a policy-document surface
+    // per docs/specs/PEAC-TXT.md; this verifier only records the observation
+    // (URL + etag) and does NOT read key-discovery fields from the parsed
+    // result. Key resolution uses /.well-known/peac-issuer.json -> jwks_uri
+    // -> JWKS elsewhere in the verify path.
     try {
       checkTimeLimit();
       const peacUrl = new URL('/.well-known/peac.txt', resource).toString();

--- a/docs/PACKAGE_STATUS.md
+++ b/docs/PACKAGE_STATUS.md
@@ -62,7 +62,6 @@ Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scri
 | `packages/net/node`                    | `@peac/net-node`                   | 0.2  | 4     |
 | `packages/pay402`                      | `@peac/pay402`                     | 0.2  | 4     |
 | `packages/receipts`                    | `@peac/receipts`                   | 0.2  | 4     |
-| `packages/aipref`                      | `@peac/pref`                       | 0.2  | 4     |
 | `packages/server`                      | `@peac/server`                     | 0.2  | 5     |
 | `packages/conformance-harness`         | -                                  | 0.2  | 5     |
 | `packages/worker-core`                 | `@peac/worker-core`                | 0.2  | 5     |
@@ -89,9 +88,10 @@ Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scri
 
 ## Deprecated (removal scheduled)
 
-| Package         | npm          | Removal | Note                                                                                                  |
-| --------------- | ------------ | ------- | ----------------------------------------------------------------------------------------------------- |
-| `packages/core` | `@peac/core` | v0.13.0 | Monolithic pre-v0.10.0 package. Use @peac/kernel, @peac/schema, @peac/crypto, @peac/protocol instead. |
+| Package           | npm          | Removal | Note                                                                                                                                                                                                                                                                    |
+| ----------------- | ------------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/aipref` | `@peac/pref` | v0.13.0 | Thin deprecated facade over @peac/mappings-content-signals (RFC 8941/9651 Structured Fields Content-Usage, RFC 9309 robots.txt, tdmrep). No in-package network I/O. Full RFC 8785 JCS + SHA-256 digest. Emits PEAC_DEPRECATED_PREF DeprecationWarning on instantiation. |
+| `packages/core`   | `@peac/core` | v0.13.0 | Monolithic pre-v0.10.0 package. Use @peac/kernel, @peac/schema, @peac/crypto, @peac/protocol instead.                                                                                                                                                                   |
 
 ## Archived (non-default, may be removed)
 

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -58,7 +58,7 @@ Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scri
 | `packages/adapters/x402/daydreams`     | `@peac/adapter-x402-daydreams`     | supported    | 0.2  |
 | `packages/adapters/x402/fluora`        | `@peac/adapter-x402-fluora`        | supported    | 0.2  |
 | `packages/adapters/x402/pinata`        | `@peac/adapter-x402-pinata`        | supported    | 0.2  |
-| `packages/aipref`                      | `@peac/pref`                       | supported    | 0.2  |
+| `packages/aipref`                      | `@peac/pref`                       | deprecated   | 0.2  |
 | `packages/contracts`                   | `@peac/contracts`                  | supported    | 0.2  |
 | `packages/http-signatures`             | `@peac/http-signatures`            | supported    | 0.2  |
 | `packages/jwks-cache`                  | `@peac/jwks-cache`                 | supported    | 0.2  |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -72,6 +72,47 @@ export default [
     },
   },
 
+  // --- @peac/pref and @peac/mappings-content-signals: forbid network imports ---
+  // Content-signal parser packages take pre-fetched bytes only.
+  // Tests are exempt. @peac/pref robots.ts keeps a deprecated throwing fetchRobots
+  // stub; nothing else may import network primitives here.
+  {
+    files: [
+      'packages/aipref/src/**/*.ts',
+      'packages/mappings/content-signals/src/**/*.ts',
+    ],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            { name: 'node-fetch', message: 'Network I/O forbidden in content-signal parser packages. Pass pre-fetched bytes to the parser.' },
+            { name: 'got', message: 'Network I/O forbidden in content-signal parser packages.' },
+            { name: 'axios', message: 'Network I/O forbidden in content-signal parser packages.' },
+            { name: 'undici', message: 'Network I/O forbidden in content-signal parser packages.' },
+            { name: 'node:http', message: 'Network I/O forbidden in content-signal parser packages.' },
+            { name: 'node:https', message: 'Network I/O forbidden in content-signal parser packages.' },
+            { name: 'node:net', message: 'Network I/O forbidden in content-signal parser packages.' },
+            { name: 'http', message: 'Network I/O forbidden in content-signal parser packages.' },
+            { name: 'https', message: 'Network I/O forbidden in content-signal parser packages.' },
+            { name: 'net', message: 'Network I/O forbidden in content-signal parser packages.' },
+          ],
+          patterns: [
+            { group: ['node:http', 'node:https', 'node:net'], message: 'Network I/O forbidden in content-signal parser packages.' },
+          ],
+        },
+      ],
+      'no-restricted-globals': [
+        'error',
+        {
+          name: 'fetch',
+          message:
+            'Network I/O forbidden in content-signal parser packages. Callers pass pre-fetched bytes; parsers operate on bytes only.',
+        },
+      ],
+    },
+  },
+
   // --- @peac/mcp-server: forbid console.log (stdout is reserved for JSON-RPC) ---
   // Use process.stderr.write() for diagnostics, never console.log/warn/error.
   {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "verify:commerce-coverage": "node scripts/conformance/check-commerce-coverage.mjs",
     "verify:protocol-strings": "node scripts/verify-protocol-strings.mjs",
     "verify:no-network-in-parsers": "node scripts/verify-no-network-in-content-signal-parsers.mjs",
+    "verify:no-bidi-controls": "node scripts/verify-no-bidi-controls.mjs",
     "verify:spec-drift": "node scripts/verify-spec-drift.mjs",
     "verify:docs-examples": "node scripts/verify-docs-examples.mjs",
     "verify:bundle-drift": "node scripts/verify-bundle-drift.mjs",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "verify:examples-commerce": "pnpm --filter @peac/example-paymentauth-evidence build && pnpm --filter @peac/example-paymentauth-jsonrpc build && pnpm --filter @peac/example-acp-session-lifecycle build && pnpm --filter @peac/example-stripe-spt-evidence build && pnpm --filter @peac/example-commerce-evidence-bundle build && pnpm --filter @peac/example-x402-dual-header-read build && pnpm --filter @peac/example-paymentauth-evidence demo && pnpm --filter @peac/example-paymentauth-jsonrpc demo && pnpm --filter @peac/example-acp-session-lifecycle demo && pnpm --filter @peac/example-stripe-spt-evidence demo && pnpm --filter @peac/example-commerce-evidence-bundle demo && pnpm --filter @peac/example-x402-dual-header-read demo",
     "verify:commerce-coverage": "node scripts/conformance/check-commerce-coverage.mjs",
     "verify:protocol-strings": "node scripts/verify-protocol-strings.mjs",
+    "verify:no-network-in-parsers": "node scripts/verify-no-network-in-content-signal-parsers.mjs",
     "verify:spec-drift": "node scripts/verify-spec-drift.mjs",
     "verify:docs-examples": "node scripts/verify-docs-examples.mjs",
     "verify:bundle-drift": "node scripts/verify-bundle-drift.mjs",

--- a/packages/aipref/README.md
+++ b/packages/aipref/README.md
@@ -1,76 +1,139 @@
-# @peac/pref
+# @peac/pref (DEPRECATED)
 
-AIPREF resolver with robots.txt bridge: resolves content-usage preferences from multiple sources with strict merge order.
+> **Deprecated as of v0.12.14.** `@peac/pref` is now a thin facade over
+> [`@peac/mappings-content-signals`](../mappings/content-signals/). Use
+> `@peac/mappings-content-signals` directly for RFC-compliant parsing and
+> resolution. Importing `@peac/pref` emits a one-shot
+> `PEAC_DEPRECATED_PREF` `DeprecationWarning`. Removal target: next cleanup
+> release.
 
-## Installation
+## Why it's deprecated
 
-```bash
-pnpm add @peac/pref
-```
+The pre-v0.12.14 `@peac/pref` shipped:
 
-## What It Does
+- a comma-split `Content-Usage` header parser (not RFC 8941 / 9651
+  structured fields),
+- a truncated 12-character digest labelled `JCS-SHA256` (not RFC 8785
+  canonical + full SHA-256),
+- in-package `fetch()` calls for `peac.txt`, AIPREF JSON, and `robots.txt`
+  (parsing packages should not perform network I/O),
+- comment-line scanning of `peac.txt` for policy hints.
 
-`@peac/pref` resolves AI content-usage preferences (AIPREF) for a given URI by checking multiple sources in priority order: request headers, AIPREF JSON, `peac.txt`, and `robots.txt`. It normalizes these signals into a unified `AIPrefPolicy` with a computed digest. The package also provides a `robotsToPeacStarter()` migration helper that converts `robots.txt` rules into a starter PEAC policy document.
+All four behaviours are replaced in v0.12.14:
 
-## How Do I Use It?
+| Concern                 | Pre-v0.12.14                                 | v0.12.14+ facade                                                                           |
+| ----------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `Content-Usage` parsing | comma-split strings                          | `@peac/mappings-content-signals.parseContentUsage` (RFC 9651 Structured Fields Dictionary) |
+| `robots.txt` parsing    | custom regex parser                          | `@peac/mappings-content-signals.parseRobotsTxt` (RFC 9309)                                 |
+| tdmrep parsing          | not supported                                | `@peac/mappings-content-signals.parseTdmrep`                                               |
+| Precedence resolution   | priority loop in `PrefResolver`              | `@peac/mappings-content-signals.resolveSignals`                                            |
+| Digest                  | truncated 12-hex                             | `@peac/crypto.jcsHash` (RFC 8785 JCS + full SHA-256)                                       |
+| Network I/O             | `fetch()` for peac.txt / AIPREF / robots.txt | **removed**; callers pass pre-fetched bytes                                                |
 
-### Resolve preferences for a URI
+## Behavior changes (deprecation-window, v0.12.14)
+
+These are deliberate behavioral changes inside the one-minor deprecation
+window. Callers that treated `@peac/pref` outputs as opaque are not
+affected; callers that read specific fields should review the list below
+before updating.
+
+- **Digest format widened.** `AIPrefDigest.val` previously shipped as a
+  truncated 12-character hex string labelled `JCS-SHA256`. In v0.12.14
+  `val` is the full 64-character lowercase hex string produced by
+  `@peac/crypto.jcsHash` (RFC 8785 JCS + SHA-256). The `alg` literal
+  remains `'JCS-SHA256'` so the type shape is stable; only the byte
+  length of `val` changes. This is a real behavioral change, not just an
+  implementation detail: anything that compared `val` to a previously
+  recorded 12-hex value will no longer match.
+- **`Content-Usage` parsing is now RFC 9651 Structured-Fields.** The
+  pre-v0.12.14 comma-split parser accepted inputs that do not round-trip
+  under structured fields; those inputs now produce no entries instead of
+  silently guessing.
+- **`fetchRobots()` rejects with `PEAC_DEPRECATED_PREF_NETWORK`.** The
+  `@peac/pref` facade never opens a socket; callers fetch in their own
+  code and pass the bytes to the parsers.
+- **`peac.txt` comment-line hint extraction was removed.** The
+  pre-v0.12.14 resolver scanned `# no training` / `# no crawling`
+  comments; those are no longer recognized. Callers that relied on this
+  path should surface the underlying signal via
+  `Content-Usage` / `robots.txt` / `tdmrep.json` / a
+  `peac-policy/0.1` document fetched by the caller.
+- **`commercial` is no longer populated from signals.** The modern AIPREF
+  vocabulary does not express a `commercial` axis, and
+  `@peac/mappings-content-signals` does not emit a commercial decision.
+  `AIPrefSnapshot.commercial` is retained on the type surface but is
+  never set by the facade.
+
+## Migration
+
+### Replace `resolveAIPref` / `PrefResolver` with `@peac/mappings-content-signals`
+
+Before:
 
 ```typescript
 import { resolveAIPref } from '@peac/pref';
 
-const policy = await resolveAIPref('https://example.com/article');
-
-console.log(policy.status); // 'active' | 'not_found' | 'error'
-console.log(policy.snapshot); // { crawl: true, 'train-ai': false, commercial: false }
-console.log(policy.source); // 'header' | 'aipref' | 'peac' | 'robots' | 'default'
-```
-
-### Use the PrefResolver class for repeated lookups
-
-```typescript
-import { PrefResolver } from '@peac/pref';
-
-const resolver = new PrefResolver();
-const policy = await resolver.resolve({
-  uri: 'https://example.com/article',
-  headers: { 'Content-Usage': 'no-train' },
+const policy = await resolveAIPref('https://example.com/article', {
+  'Content-Usage': 'train-ai=n, search=y',
 });
-
-console.log(policy.snapshot?.['train-ai']); // false
 ```
 
-### Convert robots.txt to a starter PEAC policy
+After:
 
 ```typescript
-import { robotsToPeacStarter } from '@peac/pref';
+import {
+  parseContentUsage,
+  resolveSignals,
+  getDecisionForPurpose,
+} from '@peac/mappings-content-signals';
 
-const result = robotsToPeacStarter(`
-User-agent: GPTBot
-Disallow: /
-
-User-agent: *
-Allow: /
-`);
-
-console.log(result.hasAiRestrictions); // true
-console.log(result.policy.rules); // [{ name: 'deny-gptbot', decision: 'deny', ... }]
-console.log(result.notes); // advisory notes about the conversion
+const { entries } = parseContentUsage('train-ai=n, search=y');
+const resolved = resolveSignals(entries);
+const trainDecision = getDecisionForPurpose(resolved, 'ai-training'); // 'deny'
+const searchDecision = getDecisionForPurpose(resolved, 'ai-search'); // 'allow'
 ```
 
-## Integrates With
+### Combine multiple pre-fetched signals
 
-- `@peac/policy-kit`: Policy document types used by `robotsToPeacStarter()`
-- `@peac/schema` (Layer 1): Content signal schemas and AIPREF version constants
-- `@peac/consent`: Consent pillar for data-subject preference evidence
+```typescript
+import {
+  parseContentUsage,
+  parseRobotsTxt,
+  parseTdmrep,
+  resolveSignals,
+  createObservation,
+} from '@peac/mappings-content-signals';
 
-## For Agent Developers
+const entries = [
+  ...parseContentUsage(contentUsageHeaderValue).entries,
+  ...parseRobotsTxt(robotsTxtBytes),
+  ...parseTdmrep(tdmrepJsonBytes),
+];
+const resolved = resolveSignals(entries);
 
-If you are building an AI agent or MCP server that needs evidence receipts:
+// or package into an observation shape for downstream binding / reporting:
+const observation = createObservation({
+  target_uri: 'https://example.com/article',
+  content_usage: contentUsageHeaderValue,
+  robots_txt: robotsTxtBytes,
+  tdmrep_json: tdmrepJsonBytes,
+});
+```
 
-- Start with [`@peac/mcp-server`](https://www.npmjs.com/package/@peac/mcp-server) for a ready-to-use MCP tool server
-- Use `@peac/protocol` for programmatic receipt issuance and verification
-- See the [llms.txt](https://github.com/peacprotocol/peac/blob/main/llms.txt) for a concise overview
+### Fetching remains the caller's responsibility
+
+v0.12.14+ parsing packages do not open sockets. Fetch with your preferred
+client (`undici` / `fetch` / `node:https`) subject to your SSRF, redirect,
+and timeout policy, then pass the bytes to the parsers above. The legacy
+`fetchRobots` entrypoint now rejects with `PEAC_DEPRECATED_PREF_NETWORK`.
+
+## Backward-compat shape
+
+The legacy `PrefResolver`, `AIPrefPolicy`, `AIPrefSnapshot`, and
+`ResolveContext` types still export from `@peac/pref` to keep existing
+import paths compiling for one minor. `ResolveContext` gains optional
+`robotsTxt` / `tdmrep` fields so callers can supply pre-fetched bytes to
+the facade.
 
 ## License
 
@@ -78,6 +141,7 @@ Apache-2.0
 
 ---
 
-PEAC Protocol is an open source project stewarded by Originary and community contributors.
+PEAC Protocol is an open source project stewarded by Originary and community
+contributors.
 
 [Docs](https://www.peacprotocol.org) | [GitHub](https://github.com/peacprotocol/peac) | [Originary](https://www.originary.xyz)

--- a/packages/aipref/README.md
+++ b/packages/aipref/README.md
@@ -64,6 +64,18 @@ before updating.
   `AIPrefSnapshot.commercial` is retained on the type surface but is
   never set by the facade.
 
+### Digest width: migration note
+
+- Callers that treated `AIPrefDigest.val` as an **opaque token** are
+  unaffected (the bytes are still a lowercase hex string tagged `alg:
+'JCS-SHA256'`).
+- Callers that hard-coded the **byte length** (for example asserting 12
+  characters, or using a fixed-width database column) MUST update: the
+  value is now the full 64-character RFC 8785 JCS + SHA-256 hex. Widen
+  the column, remove the fixed-width check, or compute the digest once
+  against the new output and re-key any store that indexed by the
+  previous truncated value.
+
 ## Migration
 
 ### Replace `resolveAIPref` / `PrefResolver` with `@peac/mappings-content-signals`

--- a/packages/aipref/__tests__/facade.test.ts
+++ b/packages/aipref/__tests__/facade.test.ts
@@ -15,7 +15,6 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   parseContentUsage,
   parseRobotsTxt,
-  parseTdmrep,
   resolveSignals,
   getDecisionForPurpose,
 } from '@peac/mappings-content-signals';

--- a/packages/aipref/__tests__/facade.test.ts
+++ b/packages/aipref/__tests__/facade.test.ts
@@ -1,0 +1,250 @@
+/**
+ * @peac/pref facade tests (v0.12.14+).
+ *
+ * Asserts:
+ *   - Facade produces the same resolved decision as @peac/mappings-content-signals
+ *     canonical path for the supported input matrix.
+ *   - Digest is a full-length SHA-256 (64 hex), not the pre-v0.12.14 12-hex truncation.
+ *   - `PrefResolver` emits a single `PEAC_DEPRECATED_PREF` `DeprecationWarning`
+ *     per process.
+ *   - The package performs no in-process network I/O; `fetchRobots` rejects
+ *     with `PEAC_DEPRECATED_PREF_NETWORK`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  parseContentUsage,
+  parseRobotsTxt,
+  parseTdmrep,
+  resolveSignals,
+  getDecisionForPurpose,
+} from '@peac/mappings-content-signals';
+import { PrefResolver, fetchRobots, robotsToAIPref } from '../src/index.js';
+import { __resetDeprecationWarningForTests } from '../src/resolver.js';
+
+describe('PrefResolver: Content-Usage header parity with @peac/mappings-content-signals', () => {
+  beforeEach(() => __resetDeprecationWarningForTests());
+
+  it('maps train-ai=n + search=y to legacy AIPrefSnapshot (allow-search, deny-train)', async () => {
+    const headerValue = 'train-ai=n, search=y';
+
+    // Canonical path
+    const entries = parseContentUsage(headerValue).entries;
+    const resolved = resolveSignals(entries);
+    expect(getDecisionForPurpose(resolved, 'ai-training')).toBe('deny');
+    expect(getDecisionForPurpose(resolved, 'ai-search')).toBe('allow');
+
+    // Facade path
+    const resolver = new PrefResolver();
+    const policy = await resolver.resolve({
+      uri: 'https://example.com/',
+      headers: { 'content-usage': headerValue },
+    });
+    expect(policy.status).toBe('active');
+    expect(policy.source).toBe('header');
+    expect(policy.snapshot?.['train-ai']).toBe(false);
+    expect(policy.snapshot?.crawl).toBe(true);
+  });
+
+  it('returns not_found + defaults when no content signals are supplied', async () => {
+    const resolver = new PrefResolver();
+    const policy = await resolver.resolve({ uri: 'https://example.com/' });
+    expect(policy.status).toBe('not_found');
+    expect(policy.source).toBe('default');
+    expect(policy.snapshot?.crawl).toBe(true);
+    expect(policy.snapshot?.['train-ai']).toBe(true);
+  });
+
+  it('accepts pre-fetched robotsTxt bytes', async () => {
+    const robotsTxt = ['User-agent: GPTBot', 'Disallow: /', '', 'User-agent: *', 'Allow: /'].join(
+      '\n'
+    );
+
+    const canonicalResolved = resolveSignals(parseRobotsTxt(robotsTxt));
+    // Canonical path says ai-training denied for GPTBot-targeted rule.
+    expect(getDecisionForPurpose(canonicalResolved, 'ai-training')).toBe('deny');
+
+    const resolver = new PrefResolver();
+    const policy = await resolver.resolve({ uri: 'https://example.com/', robotsTxt });
+    expect(policy.status).toBe('active');
+    expect(policy.source).toBe('robots');
+    expect(policy.snapshot?.['train-ai']).toBe(false);
+  });
+
+  it('accepts pre-fetched tdmrep JSON', async () => {
+    const tdmrep = JSON.stringify({
+      location: 'https://example.com/',
+      'tdm-reservation': 1,
+    });
+    const resolver = new PrefResolver();
+    const policy = await resolver.resolve({ uri: 'https://example.com/', tdmrep });
+    expect(policy.status).toBe('active');
+    expect(policy.source).toBe('tdmrep');
+    expect(policy.snapshot?.crawl).toBe(false);
+    expect(policy.snapshot?.['train-ai']).toBe(false);
+  });
+
+  it('maps tdmrep reservation 0 to allow', async () => {
+    const tdmrep = JSON.stringify({
+      location: 'https://example.com/',
+      'tdm-reservation': 0,
+    });
+    const resolver = new PrefResolver();
+    const policy = await resolver.resolve({ uri: 'https://example.com/', tdmrep });
+    expect(policy.source).toBe('tdmrep');
+    expect(policy.snapshot?.crawl).toBe(true);
+    expect(policy.snapshot?.['train-ai']).toBe(true);
+  });
+});
+
+describe('PrefResolver: digest discipline', () => {
+  beforeEach(() => __resetDeprecationWarningForTests());
+
+  it('produces a full 64-character hex digest (RFC 8785 JCS + SHA-256)', async () => {
+    const resolver = new PrefResolver();
+    const policy = await resolver.resolve({
+      uri: 'https://example.com/',
+      headers: { 'content-usage': 'train-ai=n' },
+    });
+    expect(policy.digest).toBeDefined();
+    expect(policy.digest?.alg).toBe('JCS-SHA256');
+    expect(policy.digest?.val).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic: same snapshot produces identical digest', async () => {
+    const resolver = new PrefResolver();
+    const p1 = await resolver.resolve({
+      uri: 'https://example.com/a',
+      headers: { 'content-usage': 'train-ai=n, search=y' },
+    });
+    const p2 = await resolver.resolve({
+      uri: 'https://example.com/b',
+      headers: { 'content-usage': 'train-ai=n, search=y' },
+    });
+    expect(p1.digest?.val).toBe(p2.digest?.val);
+  });
+
+  it('differs when snapshot bytes differ', async () => {
+    const resolver = new PrefResolver();
+    const denyTrain = await resolver.resolve({
+      uri: 'https://example.com/',
+      headers: { 'content-usage': 'train-ai=n' },
+    });
+    const allowTrain = await resolver.resolve({
+      uri: 'https://example.com/',
+      headers: { 'content-usage': 'train-ai=y' },
+    });
+    expect(denyTrain.digest?.val).not.toBe(allowTrain.digest?.val);
+  });
+});
+
+describe('PrefResolver: deprecation warning', () => {
+  let emitWarningSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    __resetDeprecationWarningForTests();
+    emitWarningSpy = vi.spyOn(process, 'emitWarning').mockImplementation(() => {
+      /* suppress */
+    });
+  });
+
+  afterEach(() => emitWarningSpy.mockRestore());
+
+  it('fires PEAC_DEPRECATED_PREF exactly once per process on instantiation', () => {
+    void new PrefResolver();
+    void new PrefResolver();
+    void new PrefResolver();
+    expect(emitWarningSpy).toHaveBeenCalledTimes(1);
+    const [message, options] = emitWarningSpy.mock.calls[0];
+    expect(String(message)).toMatch(/@peac\/pref is deprecated/);
+    expect(options).toMatchObject({
+      code: 'PEAC_DEPRECATED_PREF',
+      type: 'DeprecationWarning',
+    });
+  });
+});
+
+describe('@peac/pref: no network I/O', () => {
+  it('fetchRobots rejects with PEAC_DEPRECATED_PREF_NETWORK (no socket opened)', async () => {
+    await expect(fetchRobots('https://example.com/')).rejects.toMatchObject({
+      code: 'PEAC_DEPRECATED_PREF_NETWORK',
+    });
+  });
+});
+
+describe('robotsToAIPref (legacy shape; defers to @peac/mappings-content-signals)', () => {
+  it('maps GPTBot Disallow: / to train-ai=false', () => {
+    const robotsTxt = 'User-agent: GPTBot\nDisallow: /\n';
+    const snapshot = robotsToAIPref(robotsTxt);
+    expect(snapshot?.['train-ai']).toBe(false);
+  });
+
+  it('returns null when no AI-relevant signals', () => {
+    const robotsTxt = 'User-agent: Googlebot\nDisallow: /private/\n';
+    const snapshot = robotsToAIPref(robotsTxt);
+    expect(snapshot).toBeNull();
+  });
+});
+
+describe('PrefResolver: byte-for-byte canonical parity', () => {
+  beforeEach(() => __resetDeprecationWarningForTests());
+
+  const VECTORS: Array<{
+    name: string;
+    header: string;
+    aiTraining: 'allow' | 'deny' | 'unspecified';
+    aiSearch: 'allow' | 'deny' | 'unspecified';
+  }> = [
+    {
+      name: 'explicit deny-train / allow-search',
+      header: 'train-ai=n, search=y',
+      aiTraining: 'deny',
+      aiSearch: 'allow',
+    },
+    {
+      name: 'explicit allow-train / deny-search',
+      header: 'train-ai=y, search=n',
+      aiTraining: 'allow',
+      aiSearch: 'deny',
+    },
+    {
+      name: 'only train-ai specified',
+      header: 'train-ai=n',
+      aiTraining: 'deny',
+      aiSearch: 'unspecified',
+    },
+    {
+      name: 'only search specified',
+      header: 'search=y',
+      aiTraining: 'unspecified',
+      aiSearch: 'allow',
+    },
+  ];
+
+  for (const v of VECTORS) {
+    it(`facade decisions match @peac/mappings-content-signals canonical path: ${v.name}`, async () => {
+      // Canonical path
+      const canonical = resolveSignals(parseContentUsage(v.header).entries);
+      expect(getDecisionForPurpose(canonical, 'ai-training')).toBe(v.aiTraining);
+      expect(getDecisionForPurpose(canonical, 'ai-search')).toBe(v.aiSearch);
+
+      // Facade path
+      const resolver = new PrefResolver();
+      const policy = await resolver.resolve({
+        uri: 'https://example.com/',
+        headers: { 'content-usage': v.header },
+      });
+
+      // Derive expected legacy snapshot from canonical decisions via the
+      // same purpose->legacy-field mapping the facade applies internally.
+      // When a canonical decision is 'unspecified', the facade leaves the
+      // corresponding legacy field unset (defaults are only used when the
+      // input had zero entries; these vectors all have at least one).
+      const expectedSnapshot: Record<string, boolean> = {};
+      if (v.aiTraining !== 'unspecified') expectedSnapshot['train-ai'] = v.aiTraining === 'allow';
+      if (v.aiSearch !== 'unspecified') expectedSnapshot.crawl = v.aiSearch === 'allow';
+
+      expect(policy.snapshot).toEqual(expectedSnapshot);
+    });
+  }
+});

--- a/packages/aipref/__tests__/vitest.setup.ts
+++ b/packages/aipref/__tests__/vitest.setup.ts
@@ -1,0 +1,31 @@
+/**
+ * Vitest setup for @peac/pref: silences expected deprecation warnings so CI
+ * output stays readable. The deprecation contract itself is covered by a
+ * dedicated assertion test (`facade.test.ts` -> "fires PEAC_DEPRECATED_PREF
+ * exactly once per process"). All other tests instantiate `PrefResolver`
+ * for legitimate reasons and would otherwise flood CI logs with the
+ * expected `PEAC_DEPRECATED_PREF` warning.
+ *
+ * Strategy: remove Node's default `warning` listener (which writes to
+ * stderr) and install a filter that swallows `PEAC_DEPRECATED_PREF` and
+ * `PEAC_LEGACY_PEAC_TXT_KEY_FIELD` warnings. Other warnings still reach
+ * stderr via a fresh default-style listener, so unexpected warnings remain
+ * visible.
+ */
+
+const EXPECTED_DEPRECATION_CODES = new Set([
+  'PEAC_DEPRECATED_PREF',
+  'PEAC_LEGACY_PEAC_TXT_KEY_FIELD',
+]);
+
+for (const listener of process.listeners('warning')) {
+  process.off('warning', listener);
+}
+
+process.on('warning', (warning: NodeJS.ErrnoException & { code?: string }) => {
+  if (warning.code && EXPECTED_DEPRECATION_CODES.has(warning.code)) {
+    return; // swallowed in tests; behaviour is asserted elsewhere
+  }
+  // Preserve visibility of any unexpected warning.
+  process.stderr.write(`(node:warning) ${warning.name}: ${warning.message}\n`);
+});

--- a/packages/aipref/package.json
+++ b/packages/aipref/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@peac/pref",
   "version": "0.12.13",
-  "description": "AIPREF resolver with robots.txt bridge",
+  "description": "Deprecated facade over @peac/mappings-content-signals (AIPREF / robots.txt / tdmrep). Use @peac/mappings-content-signals directly.",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -24,6 +24,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@peac/crypto": "workspace:*",
+    "@peac/mappings-content-signals": "workspace:*",
     "@peac/policy-kit": "workspace:*"
   },
   "devDependencies": {

--- a/packages/aipref/src/index.ts
+++ b/packages/aipref/src/index.ts
@@ -1,6 +1,12 @@
 /**
- * @peac/pref - AIPREF resolver with robots.txt bridge
- * Implements strict merge order for effective policy resolution
+ * @peac/pref - DEPRECATED facade over @peac/mappings-content-signals.
+ *
+ * @deprecated @peac/pref is deprecated as of v0.12.14. Use
+ * `@peac/mappings-content-signals` directly for RFC 8941/9651
+ * Structured-Fields `Content-Usage` parsing, RFC 9309 robots.txt parsing,
+ * tdmrep parsing, and `resolveSignals()`. Emits a one-shot structured
+ * `PEAC_DEPRECATED_PREF` warning on first `PrefResolver` instantiation.
+ * Removal target: next cleanup release.
  */
 
 export { PrefResolver } from './resolver.js';
@@ -9,12 +15,19 @@ export type { RobotsToPeacResult } from './robots.js';
 export type {
   AIPrefSnapshot,
   AIPrefPolicy,
+  AIPrefDigest,
   RobotsRule,
   PrefSource,
   ResolveContext,
 } from './types.js';
 
-// Convenience function for single-use resolution
+/**
+ * @deprecated Use `@peac/mappings-content-signals.createObservation` or
+ * instantiate a `PrefResolver` and pass pre-fetched content via
+ * `ResolveContext`. The v0.12.14+ facade does not perform network I/O;
+ * `headers` is the only input consulted via this convenience helper.
+ * Removal target: next cleanup release.
+ */
 export async function resolveAIPref(
   uri: string,
   headers?: Record<string, string>

--- a/packages/aipref/src/resolver.ts
+++ b/packages/aipref/src/resolver.ts
@@ -1,13 +1,89 @@
 /**
- * @peac/pref/resolver - AIPREF policy resolver with strict merge order
- * Priority: request headers > AIPREF JSON > peac.txt > robots.txt > defaults
+ * @peac/pref/resolver - deprecated facade over @peac/mappings-content-signals.
+ *
+ * @peac/pref is deprecated. Use @peac/mappings-content-signals directly for
+ * RFC 8941/9651 Structured-Fields `Content-Usage` parsing, RFC 9309
+ * robots.txt parsing, tdmrep parsing, and `resolveSignals()`.
+ *
+ * This module preserves the @peac/pref public API shape (`PrefResolver`,
+ * `AIPrefPolicy`, `AIPrefSnapshot`) while delegating all parsing to
+ * @peac/mappings-content-signals.
+ *
+ * Behavior contract:
+ *   - No in-package `fetch()` calls. Callers pass pre-fetched content via
+ *     `ResolveContext` fields.
+ *   - `Content-Usage` parsing uses RFC 9651 Structured-Fields.
+ *   - Digest output is a full-length RFC 8785 JCS + SHA-256 (64 hex chars)
+ *     computed via `@peac/crypto.jcsHash`.
+ *   - A one-shot structured DeprecationWarning with code
+ *     `PEAC_DEPRECATED_PREF` fires on first `PrefResolver` instantiation.
  */
 
-import { fetchRobots, parseRobots, robotsToAIPref } from './robots.js';
-import type { AIPrefPolicy, AIPrefSnapshot, ResolveContext, PrefSource } from './types.js';
+import {
+  parseContentUsage,
+  parseRobotsTxt,
+  parseTdmrep,
+  resolveSignals,
+  type ContentSignalEntry,
+} from '@peac/mappings-content-signals';
+import { jcsHash } from '@peac/crypto';
+import type { AIPrefDigest, AIPrefPolicy, AIPrefSnapshot, ResolveContext } from './types.js';
 
+let deprecationWarningFired = false;
+
+function fireDeprecationWarning(): void {
+  if (deprecationWarningFired) return;
+  deprecationWarningFired = true;
+  if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+    process.emitWarning(
+      '@peac/pref is deprecated. Use @peac/mappings-content-signals for ' +
+        'RFC 8941/9651 Structured-Fields Content-Usage parsing, RFC 9309 ' +
+        'robots.txt parsing, tdmrep parsing, and resolveSignals().',
+      { code: 'PEAC_DEPRECATED_PREF', type: 'DeprecationWarning' }
+    );
+  }
+}
+
+/** @internal exposed for tests that need to observe the warning more than once. */
+export function __resetDeprecationWarningForTests(): void {
+  deprecationWarningFired = false;
+}
+
+/**
+ * Map @peac/mappings-content-signals entries into the legacy AIPrefSnapshot
+ * shape. Preserved for backward compat of the @peac/pref public API. New
+ * code should consume `ContentSignalEntry[]` directly from
+ * `@peac/mappings-content-signals.resolveSignals`.
+ */
+function entriesToSnapshot(entries: ContentSignalEntry[]): AIPrefSnapshot | null {
+  const snapshot: AIPrefSnapshot = {};
+  let hasPrefs = false;
+  for (const entry of entries) {
+    if (entry.decision === 'unspecified') continue;
+    const allow = entry.decision === 'allow';
+    switch (entry.purpose) {
+      case 'ai-training':
+      case 'ai-generative':
+      case 'ai-inference':
+        if (snapshot['train-ai'] === undefined) snapshot['train-ai'] = allow;
+        hasPrefs = true;
+        break;
+      case 'ai-search':
+      case 'tdm':
+        if (snapshot.crawl === undefined) snapshot.crawl = allow;
+        hasPrefs = true;
+        break;
+    }
+  }
+  return hasPrefs ? snapshot : null;
+}
+
+/**
+ * @deprecated Use `@peac/mappings-content-signals` directly. Retained for
+ * backward compat of the @peac/pref public API. Emits a one-shot structured
+ * `PEAC_DEPRECATED_PREF` DeprecationWarning on instantiation.
+ */
 export class PrefResolver {
-  private sources: PrefSource[] = [];
   private defaults: AIPrefSnapshot = {
     crawl: true,
     'train-ai': true,
@@ -15,203 +91,86 @@ export class PrefResolver {
   };
 
   constructor() {
-    this.registerSources();
+    fireDeprecationWarning();
   }
 
-  private registerSources() {
-    // Priority 1: Request headers (handled separately)
-
-    // Priority 2: AIPREF JSON
-    this.sources.push({
-      priority: 2,
-      name: 'aipref',
-      fetch: this.fetchAIPrefJson.bind(this),
-    });
-
-    // Priority 3: peac.txt hints
-    this.sources.push({
-      priority: 3,
-      name: 'peac',
-      fetch: this.fetchPeacTxt.bind(this),
-    });
-
-    // Priority 4: robots.txt
-    this.sources.push({
-      priority: 4,
-      name: 'robots',
-      fetch: this.fetchRobotsTxt.bind(this),
-    });
-  }
-
+  /**
+   * Resolve AI preferences from pre-fetched content. Does not perform network
+   * I/O. Callers supply all content via `ResolveContext` optional fields
+   * (`headers['content-usage']`, `robotsTxt`, `tdmrep`).
+   */
   async resolve(ctx: ResolveContext): Promise<AIPrefPolicy> {
-    try {
-      // Priority 1: Check request headers first
-      const headerPrefs = this.parseHeaders(ctx.headers);
-      if (headerPrefs) {
-        return {
-          status: 'active',
-          checked_at: new Date().toISOString(),
-          snapshot: headerPrefs,
-          digest: await this.computeDigest(headerPrefs),
-          source: 'header',
-        };
-      }
+    const checkedAt = new Date().toISOString();
+    const entries: ContentSignalEntry[] = [];
 
-      // Priority 2-4: Fetch from sources in priority order
-      for (const source of this.sources) {
-        try {
-          const snapshot = await source.fetch(ctx.uri);
-          if (snapshot) {
-            return {
-              status: 'active',
-              checked_at: new Date().toISOString(),
-              snapshot,
-              digest: await this.computeDigest(snapshot),
-              source: source.name as any,
-            };
-          }
-        } catch (error) {
-          console.warn(`AIPREF source ${source.name} failed:`, error);
-        }
+    const contentUsage = ctx.headers?.['content-usage'] ?? ctx.headers?.['Content-Usage'];
+    if (typeof contentUsage === 'string' && contentUsage.length > 0) {
+      try {
+        entries.push(...parseContentUsage(contentUsage).entries);
+      } catch {
+        // Malformed header: fall through to other sources.
       }
+    }
+    if (typeof ctx.robotsTxt === 'string' && ctx.robotsTxt.length > 0) {
+      try {
+        entries.push(...parseRobotsTxt(ctx.robotsTxt));
+      } catch {
+        // ignore
+      }
+    }
+    if (typeof ctx.tdmrep === 'string' && ctx.tdmrep.length > 0) {
+      try {
+        entries.push(...parseTdmrep(ctx.tdmrep));
+      } catch {
+        // ignore
+      }
+    }
 
-      // Priority 5: Use defaults
+    if (entries.length === 0) {
+      const snapshot = this.defaults;
       return {
         status: 'not_found',
-        checked_at: new Date().toISOString(),
-        snapshot: this.defaults,
-        digest: await this.computeDigest(this.defaults),
+        checked_at: checkedAt,
+        snapshot,
+        digest: await this.computeDigest(snapshot),
         source: 'default',
-        reason: 'No AIPREF policy found, using defaults',
-      };
-    } catch (error) {
-      return {
-        status: 'error',
-        checked_at: new Date().toISOString(),
-        reason: `AIPREF resolution failed: ${error instanceof Error ? error.message : String(error)}`,
-        source: 'default',
+        reason: 'No content signals supplied; using defaults',
       };
     }
-  }
 
-  private parseHeaders(headers?: Record<string, string>): AIPrefSnapshot | null {
-    if (!headers) return null;
-
-    const contentUsage = headers['content-usage'] || headers['Content-Usage'];
-    if (!contentUsage) return null;
-
-    const snapshot: AIPrefSnapshot = {};
-    const directives = contentUsage.split(',').map((d) => d.trim().toLowerCase());
-
-    for (const directive of directives) {
-      switch (directive) {
-        case 'no-train':
-          snapshot['train-ai'] = false;
-          break;
-        case 'no-crawl':
-          snapshot.crawl = false;
-          break;
-        case 'no-commercial':
-          snapshot.commercial = false;
-          break;
-        case 'train-ok':
-          snapshot['train-ai'] = true;
-          break;
-        case 'crawl-ok':
-          snapshot.crawl = true;
-          break;
-        case 'commercial-ok':
-          snapshot.commercial = true;
-          break;
-      }
-    }
-
-    return Object.keys(snapshot).length > 0 ? snapshot : null;
-  }
-
-  private async fetchAIPrefJson(uri: string): Promise<AIPrefSnapshot | null> {
-    try {
-      // First discover AIPREF URL from peac.txt
-      const peacUrl = new URL('/.well-known/peac.txt', new URL(uri).origin);
-      const peacResponse = await fetch(peacUrl.toString());
-      if (!peacResponse.ok) return null;
-
-      const peacContent = await peacResponse.text();
-      const aiprefMatch = peacContent.match(/^preferences:\s*(.+)$/m);
-      if (!aiprefMatch) return null;
-
-      const aiprefUrl = aiprefMatch[1].trim();
-      const aiprefResponse = await fetch(aiprefUrl);
-      if (!aiprefResponse.ok) return null;
-
-      const aiprefData = await aiprefResponse.json();
-      return this.normalizeSnapshot(aiprefData);
-    } catch {
-      return null;
-    }
-  }
-
-  private async fetchPeacTxt(uri: string): Promise<AIPrefSnapshot | null> {
-    try {
-      const peacUrl = new URL('/.well-known/peac.txt', new URL(uri).origin);
-      const response = await fetch(peacUrl.toString());
-      if (!response.ok) return null;
-
-      const content = await response.text();
-      const snapshot: AIPrefSnapshot = {};
-
-      // Extract hints from peac.txt
-      const lines = content.split('\n');
-      for (const line of lines) {
-        const trimmed = line.trim();
-        if (trimmed.startsWith('# ')) {
-          const hint = trimmed.substring(2).toLowerCase();
-          if (hint.includes('no training')) snapshot['train-ai'] = false;
-          if (hint.includes('no crawling')) snapshot.crawl = false;
-          if (hint.includes('non-commercial')) snapshot.commercial = false;
-        }
-      }
-
-      return Object.keys(snapshot).length > 0 ? snapshot : null;
-    } catch {
-      return null;
-    }
-  }
-
-  private async fetchRobotsTxt(uri: string): Promise<AIPrefSnapshot | null> {
-    const content = await fetchRobots(uri);
-    if (!content) return null;
-
-    const rules = parseRobots(content);
-    return robotsToAIPref(rules);
-  }
-
-  private normalizeSnapshot(data: any): AIPrefSnapshot | null {
-    if (!data || typeof data !== 'object') return null;
-
-    const snapshot: AIPrefSnapshot = {};
-    if (typeof data.crawl === 'boolean') snapshot.crawl = data.crawl;
-    if (typeof data['train-ai'] === 'boolean') snapshot['train-ai'] = data['train-ai'];
-    if (typeof data.commercial === 'boolean') snapshot.commercial = data.commercial;
-
-    return Object.keys(snapshot).length > 0 ? snapshot : null;
-  }
-
-  private async computeDigest(
-    snapshot: AIPrefSnapshot
-  ): Promise<{ alg: 'JCS-SHA256'; val: string }> {
-    // Simple canonicalization for digest
-    const canonical = JSON.stringify(snapshot, Object.keys(snapshot).sort());
-    const encoder = new TextEncoder();
-    const data = encoder.encode(canonical);
-
-    const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-    const hashArray = Array.from(new Uint8Array(hashBuffer));
-    const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+    const resolved = resolveSignals(entries);
+    const snapshot = entriesToSnapshot(resolved) ?? this.defaults;
+    const primary = resolved[0]?.source;
+    const source: AIPrefPolicy['source'] =
+      primary === 'content-usage-header'
+        ? 'header'
+        : primary === 'robots-txt'
+          ? 'robots'
+          : primary === 'tdmrep-json'
+            ? 'tdmrep'
+            : 'default';
 
     return {
-      alg: 'JCS-SHA256',
-      val: hashHex.substring(0, 12), // Truncated for brevity
+      status: 'active',
+      checked_at: checkedAt,
+      snapshot,
+      digest: await this.computeDigest(snapshot),
+      source,
     };
+  }
+
+  /**
+   * Compute a stable RFC 8785 JCS + SHA-256 digest of the snapshot. Returns a
+   * full 64-character lowercase hex string. The `alg` literal is retained as
+   * `JCS-SHA256` for API backward compat; the bytes match the canonical PEAC
+   * discipline (`@peac/crypto.jcsHash`).
+   */
+  private async computeDigest(snapshot: AIPrefSnapshot): Promise<AIPrefDigest> {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(snapshot).sort()) {
+      sorted[key] = (snapshot as Record<string, unknown>)[key];
+    }
+    const hex = await jcsHash(sorted);
+    return { alg: 'JCS-SHA256', val: hex };
   }
 }

--- a/packages/aipref/src/robots.test.js
+++ b/packages/aipref/src/robots.test.js
@@ -1,5 +1,10 @@
 /**
- * @peac/pref/robots - Test robots.txt parsing
+ * @peac/pref/robots - Legacy node:test smoke tests.
+ *
+ * v0.12.14+ facade defers parsing to @peac/mappings-content-signals. Full
+ * coverage lives in __tests__/facade.test.ts (vitest). These smoke tests
+ * keep the pre-existing `parseRobots` / `robotsToAIPref` surface exercised
+ * against the compiled dist/ output.
  */
 
 import { test } from 'node:test';
@@ -24,7 +29,11 @@ Disallow: /
   assert.strictEqual(rules[1].directives[0].value, '/');
 });
 
-test('robotsToAIPref - GPTBot disallow converts to no-train', () => {
+test('robotsToAIPref - GPTBot Disallow: / disables AI training', () => {
+  // GPTBot maps to the ai-training / ai-inference purposes in the canonical
+  // @peac/mappings-content-signals parser; the facade surfaces that as
+  // `train-ai: false` on the legacy AIPrefSnapshot. `crawl` is only set for
+  // search / tdm purposes, so it is not populated for GPTBot alone.
   const rules = [
     {
       userAgent: 'GPTBot',
@@ -33,20 +42,7 @@ test('robotsToAIPref - GPTBot disallow converts to no-train', () => {
   ];
 
   const snapshot = robotsToAIPref(rules);
-  assert.strictEqual(snapshot.crawl, false);
   assert.strictEqual(snapshot['train-ai'], false);
-});
-
-test('robotsToAIPref - wildcard allow converts to crawl-ok', () => {
-  const rules = [
-    {
-      userAgent: '*',
-      directives: [{ field: 'allow', value: '/' }],
-    },
-  ];
-
-  const snapshot = robotsToAIPref(rules);
-  assert.strictEqual(snapshot.crawl, true);
 });
 
 test('robotsToAIPref - no AI agents returns null', () => {

--- a/packages/aipref/src/robots.ts
+++ b/packages/aipref/src/robots.ts
@@ -1,65 +1,32 @@
 /**
- * @peac/pref/robots - Robots.txt parser with AIPREF bridge
- * Extracts AI-relevant directives from robots.txt
+ * @peac/pref/robots - DEPRECATED robots.txt parser with AIPREF bridge.
  *
- * IMPORTANT: robots.txt is NOT enforceable. The robotsToPeacStarter()
- * function is a MIGRATION HELPER, not a compliance tool. It generates
- * a starter PEAC policy that users should review and customize.
+ * @peac/pref is deprecated as of v0.12.14. This module is a thin, deprecated
+ * facade:
+ *   - `parseRobots` defers to @peac/mappings-content-signals robots parser.
+ *   - `robotsToAIPref` maps the content-signal result back into the legacy
+ *     AIPrefSnapshot shape for backward compat.
+ *   - `fetchRobots` is removed: parsing packages do not perform network I/O.
+ *     Callers supply pre-fetched content.
+ *   - `robotsToPeacStarter` is preserved as a one-way migration helper that
+ *     produces a starter `peac-policy/0.1` document from robots.txt bytes.
+ *
+ * Removal target: next cleanup release.
  */
 
+import { parseRobotsTxt as parseRobotsStructured } from '@peac/mappings-content-signals';
 import type { AIPrefSnapshot, RobotsRule } from './types.js';
 import type { PolicyDocument, PolicyRule } from '@peac/policy-kit';
 
-const VERSION = '0.9.15';
-const UA = `PEAC/${VERSION} (+https://www.peacprotocol.org)`;
-
-// SSRF protection: Check if hostname/IP is in private network range
-function isPrivateNetwork(hostname: string): boolean {
-  // Block localhost variants
-  if (['localhost', '127.0.0.1', '0.0.0.0', '::1'].includes(hostname)) {
-    return true;
-  }
-
-  // Block private IPv4 ranges (RFC 1918)
-  const ipv4Match = hostname.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
-  if (ipv4Match) {
-    const [, a, b, c, d] = ipv4Match.map(Number);
-
-    // 10.0.0.0/8
-    if (a === 10) return true;
-
-    // 172.16.0.0/12
-    if (a === 172 && b >= 16 && b <= 31) return true;
-
-    // 192.168.0.0/16
-    if (a === 192 && b === 168) return true;
-
-    // 169.254.0.0/16 (link-local)
-    if (a === 169 && b === 254) return true;
-
-    // 127.0.0.0/8 (loopback)
-    if (a === 127) return true;
-  }
-
-  // Block private IPv6 ranges
-  if (hostname.includes(':')) {
-    // ::1 already covered above
-    // fc00::/7 (unique local)
-    if (hostname.startsWith('fc') || hostname.startsWith('fd')) return true;
-
-    // fe80::/10 (link-local)
-    if (
-      hostname.startsWith('fe8') ||
-      hostname.startsWith('fe9') ||
-      hostname.startsWith('fea') ||
-      hostname.startsWith('feb')
-    )
-      return true;
-  }
-
-  return false;
-}
-
+/**
+ * Low-level robots.txt record parser used for the @peac/pref legacy shape.
+ * Retained for backward compat. For structured content-signal entries, call
+ * `parseRobotsTxt` from `@peac/mappings-content-signals` directly.
+ *
+ * @deprecated Retained to preserve the @peac/pref API. Use
+ * `@peac/mappings-content-signals.parseRobotsTxt` for RFC 9309-compliant
+ * parsing that produces typed `ContentSignalEntry[]`.
+ */
 export function parseRobots(content: string): RobotsRule[] {
   const rules: RobotsRule[] = [];
   const lines = content
@@ -79,10 +46,7 @@ export function parseRobots(content: string): RobotsRule[] {
 
     if (fieldLower === 'user-agent') {
       if (currentAgent && currentDirectives.length > 0) {
-        rules.push({
-          userAgent: currentAgent,
-          directives: currentDirectives,
-        });
+        rules.push({ userAgent: currentAgent, directives: currentDirectives });
       }
       currentAgent = value;
       currentDirectives = [];
@@ -92,116 +56,92 @@ export function parseRobots(content: string): RobotsRule[] {
   }
 
   if (currentAgent && currentDirectives.length > 0) {
-    rules.push({
-      userAgent: currentAgent,
-      directives: currentDirectives,
-    });
+    rules.push({ userAgent: currentAgent, directives: currentDirectives });
   }
 
   return rules;
 }
 
-export function robotsToAIPref(rules: RobotsRule[]): AIPrefSnapshot | null {
+/**
+ * Map robots.txt bytes to the legacy AIPrefSnapshot shape via the canonical
+ * content-signal resolver in `@peac/mappings-content-signals`. Preserved for
+ * backward compat of the @peac/pref API.
+ *
+ * @deprecated Use `@peac/mappings-content-signals.parseRobotsTxt` +
+ * `resolveSignals` directly. Removal target: next cleanup release.
+ */
+export function robotsToAIPref(rulesOrContent: RobotsRule[] | string): AIPrefSnapshot | null {
+  const content =
+    typeof rulesOrContent === 'string' ? rulesOrContent : rulesToRobotsText(rulesOrContent);
+  const entries = parseRobotsStructured(content);
   const snapshot: AIPrefSnapshot = {};
   let hasPrefs = false;
-
-  // Look for AI-related user agents and directives
-  const aiAgents = [
-    'gptbot',
-    'chatgpt-user',
-    'claude-web',
-    'anthropic-ai',
-    'openai',
-    'google-extended',
-  ];
-
-  for (const rule of rules) {
-    const ua = rule.userAgent.toLowerCase();
-    const isAiAgent = aiAgents.some((agent) => ua.includes(agent)) || ua === '*';
-
-    if (isAiAgent) {
-      for (const directive of rule.directives) {
-        // Map robots directives to AIPREF fields
-        switch (directive.field) {
-          case 'disallow':
-            if (directive.value === '/' || directive.value === '*') {
-              snapshot.crawl = false;
-              snapshot['train-ai'] = false;
-              hasPrefs = true;
-            }
-            break;
-          case 'allow':
-            if (directive.value === '/' || directive.value === '*') {
-              snapshot.crawl = true;
-              hasPrefs = true;
-            }
-            break;
-          case 'noai':
-            snapshot['train-ai'] = false;
-            hasPrefs = true;
-            break;
-          case 'nofollow':
-            snapshot.crawl = false;
-            hasPrefs = true;
-            break;
-        }
-      }
+  for (const entry of entries) {
+    if (entry.decision === 'unspecified') continue;
+    const allow = entry.decision === 'allow';
+    switch (entry.purpose) {
+      case 'ai-training':
+      case 'ai-generative':
+      case 'ai-inference':
+        if (snapshot['train-ai'] === undefined) snapshot['train-ai'] = allow;
+        hasPrefs = true;
+        break;
+      case 'ai-search':
+      case 'tdm':
+        if (snapshot.crawl === undefined) snapshot.crawl = allow;
+        hasPrefs = true;
+        break;
     }
   }
-
   return hasPrefs ? snapshot : null;
 }
 
-export async function fetchRobots(uri: string, timeout = 5000): Promise<string | null> {
-  try {
-    const url = new URL(uri);
-
-    // SSRF protection: Only allow HTTPS/HTTP schemes
-    if (!['https:', 'http:'].includes(url.protocol)) {
-      throw new Error('Invalid protocol: only https:// and http:// are allowed');
+function rulesToRobotsText(rules: RobotsRule[]): string {
+  const lines: string[] = [];
+  for (const rule of rules) {
+    lines.push(`User-agent: ${rule.userAgent}`);
+    for (const directive of rule.directives) {
+      lines.push(`${directive.field}: ${directive.value}`);
     }
-
-    // SSRF protection: Block private IP ranges and localhost
-    const hostname = url.hostname.toLowerCase();
-    if (isPrivateNetwork(hostname)) {
-      throw new Error('Access to private networks is not allowed');
-    }
-
-    const robotsUrl = new URL('/robots.txt', url.origin);
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeout);
-
-    const response = await fetch(robotsUrl.toString(), {
-      signal: controller.signal,
-      headers: { 'User-Agent': UA },
-    });
-
-    clearTimeout(timeoutId);
-
-    if (!response.ok) return null;
-    return await response.text();
-  } catch {
-    return null;
+    lines.push('');
   }
+  return lines.join('\n');
 }
 
 /**
- * Result of converting robots.txt to PEAC policy starter
+ * @deprecated v0.12.14 facade does not perform network I/O. Parsing packages
+ * take pre-fetched content only. Fetch robots.txt in the caller (subject to
+ * the caller's SSRF / redirect / timeout policy) and pass the bytes to
+ * `parseRobots`, `robotsToAIPref`, or the RFC-compliant
+ * `@peac/mappings-content-signals.parseRobotsTxt`. Removal target: next
+ * cleanup release.
+ */
+export function fetchRobots(_uri: string, _timeout?: number): Promise<string | null> {
+  const err = new Error(
+    '@peac/pref fetchRobots() was removed in v0.12.14: parsing packages do not ' +
+      'perform network I/O. Fetch robots.txt in the caller and pass the bytes to ' +
+      'parseRobots() / robotsToAIPref() / @peac/mappings-content-signals.parseRobotsTxt().'
+  );
+  (err as Error & { code?: string }).code = 'PEAC_DEPRECATED_PREF_NETWORK';
+  return Promise.reject(err);
+}
+
+/**
+ * Result of converting robots.txt to a PEAC policy starter.
  */
 export interface RobotsToPeacResult {
-  /** Generated starter policy document */
+  /** Generated starter policy document. */
   policy: PolicyDocument;
-  /** Advisory notes about the conversion */
+  /** Advisory notes about the conversion. */
   notes: string[];
-  /** User agents that were processed */
+  /** User agents that were processed. */
   processedAgents: string[];
-  /** Whether any AI-related restrictions were found */
+  /** Whether any AI-related restrictions were found. */
   hasAiRestrictions: boolean;
 }
 
 /**
- * Known AI crawler user agents
+ * Known AI crawler user agents.
  */
 const AI_CRAWLER_AGENTS = [
   'gptbot',
@@ -221,37 +161,14 @@ const AI_CRAWLER_AGENTS = [
 ] as const;
 
 /**
- * Convert robots.txt content to a PEAC policy starter document.
+ * Convert robots.txt content to a `peac-policy/0.1` starter document.
  *
- * ADVISORY ONLY: This is a migration helper, not a compliance tool.
- * The generated policy is a starting point that users MUST review
- * and customize for their specific needs.
+ * ADVISORY ONLY: a migration helper, not a compliance tool. Generated output
+ * is a starting point that operators MUST review and customize.
  *
- * Limitations:
- * - robots.txt is less expressive than PEAC policies
- * - Path-specific rules are simplified to domain-level
- * - Crawl-delay and sitemap directives are noted but not mapped
- * - This is a ONE-WAY import, not round-trippable
- *
- * @param robotsContent - Raw robots.txt content
- * @returns Starter policy document with advisory notes
- *
- * @example
- * ```typescript
- * const result = robotsToPeacStarter(`
- * User-agent: GPTBot
- * Disallow: /
- *
- * User-agent: *
- * Allow: /
- * `);
- *
- * console.log(result.policy);
- * // PolicyDocument with rules denying GPTBot access
- *
- * console.log(result.notes);
- * // Advisory notes about the conversion
- * ```
+ * Limitations: robots.txt is less expressive than PEAC policies; path-specific
+ * rules are simplified to domain-level; crawl-delay and sitemap directives are
+ * noted but not mapped; one-way (not round-trippable).
  */
 export function robotsToPeacStarter(robotsContent: string): RobotsToPeacResult {
   const rules = parseRobots(robotsContent);
@@ -260,26 +177,21 @@ export function robotsToPeacStarter(robotsContent: string): RobotsToPeacResult {
   const policyRules: PolicyRule[] = [];
   let hasAiRestrictions = false;
 
-  // Advisory header note
   notes.push(
     'ADVISORY: This policy was generated from robots.txt and is for migration purposes only.'
   );
   notes.push('Review and customize this policy before using in production.');
 
-  // Process each rule
   for (const rule of rules) {
     const ua = rule.userAgent.toLowerCase();
     processedAgents.push(rule.userAgent);
 
-    // Check if this is an AI-related agent
     const isAiAgent = AI_CRAWLER_AGENTS.some((agent) => ua.includes(agent));
     const isWildcard = ua === '*';
 
-    // Analyze directives for this agent
     let hasDisallowAll = false;
     let hasAllowAll = false;
     let hasPartialRules = false;
-    let hasCrawlDelay = false;
 
     for (const directive of rule.directives) {
       switch (directive.field) {
@@ -298,7 +210,6 @@ export function robotsToPeacStarter(robotsContent: string): RobotsToPeacResult {
           }
           break;
         case 'crawl-delay':
-          hasCrawlDelay = true;
           notes.push(
             `Note: Crawl-delay for ${rule.userAgent} (${directive.value}s) not mapped - consider rate limits.`
           );
@@ -309,29 +220,23 @@ export function robotsToPeacStarter(robotsContent: string): RobotsToPeacResult {
       }
     }
 
-    // Generate policy rules for AI agents
     if (isAiAgent) {
       if (hasDisallowAll) {
         hasAiRestrictions = true;
         policyRules.push({
           name: `deny-${ua.replace(/[^a-z0-9]/g, '-')}`,
-          subject: {
-            labels: [ua],
-          },
+          subject: { labels: [ua] },
           decision: 'deny',
           reason: `Converted from robots.txt: Disallow / for ${rule.userAgent}`,
         });
       } else if (hasAllowAll) {
         policyRules.push({
           name: `allow-${ua.replace(/[^a-z0-9]/g, '-')}`,
-          subject: {
-            labels: [ua],
-          },
+          subject: { labels: [ua] },
           decision: 'allow',
           reason: `Converted from robots.txt: Allow for ${rule.userAgent}`,
         });
       }
-
       if (hasPartialRules) {
         notes.push(
           `Warning: Path-specific rules for ${rule.userAgent} simplified to domain-level.`
@@ -339,17 +244,12 @@ export function robotsToPeacStarter(robotsContent: string): RobotsToPeacResult {
       }
     }
 
-    // Handle wildcard rules that affect AI crawlers
     if (isWildcard && hasDisallowAll) {
       hasAiRestrictions = true;
       notes.push('Note: Wildcard Disallow: / detected. Consider if this applies to all AI agents.');
-
-      // Add a catch-all deny rule for AI crawlers (lower priority)
       policyRules.push({
         name: 'deny-all-crawlers-wildcard',
-        subject: {
-          type: 'agent',
-        },
+        subject: { type: 'agent' },
         purpose: 'index',
         decision: 'deny',
         reason: 'Converted from robots.txt: Wildcard Disallow: /',
@@ -357,14 +257,12 @@ export function robotsToPeacStarter(robotsContent: string): RobotsToPeacResult {
     }
   }
 
-  // If no AI-specific rules found, add a note
   if (policyRules.length === 0) {
     notes.push(
       'No AI-specific restrictions found in robots.txt. Generated minimal starter policy.'
     );
   }
 
-  // Build the policy document
   const policy: PolicyDocument = {
     version: 'peac-policy/0.1',
     name: 'Policy generated from robots.txt',
@@ -375,10 +273,5 @@ export function robotsToPeacStarter(robotsContent: string): RobotsToPeacResult {
     rules: policyRules,
   };
 
-  return {
-    policy,
-    notes,
-    processedAgents,
-    hasAiRestrictions,
-  };
+  return { policy, notes, processedAgents, hasAiRestrictions };
 }

--- a/packages/aipref/src/types.ts
+++ b/packages/aipref/src/types.ts
@@ -1,5 +1,10 @@
 /**
- * @peac/pref/types - AIPREF types with robots.txt bridge
+ * @peac/pref/types - AIPREF types with robots.txt bridge.
+ *
+ * @deprecated @peac/pref is deprecated. Use @peac/mappings-content-signals
+ * directly for RFC 8941/9651 Structured-Fields `Content-Usage` parsing,
+ * RFC 9309 robots.txt parsing, tdmrep parsing, and `resolveSignals()`.
+ * Removal target: next cleanup release.
  */
 
 export interface AIPrefSnapshot {
@@ -9,13 +14,27 @@ export interface AIPrefSnapshot {
   [key: string]: boolean | undefined;
 }
 
+/**
+ * Digest of an AIPrefSnapshot.
+ *
+ * Pre-v0.12.14: `val` was a truncated 12-character hex string (fake "JCS-SHA256").
+ * v0.12.14+: `val` is a full 64-character hex string of the RFC 8785 JCS
+ * canonicalization + SHA-256 (canonical PEAC discipline). The `alg` literal is
+ * retained for backward-compat of the `AIPrefPolicy` shape; new consumers
+ * should prefer the lowercase `sha-256` scheme from @peac/mappings-content-signals.
+ */
+export interface AIPrefDigest {
+  alg: 'JCS-SHA256';
+  val: string;
+}
+
 export interface AIPrefPolicy {
   status: 'active' | 'not_found' | 'error' | 'not_applicable';
   checked_at: string;
   snapshot?: AIPrefSnapshot;
-  digest?: { alg: 'JCS-SHA256'; val: string };
+  digest?: AIPrefDigest;
   reason?: string;
-  source?: 'header' | 'aipref' | 'peac' | 'robots' | 'default';
+  source?: 'header' | 'aipref' | 'peac' | 'robots' | 'tdmrep' | 'default';
 }
 
 export interface RobotsRule {
@@ -26,14 +45,32 @@ export interface RobotsRule {
   }>;
 }
 
+/**
+ * @deprecated v0.12.14 facade does not maintain an internal source registry.
+ * This type is retained to preserve the @peac/pref public API shape for one
+ * minor. Removal target: next cleanup release.
+ */
 export interface PrefSource {
   priority: number;
   name: string;
   fetch(uri: string): Promise<AIPrefSnapshot | null>;
 }
 
+/**
+ * Context for resolving AI preferences. Callers MUST pass pre-fetched content
+ * via the optional fields; the v0.12.14+ facade does not perform network I/O.
+ */
 export interface ResolveContext {
   uri: string;
   headers?: Record<string, string>;
+  /** Pre-fetched robots.txt bytes, if available. */
+  robotsTxt?: string;
+  /** Pre-fetched tdmrep.json bytes, if available. */
+  tdmrep?: string;
+  /**
+   * @deprecated Retained for API compatibility; ignored by the v0.12.14+
+   * facade. Set an outer `AbortSignal` on the fetch that provides
+   * `robotsTxt` / `tdmrep` instead.
+   */
   timeout?: number;
 }

--- a/packages/aipref/vitest.config.ts
+++ b/packages/aipref/vitest.config.ts
@@ -5,5 +5,9 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['__tests__/**/*.test.ts'],
+    // Suppress expected PEAC_DEPRECATED_* warnings so CI output stays
+    // readable. The deprecation contract is covered by a dedicated
+    // assertion test in facade.test.ts.
+    setupFiles: ['./__tests__/vitest.setup.ts'],
   },
 });

--- a/packages/cli/src/commands/discover.ts
+++ b/packages/cli/src/commands/discover.ts
@@ -1,6 +1,10 @@
 /**
  * peac discover <url> command
- * Thin wrapper around @peac/disc for discovery
+ * Thin wrapper around @peac/disc for peac.txt policy-document discovery.
+ *
+ * peac.txt is a policy-document surface per docs/specs/PEAC-TXT.md.
+ * For cryptographic key discovery, callers should use
+ * /.well-known/peac-issuer.json (see docs/specs/PEAC-ISSUER.md).
  */
 
 import { discover } from '@peac/disc';
@@ -19,15 +23,17 @@ export class DiscoverCommand {
 
       const discoveryResult = await discover(url);
 
-      // Assert peac.txt ≤ 20 lines if present
-      if (discoveryResult?.data) {
-        // The discover function from @peac/disc returns a ParseResult
-        // We'll just validate line count if needed at the API level
+      const hints: string[] = [];
+      if (discoveryResult?.warnings && discoveryResult.warnings.length > 0) {
+        hints.push(
+          'peac.txt is a policy-document surface (docs/specs/PEAC-TXT.md). ' +
+            'For key discovery, use /.well-known/peac-issuer.json (docs/specs/PEAC-ISSUER.md).'
+        );
       }
 
       return {
         success: true,
-        data: discoveryResult,
+        data: hints.length > 0 ? { ...discoveryResult, hints } : discoveryResult,
         timing: timer.end(),
       };
     } catch (error) {

--- a/packages/discovery/README.md
+++ b/packages/discovery/README.md
@@ -1,6 +1,6 @@
 # @peac/disc
 
-PEAC issuer discovery: ABNF-compliant `.well-known/peac.txt` parser, generator, and remote fetcher.
+Thin loader / validator and remote fetcher for `peac.txt` policy documents.
 
 ## Installation
 
@@ -10,37 +10,65 @@ pnpm add @peac/disc
 
 ## What It Does
 
-`@peac/disc` parses and generates `.well-known/peac.txt` discovery documents that allow verifiers to find an issuer's public keys and policy information. It enforces the normative 20-line limit, validates document structure against the ABNF grammar, and provides a convenience `discover()` function for remote resolution.
+`@peac/disc` is a thin wrapper around
+[`@peac/policy-kit`](../policy-kit) specialized for the `peac.txt`
+discovery surface. It:
+
+- fetches `/.well-known/peac.txt` with `discover(origin)`,
+- delegates parsing of `peac-policy/0.1` YAML / JSON bytes to
+  `@peac/policy-kit.parsePolicyDocument`,
+- returns a tolerant `ParseResult` (rather than throwing) that carries a
+  validated `PolicyDocument`, error messages, and advisory warnings,
+- tolerates legacy key-discovery lines (`verify:`, `public_keys:`, `jwks:`)
+  in older example documents by stripping them before validation and
+  surfacing a structured `PEAC_LEGACY_PEAC_TXT_KEY_FIELD`
+  `DeprecationWarning`.
+
+`peac.txt` is the **policy-document surface** per
+`docs/specs/PEAC-TXT.md`. It is **not** a key discovery surface.
+Cryptographic key resolution uses the normative chain
+`iss` -> `/.well-known/peac-issuer.json` -> `jwks_uri` -> JWKS (see
+`docs/specs/PEAC-ISSUER.md`). For that flow, use `parseIssuerConfig` /
+`fetchIssuerConfig` from `@peac/protocol`.
 
 ## How Do I Use It?
 
-### Parse a discovery document
+### Parse a policy document
 
 ```typescript
-import { parse, validate } from '@peac/disc';
+import { parse } from '@peac/disc';
 
 const result = parse(`
-version: peac/0.1
-issuer: https://example.com
-jwks: https://example.com/.well-known/jwks.json
+version: 'peac-policy/0.1'
+defaults:
+  decision: deny
+rules:
+  - name: allow-verified-agents
+    subject:
+      type: agent
+      labels: [verified]
+    purpose: inference
+    decision: allow
 `);
 
 if (result.valid) {
-  console.log(result.discovery.issuer); // 'https://example.com'
+  console.log(result.data?.version); // 'peac-policy/0.1'
+  console.log(result.data?.rules[0].decision); // 'allow'
+}
+
+if (result.warnings) {
+  // e.g. legacy key-discovery lines were stripped on parse
+  console.warn(result.warnings);
 }
 ```
 
-### Generate a discovery document
+### Emit a policy document as YAML
 
 ```typescript
 import { emit } from '@peac/disc';
+import { createExamplePolicy } from '@peac/policy-kit';
 
-const txt = emit({
-  version: 'peac/0.1',
-  issuer: 'https://example.com',
-  jwks_uri: 'https://example.com/.well-known/jwks.json',
-});
-
+const yaml = emit(createExamplePolicy());
 // Serve at /.well-known/peac.txt
 ```
 
@@ -51,25 +79,30 @@ import { discover, WELL_KNOWN_PATH } from '@peac/disc';
 
 const result = await discover('https://example.com');
 if (result.valid) {
-  console.log(result.discovery);
+  console.log(result.data);
 }
-
 console.log(WELL_KNOWN_PATH); // '/.well-known/peac.txt'
 ```
 
+The caller's user-agent is taken from the `PEAC_USER_AGENT` environment
+variable when present; otherwise `peac-disc` is used. `@peac/disc` does
+not hard-code a package version in the user-agent (runtime-visible
+version constants belong in release tooling).
+
+## Limits
+
+Per `docs/specs/PEAC-TXT.md` §6.1, remote documents larger than
+**256 KiB** are rejected by `discover()`. Nesting depth, array length,
+and string length limits are enforced by the underlying
+`@peac/policy-kit` validator.
+
 ## Integrates With
 
-- `@peac/policy-kit`: Policy compilation generates `peac.txt` artifacts
-- `@peac/protocol` (Layer 3): Issuer resolution during receipt verification
-- `@peac/jwks-cache`: Fetches JWKS from the URI discovered via `peac.txt`
-
-## For Agent Developers
-
-If you are building an AI agent or MCP server that needs evidence receipts:
-
-- Start with [`@peac/mcp-server`](https://www.npmjs.com/package/@peac/mcp-server) for a ready-to-use MCP tool server
-- Use `@peac/protocol` for programmatic receipt issuance and verification
-- See the [llms.txt](https://github.com/peacprotocol/peac/blob/main/llms.txt) for a concise overview
+- `@peac/policy-kit`: canonical compiler / parser / evaluator for
+  `peac-policy/0.1` documents. `@peac/disc.parse` delegates to
+  `@peac/policy-kit.parsePolicyDocument`.
+- `@peac/protocol`: `parseIssuerConfig` / `fetchIssuerConfig` for the
+  normative key-discovery chain.
 
 ## License
 
@@ -77,6 +110,7 @@ Apache-2.0
 
 ---
 
-PEAC Protocol is an open source project stewarded by Originary and community contributors.
+PEAC Protocol is an open source project stewarded by Originary and community
+contributors.
 
 [Docs](https://www.peacprotocol.org) | [GitHub](https://github.com/peacprotocol/peac) | [Originary](https://www.originary.xyz)

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@peac/disc",
   "version": "0.12.13",
-  "description": "PEAC discovery with ≤20 lines enforcement",
+  "description": "Thin loader / validator and remote fetcher for peac.txt policy documents (peac-policy/0.1; docs/specs/PEAC-TXT.md)",
   "type": "module",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",
@@ -29,7 +29,9 @@
     "typecheck": "tsc --noEmit",
     "build:js": "tsup"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@peac/policy-kit": "workspace:*"
+  },
   "devDependencies": {
     "typescript": "^5.0.0",
     "tsup": "^8.0.0"

--- a/packages/discovery/src/index.ts
+++ b/packages/discovery/src/index.ts
@@ -1,24 +1,53 @@
 /**
- * @peac/disc - PEAC discovery with ≤20 lines enforcement
- * ABNF-compliant .well-known/peac.txt parser and generator
+ * @peac/disc - thin peac.txt policy-document loader/validator and remote fetcher.
+ *
+ * peac.txt is a POLICY DOCUMENT surface per docs/specs/PEAC-TXT.md. Full
+ * parsing is delegated to `@peac/policy-kit.parsePolicyDocument`; this
+ * package provides a tolerant `parse()` wrapper, a `discover()` remote
+ * fetcher, and structured warnings for legacy key-discovery lines that
+ * appeared in older peac.txt examples.
+ *
+ * `peac.txt` is NOT a key discovery surface. Cryptographic key resolution
+ * flows through `iss` -> /.well-known/peac-issuer.json -> `jwks_uri` -> JWKS
+ * (docs/specs/PEAC-ISSUER.md). Callers that need key material MUST use
+ * `parseIssuerConfig` / `fetchIssuerConfig` from `@peac/protocol`.
+ *
+ * Legacy key-discovery lines (`verify:`, `public_keys:`, `jwks:`) are
+ * tolerated on parse: they are stripped before validation, surfaced on
+ * `ParseResult.warnings`, and fire a structured `process.emitWarning`
+ * with code `PEAC_LEGACY_PEAC_TXT_KEY_FIELD` once per process.
  */
 
-export { parse, emit, validate } from './parser.js';
-export type { PeacDiscovery, PublicKeyInfo, ParseResult, ValidationOptions } from './types.js';
+export { parse, emit, validate, __resetLegacyWarningForTests } from './parser.js';
+export type { ParseResult, ValidationOptions, PolicyDocument } from './types.js';
 
-// Constants
-export const VERSION = '0.9.15';
-export const MAX_LINES = 20;
+/**
+ * @deprecated Retained for one minor to keep existing import paths
+ * compiling. peac.txt policy documents now resolve to a `PolicyDocument`
+ * (re-exported from `@peac/policy-kit`). Removal target: next cleanup
+ * release.
+ */
+export type { PeacDiscovery, PublicKeyInfo } from './types.js';
+
+export const MAX_BYTES = 262144; // 256 KiB, per docs/specs/PEAC-TXT.md §6.1
 export const WELL_KNOWN_PATH = '/.well-known/peac.txt';
 
-const UA = `PEAC/${VERSION} (+https://www.peacprotocol.org)`;
-
-// Convenience function for fetching and parsing discovery documents
+/**
+ * Fetch and parse a remote peac.txt policy document. On success returns a
+ * `ParseResult` whose `data` is the validated `peac-policy/0.1`
+ * `PolicyDocument`. Legacy key-discovery lines in the fetched bytes are
+ * surfaced as warnings but never populate `data`.
+ *
+ * Callers supply the user-agent via the `PEAC_USER_AGENT` environment
+ * variable if needed; this package does not hard-code a version string
+ * (that belongs in release-prep metadata, not a feature package).
+ */
 export async function discover(origin: string): Promise<import('./types.js').ParseResult> {
   try {
     const url = new URL(WELL_KNOWN_PATH, origin);
+    const ua = (typeof process !== 'undefined' && process.env?.PEAC_USER_AGENT) || 'peac-disc';
     const response = await fetch(url.toString(), {
-      headers: { 'User-Agent': UA },
+      headers: { 'User-Agent': ua },
     });
 
     if (!response.ok) {
@@ -29,6 +58,12 @@ export async function discover(origin: string): Promise<import('./types.js').Par
     }
 
     const content = await response.text();
+    if (content.length > MAX_BYTES) {
+      return {
+        valid: false,
+        errors: [`peac.txt exceeds ${MAX_BYTES} bytes (got ${content.length})`],
+      };
+    }
     const { parse } = await import('./parser.js');
     return parse(content);
   } catch (error) {

--- a/packages/discovery/src/index.ts
+++ b/packages/discovery/src/index.ts
@@ -31,23 +31,105 @@ export type { PeacDiscovery, PublicKeyInfo } from './types.js';
 
 export const MAX_BYTES = 262144; // 256 KiB, per docs/specs/PEAC-TXT.md §6.1
 export const WELL_KNOWN_PATH = '/.well-known/peac.txt';
+export const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_USER_AGENT = 'peac-disc';
+
+/**
+ * Minimal fetch signature accepted by `discover`. `undici` / `node-fetch` /
+ * browser / test-double implementations all satisfy this.
+ */
+export type DiscoverFetch = (
+  input: string,
+  init?: {
+    headers?: Record<string, string>;
+    signal?: AbortSignal;
+    redirect?: 'follow' | 'error' | 'manual';
+  }
+) => Promise<{
+  ok: boolean;
+  status: number;
+  statusText: string;
+  text(): Promise<string>;
+}>;
+
+export interface DiscoverOptions {
+  /**
+   * HTTP fetch implementation. Defaults to the ambient `fetch` global.
+   * Supply `undici.fetch`, a test double, or a policy-wrapping client as
+   * needed.
+   */
+  fetchImpl?: DiscoverFetch;
+  /**
+   * User-agent string. Precedence (highest first): this option, the
+   * `PEAC_USER_AGENT` environment variable, then `peac-disc`.
+   */
+  userAgent?: string;
+  /** Caller-supplied abort signal. */
+  signal?: AbortSignal;
+  /**
+   * Millisecond timeout. Ignored when `signal` is supplied (the caller
+   * owns cancellation). Defaults to 5_000 when neither is provided.
+   */
+  timeoutMs?: number;
+  /** Override the 256 KiB body cap from docs/specs/PEAC-TXT.md §6.1. */
+  maxBytes?: number;
+  /**
+   * Redirect policy. Defaults to `error` to avoid cross-origin surprise
+   * on a well-known discovery endpoint; set to `follow` explicitly if the
+   * deployment relies on server-side redirects.
+   */
+  redirect?: 'follow' | 'error' | 'manual';
+}
 
 /**
  * Fetch and parse a remote peac.txt policy document. On success returns a
  * `ParseResult` whose `data` is the validated `peac-policy/0.1`
  * `PolicyDocument`. Legacy key-discovery lines in the fetched bytes are
  * surfaced as warnings but never populate `data`.
- *
- * Callers supply the user-agent via the `PEAC_USER_AGENT` environment
- * variable if needed; this package does not hard-code a version string
- * (that belongs in release-prep metadata, not a feature package).
  */
-export async function discover(origin: string): Promise<import('./types.js').ParseResult> {
+export async function discover(
+  origin: string,
+  options: DiscoverOptions = {}
+): Promise<import('./types.js').ParseResult> {
+  const fetchImpl = (options.fetchImpl ?? (globalThis as { fetch?: DiscoverFetch }).fetch) as
+    | DiscoverFetch
+    | undefined;
+  if (typeof fetchImpl !== 'function') {
+    return {
+      valid: false,
+      errors: [
+        'Discovery failed: no fetch implementation available (supply options.fetchImpl or provide a global fetch)',
+      ],
+    };
+  }
+
+  const envUa =
+    typeof process !== 'undefined' && typeof process.env === 'object'
+      ? process.env.PEAC_USER_AGENT
+      : undefined;
+  const userAgent = options.userAgent ?? envUa ?? DEFAULT_USER_AGENT;
+  const maxBytes = options.maxBytes ?? MAX_BYTES;
+  const redirect = options.redirect ?? 'error';
+
+  // If the caller did not supply an AbortSignal, install a local one driven by timeoutMs.
+  let localController: AbortController | undefined;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let signal = options.signal;
+  if (!signal) {
+    localController = new AbortController();
+    signal = localController.signal;
+    const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    if (timeoutMs > 0 && Number.isFinite(timeoutMs)) {
+      timer = setTimeout(() => localController?.abort(), timeoutMs);
+    }
+  }
+
   try {
     const url = new URL(WELL_KNOWN_PATH, origin);
-    const ua = (typeof process !== 'undefined' && process.env?.PEAC_USER_AGENT) || 'peac-disc';
-    const response = await fetch(url.toString(), {
-      headers: { 'User-Agent': ua },
+    const response = await fetchImpl(url.toString(), {
+      headers: { 'User-Agent': userAgent },
+      signal,
+      redirect,
     });
 
     if (!response.ok) {
@@ -58,10 +140,10 @@ export async function discover(origin: string): Promise<import('./types.js').Par
     }
 
     const content = await response.text();
-    if (content.length > MAX_BYTES) {
+    if (content.length > maxBytes) {
       return {
         valid: false,
-        errors: [`peac.txt exceeds ${MAX_BYTES} bytes (got ${content.length})`],
+        errors: [`peac.txt exceeds ${maxBytes} bytes (got ${content.length})`],
       };
     }
     const { parse } = await import('./parser.js');
@@ -71,5 +153,7 @@ export async function discover(origin: string): Promise<import('./types.js').Par
       valid: false,
       errors: [`Discovery failed: ${error instanceof Error ? error.message : String(error)}`],
     };
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }

--- a/packages/discovery/src/parser.test.js
+++ b/packages/discovery/src/parser.test.js
@@ -1,91 +1,81 @@
 /**
- * @peac/disc/parser - Test peac.txt parsing with ≤20 lines enforcement
+ * @peac/disc/parser - Legacy node:test smoke tests (runs against dist/).
+ *
+ * v0.12.14+: @peac/disc is a thin loader over peac-policy/0.1 via
+ * @peac/policy-kit. Full coverage lives in tests/parser.test.ts (vitest).
  */
 
 import { test } from 'node:test';
 import assert from 'node:assert';
 import { parse, emit, validate } from '../dist/index.js';
 
-test('parse - minimal valid peac.txt', () => {
-  const content = `verify: https://example.com/peac/verify`;
+const VALID_YAML_POLICY = [
+  "version: 'peac-policy/0.1'",
+  'defaults:',
+  '  decision: deny',
+  'rules:',
+  '  - name: allow-verified',
+  '    subject: { type: agent, labels: [verified] }',
+  '    decision: allow',
+].join('\n');
 
+const VALID_JSON_POLICY = JSON.stringify({
+  version: 'peac-policy/0.1',
+  defaults: { decision: 'allow' },
+  rules: [{ name: 'allow-everyone', decision: 'allow' }],
+});
+
+test('parse - valid YAML peac-policy/0.1', () => {
+  const result = parse(VALID_YAML_POLICY);
+  assert.strictEqual(result.valid, true);
+  assert.strictEqual(result.data.version, 'peac-policy/0.1');
+  assert.strictEqual(result.data.defaults.decision, 'deny');
+  assert.strictEqual(result.data.rules.length, 1);
+});
+
+test('parse - valid JSON peac-policy/0.1', () => {
+  const result = parse(VALID_JSON_POLICY);
+  assert.strictEqual(result.valid, true);
+  assert.strictEqual(result.data.rules[0].decision, 'allow');
+});
+
+test('parse - rejects empty input', () => {
+  const result = parse('');
+  assert.strictEqual(result.valid, false);
+  assert(result.errors[0].includes('Empty policy document'));
+});
+
+test('parse - rejects missing version', () => {
+  const result = parse('defaults:\n  decision: deny\nrules: []\n');
+  assert.strictEqual(result.valid, false);
+});
+
+test('parse - strips legacy verify line with structured warning', () => {
+  const content = 'verify: https://api.example.com/verify\n' + VALID_YAML_POLICY;
   const result = parse(content);
   assert.strictEqual(result.valid, true);
-  assert.strictEqual(result.data.verify, 'https://example.com/peac/verify');
-  assert.strictEqual(result.lineCount, 1);
+  assert(Array.isArray(result.warnings));
+  assert(result.warnings.some((w) => w.includes('legacy key-discovery field "verify" ignored')));
 });
 
-test('parse - full peac.txt within line limit', () => {
-  const content = `
-preferences: https://example.com/.well-known/aipref.json
-access_control: http-402
-payments: ["l402", "x402", "stripe"]
-provenance: c2pa
-receipts: required
-verify: https://example.com/peac/verify
-public_keys: ["test-key-001:EdDSA:11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"]
-  `.trim();
-
+test('parse - strips legacy public_keys line with structured warning', () => {
+  const content = 'public_keys: ["k:EdDSA:a"]\n' + VALID_YAML_POLICY;
   const result = parse(content);
   assert.strictEqual(result.valid, true);
-  assert.strictEqual(result.data.preferences, 'https://example.com/.well-known/aipref.json');
-  assert.strictEqual(result.data.access_control, 'http-402');
-  assert.deepStrictEqual(result.data.payments, ['l402', 'x402', 'stripe']);
-  assert.strictEqual(result.data.provenance, 'c2pa');
-  assert.strictEqual(result.data.receipts, 'required');
-  assert.strictEqual(result.lineCount, 7);
+  assert(
+    result.warnings.some((w) => w.includes('legacy key-discovery field "public_keys" ignored'))
+  );
 });
 
-test('parse - line limit enforcement', () => {
-  const lines = Array(25).fill('verify: https://example.com/peac/verify');
-  const content = lines.join('\n');
-
-  const result = parse(content);
-  assert.strictEqual(result.valid, false);
-  assert.strictEqual(result.lineCount, 25);
-  assert(result.errors[0].includes('Line limit exceeded'));
+test('emit - round-trip', () => {
+  const original = parse(VALID_YAML_POLICY).data;
+  const emitted = emit(original);
+  const reparsed = parse(emitted);
+  assert.strictEqual(reparsed.valid, true);
+  assert.deepStrictEqual(reparsed.data, original);
 });
 
-test('parse - missing required verify field', () => {
-  const content = `preferences: https://example.com/.well-known/aipref.json`;
-
-  const result = parse(content);
-  assert.strictEqual(result.valid, false);
-  assert(result.errors.some((e) => e.includes('Missing required field: verify')));
-});
-
-test('parse - invalid line format', () => {
-  const content = `
-verify: https://example.com/peac/verify
-invalid-line-without-colon
-  `.trim();
-
-  const result = parse(content);
-  assert.strictEqual(result.valid, false);
-  assert(result.errors.some((e) => e.includes('Invalid format')));
-});
-
-test('emit - generates valid peac.txt', () => {
-  const data = {
-    verify: 'https://example.com/peac/verify',
-    payments: ['x402', 'stripe'],
-    receipts: 'required',
-  };
-
-  const content = emit(data);
-  assert(content.includes('verify: https://example.com/peac/verify'));
-  assert(content.includes('payments: ["x402", "stripe"]'));
-  assert(content.includes('receipts: required'));
-
-  // Roundtrip test
-  const result = parse(content);
-  assert.strictEqual(result.valid, true);
-});
-
-test('validate - convenience function', () => {
-  const validContent = `verify: https://example.com/peac/verify`;
-  const invalidContent = `invalid-format`;
-
-  assert.strictEqual(validate(validContent), true);
-  assert.strictEqual(validate(invalidContent), false);
+test('validate - convenience', () => {
+  assert.strictEqual(validate(VALID_YAML_POLICY), true);
+  assert.strictEqual(validate('not-a-policy'), false);
 });

--- a/packages/discovery/src/parser.ts
+++ b/packages/discovery/src/parser.ts
@@ -79,61 +79,83 @@ function collectLegacyWarnings(text: string): { warnings: string[]; firstField: 
  * `peac-policy/0.1` `PolicyDocument`.
  *
  * Legacy key-discovery lines (`verify:`, `public_keys:`, `jwks:`) are
- * stripped before policy-doc validation, listed in `warnings`, and surface
- * a structured `PEAC_LEGACY_PEAC_TXT_KEY_FIELD` `DeprecationWarning` once
- * per process. They never populate the parsed result.
+ * tolerated via a two-pass strategy: first the raw bytes are handed to
+ * `parsePolicyDocument`; if validation fails AND top-level legacy lines
+ * are present, the legacy lines are stripped and parsing is retried
+ * once. Detected legacy lines are listed in `warnings` and surface a
+ * structured `PEAC_LEGACY_PEAC_TXT_KEY_FIELD` `DeprecationWarning` once
+ * per process. They never populate the parsed result. This preserves
+ * the original bytes when a policy document happens to mention those
+ * tokens inside comments, block scalars, or rule text.
  */
 export function parse(text: string): ParseResult {
   const warnings: string[] = [];
 
-  // Advisory: pre-scan for legacy key-discovery lines and strip them so the
-  // underlying policy-doc validator does not fail on unknown fields. Legacy
-  // lines never affect the parsed result.
-  let body = text;
-  if (LEGACY_KEY_LINE.test(text)) {
-    const legacy = collectLegacyWarnings(text);
-    warnings.push(...legacy.warnings);
-    if (legacy.firstField) fireLegacyWarning(legacy.firstField);
-    body = text.replace(LEGACY_KEY_FULL_LINE_GLOBAL, '');
-  }
-
-  const trimmed = body.trim();
-  if (trimmed.length === 0) {
+  if (text.trim().length === 0) {
     return {
       valid: false,
       errors: ['Empty policy document. Expected peac-policy/0.1 YAML or JSON.'],
-      warnings: warnings.length > 0 ? warnings : undefined,
     };
   }
 
-  let data: PolicyDocument;
+  const hasLegacyLines = LEGACY_KEY_LINE.test(text);
+
+  // First pass: try the raw bytes. If they parse cleanly, legacy-looking
+  // substrings inside block scalars / comments / rule text are not
+  // mutated.
   try {
-    data = parsePolicyDocument(body);
-  } catch (err) {
-    if (err instanceof PolicyValidationError) {
-      return {
-        valid: false,
-        errors: [err.message],
-        warnings: warnings.length > 0 ? warnings : undefined,
-      };
-    }
-    if (err instanceof PolicyLoadError) {
-      return {
-        valid: false,
-        errors: [err.message],
-        warnings: warnings.length > 0 ? warnings : undefined,
-      };
+    const data = parsePolicyDocument(text);
+    if (hasLegacyLines) {
+      const legacy = collectLegacyWarnings(text);
+      warnings.push(...legacy.warnings);
+      if (legacy.firstField) fireLegacyWarning(legacy.firstField);
     }
     return {
+      valid: true,
+      data,
+      warnings: warnings.length > 0 ? warnings : undefined,
+    };
+  } catch (firstErr) {
+    if (!hasLegacyLines) {
+      return failure(firstErr, warnings);
+    }
+    // Second pass: strip top-level legacy key-discovery lines and retry.
+    const legacy = collectLegacyWarnings(text);
+    warnings.push(...legacy.warnings);
+    if (legacy.firstField) fireLegacyWarning(legacy.firstField);
+
+    const stripped = text.replace(LEGACY_KEY_FULL_LINE_GLOBAL, '');
+    if (stripped.trim().length === 0) {
+      return {
+        valid: false,
+        errors: ['Empty policy document after stripping legacy key-discovery lines.'],
+        warnings: warnings.length > 0 ? warnings : undefined,
+      };
+    }
+    try {
+      const data = parsePolicyDocument(stripped);
+      return {
+        valid: true,
+        data,
+        warnings: warnings.length > 0 ? warnings : undefined,
+      };
+    } catch (retryErr) {
+      return failure(retryErr, warnings);
+    }
+  }
+}
+
+function failure(err: unknown, warnings: string[]): ParseResult {
+  if (err instanceof PolicyValidationError || err instanceof PolicyLoadError) {
+    return {
       valid: false,
-      errors: [err instanceof Error ? err.message : String(err)],
+      errors: [err.message],
       warnings: warnings.length > 0 ? warnings : undefined,
     };
   }
-
   return {
-    valid: true,
-    data,
+    valid: false,
+    errors: [err instanceof Error ? err.message : String(err)],
     warnings: warnings.length > 0 ? warnings : undefined,
   };
 }

--- a/packages/discovery/src/parser.ts
+++ b/packages/discovery/src/parser.ts
@@ -1,179 +1,156 @@
 /**
- * @peac/disc/parser - peac.txt parser with ≤20 lines enforcement
- * ABNF-compliant discovery document parsing
+ * @peac/disc/parser - thin peac.txt policy-document loader/validator.
+ *
+ * peac.txt is a POLICY DOCUMENT surface per docs/specs/PEAC-TXT.md.
+ * Full parsing is delegated to `@peac/policy-kit.parsePolicyDocument`;
+ * this module only provides:
+ *
+ *   - format detection (YAML vs JSON) per PEAC-TXT.md §5.1
+ *   - a tolerant `parse()` wrapper that returns a structured `ParseResult`
+ *     (rather than throwing)
+ *   - structured warnings for legacy key-discovery lines (`verify`,
+ *     `public_keys`, `jwks`) that appeared in pre-v0.12.14 peac.txt
+ *     examples. Those lines are NEVER honored here: key discovery flows
+ *     through `iss` -> /.well-known/peac-issuer.json -> `jwks_uri` -> JWKS
+ *     (docs/specs/PEAC-ISSUER.md).
+ *   - a tiny `emit()` helper that serializes a `PolicyDocument` via
+ *     `@peac/policy-kit.serializePolicyYaml`
+ *
+ * @see docs/specs/PEAC-TXT.md
+ * @see docs/specs/PEAC-ISSUER.md
  */
 
-import type { PeacDiscovery, ParseResult, PublicKeyInfo, ValidationOptions } from './types.js';
+import {
+  PolicyLoadError,
+  PolicyValidationError,
+  parsePolicyDocument,
+  serializePolicyYaml,
+  type PolicyDocument,
+} from '@peac/policy-kit';
+import type { ParseResult } from './types.js';
 
-const MAX_LINES = 20;
-const FIELD_PATTERNS = {
-  preferences: /^preferences:\s*(.+)$/,
-  access_control: /^access_control:\s*(.+)$/,
-  payments: /^payments:\s*\[([^\]]+)\]$/,
-  provenance: /^provenance:\s*(.+)$/,
-  receipts: /^receipts:\s*(required|optional)$/,
-  verify: /^verify:\s*(.+)$/,
-  public_keys: /^public_keys:\s*\[([^\]]+)\]$/,
-};
+const LEGACY_KEY_LINE = /^\s*(verify|public_keys|jwks)\s*:/m;
+/** Strips the whole line (including the trailing newline) when matched. */
+const LEGACY_KEY_FULL_LINE_GLOBAL = /^\s*(verify|public_keys|jwks)\s*:.*\r?\n?/gm;
 
-export function parse(content: string, options: ValidationOptions = {}): ParseResult {
-  const maxLines = options.maxLines ?? MAX_LINES;
-  const errors: string[] = [];
-  const data: PeacDiscovery = {};
+let legacyWarningFired = false;
 
-  const lines = content
-    .split('\n')
-    .map((l) => l.trim())
-    .filter((l) => l && !l.startsWith('#'));
-
-  // Enforce line limit
-  if (lines.length > maxLines) {
-    return {
-      valid: false,
-      errors: [`Line limit exceeded: ${lines.length} > ${maxLines}`],
-      lineCount: lines.length,
-    };
-  }
-
-  // Parse each line
-  for (const [index, line] of lines.entries()) {
-    let matched = false;
-
-    for (const [field, pattern] of Object.entries(FIELD_PATTERNS)) {
-      const match = line.match(pattern);
-      if (match) {
-        matched = true;
-        try {
-          switch (field) {
-            case 'preferences':
-            case 'access_control':
-            case 'provenance':
-            case 'verify':
-              data[field] = match[1].trim();
-              break;
-            case 'receipts':
-              data.receipts = match[1] as 'required' | 'optional';
-              break;
-            case 'payments':
-              data.payments = parseArray(match[1]);
-              break;
-            case 'public_keys':
-              data.public_keys = parsePublicKeys(match[1]);
-              break;
-          }
-        } catch (error) {
-          errors.push(
-            `Line ${index + 1}: ${error instanceof Error ? error.message : String(error)}`
-          );
-        }
-        break;
-      }
-    }
-
-    if (!matched) {
-      errors.push(`Line ${index + 1}: Invalid format: ${line}`);
-    }
-  }
-
-  // Validate required fields
-  if (!data.verify) {
-    errors.push('Missing required field: verify');
-  }
-
-  return {
-    valid: errors.length === 0,
-    data: errors.length === 0 ? data : undefined,
-    errors: errors.length > 0 ? errors : undefined,
-    lineCount: lines.length,
-  };
-}
-
-function parseArray(content: string): string[] {
-  return content
-    .split(',')
-    .map((item) => item.trim().replace(/^["']|["']$/g, ''))
-    .filter((item) => item.length > 0);
-}
-
-function parsePublicKeys(content: string): PublicKeyInfo[] {
-  const keyStrings = parseArray(content);
-  const keys: PublicKeyInfo[] = [];
-
-  for (const keyString of keyStrings) {
-    const keyMatch = keyString.match(/^([^:]+):([^:]+):(.+)$/);
-    if (!keyMatch) {
-      throw new Error(`Invalid public key format: ${keyString}`);
-    }
-
-    keys.push({
-      kid: keyMatch[1],
-      alg: keyMatch[2],
-      key: keyMatch[3],
-    });
-  }
-
-  return keys;
-}
-
-/** Characters that break peac.txt wire format: quotes, colons, brackets, control chars */
-const UNSAFE_FIELD_CHARS = /["\n\r\x00-\x1f:[\]]/;
-
-function assertSafeFieldValue(value: string, fieldName: string): void {
-  if (UNSAFE_FIELD_CHARS.test(value)) {
-    throw new Error(
-      `Invalid ${fieldName}: must not contain quotes, colons, brackets, newlines, or control characters`
+function fireLegacyWarning(field: string): void {
+  if (legacyWarningFired) return;
+  legacyWarningFired = true;
+  if (typeof process !== 'undefined' && typeof process.emitWarning === 'function') {
+    process.emitWarning(
+      `peac.txt legacy key-discovery field "${field}" is deprecated and ignored. ` +
+        `peac.txt is a policy-document surface (docs/specs/PEAC-TXT.md). ` +
+        `Key resolution uses iss -> /.well-known/peac-issuer.json -> jwks_uri -> JWKS.`,
+      { code: 'PEAC_LEGACY_PEAC_TXT_KEY_FIELD', type: 'DeprecationWarning' }
     );
   }
 }
 
-export function emit(data: PeacDiscovery): string {
-  const lines: string[] = [];
-
-  if (data.preferences) {
-    lines.push(`preferences: ${data.preferences}`);
-  }
-
-  if (data.access_control) {
-    lines.push(`access_control: ${data.access_control}`);
-  }
-
-  if (data.payments && data.payments.length > 0) {
-    data.payments.forEach((p) => assertSafeFieldValue(p, 'payment'));
-    const paymentsStr = data.payments.map((p) => `"${p}"`).join(', ');
-    lines.push(`payments: [${paymentsStr}]`);
-  }
-
-  if (data.provenance) {
-    lines.push(`provenance: ${data.provenance}`);
-  }
-
-  if (data.receipts) {
-    lines.push(`receipts: ${data.receipts}`);
-  }
-
-  if (data.verify) {
-    lines.push(`verify: ${data.verify}`);
-  }
-
-  if (data.public_keys && data.public_keys.length > 0) {
-    data.public_keys.forEach((k) => {
-      assertSafeFieldValue(k.kid, 'kid');
-      assertSafeFieldValue(k.alg, 'alg');
-      assertSafeFieldValue(k.key, 'key');
-    });
-    const keysStr = data.public_keys.map((k) => `"${k.kid}:${k.alg}:${k.key}"`).join(', ');
-    lines.push(`public_keys: [${keysStr}]`);
-  }
-
-  // Enforce line limit during emission
-  if (lines.length > MAX_LINES) {
-    throw new Error(`Generated peac.txt exceeds ${MAX_LINES} lines: ${lines.length}`);
-  }
-
-  return lines.join('\n');
+/**
+ * Reset the one-shot legacy-warning flag. Exposed for tests that need to
+ * observe the warning more than once per process.
+ */
+export function __resetLegacyWarningForTests(): void {
+  legacyWarningFired = false;
 }
 
-export function validate(content: string): boolean {
-  const result = parse(content);
-  return result.valid;
+function collectLegacyWarnings(text: string): { warnings: string[]; firstField: string | null } {
+  const warnings: string[] = [];
+  let firstField: string | null = null;
+  const lines = text.split(/\r?\n/);
+  lines.forEach((line, idx) => {
+    const match = line.match(/^\s*(verify|public_keys|jwks)\s*:/);
+    if (match) {
+      if (firstField === null) firstField = match[1];
+      warnings.push(
+        `Line ${idx + 1}: legacy key-discovery field "${match[1]}" ignored ` +
+          `(peac.txt is policy-only; use peac-issuer.json for keys)`
+      );
+    }
+  });
+  return { warnings, firstField };
+}
+
+/**
+ * Parse a peac.txt policy document. Accepts YAML or JSON per
+ * `docs/specs/PEAC-TXT.md` §5.1. On success, `data` is the validated
+ * `peac-policy/0.1` `PolicyDocument`.
+ *
+ * Legacy key-discovery lines (`verify:`, `public_keys:`, `jwks:`) are
+ * stripped before policy-doc validation, listed in `warnings`, and surface
+ * a structured `PEAC_LEGACY_PEAC_TXT_KEY_FIELD` `DeprecationWarning` once
+ * per process. They never populate the parsed result.
+ */
+export function parse(text: string): ParseResult {
+  const warnings: string[] = [];
+
+  // Advisory: pre-scan for legacy key-discovery lines and strip them so the
+  // underlying policy-doc validator does not fail on unknown fields. Legacy
+  // lines never affect the parsed result.
+  let body = text;
+  if (LEGACY_KEY_LINE.test(text)) {
+    const legacy = collectLegacyWarnings(text);
+    warnings.push(...legacy.warnings);
+    if (legacy.firstField) fireLegacyWarning(legacy.firstField);
+    body = text.replace(LEGACY_KEY_FULL_LINE_GLOBAL, '');
+  }
+
+  const trimmed = body.trim();
+  if (trimmed.length === 0) {
+    return {
+      valid: false,
+      errors: ['Empty policy document. Expected peac-policy/0.1 YAML or JSON.'],
+      warnings: warnings.length > 0 ? warnings : undefined,
+    };
+  }
+
+  let data: PolicyDocument;
+  try {
+    data = parsePolicyDocument(body);
+  } catch (err) {
+    if (err instanceof PolicyValidationError) {
+      return {
+        valid: false,
+        errors: [err.message],
+        warnings: warnings.length > 0 ? warnings : undefined,
+      };
+    }
+    if (err instanceof PolicyLoadError) {
+      return {
+        valid: false,
+        errors: [err.message],
+        warnings: warnings.length > 0 ? warnings : undefined,
+      };
+    }
+    return {
+      valid: false,
+      errors: [err instanceof Error ? err.message : String(err)],
+      warnings: warnings.length > 0 ? warnings : undefined,
+    };
+  }
+
+  return {
+    valid: true,
+    data,
+    warnings: warnings.length > 0 ? warnings : undefined,
+  };
+}
+
+/**
+ * Serialize a `peac-policy/0.1` `PolicyDocument` as YAML suitable for
+ * serving at `/.well-known/peac.txt`. Delegates to
+ * `@peac/policy-kit.serializePolicyYaml`.
+ */
+export function emit(doc: PolicyDocument): string {
+  return serializePolicyYaml(doc);
+}
+
+/**
+ * Convenience predicate: returns `true` iff `text` parses as a valid
+ * `peac-policy/0.1` document.
+ */
+export function validate(text: string): boolean {
+  return parse(text).valid;
 }

--- a/packages/discovery/src/types.ts
+++ b/packages/discovery/src/types.ts
@@ -1,31 +1,62 @@
 /**
- * @peac/disc/types - Discovery types for .well-known/peac.txt
+ * @peac/disc/types - Discovery result types for .well-known/peac.txt
+ *
+ * peac.txt is a POLICY DOCUMENT surface per docs/specs/PEAC-TXT.md.
+ * It is NOT a key discovery surface. Key resolution uses the normative
+ * chain: `iss` -> /.well-known/peac-issuer.json -> `jwks_uri` -> JWKS.
+ *
+ * `@peac/disc` is a thin loader/validator over peac-policy/0.1 bytes
+ * (YAML or JSON). Full parsing is delegated to
+ * `@peac/policy-kit.parsePolicyDocument`; the canonical `PolicyDocument`
+ * type is re-exported from `@peac/policy-kit`.
+ *
+ * @see docs/specs/PEAC-TXT.md
+ * @see docs/specs/PEAC-ISSUER.md
  */
 
-export interface PeacDiscovery {
-  preferences?: string;
-  access_control?: string;
-  payments?: string[];
-  provenance?: string;
-  receipts?: 'required' | 'optional';
-  verify?: string;
-  public_keys?: PublicKeyInfo[];
+import type { PolicyDocument } from '@peac/policy-kit';
+
+export type { PolicyDocument };
+
+/**
+ * Result of `parse()`. On success, `data` is the validated
+ * `peac-policy/0.1` `PolicyDocument`. On failure, `errors` explains why.
+ * `warnings` carries non-fatal advisories; in particular, legacy
+ * key-discovery lines (`verify`, `public_keys`, `jwks`) that appeared in
+ * older peac.txt examples are listed here and also fire a structured
+ * `process.emitWarning` with code `PEAC_LEGACY_PEAC_TXT_KEY_FIELD`
+ * once per process.
+ */
+export interface ParseResult {
+  valid: boolean;
+  data?: PolicyDocument;
+  errors?: string[];
+  warnings?: string[];
 }
 
+export interface ValidationOptions {
+  /** Soft line cap for advisory purposes (default 100, per PEAC-TXT.md §6.2). */
+  recommendedMaxLines?: number;
+}
+
+/**
+ * @deprecated Key discovery via peac.txt is retired. Use the normative
+ * discovery chain `iss` -> /.well-known/peac-issuer.json -> `jwks_uri` ->
+ * JWKS instead. This type is retained for one minor to keep existing import
+ * paths compiling. Removal target: next cleanup release.
+ */
 export interface PublicKeyInfo {
   kid: string;
   alg: string;
   key: string;
 }
 
-export interface ParseResult {
-  valid: boolean;
-  data?: PeacDiscovery;
-  errors?: string[];
-  lineCount?: number;
-}
-
-export interface ValidationOptions {
-  maxLines?: number;
-  strictAbnf?: boolean;
+/**
+ * @deprecated pre-v0.12.14 alias for the legacy line-based PEAC discovery
+ * shape. Use the `ParseResult.data` (`PolicyDocument`) returned by `parse()`.
+ * Retained for one minor so existing import paths keep compiling; removal
+ * target: next cleanup release.
+ */
+export interface PeacDiscovery {
+  [key: string]: unknown;
 }

--- a/packages/discovery/tests/parser.test.ts
+++ b/packages/discovery/tests/parser.test.ts
@@ -1,99 +1,137 @@
 /**
- * Tests for peac.txt parser emit() sanitization
+ * Tests for peac.txt parser: thin loader over peac-policy/0.1 + legacy
+ * key-discovery line tolerance with structured DeprecationWarning.
  */
 
-import { describe, it, expect } from 'vitest';
-import { parse, emit } from '../src/parser.js';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { parse, emit, validate, __resetLegacyWarningForTests } from '../src/parser.js';
 
-describe('emit() sanitization', () => {
-  const validData = {
-    verify: 'https://api.example.com/verify',
-    payments: ['x402', 'stripe'],
-    public_keys: [{ kid: 'key-1', alg: 'EdDSA', key: 'base64urlPublicKey' }],
-  };
+const VALID_YAML_POLICY = [
+  "version: 'peac-policy/0.1'",
+  'name: Example PEAC Policy',
+  'defaults:',
+  '  decision: deny',
+  "  reason: 'No matching rule'",
+  'rules:',
+  '  - name: allow-verified-agents-inference',
+  '    subject:',
+  '      type: agent',
+  '      labels: [verified]',
+  '    purpose: inference',
+  '    decision: allow',
+  "    reason: 'Verified agents may run inference'",
+].join('\n');
 
-  it('should emit valid data without errors', () => {
-    const output = emit(validData);
-    expect(output).toContain('verify: https://api.example.com/verify');
-    expect(output).toContain('payments: ["x402", "stripe"]');
-    expect(output).toContain('public_keys: ["key-1:EdDSA:base64urlPublicKey"]');
+const VALID_JSON_POLICY = JSON.stringify({
+  version: 'peac-policy/0.1',
+  defaults: { decision: 'allow' },
+  rules: [{ name: 'allow-everyone', decision: 'allow' }],
+});
+
+describe('parse() — peac-policy/0.1 via @peac/policy-kit', () => {
+  it('parses a valid YAML peac-policy/0.1 document', () => {
+    const result = parse(VALID_YAML_POLICY);
+    expect(result.valid).toBe(true);
+    expect(result.data?.version).toBe('peac-policy/0.1');
+    expect(result.data?.defaults.decision).toBe('deny');
+    expect(result.data?.rules).toHaveLength(1);
+    expect(result.data?.rules[0].name).toBe('allow-verified-agents-inference');
   });
 
-  it('should throw when payment contains a double quote', () => {
-    expect(() => emit({ ...validData, payments: ['x"402'] })).toThrow(/Invalid payment/);
+  it('parses a valid JSON peac-policy/0.1 document', () => {
+    const result = parse(VALID_JSON_POLICY);
+    expect(result.valid).toBe(true);
+    expect(result.data?.rules[0].decision).toBe('allow');
   });
 
-  it('should throw when payment contains a colon', () => {
-    expect(() => emit({ ...validData, payments: ['x:402'] })).toThrow(/Invalid payment/);
+  it('rejects an empty document', () => {
+    const result = parse('');
+    expect(result.valid).toBe(false);
+    expect(result.errors?.[0]).toMatch(/Empty policy document/);
   });
 
-  it('should throw when payment contains a bracket', () => {
-    expect(() => emit({ ...validData, payments: ['x[402'] })).toThrow(/Invalid payment/);
-
-    expect(() => emit({ ...validData, payments: ['x]402'] })).toThrow(/Invalid payment/);
+  it('rejects a document missing the version literal', () => {
+    const result = parse('defaults:\n  decision: deny\nrules: []\n');
+    expect(result.valid).toBe(false);
+    expect(result.errors?.[0]).toMatch(/validation failed|version/i);
   });
 
-  it('should throw when payment contains a newline', () => {
-    expect(() => emit({ ...validData, payments: ['x\n402'] })).toThrow(/Invalid payment/);
-  });
-
-  it('should throw when payment contains a control character', () => {
-    expect(() => emit({ ...validData, payments: ['x\x00402'] })).toThrow(/Invalid payment/);
-  });
-
-  it('should throw when kid contains a colon', () => {
-    expect(() =>
-      emit({
-        ...validData,
-        public_keys: [{ kid: 'key:1', alg: 'EdDSA', key: 'abc' }],
-      })
-    ).toThrow(/Invalid kid/);
-  });
-
-  it('should throw when kid contains a bracket', () => {
-    expect(() =>
-      emit({
-        ...validData,
-        public_keys: [{ kid: 'key]1', alg: 'EdDSA', key: 'abc' }],
-      })
-    ).toThrow(/Invalid kid/);
-  });
-
-  it('should throw when alg contains a quote', () => {
-    expect(() =>
-      emit({
-        ...validData,
-        public_keys: [{ kid: 'key-1', alg: 'Ed"DSA', key: 'abc' }],
-      })
-    ).toThrow(/Invalid alg/);
-  });
-
-  it('should throw when key contains a control character', () => {
-    expect(() =>
-      emit({
-        ...validData,
-        public_keys: [{ kid: 'key-1', alg: 'EdDSA', key: 'abc\x01def' }],
-      })
-    ).toThrow(/Invalid key/);
+  it('rejects a document with the wrong version literal', () => {
+    const result = parse("version: 'peac-policy/0.9'\ndefaults:\n  decision: deny\nrules: []\n");
+    expect(result.valid).toBe(false);
+    expect(result.errors?.[0]).toMatch(/validation failed|version/i);
   });
 });
 
-describe('parse/emit round-trip', () => {
-  it('should round-trip valid peac.txt content', () => {
-    const original = {
-      verify: 'https://api.example.com/verify',
-      receipts: 'required' as const,
-      payments: ['x402', 'stripe'],
-      public_keys: [{ kid: 'key-1', alg: 'EdDSA', key: 'base64urlPublicKey' }],
-    };
-
+describe('emit() — serializes peac-policy/0.1 via @peac/policy-kit', () => {
+  it('round-trips a minimal policy document', () => {
+    const original = parse(VALID_YAML_POLICY).data!;
     const emitted = emit(original);
-    const parsed = parse(emitted);
+    const reparsed = parse(emitted);
+    expect(reparsed.valid).toBe(true);
+    expect(reparsed.data).toEqual(original);
+  });
+});
 
-    expect(parsed.valid).toBe(true);
-    expect(parsed.data?.verify).toBe(original.verify);
-    expect(parsed.data?.receipts).toBe(original.receipts);
-    expect(parsed.data?.payments).toEqual(original.payments);
-    expect(parsed.data?.public_keys).toEqual(original.public_keys);
+describe('validate() — convenience predicate', () => {
+  it('returns true for a valid document', () => {
+    expect(validate(VALID_YAML_POLICY)).toBe(true);
+  });
+
+  it('returns false for invalid input', () => {
+    expect(validate('not a policy')).toBe(false);
+  });
+});
+
+describe('legacy key-discovery field tolerance', () => {
+  let emitWarningSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    __resetLegacyWarningForTests();
+    emitWarningSpy = vi.spyOn(process, 'emitWarning').mockImplementation(() => {
+      /* suppress */
+    });
+  });
+
+  afterEach(() => {
+    emitWarningSpy.mockRestore();
+  });
+
+  it('strips legacy "verify:" line and surfaces structured warning', () => {
+    const content = `verify: https://api.example.com/verify\n` + VALID_YAML_POLICY;
+    const result = parse(content);
+    expect(result.valid).toBe(true);
+    expect(result.data?.version).toBe('peac-policy/0.1');
+    expect(result.warnings?.[0]).toMatch(/legacy key-discovery field "verify" ignored/);
+    expect(emitWarningSpy).toHaveBeenCalledTimes(1);
+    const [message, options] = emitWarningSpy.mock.calls[0];
+    expect(String(message)).toMatch(/peac\.txt legacy key-discovery field "verify"/);
+    expect(options).toMatchObject({
+      code: 'PEAC_LEGACY_PEAC_TXT_KEY_FIELD',
+      type: 'DeprecationWarning',
+    });
+  });
+
+  it('strips legacy "public_keys:" line and surfaces structured warning', () => {
+    const content = `public_keys: ["key-1:EdDSA:abc"]\n` + VALID_YAML_POLICY;
+    const result = parse(content);
+    expect(result.valid).toBe(true);
+    expect(result.warnings?.[0]).toMatch(/legacy key-discovery field "public_keys" ignored/);
+    expect(emitWarningSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('strips legacy "jwks:" line and surfaces structured warning', () => {
+    const content = `jwks: https://example.com/.well-known/jwks.json\n` + VALID_YAML_POLICY;
+    const result = parse(content);
+    expect(result.valid).toBe(true);
+    expect(result.warnings?.[0]).toMatch(/legacy key-discovery field "jwks" ignored/);
+    expect(emitWarningSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires the legacy process.emitWarning only once per process', () => {
+    parse(`verify: https://example.com/\n` + VALID_YAML_POLICY);
+    parse(`public_keys: ["k:EdDSA:a"]\n` + VALID_YAML_POLICY);
+    parse(`jwks: https://example.com/\n` + VALID_YAML_POLICY);
+    expect(emitWarningSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/discovery/tests/parser.test.ts
+++ b/packages/discovery/tests/parser.test.ts
@@ -28,7 +28,7 @@ const VALID_JSON_POLICY = JSON.stringify({
   rules: [{ name: 'allow-everyone', decision: 'allow' }],
 });
 
-describe('parse() — peac-policy/0.1 via @peac/policy-kit', () => {
+describe('parse(): peac-policy/0.1 via @peac/policy-kit', () => {
   it('parses a valid YAML peac-policy/0.1 document', () => {
     const result = parse(VALID_YAML_POLICY);
     expect(result.valid).toBe(true);
@@ -63,7 +63,7 @@ describe('parse() — peac-policy/0.1 via @peac/policy-kit', () => {
   });
 });
 
-describe('emit() — serializes peac-policy/0.1 via @peac/policy-kit', () => {
+describe('emit(): serializes peac-policy/0.1 via @peac/policy-kit', () => {
   it('round-trips a minimal policy document', () => {
     const original = parse(VALID_YAML_POLICY).data!;
     const emitted = emit(original);
@@ -73,7 +73,7 @@ describe('emit() — serializes peac-policy/0.1 via @peac/policy-kit', () => {
   });
 });
 
-describe('validate() — convenience predicate', () => {
+describe('validate(): convenience predicate', () => {
   it('returns true for a valid document', () => {
     expect(validate(VALID_YAML_POLICY)).toBe(true);
   });

--- a/packages/policy-kit/src/index.ts
+++ b/packages/policy-kit/src/index.ts
@@ -73,6 +73,7 @@ export {
 export {
   loadPolicy,
   parsePolicy,
+  parsePolicyDocument,
   validatePolicy,
   policyFileExists,
   createExamplePolicy,

--- a/packages/policy-kit/src/loader.ts
+++ b/packages/policy-kit/src/loader.ts
@@ -40,6 +40,31 @@ export class PolicyValidationError extends PolicyLoadError {
 }
 
 /**
+ * Parse a `peac-policy/0.1` document from raw bytes and validate against the
+ * normative schema. Accepts the document format referenced from `peac.txt`
+ * (via `policy_doc.url` or `policy_doc.inline`) or the inline payload of a
+ * `docs/specs/PEAC-TXT.md`-conformant policy document fetched separately.
+ *
+ * Auto-detects JSON vs YAML. Throws `PolicyValidationError` when the document
+ * is well-formed but does not satisfy `peac-policy/0.1` (e.g. missing
+ * `version`, unknown `defaults.decision`, malformed `rules`). Throws
+ * `PolicyLoadError` when the text cannot be parsed as either JSON or YAML.
+ *
+ * This function is network-free and accepts pre-fetched bytes. Callers are
+ * responsible for fetching the document (typically via the URL returned by
+ * `@peac/disc.parse(...).data.policy_doc.url`) and passing the bytes here.
+ *
+ * @param text - Raw UTF-8 bytes of a `peac-policy/0.1` document (YAML or JSON)
+ * @returns Validated `PolicyDocument`
+ * @throws PolicyLoadError on parse failure
+ * @throws PolicyValidationError on schema validation failure
+ * @see docs/specs/PEAC-TXT.md
+ */
+export function parsePolicyDocument(text: string): PolicyDocument {
+  return parsePolicy(text);
+}
+
+/**
  * Parse policy from string content
  *
  * @param content - YAML or JSON string

--- a/packages/policy-kit/tests/loader.test.ts
+++ b/packages/policy-kit/tests/loader.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   parsePolicy,
+  parsePolicyDocument,
   validatePolicy,
   createExamplePolicy,
   serializePolicyYaml,
@@ -341,5 +342,69 @@ describe('complex policy validation', () => {
 
       expect(() => validatePolicy(policy)).not.toThrow();
     }
+  });
+});
+
+describe('parsePolicyDocument (peac-policy/0.1)', () => {
+  it('parses a valid YAML peac-policy/0.1 document', () => {
+    const yaml = `
+version: "peac-policy/0.1"
+defaults:
+  decision: deny
+rules:
+  - name: allow-verified-agents
+    subject:
+      type: agent
+      labels: [verified]
+    purpose: inference
+    decision: allow
+`;
+    const policy = parsePolicyDocument(yaml);
+    expect(policy.version).toBe(POLICY_VERSION);
+    expect(policy.defaults.decision).toBe('deny');
+    expect(policy.rules).toHaveLength(1);
+    expect(policy.rules[0].name).toBe('allow-verified-agents');
+  });
+
+  it('parses a valid JSON peac-policy/0.1 document', () => {
+    const json = JSON.stringify({
+      version: 'peac-policy/0.1',
+      defaults: { decision: 'allow' },
+      rules: [{ name: 'deny-unknown', decision: 'deny' }],
+    });
+    const policy = parsePolicyDocument(json);
+    expect(policy.version).toBe(POLICY_VERSION);
+    expect(policy.rules[0].decision).toBe('deny');
+  });
+
+  it('rejects a document missing the version header', () => {
+    const invalid = JSON.stringify({
+      defaults: { decision: 'deny' },
+      rules: [],
+    });
+    expect(() => parsePolicyDocument(invalid)).toThrow(PolicyValidationError);
+  });
+
+  it('rejects a document with the wrong version literal', () => {
+    const invalid = JSON.stringify({
+      version: 'peac-policy/0.9',
+      defaults: { decision: 'deny' },
+      rules: [],
+    });
+    expect(() => parsePolicyDocument(invalid)).toThrow(PolicyValidationError);
+  });
+
+  it('rejects a malformed text (neither JSON nor YAML-parseable into schema)', () => {
+    expect(() => parsePolicyDocument('::::not-parseable::::')).toThrow(PolicyLoadError);
+  });
+
+  it('returns a policy structurally identical to parsePolicy auto-detect', () => {
+    const yaml = `
+version: "peac-policy/0.1"
+defaults:
+  decision: review
+rules: []
+`;
+    expect(parsePolicyDocument(yaml)).toEqual(parsePolicy(yaml));
   });
 });

--- a/packages/protocol/src/discovery.ts
+++ b/packages/protocol/src/discovery.ts
@@ -399,10 +399,17 @@ export async function fetchPolicyManifest(baseUrl: string): Promise<PEACPolicyMa
 // ============================================================================
 
 /**
- * @deprecated Use parseIssuerConfig instead. Will be removed in v1.0.
+ * @deprecated Parses a legacy dual-purpose `peac.txt` manifest that carried
+ * both policy hints and key-discovery fields (`verify`, `jwks`). This shape
+ * is retired: `peac.txt` is a policy-document surface per
+ * `docs/specs/PEAC-TXT.md`, and the normative key-discovery chain is
+ * `iss` -> /.well-known/peac-issuer.json -> `jwks_uri` -> JWKS
+ * (see `docs/specs/PEAC-ISSUER.md`). Use `parseIssuerConfig` for issuer
+ * metadata, and `@peac/policy-kit.parsePolicyDocument` for `peac-policy/0.1`
+ * documents referenced from `peac.txt`. Removal target: next cleanup release.
  *
- * Parse a PEAC discovery manifest from YAML-like text.
- * This function is maintained for backward compatibility only.
+ * Parse a PEAC discovery manifest from YAML-like text. Retained only for
+ * backward compatibility with callers that have not yet migrated.
  */
 export function parseDiscovery(text: string): PEACDiscovery {
   const bytes = new TextEncoder().encode(text).length;
@@ -457,10 +464,18 @@ export function parseDiscovery(text: string): PEACDiscovery {
 }
 
 /**
- * @deprecated Use fetchIssuerConfig instead. Will be removed in v1.0.
+ * @deprecated Fetches /.well-known/peac.txt and parses it as a legacy
+ * dual-purpose manifest. This shape is retired: `peac.txt` is a policy
+ * document (see `docs/specs/PEAC-TXT.md`) and key discovery flows through
+ * `iss` -> /.well-known/peac-issuer.json -> `jwks_uri` -> JWKS
+ * (see `docs/specs/PEAC-ISSUER.md`). Use `fetchIssuerConfig` for issuer
+ * metadata. To parse the `peac-policy/0.1` document referenced from
+ * `peac.txt`, fetch its bytes and call
+ * `@peac/policy-kit.parsePolicyDocument`. Removal target: next cleanup
+ * release.
  *
- * Fetch and parse PEAC discovery from an issuer URL.
- * This function is maintained for backward compatibility only.
+ * Fetch and parse PEAC discovery from an issuer URL. Retained only for
+ * backward compatibility with callers that have not yet migrated.
  */
 export async function fetchDiscovery(issuerUrl: string): Promise<PEACDiscovery> {
   if (!issuerUrl.startsWith('https://')) {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -163,19 +163,32 @@ app.post('/verify', async (c) => {
 });
 
 /**
- * GET /.well-known/peac.txt - Discovery manifest
+ * GET /.well-known/peac.txt - `peac-policy/0.1` policy document.
+ *
+ * peac.txt is the policy-document surface per docs/specs/PEAC-TXT.md.
+ * Key discovery flows through /.well-known/peac-issuer.json -> jwks_uri ->
+ * JWKS (served from /.well-known/peac-issuer.json, not this path).
  */
 app.get('/.well-known/peac.txt', (c) => {
-  const manifest = `version: peac/0.9
-issuer: https://api.example.com
-verify: https://api.example.com/verify
-jwks: https://keys.peacprotocol.org/jwks.json
-payments:
-  - rail: payment_rail_1
-  - rail: payment_rail_2`;
+  const manifest = [
+    "version: 'peac-policy/0.1'",
+    'name: Example PEAC Policy',
+    'defaults:',
+    '  decision: deny',
+    "  reason: 'No matching rule'",
+    'rules:',
+    '  - name: allow-verified-agents-inference',
+    '    subject:',
+    '      type: agent',
+    '      labels: [verified]',
+    '    purpose: inference',
+    '    decision: allow',
+    "    reason: 'Verified agents may run inference'",
+    '',
+  ].join('\n');
 
   c.header('Cache-Control', 'public, max-age=3600');
-  c.header('Content-Type', 'text/plain; charset=utf-8');
+  c.header('Content-Type', 'text/yaml; charset=utf-8');
 
   return c.text(manifest);
 });

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -167,25 +167,23 @@ app.post('/verify', async (c) => {
  *
  * peac.txt is the policy-document surface per docs/specs/PEAC-TXT.md.
  * Key discovery flows through /.well-known/peac-issuer.json -> jwks_uri ->
- * JWKS (served from /.well-known/peac-issuer.json, not this path).
+ * JWKS (served at /.well-known/peac-issuer.json, not this path).
  */
 app.get('/.well-known/peac.txt', (c) => {
-  const manifest = [
-    "version: 'peac-policy/0.1'",
-    'name: Example PEAC Policy',
-    'defaults:',
-    '  decision: deny',
-    "  reason: 'No matching rule'",
-    'rules:',
-    '  - name: allow-verified-agents-inference',
-    '    subject:',
-    '      type: agent',
-    '      labels: [verified]',
-    '    purpose: inference',
-    '    decision: allow',
-    "    reason: 'Verified agents may run inference'",
-    '',
-  ].join('\n');
+  const manifest =
+    `version: 'peac-policy/0.1'\n` +
+    `name: Example PEAC Policy\n` +
+    `defaults:\n` +
+    `  decision: deny\n` +
+    `  reason: 'No matching rule'\n` +
+    `rules:\n` +
+    `  - name: allow-verified-agents-inference\n` +
+    `    subject:\n` +
+    `      type: agent\n` +
+    `      labels: [verified]\n` +
+    `    purpose: inference\n` +
+    `    decision: allow\n` +
+    `    reason: 'Verified agents may run inference'\n`;
 
   c.header('Cache-Control', 'public, max-age=3600');
   c.header('Content-Type', 'text/yaml; charset=utf-8');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1056,6 +1056,12 @@ importers:
 
   packages/aipref:
     dependencies:
+      '@peac/crypto':
+        specifier: workspace:*
+        version: link:../crypto
+      '@peac/mappings-content-signals':
+        specifier: workspace:*
+        version: link:../mappings/content-signals
       '@peac/policy-kit':
         specifier: workspace:*
         version: link:../policy-kit
@@ -1323,6 +1329,10 @@ importers:
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/discovery:
+    dependencies:
+      '@peac/policy-kit':
+        specifier: workspace:*
+        version: link:../policy-kit
     devDependencies:
       tsup:
         specifier: ^8.0.0

--- a/scripts/verify-no-bidi-controls.mjs
+++ b/scripts/verify-no-bidi-controls.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * verify-no-bidi-controls.mjs
+ *
+ * CI gate: no Unicode bidi controls or zero-width / invisible characters in
+ * tracked source, docs, or configuration. Thin wrapper around
+ * `scripts/find-invisible-unicode.mjs` with a tighter CI-facing summary.
+ *
+ * Scans every tracked `.ts` / `.tsx` / `.js` / `.jsx` / `.mjs` / `.cjs` /
+ * `.json` / `.md` / `.yaml` / `.yml` file except `archive/` and
+ * `node_modules/`, and exits non-zero on the first dangerous codepoint
+ * (Trojan Source, zero-width, bidi controls, etc.).
+ *
+ * Exit codes:
+ *   0 - no dangerous Unicode found
+ *   1 - one or more dangerous codepoints detected
+ *   2 - script error (missing underlying scanner, unexpected I/O failure)
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCANNER = join(HERE, 'find-invisible-unicode.mjs');
+
+if (!existsSync(SCANNER)) {
+  console.error(`verify-no-bidi-controls: missing scanner at ${SCANNER}`);
+  process.exit(2);
+}
+
+const EXTS = ['*.ts', '*.tsx', '*.js', '*.jsx', '*.mjs', '*.cjs', '*.json', '*.md', '*.yaml', '*.yml'];
+
+const ls = spawnSync('git', ['ls-files', '--', ...EXTS], { encoding: 'utf8' });
+if (ls.status !== 0) {
+  console.error('verify-no-bidi-controls: git ls-files failed');
+  console.error(ls.stderr);
+  process.exit(2);
+}
+
+const files = ls.stdout
+  .split('\n')
+  .map((l) => l.trim())
+  .filter((l) => l.length > 0 && !l.startsWith('archive/') && !l.startsWith('node_modules/'));
+
+if (files.length === 0) {
+  console.log('verify-no-bidi-controls: no tracked files to scan');
+  process.exit(0);
+}
+
+const scan = spawnSync('node', [SCANNER, '--stdin'], {
+  input: files.join('\n') + '\n',
+  encoding: 'utf8',
+});
+
+if (scan.status === 0) {
+  console.log(`verify-no-bidi-controls: clean (${files.length} files scanned)`);
+  process.exit(0);
+}
+
+if (scan.stdout) process.stdout.write(scan.stdout);
+if (scan.stderr) process.stderr.write(scan.stderr);
+console.error(
+  '\nverify-no-bidi-controls: dangerous Unicode detected. ' +
+    'Re-run with `node scripts/find-invisible-unicode.mjs --fix <files>` to remediate.'
+);
+process.exit(1);

--- a/scripts/verify-no-network-in-content-signal-parsers.mjs
+++ b/scripts/verify-no-network-in-content-signal-parsers.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+/**
+ * verify-no-network-in-content-signal-parsers.mjs
+ *
+ * CI gate: no network I/O in the content-signal parser packages.
+ *
+ * The content-signal-family parser packages take pre-fetched bytes only.
+ * Callers are responsible for network I/O (subject to their own SSRF /
+ * redirect / timeout / size-cap policy).
+ *
+ * Watched:
+ *   - `packages/aipref/src/**` (deprecated facade over
+ *     @peac/mappings-content-signals)
+ *   - `packages/mappings/content-signals/src/**`
+ *
+ * Other mapping packages (for example `packages/mappings/ucp/`) that
+ * legitimately fetch upstream profile documents are intentionally out of
+ * scope. Broadening the rule to `packages/mappings/**` is tracked as a
+ * follow-up in the roadmap when each mapping has been classified.
+ *
+ * This script scans every tracked `.ts` / `.mjs` / `.js` file under the
+ * watched globs for:
+ *
+ *   - bare-name `fetch(` calls
+ *   - imports of `node:http`, `node:https`, `node:net`, `http`, `https`,
+ *     `net`, `undici`, `node-fetch`, `got`, `axios`
+ *
+ * Exceptions:
+ *   - `packages/aipref/src/robots.ts` is allowed to mention the literal
+ *     string `fetchRobots` in the deprecated throwing stub; the stub does
+ *     not call `fetch` or import any network primitive.
+ *   - Test files (`*.test.*`, `**\/tests/**`, `**\/__tests__/**`) are
+ *     scanned with the same rules; we do NOT want tests to accidentally
+ *     depend on network either.
+ *
+ * Exit codes:
+ *   0 - clean
+ *   1 - violations found (listed as `<file>:<line>: <reason>`)
+ *   2 - script error
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+// Scope: parser packages whose job is to map pre-fetched content into typed
+// content-signal entries or AIPrefPolicy. UCP and other mapping packages
+// that legitimately fetch their upstream profile documents are not in
+// scope; any future broadening of the rule is tracked separately.
+const WATCHED_ROOTS = [
+  join(REPO_ROOT, 'packages', 'aipref', 'src'),
+  join(REPO_ROOT, 'packages', 'mappings', 'content-signals', 'src'),
+];
+
+const EXT_RE = /\.(mjs|cjs|js|ts|tsx)$/;
+
+const FORBIDDEN_IMPORT_SPECIFIERS = new Set([
+  'node:http',
+  'node:https',
+  'node:net',
+  'http',
+  'https',
+  'net',
+  'undici',
+  'node-fetch',
+  'got',
+  'axios',
+]);
+
+// Skips: dist / node_modules / test-and-tooling areas we do not care to scan.
+const SKIP_DIR_NAMES = new Set(['dist', 'node_modules', '.turbo', '.cache']);
+
+function* walk(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return;
+    throw err;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIP_DIR_NAMES.has(entry.name)) continue;
+      yield* walk(full);
+    } else if (entry.isFile() && EXT_RE.test(entry.name)) {
+      yield full;
+    }
+  }
+}
+
+function checkFile(file) {
+  const violations = [];
+  let source;
+  try {
+    source = readFileSync(file, 'utf8');
+  } catch {
+    return violations;
+  }
+
+  const rel = relative(REPO_ROOT, file).split(sep).join('/');
+  const lines = source.split('\n');
+
+  // fetchRobots throwing stub in @peac/pref/robots.ts: the function body
+  // intentionally references the literal "fetch" in a diagnostic message and
+  // exports a stub named `fetchRobots`. The stub does NOT call `fetch()` and
+  // does NOT import any network module; we scan the file the same as others
+  // and rely on the rules below to recognize that absence.
+
+  const importRe = /^\s*import\s+(?:[^'";]*\s+from\s+)?['"]([^'"]+)['"]/;
+  const dynamicImportRe = /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+  const requireRe = /\brequire\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+  const fetchCallRe = /\bfetch\s*\(/g;
+
+  let inBlockComment = false;
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i];
+    const lineNo = i + 1;
+
+    // Strip single-line block comments and leading block-comment bodies
+    // ("* @peac/pref ..." inside /** ... */). This is a coarse heuristic
+    // sufficient to avoid false positives in JSDoc / banner comments.
+    const trimmed = line.trim();
+    if (inBlockComment) {
+      if (trimmed.includes('*/')) inBlockComment = false;
+      continue;
+    }
+    if (trimmed.startsWith('//')) continue;
+    if (trimmed.startsWith('/*') && !trimmed.includes('*/')) {
+      inBlockComment = true;
+      continue;
+    }
+    if (trimmed.startsWith('*')) continue;
+    // Strip trailing `// ...` line comments before scanning.
+    const commentIdx = line.indexOf('//');
+    if (commentIdx >= 0) line = line.slice(0, commentIdx);
+
+    const importMatch = line.match(importRe);
+    if (importMatch && FORBIDDEN_IMPORT_SPECIFIERS.has(importMatch[1])) {
+      violations.push(`${rel}:${lineNo}: forbidden network import "${importMatch[1]}"`);
+    }
+
+    let m;
+    dynamicImportRe.lastIndex = 0;
+    while ((m = dynamicImportRe.exec(line)) !== null) {
+      if (FORBIDDEN_IMPORT_SPECIFIERS.has(m[1])) {
+        violations.push(`${rel}:${lineNo}: forbidden dynamic import "${m[1]}"`);
+      }
+    }
+
+    requireRe.lastIndex = 0;
+    while ((m = requireRe.exec(line)) !== null) {
+      if (FORBIDDEN_IMPORT_SPECIFIERS.has(m[1])) {
+        violations.push(`${rel}:${lineNo}: forbidden require() of "${m[1]}"`);
+      }
+    }
+
+    fetchCallRe.lastIndex = 0;
+    while ((m = fetchCallRe.exec(line)) !== null) {
+      const before = line.slice(0, m.index);
+      if (/[.\w$]$/.test(before)) continue; // e.g., `await myObj.fetch(` or `fetchRobots(`
+      // Skip method signatures in interfaces / type literals (no `new` / `=` /
+      // `await` / `return` token on the call line and a TypeScript return-type
+      // annotation after the parens).
+      const afterParens = line.slice(m.index);
+      const looksLikeMethodSig =
+        !/\b(await|return|new)\b/.test(before) && /\)\s*:/.test(afterParens) && /;\s*$/.test(line);
+      if (looksLikeMethodSig) continue;
+      violations.push(`${rel}:${lineNo}: forbidden call to global fetch()`);
+    }
+  }
+
+  return violations;
+}
+
+function main() {
+  const violations = [];
+
+  for (const root of WATCHED_ROOTS) {
+    try {
+      statSync(root);
+    } catch {
+      continue;
+    }
+    for (const file of walk(root)) {
+      violations.push(...checkFile(file));
+    }
+  }
+
+  if (violations.length > 0) {
+    console.error('verify-no-network-in-parsers: violations detected\n');
+    for (const v of violations) console.error(`  ${v}`);
+    console.error(
+      '\nContent-signal parser packages take pre-fetched bytes only. ' +
+        'Move network I/O to the caller.'
+    );
+    process.exit(1);
+  }
+
+  console.log('verify-no-network-in-parsers: clean');
+  process.exit(0);
+}
+
+try {
+  main();
+} catch (err) {
+  console.error('verify-no-network-in-parsers: script error');
+  console.error(err);
+  process.exit(2);
+}

--- a/tests/vitest-setup-peac-deprecations.ts
+++ b/tests/vitest-setup-peac-deprecations.ts
@@ -1,0 +1,31 @@
+/**
+ * Root-level vitest setup: silence expected PEAC deprecation warnings.
+ *
+ * v0.12.14 introduces two deprecation codes that many tests legitimately
+ * trigger (`PEAC_DEPRECATED_PREF` on every `PrefResolver` instantiation,
+ * `PEAC_LEGACY_PEAC_TXT_KEY_FIELD` on every peac.txt parse that includes a
+ * legacy key-discovery line). The behaviour itself is covered by dedicated
+ * assertion tests that spy on `process.emitWarning`. Letting the warnings
+ * flow to stderr across the other ~7,600 tests floods CI logs and buries
+ * real warnings.
+ *
+ * This setup removes Node's default `warning` listener and installs a
+ * filter that swallows the two expected PEAC codes. Any other warning
+ * still reaches stderr.
+ */
+
+const EXPECTED_PEAC_DEPRECATION_CODES = new Set([
+  'PEAC_DEPRECATED_PREF',
+  'PEAC_LEGACY_PEAC_TXT_KEY_FIELD',
+]);
+
+for (const listener of process.listeners('warning')) {
+  process.off('warning', listener);
+}
+
+process.on('warning', (warning: NodeJS.ErrnoException & { code?: string }) => {
+  if (warning.code && EXPECTED_PEAC_DEPRECATION_CODES.has(warning.code)) {
+    return;
+  }
+  process.stderr.write(`(node:warning) ${warning.name}: ${warning.message}\n`);
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -96,6 +96,9 @@ export default defineConfig({
       // apps/api new .test.ts files (vitest); legacy .test.js files use node --test
       'apps/api/tests/**/*.test.ts',
     ],
+    // Silence expected PEAC_DEPRECATED_* warnings so CI logs stay readable;
+    // behaviour is still covered by dedicated spy-based assertion tests.
+    setupFiles: ['tests/vitest-setup-peac-deprecations.ts'],
     // Timeout for tests
     testTimeout: 10000,
     // Fail fast on first error in CI


### PR DESCRIPTION
## Summary

`@peac/disc` is now a thin loader over `@peac/policy-kit`. `peac.txt` is
parsed as a `peac-policy/0.1` document (YAML or JSON per
`docs/specs/PEAC-TXT.md`). Legacy key-discovery lines (`verify`,
`public_keys`, `jwks`) are stripped before validation, returned on
`ParseResult.warnings`, and emit a one-shot
`PEAC_LEGACY_PEAC_TXT_KEY_FIELD` `DeprecationWarning`.

`@peac/pref` is now a deprecated facade over
`@peac/mappings-content-signals`. Parsing delegates to the canonical
`Content-Usage`, `robots.txt`, and `tdmrep` parsers. No in-package
`fetch()`. Digest output is `@peac/crypto.jcsHash` (RFC 8785 JCS +
SHA-256, 64 hex), replacing the previous truncated 12-character output.

`@peac/policy-kit` exports `parsePolicyDocument(text)`.

`@peac/protocol` strengthens the deprecated JSDoc on
`parseDiscovery` / `fetchDiscovery`, pointing to
`parseIssuerConfig` / `fetchIssuerConfig`.

## Behavior changes

- `peac.txt` is parsed as a `peac-policy/0.1` document.
- Legacy `verify`, `public_keys`, and `jwks` lines never populate the parsed result.
- `@peac/pref` digest output changes from truncated 12-character hex to full 64-character RFC 8785 JCS + SHA-256 hex.
- `@peac/pref` performs no network I/O. `fetchRobots(...)` rejects with `PEAC_DEPRECATED_PREF_NETWORK`.
- `ResolveContext` adds optional `robotsTxt` and `tdmrep` fields for pre-fetched bytes.
- Instantiating `PrefResolver` emits a one-shot `PEAC_DEPRECATED_PREF` `DeprecationWarning`.

## Reference surfaces

- `@peac/server` serves a `peac-policy/0.1` YAML example at `/.well-known/peac.txt`.
- `@peac/cli discover` surfaces a policy-only hint when legacy warnings appear.
- `apps/api` verifier comment clarifies the policy-only observation stance.

## Tooling and CI

- `scripts/verify-no-network-in-content-signal-parsers.mjs` forbids `fetch()` calls and network imports under `packages/aipref/src` and `packages/mappings/content-signals/src`.
- `eslint.config.mjs` enforces the same boundary.
- Root Vitest setup filters expected `PEAC_DEPRECATED_PREF` and `PEAC_LEGACY_PEAC_TXT_KEY_FIELD` warnings; dedicated tests still assert the warning contract.

## Validation

- `pnpm lint`
- `pnpm typecheck:core`
- `pnpm vitest run` — 7623 / 7623 across 305 files
- `./scripts/guard.sh`
- `pnpm verify:no-network-in-parsers`
- `pnpm format:check`
