### PR TITLE
feat: cf-policy-x402-terms demo and composition docs

### DIFF
--- a/docs/SOLUTIONS/README.md
+++ b/docs/SOLUTIONS/README.md
@@ -9,6 +9,7 @@ Outcome-led recipes. Each one states the real-world problem, the PEAC pieces you
 | [MCP tool-call receipts](mcp-tool-call-receipts.md)     | Attach signed records to MCP tool-call responses.                                                      | MCP server operator         |
 | [Commerce evidence bundle](commerce-evidence-bundle.md) | Bundle observational evidence across x402, ACP, and paymentauth without synthesizing payment finality. | Agentic commerce operator   |
 | [Regulatory audit trail](regulatory-audit-trail.md)     | Build a portable, signed audit trail for EU AI Act, NIST AI RMF, and ISO 42001 review.                 | Compliance / audit lead     |
+| [Cloudflare + x402 + PEAC](cloudflare-x402-peac.md)     | Compose Cloudflare delivery surfaces and x402 PR-1986 terms with PEAC policy and terms binding.        | Cloudflare-fronted operator |
 
 Each recipe follows the same structure:
 

--- a/docs/SOLUTIONS/cloudflare-x402-peac.md
+++ b/docs/SOLUTIONS/cloudflare-x402-peac.md
@@ -1,0 +1,118 @@
+# Cloudflare composition: policy + x402 terms + PEAC binding
+
+> **Outcome:** A site delivered by Cloudflare advertises x402 PR-1986 `terms` in four representations and binds them (alongside its `peac-policy/0.1` document) into PEAC interaction records that any consumer can verify offline.
+>
+> **Audience:** Operator of a Cloudflare-fronted API or content service that wants to compose with x402 PR-1986 terms and AI Crawl Control without taking a dependency on any single provider.
+>
+> **Time:** About 5 minutes from a clean clone using the runnable demo; longer for a real Cloudflare deployment.
+
+## The problem
+
+The Cloudflare ecosystem operationalises three adjacent surfaces:
+
+- **Markdown for Agents** delivers content with `Accept: text/markdown` content negotiation, `vary: accept`, and `content-signal` response headers.
+- **AI Crawl Control** controls who reaches what; pay-per-crawl is in private beta.
+- **x402 SDKs** wire payment rails into agent flows.
+
+None of these produce a verifiable record of what was surfaced and bound. PEAC fills that gap as the records layer: it binds the policy and terms a publisher exposes and emits portable signed records that survive organizational boundaries.
+
+## What you'll use
+
+PEAC packages:
+
+- `@peac/protocol`: issuance, offline verification, document binding.
+- `@peac/adapter-x402`: x402 mappers including `computeX402TermsDigest`.
+- `@peac/policy-kit`: optional, for compiling `peac-policy/0.1` source documents.
+- `@peac/crypto`: signing.
+
+Adjacent surfaces (operator's choice):
+
+- Cloudflare Workers / Cloudflare Pages for the delivery side.
+- Cloudflare AI Crawl Control for crawler-side enforcement.
+- An x402 SDK (`@x402/fetch`, `x402-hono`, `agents/x402`) for payment.
+- Any compatible reference verifier: this repo ships [`surfaces/reference-verifier/`](../../surfaces/reference-verifier/) Dockerfile, docker-compose, and Cloudflare Worker variants.
+
+Prerequisites: Node 22+, pnpm 8+, a Cloudflare account if you intend to deploy. The runnable demo is offline.
+
+## Recipe
+
+### 1. Author the policy and terms
+
+Author the `peac-policy/0.1` source document and the four x402 PR-1986 representations (`uri`, `markdown`, `plaintext`, `json`). The runnable example under [`examples/cf-policy-x402-terms/`](../../examples/cf-policy-x402-terms/) is the canonical template.
+
+### 2. Compute and bind the policy digest
+
+Compute the JCS+SHA-256 digest of the policy document and bind it into the issued receipt's `policy.digest` field via `issue()`. Verifiers compute the same digest locally and report `policy_binding = 'verified'` on a match.
+
+### 3. Compute per-representation terms digests
+
+For each of the four x402 `terms` representations the publisher exposes, compute the corresponding digest with `computeX402TermsDigest`. Each representation envelope is its own binding identity.
+
+```ts
+import { computeX402TermsDigest } from '@peac/adapter-x402';
+
+const mdDigest = await computeX402TermsDigest({
+  representation: 'markdown',
+  bytes: markdownBytes,
+});
+const jsonDigest = await computeX402TermsDigest({
+  representation: 'json',
+  value: termsObject,
+});
+// uri without bytes returns 'unavailable'
+const uriDigest = await computeX402TermsDigest({
+  representation: 'uri',
+  uri: 'https://api.example.com/.well-known/peac-terms.txt',
+});
+```
+
+### 4. Compose with Cloudflare Markdown for Agents
+
+When Cloudflare serves the markdown representation via `Accept: text/markdown`, the bytes returned are the binding identity. The PEAC binding still applies: the consumer hashes the bytes it received and compares against the publisher digest. Cloudflare's `vary: accept` and `content-signal` headers are observable inputs the consumer MAY also project into a PEAC record via `@peac/mappings-content-signals`.
+
+### 5. Compose with x402 PR-1986
+
+x402 PR-1986 advertises the `terms` field but does not define consent or binding. PEAC adds the binding/proof layer: the same publisher who advertises the terms also issues PEAC records that bind the digest and prove what was surfaced. See the upstream comment trail on [x402 PR #1986](https://github.com/x402-foundation/x402/pull/1986) for the alignment.
+
+### 6. Verify offline
+
+```ts
+import { verifyLocal, checkDocumentBinding, computeTextDocumentDigestUtf8 } from '@peac/protocol';
+
+const verifierTermsDigest = await computeTextDocumentDigestUtf8(markdownBytes, 'markdown');
+const termsBinding = {
+  ref: 'terms.md',
+  representation: 'markdown' as const,
+  status: checkDocumentBinding(publisherTermsDigest, verifierTermsDigest),
+};
+
+const report = await verifyLocal(jws, publicKey, {
+  issuer,
+  policyDigest,
+  bindings: { terms: termsBinding },
+});
+```
+
+The verifier never performs network I/O on the URI representation. If the consumer needs to bind the URI envelope, they fetch the bytes under their own SSRF / redirect / timeout policy and call the helper with `bytes` populated.
+
+## Validated with
+
+- Runnable demo: [`examples/cf-policy-x402-terms/demo.ts`](../../examples/cf-policy-x402-terms/demo.ts).
+- Document-binding helpers: [`packages/protocol/src/document-binding.ts`](../../packages/protocol/src/document-binding.ts).
+- Test fixtures: [`packages/protocol/__tests__/document-binding.test.ts`](../../packages/protocol/__tests__/document-binding.test.ts).
+- x402 terms helper tests: [`packages/adapters/x402/tests/terms.test.ts`](../../packages/adapters/x402/tests/terms.test.ts).
+
+## Cross-references
+
+- [docs/specs/DOCUMENT-BINDING.md](../specs/DOCUMENT-BINDING.md): normative binding semantics.
+- [docs/specs/X402-PROFILE.md](../specs/X402-PROFILE.md): x402 profile.
+- [docs/specs/AIPREF-COMPOSITION.md](../specs/AIPREF-COMPOSITION.md): composing AIPREF content-use signals into PEAC records.
+- [docs/specs/SCITT-COMPOSITION.md](../specs/SCITT-COMPOSITION.md): wrapping a PEAC record as a SCITT Signed Statement.
+- [docs/privacy/](../privacy/README.md): privacy-aware deployment guidance for Cloudflare-fronted PEAC deployments.
+
+## What this recipe does NOT do
+
+- Does not replace Cloudflare AI Crawl Control. PEAC records what was bound and verified; AI Crawl Control records who reached it.
+- Does not replace the x402 payment rail. PEAC records the terms binding; x402 handles the payment.
+- Does not perform network I/O from the binding layer. Callers fetch under their own SSRF / redirect / timeout policy.
+- Does not stamp `terms` digests into the emitted receipt or envelope. The digest is verifier-report-only; see [DOCUMENT-BINDING.md](../specs/DOCUMENT-BINDING.md) §6.

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -9,7 +9,7 @@
     "tests": 7600,
     "test_files": 304,
     "published_packages": 37,
-    "build_targets": 105,
+    "build_targets": 106,
     "conformance_requirement_ids": 224,
     "conformance_sections": 25
   },

--- a/docs/specs/AIPREF-COMPOSITION.md
+++ b/docs/specs/AIPREF-COMPOSITION.md
@@ -1,0 +1,103 @@
+# PEAC and IETF AIPREF Composition
+
+**Status:** Informative
+**Version:** 0.1
+**Applies to:** Operators wiring AIPREF content-use signals
+(`draft-ietf-aipref-attach`, `draft-ietf-aipref-vocab`) into PEAC
+records. Composes with the canonical `@peac/mappings-content-signals`
+parser.
+
+---
+
+## Why this document exists
+
+AIPREF defines the language for content-use preferences:
+
+- [`draft-ietf-aipref-attach`](https://datatracker.ietf.org/doc/draft-ietf-aipref-attach/)
+  defines an HTTP `Content-Usage` header (RFC 9651 Structured Fields
+  Dictionary) and a robots.txt directive form.
+- [`draft-ietf-aipref-vocab`](https://datatracker.ietf.org/doc/draft-ietf-aipref-vocab/)
+  defines the vocabulary (`train-ai`, `search`) with
+  `y` / `n` / `unknown` token values.
+
+PEAC is the records layer. PEAC composes with AIPREF rather than
+replacing it: AIPREF is the input language; PEAC binds and proves
+what was surfaced. This document specifies that composition.
+
+## Boundary
+
+- PEAC does not mint AIPREF preferences.
+- PEAC does not claim that an AIPREF preference is GDPR consent.
+  Preferences are publisher-asserted signals, not data-subject
+  consent. See
+  [docs/privacy/DATA-SUBJECT-RIGHTS.md](../privacy/DATA-SUBJECT-RIGHTS.md)
+  §2.
+- PEAC does not normatively compile AIPREF into `@peac/policy-kit`
+  policy decisions. AIPREF can be projected into a PEAC record as an
+  observation (via `@peac/mappings-content-signals`), but the policy
+  surface is independent.
+
+## Composition pattern
+
+The recommended composition has three layers:
+
+1. **Surfacing.** The publisher exposes AIPREF preferences via the
+   `Content-Usage` HTTP header, a robots.txt directive, or both.
+2. **Parsing.** A consumer parses the surfaced preferences via
+   `@peac/mappings-content-signals` (`parseContentUsage`,
+   `parseRobotsTxt`, `parseTdmrep`, `resolveSignals`). Parsing is
+   bytes-in / structured-out and performs no network I/O of its own.
+3. **Recording.** The consumer projects the parsed preferences into a
+   PEAC record either as an observation extension or, where the
+   publisher chose to bind, as a referenced document with a
+   `bindings.documents[]` entry computed via `computeDocumentDigest`.
+
+### Wire-side projection (observation)
+
+Treat AIPREF preferences as an observation: what the consumer saw
+when it fetched the resource. The consumer issues a PEAC evidence
+record describing the surfaced preference set; the verifier
+reconstructs the same digest from the same bytes. AIPREF values do
+not become PEAC policy decisions.
+
+### Document-binding projection (referenced doc)
+
+Treat the AIPREF surface (e.g. the exact `Content-Usage` header value
+or the served robots.txt body) as a referenced document and bind it
+into the verifier report's `bindings.documents` array. The publisher
+need not issue the record themselves; any consumer who fetched the
+bytes can record what they observed and bind it for replay.
+
+## Helper-naming reminder
+
+When projecting AIPREF preferences into a record, follow the
+`docs/specs/DOCUMENT-BINDING.md` helper-naming contract:
+
+- Hash the parsed JSON observation via `computeJsonDocumentDigestJcs`.
+- Hash the served `Content-Usage` header bytes (markdown / plaintext
+  envelopes do not apply to a single header line; treat the header
+  value as a `plaintext` representation if you bind the literal
+  bytes).
+- Use `computeDocumentDigest` as the dispatcher when the
+  representation is selected at runtime.
+
+## Cross-references
+
+- [docs/specs/DOCUMENT-BINDING.md](DOCUMENT-BINDING.md): normative
+  binding semantics including the publisher-supplied
+  `canonical_digest` rule.
+- [docs/specs/VERIFICATION-REPORT-FORMAT.md](VERIFICATION-REPORT-FORMAT.md):
+  verifier report `bindings` shape.
+- [docs/privacy/DATA-SUBJECT-RIGHTS.md](../privacy/DATA-SUBJECT-RIGHTS.md):
+  AIPREF preferences are not consent.
+- [`packages/mappings/content-signals/`](../../packages/mappings/content-signals/):
+  RFC 9651 SF parsers for AIPREF, robots, tdmrep.
+
+## References
+
+- [RFC 9651: HTTP Structured Fields](https://www.rfc-editor.org/rfc/rfc9651.html).
+- [`draft-ietf-aipref-attach`](https://datatracker.ietf.org/doc/draft-ietf-aipref-attach/):
+  attach mechanism.
+- [`draft-ietf-aipref-vocab`](https://datatracker.ietf.org/doc/draft-ietf-aipref-vocab/):
+  preference vocabulary.
+- [RFC 9309: Robots Exclusion Protocol](https://www.rfc-editor.org/rfc/rfc9309.html).

--- a/docs/specs/AIPREF-COMPOSITION.md
+++ b/docs/specs/AIPREF-COMPOSITION.md
@@ -1,4 +1,4 @@
-# PEAC and IETF AIPREF Composition
+# PEAC and AIPREF Composition
 
 **Status:** Informative
 **Version:** 0.1

--- a/docs/specs/SCITT-COMPOSITION.md
+++ b/docs/specs/SCITT-COMPOSITION.md
@@ -1,11 +1,12 @@
-# PEAC and IETF SCITT Composition
+# PEAC and SCITT Composition
 
 **Status:** Informative
 **Version:** 0.1
 **Applies to:** Operators planning to expose PEAC interaction records
 through a SCITT-style transparency log
-([draft-ietf-scitt-architecture](https://datatracker.ietf.org/doc/draft-ietf-scitt-architecture/),
-in RFC Editor Queue).
+([draft-ietf-scitt-architecture](https://datatracker.ietf.org/doc/draft-ietf-scitt-architecture/);
+nearing publication at the time of writing (2026-04). Check
+Datatracker for the current state before relying on the wire shape).
 
 ---
 
@@ -80,7 +81,8 @@ without parsing the PEAC record.
 ## References
 
 - [`draft-ietf-scitt-architecture`](https://datatracker.ietf.org/doc/draft-ietf-scitt-architecture/):
-  in RFC Editor Queue at the time of writing.
+  current draft at the time of writing (2026-04). Check Datatracker
+  for the latest revision before implementation.
 - [RFC 9052: CBOR Object Signing and Encryption (COSE)](https://www.rfc-editor.org/rfc/rfc9052.html).
 - [RFC 8392: CWT Claims](https://www.rfc-editor.org/rfc/rfc8392.html).
 - [RFC 7515: JSON Web Signature (JWS)](https://www.rfc-editor.org/rfc/rfc7515.html):

--- a/docs/specs/SCITT-COMPOSITION.md
+++ b/docs/specs/SCITT-COMPOSITION.md
@@ -1,0 +1,87 @@
+# PEAC and IETF SCITT Composition
+
+**Status:** Informative
+**Version:** 0.1
+**Applies to:** Operators planning to expose PEAC interaction records
+through a SCITT-style transparency log
+([draft-ietf-scitt-architecture](https://datatracker.ietf.org/doc/draft-ietf-scitt-architecture/),
+in RFC Editor Queue).
+
+---
+
+## Why this document exists
+
+SCITT (Supply Chain Integrity, Transparency, and Trust) defines a
+COSE_Sign1-based transparency-log architecture for "signed
+statements" with "receipts" and "transparent statements." PEAC ships
+JWS-based interaction records on the wire today.
+
+This document describes how the two compose. It is informative; it
+does not change the PEAC wire format.
+
+## Boundary
+
+- PEAC does not switch its wire-format default to COSE/CBOR.
+  COSE/CBOR remains experimental in PEAC; the v0.13.x reboot covers
+  any wire-codec evolution under its own gates.
+- PEAC does not host a transparency log. SCITT-aware deployers
+  operate the log themselves or use an existing operator.
+- PEAC does not redefine SCITT terminology. The mapping below
+  reflects the SCITT architecture draft; operators MUST verify
+  against the latest draft when implementing.
+
+## Term mapping
+
+| SCITT term            | PEAC analogue                                                                                                                  |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Signed Statement      | A PEAC interaction record (JWS) is the natural "Statement" payload. The signing identity is the issuer in the JOSE header.     |
+| Receipt               | Currently SCITT-specific; PEAC verifier reports are the closest local analogue but are not byte-equivalent to a SCITT receipt. |
+| Transparent Statement | A SCITT log entry containing the PEAC record + the SCITT receipt for that record.                                              |
+| Issuer                | The PEAC issuer (same identity surfaced via `kid` and `iss`).                                                                  |
+| Verifier              | A SCITT verifier MAY accept the PEAC record as the wrapped Statement. PEAC `verifyLocal()` is independent.                     |
+
+## Composition pattern
+
+The recommended composition has three steps:
+
+1. **Issue.** The operator issues a PEAC interaction record via
+   `issue()`. The record is a compact JWS with `typ:
+interaction-record+jwt`.
+2. **Wrap.** The operator wraps the JWS as the payload of a SCITT
+   Signed Statement. The SCITT signing identity MAY be the same as
+   the PEAC issuer; it MAY also be a separate transparency-service
+   identity.
+3. **Append.** The Signed Statement is submitted to a SCITT-style
+   log. The log returns a SCITT Receipt; the operator stores both as
+   a Transparent Statement.
+
+PEAC verification (`verifyLocal()`) and SCITT verification are
+independent. A consumer MAY check the PEAC signature without ever
+touching the SCITT log; a consumer MAY check the SCITT receipt
+without parsing the PEAC record.
+
+## What this composition does NOT claim
+
+- It does not add a new wire field to PEAC.
+- It does not claim that a SCITT receipt is a PEAC verifier report.
+- It does not claim that a PEAC verifier report is a SCITT receipt.
+- It does not change PEAC's policy or terms binding semantics. Those
+  remain on the PEAC record per
+  [docs/specs/DOCUMENT-BINDING.md](DOCUMENT-BINDING.md).
+
+## Cross-references
+
+- [docs/specs/DOCUMENT-BINDING.md](DOCUMENT-BINDING.md): per-
+  representation envelope binding semantics.
+- [docs/specs/VERIFICATION-REPORT-FORMAT.md](VERIFICATION-REPORT-FORMAT.md):
+  PEAC verifier report shape (distinct from SCITT receipts).
+- [docs/specs/X402-PROFILE.md](X402-PROFILE.md): commerce composition.
+
+## References
+
+- [`draft-ietf-scitt-architecture`](https://datatracker.ietf.org/doc/draft-ietf-scitt-architecture/):
+  in RFC Editor Queue at the time of writing.
+- [RFC 9052: CBOR Object Signing and Encryption (COSE)](https://www.rfc-editor.org/rfc/rfc9052.html).
+- [RFC 8392: CWT Claims](https://www.rfc-editor.org/rfc/rfc8392.html).
+- [RFC 7515: JSON Web Signature (JWS)](https://www.rfc-editor.org/rfc/rfc7515.html):
+  the PEAC signing format used by `issue()`.

--- a/examples/cf-policy-x402-terms/README.md
+++ b/examples/cf-policy-x402-terms/README.md
@@ -1,0 +1,105 @@
+# cf-policy-x402-terms
+
+End-to-end demo composing PEAC policy binding with x402 PR-1986 `terms`
+across the four representation envelopes (`uri`, `markdown`,
+`plaintext`, `json`).
+
+This demo is offline by default. PEAC composes with Cloudflare delivery
+surfaces (Markdown for Agents, AI Crawl Control, x402 SDKs) and with
+x402 PR-1986 `terms`; PEAC does not replace either.
+
+## What it shows
+
+1. A `peac-policy/0.1` document is canonicalized via JCS+SHA-256 and
+   bound into a Wire 0.2 evidence receipt's `policy.digest` field.
+2. The same document advertises x402 `terms` in four representations
+   (under `terms/`). Each representation envelope produces its own
+   binding identity via `computeX402TermsDigest`.
+3. The verifier is invoked offline with `verifyLocal()`. The caller
+   threads a pre-computed `bindings.terms` result through; the
+   verifier surfaces it on the report without ever performing network
+   I/O on the terms URI.
+4. Cross-representation comparison is `failed` by design: a JSON
+   publisher digest cannot match a plaintext verifier digest of
+   nominally-equivalent content.
+5. An omitted publisher canonical digest reports `unavailable`, not
+   `failed`. Verifiers MUST NOT synthesize a canonical digest from a
+   non-JSON representation.
+
+## Run
+
+```bash
+pnpm install
+pnpm --filter @peac/example-cf-policy-x402-terms demo
+```
+
+Expected output (truncated):
+
+```text
+cf-policy-x402-terms demo
+==========================
+
+[1] policy digest:  sha256:<64 hex>
+[2] jws issued:     length=<n>
+
+[3] per-representation terms digests:
+    uri       = unavailable
+    markdown  = sha256:<64 hex>
+    plaintext = sha256:<64 hex>
+    json      = sha256:<64 hex>
+
+[4] verifyLocal report:
+    valid:               true
+    wireVersion:         0.2
+    policy_binding:      verified
+    bindings.policy:     verified
+    bindings.terms.ref:  terms.md
+    bindings.terms.repr: markdown
+    bindings.terms.stat: verified
+
+[5] cross-representation (json publisher vs plaintext verifier): failed
+[6] omitted publisher canonical_digest: unavailable
+
+Demo OK.
+```
+
+## What this demo intentionally does NOT do
+
+- Fetch the URI representation. PEAC does not perform network I/O from
+  the binding layer. The URI representation reports `unavailable`
+  unless the caller supplies fetched bytes under their own SSRF /
+  redirect / timeout policy.
+- Synthesize a canonical JSON digest from the markdown or plaintext
+  representations. Cross-representation equivalence is publisher-
+  asserted only; verifiers report `unavailable` when the publisher
+  did not supply a `canonical_digest`.
+- Stamp the `terms` digest into the emitted receipt or envelope. The
+  digest is verifier-report-only; see
+  [docs/specs/DOCUMENT-BINDING.md](../../docs/specs/DOCUMENT-BINDING.md).
+
+## Composition surfaces
+
+- **Cloudflare Markdown for Agents** can deliver the markdown
+  representation via `Accept: text/markdown` with `vary: accept` and
+  `content-signal` headers. The PEAC binding still applies because the
+  bytes are the binding identity, not the transport.
+- **Cloudflare AI Crawl Control** can enforce access to the policy and
+  terms surfaces. PEAC records what was bound and verified; AI Crawl
+  Control records who reached it.
+- **x402 PR-1986** defines the `terms` field used here. PEAC adds the
+  binding/proof layer the upstream PR explicitly does not define.
+- **AIPREF** content-use signals can be projected into PEAC records
+  via `@peac/mappings-content-signals`. Preferences are NOT consent;
+  see [docs/privacy/DATA-SUBJECT-RIGHTS.md](../../docs/privacy/DATA-SUBJECT-RIGHTS.md) §2.
+
+## Files
+
+```text
+policy.yaml            peac-policy/0.1 source document
+terms/terms.uri.txt    URI-only representation (returns unavailable without bytes)
+terms/terms.md         Markdown representation
+terms/terms.plaintext.txt  Plaintext representation
+terms/terms.json       JSON representation
+demo.ts                end-to-end runner
+fixtures/              expected verifier-report fragments (test-only)
+```

--- a/examples/cf-policy-x402-terms/README.md
+++ b/examples/cf-policy-x402-terms/README.md
@@ -95,11 +95,13 @@ Demo OK.
 ## Files
 
 ```text
-policy.yaml            peac-policy/0.1 source document
-terms/terms.uri.txt    URI-only representation (returns unavailable without bytes)
-terms/terms.md         Markdown representation
-terms/terms.plaintext.txt  Plaintext representation
-terms/terms.json       JSON representation
-demo.ts                end-to-end runner
-fixtures/              expected verifier-report fragments (test-only)
+policy.yaml                policy source (peac-policy/0.1)
+terms/terms.uri.txt        URI-only representation (returns unavailable without bytes)
+terms/terms.md             markdown representation
+terms/terms.plaintext.txt  plaintext representation
+terms/terms.json           JSON representation
+demo.ts                    end-to-end runner
+tests/demo.test.ts         smoke test that runs the demo and pins expected output
 ```
+
+Expected verifier-report values are pinned inside `tests/demo.test.ts`; no separate fixture directory is needed for this demo.

--- a/examples/cf-policy-x402-terms/demo.ts
+++ b/examples/cf-policy-x402-terms/demo.ts
@@ -1,0 +1,264 @@
+/**
+ * cf-policy-x402-terms end-to-end demo
+ *
+ * Composes PEAC policy binding with x402 PR-1986 `terms` across the four
+ * representation envelopes (`uri`, `markdown`, `plaintext`, `json`).
+ *
+ * Steps:
+ *   1. Read a `peac-policy/0.1` document and compute its JCS+SHA-256 digest.
+ *   2. Issue a Wire 0.2 evidence receipt that binds `policy.digest` and
+ *      advertises x402 terms via the commerce extension.
+ *   3. Compute a per-representation `terms` digest with
+ *      `computeX402TermsDigest` for each of the four representations.
+ *   4. Verify the receipt offline with `verifyLocal()`, threading the
+ *      caller-supplied `bindings.terms` result through; print the report.
+ *   5. Demonstrate the cross-representation `failed` lock by intentionally
+ *      mixing a publisher digest from one representation with the
+ *      verifier-side bytes of another.
+ *
+ * Network: none. All artifacts are read from disk; no fetch calls.
+ *
+ * Privacy: this demo uses non-personal-data subject identifiers
+ * (service account agent IDs). See docs/privacy/DATA-CLASSIFICATION.md
+ * for guidance on which fields may carry personal data in real
+ * deployments.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { generateKeypair, jcsHash } from '@peac/crypto';
+import {
+  issue,
+  verifyLocal,
+  computeJsonDocumentDigestJcs,
+  computeTextDocumentDigestUtf8,
+  checkDocumentBinding,
+} from '@peac/protocol';
+import { computeX402TermsDigest } from '@peac/adapter-x402';
+import type { DocumentBindingResult } from '@peac/protocol';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+function read(p: string): string {
+  return readFileSync(join(HERE, p), 'utf8');
+}
+
+/**
+ * Parse the demo policy.yaml into a JSON value. The demo deliberately
+ * uses a tiny hand-rolled YAML reader instead of pulling in `js-yaml`
+ * to keep the example dependency surface minimal. The parser only
+ * understands the demo policy shape (flat map + nested map + arrays of
+ * strings + simple scalars), and intentionally fails on anything else.
+ */
+function loadPolicy(yamlText: string): Record<string, unknown> {
+  const lines = yamlText.split('\n');
+  const root: Record<string, unknown> = {};
+  type Frame = { obj: Record<string, unknown>; indent: number; key?: string; arr?: string[] };
+  const stack: Frame[] = [{ obj: root, indent: -1 }];
+
+  for (const raw of lines) {
+    if (!raw.trim() || raw.trim().startsWith('#')) continue;
+    const indent = raw.length - raw.trimStart().length;
+    const line = raw.trim();
+
+    while (stack.length > 1 && indent <= stack[stack.length - 1].indent) {
+      const popped = stack.pop()!;
+      if (popped.arr && popped.key) {
+        stack[stack.length - 1].obj[popped.key] = popped.arr;
+      }
+    }
+
+    const frame = stack[stack.length - 1];
+
+    if (line.startsWith('- ')) {
+      // array item
+      const value = line.slice(2).trim();
+      if (!frame.arr) {
+        throw new Error(`unexpected array item at indent ${indent}: ${line}`);
+      }
+      frame.arr.push(value.replace(/^['"]|['"]$/g, ''));
+      continue;
+    }
+
+    const m = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (!m) throw new Error(`cannot parse line: ${raw}`);
+    const [, key, rest] = m;
+
+    if (rest === '' || rest === undefined) {
+      // either nested object or array follows
+      const next: Record<string, unknown> = {};
+      const arr: string[] = [];
+      // peek next non-empty line
+      const nextLineIdx = lines.indexOf(raw) + 1;
+      let peek = '';
+      for (let i = nextLineIdx; i < lines.length; i++) {
+        if (lines[i].trim() && !lines[i].trim().startsWith('#')) {
+          peek = lines[i];
+          break;
+        }
+      }
+      if (peek.trim().startsWith('- ')) {
+        frame.obj[key] = arr;
+        stack.push({ obj: {}, indent, key, arr });
+      } else {
+        frame.obj[key] = next;
+        stack.push({ obj: next, indent });
+      }
+      continue;
+    }
+
+    // scalar
+    let value: unknown = rest.replace(/^['"]|['"]$/g, '');
+    if (value === 'true') value = true;
+    else if (value === 'false') value = false;
+    else if (typeof value === 'string' && /^-?\d+$/.test(value)) value = Number(value);
+    frame.obj[key] = value;
+  }
+
+  // flush any pending arrays
+  while (stack.length > 1) {
+    const popped = stack.pop()!;
+    if (popped.arr && popped.key) {
+      stack[stack.length - 1].obj[popped.key] = popped.arr;
+    }
+  }
+
+  return root;
+}
+
+async function main() {
+  console.log('cf-policy-x402-terms demo');
+  console.log('==========================');
+
+  // 1. Load policy.yaml and compute the canonical digest.
+  const policyYaml = read('policy.yaml');
+  const policyDoc = loadPolicy(policyYaml);
+  const policyDigest = `sha256:${await jcsHash(policyDoc as never)}`;
+  console.log(`\n[1] policy digest:  ${policyDigest}`);
+
+  // 2. Issue a Wire 0.2 evidence receipt with the policy.digest bound in.
+  const { privateKey, publicKey } = await generateKeypair();
+  const kid = '2026-04-22';
+  const { jws } = await issue({
+    iss: 'https://api.example.com',
+    sub: 'agent:demo-runner',
+    kind: 'evidence',
+    type: 'org.peacprotocol/inference',
+    pillars: ['attribution', 'commerce'],
+    policy: { digest: policyDigest, version: '1' },
+    extensions: {
+      'org.peacprotocol/commerce': {
+        payment_rail: 'x402',
+        amount_minor: '100000',
+        currency: 'USD',
+      },
+    },
+    privateKey,
+    kid,
+  });
+  console.log(`[2] jws issued:     length=${jws.length}`);
+
+  // 3. Compute a per-representation terms digest for each of the four
+  //    x402 PR-1986 representations.
+  const termsUriBytes = read('terms/terms.uri.txt').trim();
+  const termsMd = read('terms/terms.md');
+  const termsPlain = read('terms/terms.plaintext.txt');
+  const termsJson = JSON.parse(read('terms/terms.json'));
+
+  const digests = {
+    uri: await computeX402TermsDigest({
+      representation: 'uri',
+      uri: termsUriBytes,
+    }),
+    markdown: await computeX402TermsDigest({
+      representation: 'markdown',
+      bytes: termsMd,
+    }),
+    plaintext: await computeX402TermsDigest({
+      representation: 'plaintext',
+      bytes: termsPlain,
+    }),
+    json: await computeX402TermsDigest({
+      representation: 'json',
+      value: termsJson,
+    }),
+  };
+  console.log('\n[3] per-representation terms digests:');
+  for (const [k, v] of Object.entries(digests)) {
+    console.log(`    ${k.padEnd(9)} = ${v}`);
+  }
+  if (digests.uri !== 'unavailable') {
+    throw new Error('uri without fetched bytes must report unavailable');
+  }
+
+  // 4. Verify the receipt offline. Thread a caller-supplied bindings.terms
+  //    for the markdown representation; use checkDocumentBinding to compare
+  //    the verifier-computed digest against the publisher digest.
+  const publisherTermsDigestMd = await computeTextDocumentDigestUtf8(termsMd, 'markdown');
+  const verifierTermsDigestMd = digests.markdown;
+  const termsBinding: DocumentBindingResult = {
+    ref: 'terms.md',
+    representation: 'markdown',
+    status: checkDocumentBinding(publisherTermsDigestMd, verifierTermsDigestMd as string),
+  };
+  const result = await verifyLocal(jws, publicKey, {
+    issuer: 'https://api.example.com',
+    policyDigest,
+    bindings: { terms: termsBinding },
+  });
+
+  if (!result.valid) {
+    console.error('\n[4] verifyLocal FAILED:', result);
+    process.exit(1);
+  }
+
+  console.log('\n[4] verifyLocal report:');
+  console.log(`    valid:               ${result.valid}`);
+  console.log(`    wireVersion:         ${(result as { wireVersion: string }).wireVersion}`);
+  console.log(`    policy_binding:      ${result.policy_binding}`);
+  console.log(`    bindings.policy:     ${result.bindings?.policy}`);
+  console.log(`    bindings.terms.ref:  ${result.bindings?.terms?.ref}`);
+  console.log(`    bindings.terms.repr: ${result.bindings?.terms?.representation}`);
+  console.log(`    bindings.terms.stat: ${result.bindings?.terms?.status}`);
+
+  if (result.policy_binding !== 'verified') {
+    throw new Error(`expected policy_binding=verified, got ${result.policy_binding}`);
+  }
+  if (result.bindings?.terms?.status !== 'verified') {
+    throw new Error(
+      `expected bindings.terms.status=verified, got ${result.bindings?.terms?.status}`
+    );
+  }
+
+  // 5. Cross-representation failed-by-design lock.
+  const crossRepStatus = checkDocumentBinding(digests.json as string, digests.plaintext as string);
+  console.log(
+    `\n[5] cross-representation (json publisher vs plaintext verifier): ${crossRepStatus}`
+  );
+  if (crossRepStatus !== 'failed') {
+    throw new Error(`cross-representation comparison must be failed by design`);
+  }
+
+  // 6. Negative case: omitted publisher canonical_digest must be unavailable,
+  //    not failed.
+  const omittedCanonical = checkDocumentBinding(undefined, digests.json as string);
+  console.log(`[6] omitted publisher canonical_digest: ${omittedCanonical}`);
+  if (omittedCanonical !== 'unavailable') {
+    throw new Error(`omitted publisher digest must be unavailable, not failed`);
+  }
+
+  // 7. Network-discipline check: confirm we used computeJsonDocumentDigestJcs
+  //    on the JSON representation byte-identically with the dispatcher.
+  const directJson = await computeJsonDocumentDigestJcs(termsJson);
+  if (directJson !== digests.json) {
+    throw new Error(`direct json helper must equal dispatcher output`);
+  }
+
+  console.log('\nDemo OK.');
+}
+
+main().catch((e) => {
+  console.error('Demo failed:', e);
+  process.exit(1);
+});

--- a/examples/cf-policy-x402-terms/demo.ts
+++ b/examples/cf-policy-x402-terms/demo.ts
@@ -48,8 +48,12 @@ function read(p: string): string {
  * Parse the demo policy.yaml into a JSON value. The demo deliberately
  * uses a tiny hand-rolled YAML reader instead of pulling in `js-yaml`
  * to keep the example dependency surface minimal. The parser only
- * understands the demo policy shape (flat map + nested map + arrays of
- * strings + simple scalars), and intentionally fails on anything else.
+ * understands the demo policy shape (flat map + nested map + arrays
+ * of strings + simple scalars), and intentionally fails on anything
+ * else. The reader is positional: it tracks the current line index
+ * directly rather than scanning by string content, so duplicated
+ * lines (e.g. blank or comment lines that happen to repeat) cannot
+ * mis-align the lookahead.
  */
 function loadPolicy(yamlText: string): Record<string, unknown> {
   const lines = yamlText.split('\n');
@@ -57,7 +61,17 @@ function loadPolicy(yamlText: string): Record<string, unknown> {
   type Frame = { obj: Record<string, unknown>; indent: number; key?: string; arr?: string[] };
   const stack: Frame[] = [{ obj: root, indent: -1 }];
 
-  for (const raw of lines) {
+  // Find the next non-empty, non-comment line index strictly after `from`.
+  function peekNextIndex(from: number): number {
+    for (let j = from + 1; j < lines.length; j++) {
+      const s = lines[j].trim();
+      if (s.length > 0 && !s.startsWith('#')) return j;
+    }
+    return -1;
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i];
     if (!raw.trim() || raw.trim().startsWith('#')) continue;
     const indent = raw.length - raw.trimStart().length;
     const line = raw.trim();
@@ -72,7 +86,6 @@ function loadPolicy(yamlText: string): Record<string, unknown> {
     const frame = stack[stack.length - 1];
 
     if (line.startsWith('- ')) {
-      // array item
       const value = line.slice(2).trim();
       if (!frame.arr) {
         throw new Error(`unexpected array item at indent ${indent}: ${line}`);
@@ -86,29 +99,22 @@ function loadPolicy(yamlText: string): Record<string, unknown> {
     const [, key, rest] = m;
 
     if (rest === '' || rest === undefined) {
-      // either nested object or array follows
-      const next: Record<string, unknown> = {};
-      const arr: string[] = [];
-      // peek next non-empty line
-      const nextLineIdx = lines.indexOf(raw) + 1;
-      let peek = '';
-      for (let i = nextLineIdx; i < lines.length; i++) {
-        if (lines[i].trim() && !lines[i].trim().startsWith('#')) {
-          peek = lines[i];
-          break;
-        }
-      }
+      // Either a nested object or an array follows. Decide by peeking at
+      // the next significant line by index, never by string content.
+      const nextIdx = peekNextIndex(i);
+      const peek = nextIdx >= 0 ? lines[nextIdx] : '';
       if (peek.trim().startsWith('- ')) {
+        const arr: string[] = [];
         frame.obj[key] = arr;
         stack.push({ obj: {}, indent, key, arr });
       } else {
+        const next: Record<string, unknown> = {};
         frame.obj[key] = next;
         stack.push({ obj: next, indent });
       }
       continue;
     }
 
-    // scalar
     let value: unknown = rest.replace(/^['"]|['"]$/g, '');
     if (value === 'true') value = true;
     else if (value === 'false') value = false;
@@ -116,7 +122,6 @@ function loadPolicy(yamlText: string): Record<string, unknown> {
     frame.obj[key] = value;
   }
 
-  // flush any pending arrays
   while (stack.length > 1) {
     const popped = stack.pop()!;
     if (popped.arr && popped.key) {

--- a/examples/cf-policy-x402-terms/package.json
+++ b/examples/cf-policy-x402-terms/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@peac/example-cf-policy-x402-terms",
+  "version": "0.0.0",
+  "private": true,
+  "description": "End-to-end demo composing PEAC policy binding with x402 PR-1986 terms across four representations.",
+  "type": "module",
+  "scripts": {
+    "demo": "tsx demo.ts",
+    "test": "vitest run --passWithNoTests",
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@peac/adapter-x402": "workspace:*",
+    "@peac/crypto": "workspace:*",
+    "@peac/protocol": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0",
+    "typescript": "^5.3.3",
+    "vitest": "^4.1.0"
+  }
+}

--- a/examples/cf-policy-x402-terms/package.json
+++ b/examples/cf-policy-x402-terms/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "demo": "tsx demo.ts",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run",
     "build": "tsc",
     "typecheck": "tsc --noEmit"
   },

--- a/examples/cf-policy-x402-terms/policy.yaml
+++ b/examples/cf-policy-x402-terms/policy.yaml
@@ -1,4 +1,4 @@
-# peac-policy/0.1 — example policy for the cf-policy-x402-terms demo
+# peac-policy/0.1: example policy for the cf-policy-x402-terms demo
 #
 # Demonstrates a publisher who:
 #   - allows search engine indexing,

--- a/examples/cf-policy-x402-terms/policy.yaml
+++ b/examples/cf-policy-x402-terms/policy.yaml
@@ -1,0 +1,32 @@
+# peac-policy/0.1 — example policy for the cf-policy-x402-terms demo
+#
+# Demonstrates a publisher who:
+#   - allows search engine indexing,
+#   - disallows AI training,
+#   - offers paid AI inference under attribution requirements,
+#   - advertises x402 PR-1986 terms in four representations (see terms/).
+#
+# This policy compiles to a peac-policy/0.1 document. Its JCS+SHA-256
+# digest is bound into the issued receipt's policy.digest field; the
+# verifier computes the same digest locally and reports policy_binding =
+# 'verified' on a match.
+version: peac-policy/0.1
+issuer: https://api.example.com
+purposes:
+  - search-indexing
+  - inference
+usage:
+  search-indexing: allowed
+  ai-train: disallowed
+  inference: conditional
+attribution:
+  required: true
+  format: 'origin-uri+author'
+payment:
+  rail: x402
+  hint:
+    network: eip155:8453
+    asset: USDC
+    amount_minor: '100000'
+contact:
+  abuse: privacy@example.com

--- a/examples/cf-policy-x402-terms/terms/terms.json
+++ b/examples/cf-policy-x402-terms/terms/terms.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "effective": "2026-04-22",
+  "endpoint": "/v1/inference",
+  "attribution": {
+    "required": true,
+    "fields": ["origin-uri", "author"]
+  },
+  "pricing": {
+    "rail": "x402",
+    "network": "eip155:8453",
+    "asset": "USDC",
+    "amount_minor": "100000",
+    "currency": "USD"
+  },
+  "caching": {
+    "max_age_seconds": 86400
+  },
+  "redistribution": false,
+  "training_use": false
+}

--- a/examples/cf-policy-x402-terms/terms/terms.md
+++ b/examples/cf-policy-x402-terms/terms/terms.md
@@ -1,0 +1,12 @@
+# Inference terms
+
+You may call `/v1/inference` under the following conditions:
+
+- Attribution: include `origin-uri` and `author` in any derived output.
+- Pricing: $0.10 USDC per request via x402 (Base mainnet, asset USDC).
+- Caching: results may be cached for up to 24 hours.
+- Re-distribution: not permitted.
+- Training: derived outputs may NOT be used to train another model.
+
+Effective: 2026-04-22.
+Version: 1.

--- a/examples/cf-policy-x402-terms/terms/terms.plaintext.txt
+++ b/examples/cf-policy-x402-terms/terms/terms.plaintext.txt
@@ -1,0 +1,12 @@
+Inference terms
+
+You may call /v1/inference under the following conditions:
+
+- Attribution: include origin-uri and author in any derived output.
+- Pricing: $0.10 USDC per request via x402 (Base mainnet, asset USDC).
+- Caching: results may be cached for up to 24 hours.
+- Re-distribution: not permitted.
+- Training: derived outputs may NOT be used to train another model.
+
+Effective: 2026-04-22.
+Version: 1.

--- a/examples/cf-policy-x402-terms/terms/terms.uri.txt
+++ b/examples/cf-policy-x402-terms/terms/terms.uri.txt
@@ -1,0 +1,1 @@
+https://api.example.com/.well-known/peac-terms.txt

--- a/examples/cf-policy-x402-terms/tests/demo.test.ts
+++ b/examples/cf-policy-x402-terms/tests/demo.test.ts
@@ -9,18 +9,24 @@
 
 import { describe, it, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const EXAMPLE_DIR = resolve(HERE, '..');
+const require = createRequire(import.meta.url);
 
 describe('cf-policy-x402-terms demo', () => {
   it('runs end-to-end and prints expected output', () => {
-    const result = spawnSync('npx', ['-y', 'tsx', 'demo.ts'], {
+    // Resolve the workspace-pinned tsx via require.resolve so the smoke
+    // test cannot reach a registry or pick up an ambient install.
+    const tsxBin = require.resolve('tsx/cli');
+    const result = spawnSync(process.execPath, [tsxBin, 'demo.ts'], {
       cwd: EXAMPLE_DIR,
       encoding: 'utf8',
       timeout: 60_000,
+      env: { ...process.env, NODE_NO_WARNINGS: '1' },
     });
 
     if (result.status !== 0) {

--- a/examples/cf-policy-x402-terms/tests/demo.test.ts
+++ b/examples/cf-policy-x402-terms/tests/demo.test.ts
@@ -1,0 +1,47 @@
+/**
+ * cf-policy-x402-terms demo smoke test.
+ *
+ * Runs `tsx demo.ts` from the example directory and asserts the demo
+ * exits 0 and prints the expected "Demo OK." line. Asserts the four
+ * representation digest lines are present and that uri reports
+ * `unavailable`. Confirms the cross-representation `failed` lock fires.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const EXAMPLE_DIR = resolve(HERE, '..');
+
+describe('cf-policy-x402-terms demo', () => {
+  it('runs end-to-end and prints expected output', () => {
+    const result = spawnSync('npx', ['-y', 'tsx', 'demo.ts'], {
+      cwd: EXAMPLE_DIR,
+      encoding: 'utf8',
+      timeout: 60_000,
+    });
+
+    if (result.status !== 0) {
+      console.error('demo stdout:\n', result.stdout);
+      console.error('demo stderr:\n', result.stderr);
+    }
+    expect(result.status).toBe(0);
+    const out = result.stdout;
+    expect(out).toContain('cf-policy-x402-terms demo');
+    expect(out).toContain('[1] policy digest:  sha256:');
+    expect(out).toContain('[2] jws issued:');
+    expect(out).toMatch(/uri\s+= unavailable/);
+    expect(out).toMatch(/markdown\s+= sha256:/);
+    expect(out).toMatch(/plaintext\s+= sha256:/);
+    expect(out).toMatch(/json\s+= sha256:/);
+    expect(out).toContain('policy_binding:      verified');
+    expect(out).toContain('bindings.terms.stat: verified');
+    expect(out).toContain(
+      '[5] cross-representation (json publisher vs plaintext verifier): failed'
+    );
+    expect(out).toContain('[6] omitted publisher canonical_digest: unavailable');
+    expect(out).toContain('Demo OK.');
+  }, 90_000);
+});

--- a/examples/cf-policy-x402-terms/tsconfig.json
+++ b/examples/cf-policy-x402-terms/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true
+  },
+  "include": ["*.ts", "tests/**/*.ts"]
+}

--- a/examples/cf-policy-x402-terms/turbo.json
+++ b/examples/cf-policy-x402-terms/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": []
+    }
+  }
+}

--- a/examples/cf-policy-x402-terms/vitest.config.ts
+++ b/examples/cf-policy-x402-terms/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    testTimeout: 90_000,
+    hookTimeout: 30_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,6 +297,28 @@ importers:
         specifier: ^5.3.0
         version: 5.9.3
 
+  examples/cf-policy-x402-terms:
+    dependencies:
+      '@peac/adapter-x402':
+        specifier: workspace:*
+        version: link:../../packages/adapters/x402
+      '@peac/crypto':
+        specifier: workspace:*
+        version: link:../../packages/crypto
+      '@peac/protocol':
+        specifier: workspace:*
+        version: link:../../packages/protocol
+    devDependencies:
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@22.19.11)(vite@6.4.1)
+
   examples/commerce-evidence-bundle:
     dependencies:
       '@peac/audit':


### PR DESCRIPTION
## Summary

Adds the cf-policy-x402-terms end-to-end demo composing PEAC policy and
terms binding with x402 PR-1986 across the four representation envelopes
(`uri`, `markdown`, `plaintext`, `json`). Adds three composition docs:
AIPREF, SCITT, and a Cloudflare operator recipe.

The demo is offline by default, runs in under a second, exits non-zero on
any binding regression, and is exercised by a vitest smoke test.

## Scope

- New `examples/cf-policy-x402-terms/`:
  - `policy.yaml` (peac-policy/0.1 source).
  - `terms/{terms.uri.txt,terms.md,terms.plaintext.txt,terms.json}` covering
    all four x402 PR-1986 representations.
  - `demo.ts` end-to-end runner: computes the policy digest, issues a
    Wire 0.2 receipt with `policy.digest` bound, computes per-
    representation terms digests, verifies offline with `verifyLocal()`
    and a caller-supplied `bindings.terms`, then asserts the cross-
    representation `failed` lock and the omitted-canonical-digest
    `unavailable` rule.
  - `tests/demo.test.ts` vitest smoke that runs the demo and pins the
    expected output lines.
  - `README.md`, `package.json`, `tsconfig.json`, `turbo.json`,
    `vitest.config.ts`.
- New `docs/specs/AIPREF-COMPOSITION.md` (informative): how PEAC composes
  with `draft-ietf-aipref-attach` / `draft-ietf-aipref-vocab` via the
  canonical `@peac/mappings-content-signals` parser; states explicitly
  that AIPREF preferences are not GDPR consent.
- New `docs/specs/SCITT-COMPOSITION.md` (informative): term mapping and
  composition pattern for wrapping a PEAC interaction record as a SCITT
  Signed Statement; no wire change.
- New `docs/SOLUTIONS/cloudflare-x402-peac.md`: operator recipe wiring
  Cloudflare Markdown for Agents, AI Crawl Control, and x402 SDKs as
  composition surfaces beneath PEAC.
- `docs/SOLUTIONS/README.md` index gains the new recipe row.

## Validation

- `pnpm --filter @peac/example-cf-policy-x402-terms demo` exits 0 with
  the expected output (policy digest, four representation digests with
  `uri = unavailable`, verifier report `policy_binding = verified` and
  `bindings.terms.status = verified`, cross-representation `failed`
  lock, omitted-canonical-digest `unavailable`).
- Demo smoke test green (1/1).
- Full repo: 7660 tests across 307 files, lint, typecheck, format,
  forbid-strings all clean.

## Notes

The demo intentionally does not perform network I/O on the URI
representation, does not synthesize a canonical JSON digest from the
markdown / plaintext representations, and does not stamp the terms
digest into the emitted receipt. Each is verifier-report-only per
`docs/specs/DOCUMENT-BINDING.md`.

The composition docs are informative, not normative. They state PEAC's
boundary explicitly: PEAC is the records layer beneath runtime governance
and does not replace AIPREF preference signaling, SCITT transparency
logging, Cloudflare delivery surfaces, or the x402 payment rail.