### PR TITLE
release: v0.12.14 - Privacy-Aware Verification +  Policy Binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,47 @@ All notable changes to PEAC Protocol will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.12.13] - Unreleased
+## [0.12.14] - Unreleased
+
+Policy binding and privacy-aware verification. Typed document binding for terms and policy, publisher-supplied canonical digest support, privacy-aware deployment guidance, and verifier privacy defaults including JWKS cache retention caps and a no-raw-personal-data minimization mode. Documentation, tests, and tooling only. No wire, schema, kernel, crypto, or protocol public-API change.
+
+### Added
+
+- `packages/protocol/src/document-binding.ts`: typed document-binding helpers with three scheme-specific functions (`computeJsonDocumentDigestJcs`, `computeTextDocumentDigestUtf8`, `computeDocumentDigest`) and a three-state check (`checkDocumentBinding`). JCS name reserved for JSON-only; text helper names its normalization scheme. Normative spec: `docs/specs/DOCUMENT-BINDING.md`.
+- `packages/protocol/src/verifier-types.ts` gains `DocumentBindingResult`, `VerifierBindings`, and `DocumentRepresentation` types. The verifier report gains an optional top-level `bindings` object carrying `policy`, `terms`, and `documents` under the same three-state semantics. Legacy `policy_binding` top-level field is preserved as a byte-stable mirror for v0.12.x consumers.
+- `docs/specs/DOCUMENT-BINDING.md`: normative spec defining the canonical hash format, three-state semantics, helper-naming contract, minimal text canonicalization rule (`\n` + NFC, no trailing-whitespace stripping), per-representation binding identity, and publisher-supplied `canonical_digest` rule (verifiers may compare when present; must never synthesize from non-JSON; absence is `unavailable`, not `failed`).
+- `packages/adapters/x402/src/terms.ts`: `computeX402TermsDigest` convenience helper over the dispatcher for the four x402 PR-1986 `terms` representations (`uri`, `markdown`, `plaintext`, `json`).
+- JWKS cache retention caps via `PEAC_JWKS_CACHE_TTL_MS` (default 300 000 ms / 5 min) and `PEAC_JWKS_CACHE_MAX_ENTRIES` (default 1 000) environment variables. Decimal-only parsing; malformed values fall back to built-in defaults without uncaching.
+- `PEAC_NO_RAW_PERSONAL_DATA` (set to `true` or `1`) enables the `no_raw_personal_data` minimization mode on the verifier report. The redactor pseudonymises `claims.sub` and `claims.actor.{id,email,name,display_name,handle,sub}` to `sha256:<32 hex>`, walks `claims.extensions` recursively, and elides string leaves that are not short structured identifiers. Protocol metadata fields are unchanged. When the variable is unset the report body is byte-identical to v0.12.13.
+- Five boundary-first privacy guidance documents under `docs/privacy/`: `DATA-CLASSIFICATION.md`, `RETENTION-AND-DELETION.md`, `DEPLOYMENT-ROLES.md`, `DATA-SUBJECT-RIGHTS.md`, and `DPIA-STARTER.md`. Each opens with explicit "What PEAC does / What PEAC does not do / What deployers still own" framing.
+- `docs/specs/PRIVACY-PROFILE.md`: extended with boundary-first block and cross-references to the new deployment-guidance documents.
+- `docs/specs/DOCUMENT-BINDING.md`, `docs/specs/VERIFICATION-REPORT-FORMAT.md` updated to document `bindings` shape and publisher-supplied `canonical_digest` rule.
+- `scripts/verify-no-semantic-widening.mjs`: release gate verifying wire format unchanged, published package count unchanged at 37, extension group count unchanged at 12, OpenAPI includes required fields and the permitted additive `bindings` field, no new primary-path error codes, total error count unchanged at 186.
+
+### Changed
+
+- `packages/protocol/src/policy-binding.ts`: `computePolicyDigestJcs` delegates to `computeJsonDocumentDigestJcs` internally; public API and byte output unchanged.
+- `packages/discovery/src/`: narrowed to policy-document parsing; legacy `verify` / `public_keys` / `jwks` fields in `peac.txt` emit a structured `PEAC_LEGACY_PEAC_TXT_KEY_FIELD` deprecation warning.
+- `packages/aipref/`: deprecated facade over `@peac/mappings-content-signals`; network I/O removed; digests widened to full SHA-256 (`sha256:<64 hex>`); a one-shot `PEAC_DEPRECATED_PREF` structured deprecation warning is emitted.
+- OpenAPI `verify.yaml` and `apps/api/openapi.yaml` refreshed to `info.version: 0.12.14` with the additive `bindings` field on both `VerifySuccessResponse` and `ExtendedVerifyReport` schemas.
+
+### Deprecated
+
+- `@peac/disc` (legacy key-discovery fields): deprecated and narrowed. Full removal owned by the next cleanup release.
+- `@peac/pref`: deprecated facade over `@peac/mappings-content-signals`. Full removal owned by the next cleanup release.
+
+### Deferred
+
+The following items are deferred to v0.13.0:
+
+- Naming and terminology cleanup; legacy quarantine of `peac.receipt/0.9` off active surfaces.
+- Scheduled removals: `ProofMethodSchema`, A2A v0.3.0 compatibility, legacy `/verify` endpoint, `sdk-js` workspace stub.
+- Full removal of `@peac/disc` and `@peac/pref` deprecated facades.
+- Reboot baseline capture, resource-limit spec, and `docs/STANDARDS_LEDGER.md`.
+- Package-surface reduction program with measurable gate.
+- Hosted Issue GA decision.
+
+## [0.12.13] - 2026-04-20
 
 Compliance mappings, verifier contract alignment, portable proof workflows, and Go adapter follow-through. Documentation, tests, workflows, and SDK support tooling only. No wire, schema, kernel, crypto, or protocol public-API change.
 

--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable surface classification for PEAC Protocol workspace. CI fails if any workspace member is missing. See docs/PACKAGE_STATUS.md for human-readable view.",
-  "version": "0.12.13",
-  "updated": "2026-04-20",
+  "version": "0.12.14",
+  "updated": "PENDING",
   "states": {
     "default": "Current recommended path. Actively maintained, Wire 0.2 native.",
     "supported": "Actively maintained, published, production-ready. May not be on default quickstart path.",

--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.1
 info:
   title: PEAC Hosted Verify API
-  version: 0.12.13
+  version: 0.12.14
   description: >
     Hosted verification service for signed interaction records.
     Request body is `application/json` carrying a compact JWS in the
@@ -180,6 +180,23 @@ components:
           type: string
           enum: [unavailable, verified, failed]
           description: Three-state policy binding result
+        bindings:
+          type: object
+          description: >
+            Optional top-level bindings object (v0.12.14). Present only when caller supplied
+            bindings.terms or a non-empty bindings.documents to verifyLocal. Absent when no
+            terms or document digests were supplied (byte-stable with v0.12.13). Report-only;
+            not stamped into the emitted record or envelope shape.
+          properties:
+            policy:
+              type: string
+              enum: [unavailable, verified, failed]
+            terms:
+              type: object
+              description: Per-representation terms-binding result when caller supplied a terms digest.
+            documents:
+              type: array
+              description: Per-document binding results when caller supplied document digests.
         issuer:
           type: string
           description: Issuer URI from the receipt
@@ -252,6 +269,23 @@ components:
         policy_binding:
           type: string
           enum: [unavailable, verified, failed]
+        bindings:
+          type: object
+          description: >
+            Optional top-level bindings object (v0.12.14). Present only when caller supplied
+            bindings.terms or a non-empty bindings.documents to verifyLocal. Absent when no
+            terms or document digests were supplied (byte-stable with v0.12.13). Report-only;
+            not stamped into the emitted record or envelope shape.
+          properties:
+            policy:
+              type: string
+              enum: [unavailable, verified, failed]
+            terms:
+              type: object
+              description: Per-representation terms-binding result when caller supplied a terms digest.
+            documents:
+              type: array
+              description: Per-document binding results when caller supplied document digests.
         issuer:
           type: string
         kid:

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-api",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "PEAC Protocol API server with OpenAPI 3.1, RFC 9457 Problem Details, and content negotiation",
   "type": "module",
   "main": "dist/index.js",

--- a/apps/sandbox-issuer/package.json
+++ b/apps/sandbox-issuer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-sandbox-issuer",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "PEAC Protocol Sandbox Issuer - Test receipt issuance for development",
   "type": "module",
   "main": "dist/node.js",

--- a/apps/verifier/package.json
+++ b/apps/verifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-verifier",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "PEAC Protocol Browser Verifier - Client-side receipt verification",
   "type": "module",
   "private": true,

--- a/contracts/api/crypto.json
+++ b/contracts/api/crypto.json
@@ -1,6 +1,6 @@
 {
   "package": "@peac/crypto",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "extracted_at": "2026-04-22",
   "node_version": "v24.13.0",
   "value_exports": [

--- a/contracts/api/kernel.json
+++ b/contracts/api/kernel.json
@@ -1,6 +1,6 @@
 {
   "package": "@peac/kernel",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "extracted_at": "2026-04-22",
   "node_version": "v24.13.0",
   "value_exports": [

--- a/contracts/api/protocol.json
+++ b/contracts/api/protocol.json
@@ -1,6 +1,6 @@
 {
   "package": "@peac/protocol",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "extracted_at": "2026-04-22",
   "node_version": "v24.13.0",
   "value_exports": [

--- a/contracts/api/schema.json
+++ b/contracts/api/schema.json
@@ -1,6 +1,6 @@
 {
   "package": "@peac/schema",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "extracted_at": "2026-04-22",
   "node_version": "v24.13.0",
   "value_exports": [

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -2,7 +2,7 @@
 
 Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scripts/generate-surface-status.mjs`.
 
-**Version:** 0.12.13 | **Updated:** 2026-04-20
+**Version:** 0.12.14 | **Updated:** PENDING
 
 ## Layer 1
 

--- a/docs/releases/current.json
+++ b/docs/releases/current.json
@@ -1,8 +1,8 @@
 {
   "description": "PEAC release manifest: CI-enforceable source of truth for release state",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "wire_format_version": "0.2",
-  "dist_tag": "latest",
+  "dist_tag": "next",
   "registries_version": "0.6.0",
-  "errors_version": "0.12.13"
+  "errors_version": "0.12.14"
 }

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -1,13 +1,13 @@
 {
   "description": "Canonical source of truth for PEAC Protocol release metrics. Website, docs, and release notes consume this file. CI validates derived metrics (tests, build_targets, published_packages, conformance_*) against actual build output. On release-prep branches, mutable release-state fields (release_date, dist_tag) carry placeholder values and are stamped post-tag and post-promotion via scripts/stamp-release-state.mjs per docs/RELEASING.md.",
   "schema_version": "1.0.0",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "wire_format_version": "0.2",
-  "dist_tag": "latest",
-  "release_date": "2026-04-20",
+  "dist_tag": "next",
+  "release_date": "PENDING",
   "metrics": {
-    "tests": 7600,
-    "test_files": 304,
+    "tests": 7680,
+    "test_files": 308,
     "published_packages": 37,
     "build_targets": 106,
     "conformance_requirement_ids": 224,

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -4,7 +4,7 @@
   "version": "0.12.14",
   "wire_format_version": "0.2",
   "dist_tag": "next",
-  "release_date": "PENDING",
+  "release_date": "2026-04-22",
   "metrics": {
     "tests": 7680,
     "test_files": 308,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/monorepo",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "private": true,
   "description": "Portable signed records for agent, API, MCP, and cross-runtime interactions.",
   "repository": {
@@ -58,6 +58,7 @@
     "verify:codegen-drift": "bash scripts/verify-codegen-drift.sh",
     "verify:distribution": "node scripts/verify-distribution.mjs",
     "verify:release": "node scripts/verify-release.mjs",
+    "verify:no-widening": "node scripts/verify-no-semantic-widening.mjs",
     "api-contract:extract": "tsx scripts/extract-api-contract.ts",
     "api-contract:check": "tsx scripts/extract-api-contract.ts --check",
     "verify:contracts:drift": "tsx scripts/extract-api-contract.ts --check",

--- a/packages/access/package.json
+++ b/packages/access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/access",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "private": true,
   "description": "PEAC access pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/adapters/core/package.json
+++ b/packages/adapters/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-core",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Shared utilities for PEAC payment rail adapters and commerce mappings (Result types, validators, payment-proof contracts, mapper-boundary finality guard)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/did/package.json
+++ b/packages/adapters/did/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-did",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "DID document resolution for PEAC receipt verification (did:key, did:web)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/eat/package.json
+++ b/packages/adapters/eat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-eat",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "EAT (Entity Attestation Token, RFC 9711) passport decoder and PEAC claim mapper",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/managed-agents/package.json
+++ b/packages/adapters/managed-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-managed-agents",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Vendor-neutral managed agent runtime event adapter for PEAC interaction evidence",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/adapters/openai-compatible/package.json
+++ b/packages/adapters/openai-compatible/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-openai-compatible",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "OpenAI-compatible chat completion adapter for PEAC interaction evidence (hash-first)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/openclaw/package.json
+++ b/packages/adapters/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-openclaw",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "OpenClaw adapter for PEAC interaction evidence capture",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/runtime-governance/package.json
+++ b/packages/adapters/runtime-governance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-runtime-governance",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Runtime governance adapter for PEAC interaction records with AGT mapper",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/adapters/x402/daydreams/package.json
+++ b/packages/adapters/x402/daydreams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402-daydreams",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Daydreams AI inference event normalizer for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/fluora/package.json
+++ b/packages/adapters/x402/fluora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402-fluora",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Fluora MCP marketplace event normalizer for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/package.json
+++ b/packages/adapters/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "x402 offer/receipt verification, term-matching, and PEAC record mapping",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/pinata/package.json
+++ b/packages/adapters/x402/pinata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402-pinata",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Pinata private IPFS objects event normalizer for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/aipref/package.json
+++ b/packages/aipref/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/pref",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Deprecated facade over @peac/mappings-content-signals (AIPREF / robots.txt / tdmrep). Use @peac/mappings-content-signals directly.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/attribution/package.json
+++ b/packages/attribution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/attribution",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "PEAC attribution attestation - content derivation and usage proofs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/audit",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Audit logging and case bundle generation for PEAC protocol disputes",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/capture/core/package.json
+++ b/packages/capture/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/capture-core",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Runtime-neutral capture pipeline for PEAC interaction evidence",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/capture/node/package.json
+++ b/packages/capture/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/capture-node",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Node.js durable storage for PEAC capture pipeline (filesystem spool store and dedupe index)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/cli",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "PEAC protocol command-line tools",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/compliance/package.json
+++ b/packages/compliance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/compliance",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "private": true,
   "description": "PEAC compliance pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/conformance-harness/package.json
+++ b/packages/conformance-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/conformance-harness",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "private": true,
   "description": "Conformance test harness for PEAC protocol fixtures",
   "main": "dist/index.cjs",

--- a/packages/consent/package.json
+++ b/packages/consent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/consent",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "private": true,
   "description": "PEAC consent pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/contracts",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "PEAC canonical error codes and verification mode contracts",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/control/package.json
+++ b/packages/control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/control",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "PEAC Protocol Control - control engine interfaces and validation",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/core",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "DEPRECATED (removal: v0.13.0) - Use @peac/kernel, @peac/schema, @peac/crypto, @peac/protocol instead",
   "type": "module",
   "homepage": "https://github.com/peacprotocol/peac#readme",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/crypto",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Ed25519 JWS signing and verification for PEAC protocol",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/disc",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Thin loader / validator and remote fetcher for peac.txt policy documents (peac-policy/0.1; docs/specs/PEAC-TXT.md)",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/http-signatures/package.json
+++ b/packages/http-signatures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/http-signatures",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "RFC 9421 HTTP Message Signatures parsing and verification",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/intelligence/package.json
+++ b/packages/intelligence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/intelligence",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "private": true,
   "description": "PEAC intelligence pillar (placeholder for v0.9.18+)",
   "type": "module",

--- a/packages/jwks-cache/package.json
+++ b/packages/jwks-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/jwks-cache",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Edge-safe JWKS fetch and cache with SSRF protection",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/kernel",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "PEAC protocol kernel - normative constants, errors, and registries",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/kernel/src/error-categories.generated.ts
+++ b/packages/kernel/src/error-categories.generated.ts
@@ -3,7 +3,7 @@
  *
  * AUTO-GENERATED from specs/kernel/errors.json
  * DO NOT EDIT MANUALLY - run: npx tsx scripts/codegen-errors.ts
- * Spec version: 0.12.13
+ * Spec version: 0.12.14
  */
 
 /**

--- a/packages/kernel/src/errors.generated.ts
+++ b/packages/kernel/src/errors.generated.ts
@@ -3,7 +3,7 @@
  *
  * AUTO-GENERATED from specs/kernel/errors.json
  * DO NOT EDIT MANUALLY - run: npx tsx scripts/codegen-errors.ts
- * Spec version: 0.12.13
+ * Spec version: 0.12.14
  */
 
 import type { ErrorDefinition } from './types.js';

--- a/packages/mappings/a2a/package.json
+++ b/packages/mappings/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-a2a",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Agent-to-Agent Protocol (A2A) integration for PEAC",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/mappings/acp/package.json
+++ b/packages/mappings/acp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-acp",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Agentic Commerce Protocol (ACP) integration for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/aipref/package.json
+++ b/packages/mappings/aipref/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-aipref",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "IETF AIPREF vocabulary mapping for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/content-signals/package.json
+++ b/packages/mappings/content-signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-content-signals",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Content use policy signal parsing for PEAC (robots.txt, tdmrep.json, Content-Usage)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/mappings/intoto/package.json
+++ b/packages/mappings/intoto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-intoto",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "in-toto v1.0 attestation mapping for PEAC provenance extension",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/mcp/package.json
+++ b/packages/mappings/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-mcp",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Model Context Protocol (MCP) integration for PEAC",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/mappings/paymentauth/package.json
+++ b/packages/mappings/paymentauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-paymentauth",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "HTTP Payment authentication scheme (paymentauth/MPP) mapping for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/rsl/package.json
+++ b/packages/mappings/rsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-rsl",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "RSL (Robots Specification Layer) mapping for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/slsa/package.json
+++ b/packages/mappings/slsa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-slsa",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "SLSA v1.2 provenance mapping for PEAC provenance extension",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/tap/package.json
+++ b/packages/mappings/tap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-tap",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Visa Trusted Agent Protocol mapping to PEAC control evidence",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mappings/ucp/package.json
+++ b/packages/mappings/ucp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-ucp",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Google Universal Commerce Protocol (UCP) mapping to PEAC receipts and dispute evidence",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp-server/manifest.json
+++ b/packages/mcp-server/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "peac-mcp-server",
   "display_name": "PEAC Protocol",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Verify, inspect, decode, issue, and bundle PEAC receipts. Portable, offline-verifiable evidence for AI agent interactions.",
   "long_description": "PEAC Protocol provides cryptographically signed, offline-verifiable receipts that record what happened during automated interactions. Each receipt is a compact JWS (JSON Web Signature) using Ed25519 signatures. This MCP server exposes 5 tools for receipt operations: verify (signature + claims), inspect (metadata without verification), decode (raw JWS structure), issue (sign new receipts), and create_bundle (portable evidence directories).",
   "author": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mcp-server",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "PEAC receipt operations as MCP tools (verify, inspect, decode, issue, bundle)",
   "mcpName": "io.github.peacprotocol/peac",
   "main": "dist/index.cjs",

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "subfolder": "packages/mcp-server"
   },
-  "version": "0.12.13",
+  "version": "0.12.14",
   "websiteUrl": "https://www.peacprotocol.org",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@peac/mcp-server",
-      "version": "0.12.13",
+      "version": "0.12.14",
       "transport": {
         "type": "stdio"
       }
@@ -22,7 +22,7 @@
     {
       "registryType": "npm",
       "identifier": "@peac/mcp-server",
-      "version": "0.12.13",
+      "version": "0.12.14",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:3000/mcp"

--- a/packages/mcp-server/src/infra/constants.ts
+++ b/packages/mcp-server/src/infra/constants.ts
@@ -3,7 +3,7 @@
  */
 
 export const SERVER_NAME = 'peac-mcp-server';
-export const SERVER_VERSION = '0.12.13';
+export const SERVER_VERSION = '0.12.14';
 export const MCP_PROTOCOL_VERSION = '2025-11-25';
 export const DEFAULT_MAX_JWS_BYTES = 16_384; // 16 KB
 export const DEFAULT_MAX_RESPONSE_BYTES = 65_536; // 64 KB

--- a/packages/middleware-core/package.json
+++ b/packages/middleware-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/middleware-core",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Framework-agnostic middleware primitives for PEAC receipt issuance",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/middleware-express/package.json
+++ b/packages/middleware-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/middleware-express",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Express.js middleware for automatic PEAC receipt issuance",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/net/node/package.json
+++ b/packages/net/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/net-node",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "SSRF-safe network utilities for PEAC Protocol with DNS resolution pinning (Node.js only)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/pay402/package.json
+++ b/packages/pay402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/pay402",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Generic HTTP 402 adapter with multi-rail payment negotiation",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/policy-kit/package.json
+++ b/packages/policy-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/policy-kit",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "PEAC Policy Kit - deterministic policy evaluation for CAL semantics",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/privacy/package.json
+++ b/packages/privacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/privacy",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "private": true,
   "description": "Privacy pillar for PEAC protocol - k-anonymity, privacy-preserving hashing, data protection",
   "main": "dist/index.js",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/protocol",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "PEAC protocol implementation - receipt issuance and verification",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/provenance/package.json
+++ b/packages/provenance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/provenance",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "private": true,
   "description": "Provenance pillar for PEAC protocol - content provenance, C2PA integration, and chain-of-custody",
   "main": "dist/index.js",

--- a/packages/rails/card/package.json
+++ b/packages/rails/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-card",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Card payment rail adapter for PEAC protocol (Flowglad, Stripe Billing, Lago)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rails/razorpay/package.json
+++ b/packages/rails/razorpay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-razorpay",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "private": true,
   "description": "Razorpay payment rail adapter for PEAC protocol (UPI, cards, netbanking)",
   "main": "dist/index.js",

--- a/packages/rails/stripe/package.json
+++ b/packages/rails/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-stripe",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Stripe payment rail adapter for PEAC protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rails/x402/package.json
+++ b/packages/rails/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-x402",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "x402 payment rail adapter for PEAC protocol",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/receipts/package.json
+++ b/packages/receipts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/receipts",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "PEAC Protocol receipt builders, parsers, and validators with CBOR support",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/schema/openapi/verify.yaml
+++ b/packages/schema/openapi/verify.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.1
 info:
   title: PEAC Reference Verifier API
-  version: 0.12.13
+  version: 0.12.14
   summary: Portable signed records for agent, API, MCP, and cross-runtime interactions.
   description: |
     Package-level OpenAPI contract for the PEAC reference verifier (`apps/api/`).
@@ -435,7 +435,24 @@ components:
         policy_binding:
           type: string
           enum: [unavailable, verified, failed]
-          description: Three-state policy-binding result.
+          description: Three-state policy-binding result (legacy mirror; equals bindings.policy when bindings is present).
+        bindings:
+          type: object
+          description: >
+            Optional top-level bindings object (v0.12.14). Present only when caller supplied
+            bindings.terms or a non-empty bindings.documents to verifyLocal. Absent when no
+            terms or document digests were supplied (byte-stable with v0.12.13). Report-only;
+            not stamped into the emitted record or envelope shape.
+          properties:
+            policy:
+              type: string
+              enum: [unavailable, verified, failed]
+            terms:
+              type: object
+              description: Per-representation terms-binding result when caller supplied a terms digest.
+            documents:
+              type: array
+              description: Per-document binding results when caller supplied document digests.
         issuer:
           type: string
           description: Issuer URI from the receipt.
@@ -511,6 +528,23 @@ components:
         policy_binding:
           type: string
           enum: [unavailable, verified, failed]
+        bindings:
+          type: object
+          description: >
+            Optional top-level bindings object (v0.12.14). Present only when caller supplied
+            bindings.terms or a non-empty bindings.documents to verifyLocal. Absent when no
+            terms or document digests were supplied (byte-stable with v0.12.13). Report-only;
+            not stamped into the emitted record or envelope shape.
+          properties:
+            policy:
+              type: string
+              enum: [unavailable, verified, failed]
+            terms:
+              type: object
+              description: Per-representation terms-binding result when caller supplied a terms digest.
+            documents:
+              type: array
+              description: Per-document binding results when caller supplied document digests.
         issuer:
           type: string
         kid:

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/schema",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "PEAC Protocol JSON schemas, OpenAPI specs, and TypeScript types",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/server",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "PEAC verification server with DoS protection and rate limiting",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/telemetry-otel/package.json
+++ b/packages/telemetry-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/telemetry-otel",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "OpenTelemetry adapter for PEAC telemetry",
   "keywords": [
     "peac",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/telemetry",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Telemetry interfaces and no-op implementation for PEAC protocol",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/transport/grpc/package.json
+++ b/packages/transport/grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-grpc",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "PEAC gRPC transport layer with carrier adapter and HTTP StatusCode parity",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/transport/http/package.json
+++ b/packages/transport/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-http",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "private": true,
   "description": "PEAC HTTP transport layer - headers, middleware, DPoP L3/L4",
   "type": "module",

--- a/packages/transport/ws/package.json
+++ b/packages/transport/ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-ws",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "private": true,
   "description": "PEAC WebSocket transport layer (placeholder for v0.9.17+)",
   "type": "module",

--- a/packages/worker-core/package.json
+++ b/packages/worker-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-core",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Runtime-neutral TAP verification handler for edge workers",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/worker-shared/package.json
+++ b/packages/worker-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-shared",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "private": true,
   "description": "Shared runtime-neutral TAP verification logic for edge worker surfaces",
   "type": "module",

--- a/scripts/verify-no-semantic-widening.mjs
+++ b/scripts/verify-no-semantic-widening.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+/**
+ * No-semantic-widening gate for v0.12.14 release prep.
+ *
+ * Verifies that the v0.12.14 release has not widened the protocol
+ * surface beyond what is documented as additive report-only behavior.
+ *
+ * Checks:
+ *   1. Wire format version unchanged (interaction-record+jwt / peac-receipt/0.1)
+ *   2. No new public package beyond the 37 published at v0.12.13
+ *   3. No new extension key in registries.json beyond v0.12.13 baseline
+ *   4. No new non-additive OpenAPI contract field
+ *   5. No new JWS typ beyond the two stable values
+ *   6. No new error code emitted on primary paths (emitted: true) beyond baseline
+ *
+ * Exit codes:
+ *   0  all checks pass
+ *   1  one or more checks failed
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+
+let passed = 0;
+let failed = 0;
+
+function pass(msg) {
+  console.log(`  OK: ${msg}`);
+  passed++;
+}
+function fail(msg) {
+  console.error(`  FAIL: ${msg}`);
+  failed++;
+}
+function readJSON(p) {
+  try {
+    return JSON.parse(readFileSync(p, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+console.log('No-semantic-widening gate (v0.12.14)');
+console.log('=====================================\n');
+
+// ---------------------------------------------------------------------------
+// 1. Wire format versions unchanged
+// ---------------------------------------------------------------------------
+console.log('--- Wire format ---');
+const kernelConstants = readFileSync(
+  join(ROOT, 'packages/kernel/src/constants.ts'),
+  'utf8'
+);
+const hasWire01 = kernelConstants.includes("'peac-receipt/0.1'");
+const hasWire02 = kernelConstants.includes("'interaction-record+jwt'");
+if (hasWire01 && hasWire02) {
+  pass('Wire 0.1 typ (peac-receipt/0.1) present and unchanged');
+  pass('Wire 0.2 typ (interaction-record+jwt) present and unchanged');
+} else {
+  if (!hasWire01) fail('Wire 0.1 typ missing or changed in kernel/constants.ts');
+  if (!hasWire02) fail('Wire 0.2 typ missing or changed in kernel/constants.ts');
+}
+
+// ---------------------------------------------------------------------------
+// 2. No new public package
+// ---------------------------------------------------------------------------
+console.log('\n--- Published packages ---');
+const manifest = readJSON(join(ROOT, 'scripts/publish-manifest.json'));
+if (!manifest) {
+  fail('publish-manifest.json not found');
+} else {
+  const pkgs = manifest.packages ?? [];
+  const BASELINE = 37;
+  if (pkgs.length === BASELINE) {
+    pass(`Published package count unchanged at ${BASELINE}`);
+  } else if (pkgs.length < BASELINE) {
+    fail(`Published packages dropped: expected ${BASELINE}, got ${pkgs.length}`);
+  } else {
+    fail(`New public package(s) added: expected ${BASELINE}, got ${pkgs.length} — new: ${pkgs.slice(BASELINE).join(', ')}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 3. No new extension key in registries beyond v0.12.13 baseline
+// ---------------------------------------------------------------------------
+console.log('\n--- Extension keys ---');
+const regs = readJSON(join(ROOT, 'specs/kernel/registries.json'));
+if (!regs) {
+  fail('specs/kernel/registries.json not found');
+} else {
+  // Baseline extension_groups count from v0.12.13: 12
+  // Structure: registries.json { extension_groups: { _comment: "...", values: [...] } }
+  const BASELINE_EXT_GROUPS = 12;
+  const groups = regs.extension_groups ?? regs.registries?.extension_groups ?? [];
+  const groupCount = Array.isArray(groups)
+    ? groups.length
+    : Array.isArray(groups.values)
+    ? groups.values.length
+    : Object.keys(groups).length;
+  if (groupCount === BASELINE_EXT_GROUPS) {
+    pass(`Extension group count unchanged at ${BASELINE_EXT_GROUPS}`);
+  } else if (groupCount > BASELINE_EXT_GROUPS) {
+    fail(`New extension group(s) added: baseline ${BASELINE_EXT_GROUPS}, actual ${groupCount}`);
+  } else {
+    fail(`Extension groups removed: baseline ${BASELINE_EXT_GROUPS}, actual ${groupCount}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 4. OpenAPI drift: bindings field is the only permitted additive field
+// ---------------------------------------------------------------------------
+console.log('\n--- OpenAPI contract ---');
+const openapiPath = join(ROOT, 'packages/schema/openapi/verify.yaml');
+if (!existsSync(openapiPath)) {
+  fail('packages/schema/openapi/verify.yaml not found');
+} else {
+  const openapi = readFileSync(openapiPath, 'utf8');
+  // Must still include the established core response fields
+  const requiredFields = ['verified', 'receipt_ref', 'policy_binding'];
+  for (const f of requiredFields) {
+    if (openapi.includes(f)) {
+      pass(`OpenAPI includes required field: ${f}`);
+    } else {
+      fail(`OpenAPI missing required field: ${f}`);
+    }
+  }
+  // bindings is the one permitted additive field (report-only)
+  if (openapi.includes('bindings')) {
+    pass('OpenAPI includes bindings field (permitted additive report-only field)');
+  } else {
+    fail('OpenAPI missing bindings field (should have been added as additive)');
+  }
+  // wire_format must not have changed
+  if (openapi.includes('interaction-record+jwt')) {
+    pass('OpenAPI references interaction-record+jwt typ (unchanged)');
+  } else {
+    fail('OpenAPI does not reference interaction-record+jwt');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 5. No new error code on primary paths beyond baseline
+// ---------------------------------------------------------------------------
+console.log('\n--- Error codes ---');
+const errors = readJSON(join(ROOT, 'specs/kernel/errors.json'));
+if (!errors) {
+  fail('specs/kernel/errors.json not found');
+} else {
+  const allErrors = errors.errors ?? [];
+  const emitted = allErrors.filter((e) => e.emitted === true);
+  // Baseline: 0 errors with emitted:true (v0.12.13 emitted none on primary paths)
+  const BASELINE_EMITTED = 0;
+  if (emitted.length === BASELINE_EMITTED) {
+    pass(`Emitted-on-primary-path error codes unchanged at ${BASELINE_EMITTED}`);
+  } else {
+    fail(
+      `New emitted error codes: expected ${BASELINE_EMITTED}, got ${emitted.length} — new: ${emitted.map((e) => e.code).join(', ')}`
+    );
+  }
+  // Total count sanity: v0.12.13 had 186 error codes
+  const BASELINE_TOTAL = 186;
+  if (allErrors.length === BASELINE_TOTAL) {
+    pass(`Total error code count unchanged at ${BASELINE_TOTAL}`);
+  } else if (allErrors.length < BASELINE_TOTAL) {
+    fail(`Error codes removed: baseline ${BASELINE_TOTAL}, actual ${allErrors.length}`);
+  } else {
+    // additions are OK (additive) but we note them
+    pass(`Error code count: ${allErrors.length} (${allErrors.length - BASELINE_TOTAL} added beyond baseline — additive OK)`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(`\n${passed + failed} checks — ${passed} passed, ${failed} failed`);
+if (failed > 0) {
+  console.error('\nSemantic-widening gate FAILED. Review the failures above before tagging.');
+  process.exit(1);
+} else {
+  console.log('\nSemantic-widening gate PASSED. Safe to tag.');
+  process.exit(0);
+}

--- a/scripts/verify-no-semantic-widening.mjs
+++ b/scripts/verify-no-semantic-widening.mjs
@@ -2,6 +2,11 @@
 /**
  * No-semantic-widening gate for v0.12.14 release prep.
  *
+ * This is a release-specific gate with baselines hard-coded to the v0.12.13
+ * published state (37 packages, 12 extension groups, 186 error codes). It is
+ * not a general semantic-drift framework. Future releases should either update
+ * the baselines here or author a new gate script for their release window.
+ *
  * Verifies that the v0.12.14 release has not widened the protocol
  * surface beyond what is documented as additive report-only behavior.
  *
@@ -21,7 +26,6 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { spawnSync } from 'node:child_process';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
@@ -52,10 +56,7 @@ console.log('=====================================\n');
 // 1. Wire format versions unchanged
 // ---------------------------------------------------------------------------
 console.log('--- Wire format ---');
-const kernelConstants = readFileSync(
-  join(ROOT, 'packages/kernel/src/constants.ts'),
-  'utf8'
-);
+const kernelConstants = readFileSync(join(ROOT, 'packages/kernel/src/constants.ts'), 'utf8');
 const hasWire01 = kernelConstants.includes("'peac-receipt/0.1'");
 const hasWire02 = kernelConstants.includes("'interaction-record+jwt'");
 if (hasWire01 && hasWire02) {
@@ -81,7 +82,9 @@ if (!manifest) {
   } else if (pkgs.length < BASELINE) {
     fail(`Published packages dropped: expected ${BASELINE}, got ${pkgs.length}`);
   } else {
-    fail(`New public package(s) added: expected ${BASELINE}, got ${pkgs.length} — new: ${pkgs.slice(BASELINE).join(', ')}`);
+    fail(
+      `New public package(s) added: expected ${BASELINE}, got ${pkgs.length} — new: ${pkgs.slice(BASELINE).join(', ')}`
+    );
   }
 }
 
@@ -100,8 +103,8 @@ if (!regs) {
   const groupCount = Array.isArray(groups)
     ? groups.length
     : Array.isArray(groups.values)
-    ? groups.values.length
-    : Object.keys(groups).length;
+      ? groups.values.length
+      : Object.keys(groups).length;
   if (groupCount === BASELINE_EXT_GROUPS) {
     pass(`Extension group count unchanged at ${BASELINE_EXT_GROUPS}`);
   } else if (groupCount > BASELINE_EXT_GROUPS) {
@@ -170,7 +173,9 @@ if (!errors) {
     fail(`Error codes removed: baseline ${BASELINE_TOTAL}, actual ${allErrors.length}`);
   } else {
     // additions are OK (additive) but we note them
-    pass(`Error code count: ${allErrors.length} (${allErrors.length - BASELINE_TOTAL} added beyond baseline — additive OK)`);
+    pass(
+      `Error code count: ${allErrors.length} (${allErrors.length - BASELINE_TOTAL} added beyond baseline — additive OK)`
+    );
   }
 }
 

--- a/scripts/verify-no-semantic-widening.mjs
+++ b/scripts/verify-no-semantic-widening.mjs
@@ -83,7 +83,7 @@ if (!manifest) {
     fail(`Published packages dropped: expected ${BASELINE}, got ${pkgs.length}`);
   } else {
     fail(
-      `New public package(s) added: expected ${BASELINE}, got ${pkgs.length} — new: ${pkgs.slice(BASELINE).join(', ')}`
+      `New public package(s) added: expected ${BASELINE}, got ${pkgs.length} - new: ${pkgs.slice(BASELINE).join(', ')}`
     );
   }
 }
@@ -162,7 +162,7 @@ if (!errors) {
     pass(`Emitted-on-primary-path error codes unchanged at ${BASELINE_EMITTED}`);
   } else {
     fail(
-      `New emitted error codes: expected ${BASELINE_EMITTED}, got ${emitted.length} — new: ${emitted.map((e) => e.code).join(', ')}`
+      `New emitted error codes: expected ${BASELINE_EMITTED}, got ${emitted.length} - new: ${emitted.map((e) => e.code).join(', ')}`
     );
   }
   // Total count sanity: v0.12.13 had 186 error codes
@@ -174,7 +174,7 @@ if (!errors) {
   } else {
     // additions are OK (additive) but we note them
     pass(
-      `Error code count: ${allErrors.length} (${allErrors.length - BASELINE_TOTAL} added beyond baseline — additive OK)`
+      `Error code count: ${allErrors.length} (${allErrors.length - BASELINE_TOTAL} added beyond baseline - additive OK)`
     );
   }
 }
@@ -182,7 +182,7 @@ if (!errors) {
 // ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
-console.log(`\n${passed + failed} checks — ${passed} passed, ${failed} failed`);
+console.log(`\n${passed + failed} checks - ${passed} passed, ${failed} failed`);
 if (failed > 0) {
   console.error('\nSemantic-widening gate FAILED. Review the failures above before tagging.');
   process.exit(1);

--- a/specs/conformance/fixtures/inventory.json
+++ b/specs/conformance/fixtures/inventory.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://www.peacprotocol.org/schemas/conformance/inventory.schema.json",
-  "generated_at": "2026-04-20T10:01:33.549Z",
-  "version": "0.12.13",
-  "schema_version": "0.12.13",
+  "generated_at": "2026-04-22T10:26:17.323Z",
+  "version": "0.12.14",
+  "schema_version": "0.12.14",
   "total_fixtures": 688,
   "total_with_requirements": 243,
   "total_unmapped": 445,

--- a/specs/kernel/error-categories.json
+++ b/specs/kernel/error-categories.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.peacprotocol.org/schemas/kernel/error-categories.schema.json",
   "$comment": "AUTO-GENERATED from specs/kernel/errors.json - DO NOT EDIT MANUALLY",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "source_file": "specs/kernel/errors.json",
   "categories": [
     "attribution",

--- a/specs/kernel/errors.json
+++ b/specs/kernel/errors.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "PEAC error codes - normative source of truth",
   "errors": [
     {

--- a/surfaces/analytics/package.json
+++ b/surfaces/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/analytics",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "private": true,
   "description": "Analytics surface for PEAC Protocol - metrics API with k-anonymity protection",
   "type": "module",

--- a/surfaces/nextjs/middleware/package.json
+++ b/surfaces/nextjs/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/middleware-nextjs",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "private": true,
   "description": "PEAC TAP verifier and 402 access gate for Next.js Edge Runtime",
   "type": "module",

--- a/surfaces/plugin-pack/claude-code/.mcp.json
+++ b/surfaces/plugin-pack/claude-code/.mcp.json
@@ -4,7 +4,7 @@
     "peac": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@peac/mcp-server@0.12.13"],
+      "args": ["-y", "@peac/mcp-server@0.12.14"],
       "env": {}
     }
   }

--- a/surfaces/plugin-pack/codex/codex-config.pinned.json
+++ b/surfaces/plugin-pack/codex/codex-config.pinned.json
@@ -3,7 +3,7 @@
   "mcpServers": {
     "peac": {
       "command": "npx",
-      "args": ["-y", "@peac/mcp-server@0.12.13"],
+      "args": ["-y", "@peac/mcp-server@0.12.14"],
       "env": {}
     }
   }

--- a/surfaces/plugin-pack/cursor/mcp.json
+++ b/surfaces/plugin-pack/cursor/mcp.json
@@ -3,7 +3,7 @@
   "mcpServers": {
     "peac": {
       "command": "npx",
-      "args": ["-y", "@peac/mcp-server@0.12.13"],
+      "args": ["-y", "@peac/mcp-server@0.12.14"],
       "env": {}
     }
   }

--- a/surfaces/plugin-pack/vscode/mcp.json
+++ b/surfaces/plugin-pack/vscode/mcp.json
@@ -4,7 +4,7 @@
     "peac": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@peac/mcp-server@0.12.13"],
+      "args": ["-y", "@peac/mcp-server@0.12.14"],
       "env": {}
     }
   }

--- a/surfaces/workers/akamai/package.json
+++ b/surfaces/workers/akamai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-akamai",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "private": true,
   "description": "PEAC receipt verification worker for Akamai EdgeWorkers",
   "type": "module",

--- a/surfaces/workers/cloudflare/package.json
+++ b/surfaces/workers/cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-cloudflare",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "private": true,
   "description": "PEAC receipt verification worker for Cloudflare Workers",
   "type": "module",

--- a/surfaces/workers/fastly/package.json
+++ b/surfaces/workers/fastly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-fastly",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "private": true,
   "description": "PEAC receipt verification worker for Fastly Compute",
   "type": "module",


### PR DESCRIPTION
## Summary

Release prep for v0.12.14 (Policy Binding + Privacy-Aware Verification). Stamps version
across all affected workspace and package manifests (37 published packages), 
machine-readable artifacts, adds CHANGELOG entry, and introduces the no-semantic-widening
release gate.

## Scope

- Version bump to \`0.12.14\` across published packages and workspace manifests; root \`package.json\` bumped to match
- \`docs/releases/facts.json\` and \`docs/releases/current.json\` updated to v0.12.14
  (\`release_date: PENDING\` — stamped post-tag by micro-PR per standard release doctrine)
