### PR TITLE
fix: publish manifest topological order for @peac/disc

### DIFF
--- a/scripts/publish-manifest.json
+++ b/scripts/publish-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Single source of truth for PEAC Protocol npm publish order",
-  "version": "0.12.13",
-  "lastUpdated": "2026-04-20",
+  "version": "0.12.14",
+  "lastUpdated": "2026-04-22",
   "totalPackages": 37,
   "packages": [
     "@peac/kernel",
@@ -13,7 +13,6 @@
     "@peac/capture-node",
     "@peac/protocol",
     "@peac/control",
-    "@peac/disc",
     "@peac/audit",
     "@peac/middleware-core",
     "@peac/middleware-express",
@@ -21,6 +20,7 @@
     "@peac/http-signatures",
     "@peac/jwks-cache",
     "@peac/policy-kit",
+    "@peac/disc",
     "@peac/adapter-core",
     "@peac/mappings-mcp",
     "@peac/mappings-acp",
@@ -50,7 +50,6 @@
     "2.5-telemetry": ["@peac/telemetry"],
     "2.5-capture": ["@peac/capture-core", "@peac/capture-node"],
     "3-protocol": ["@peac/protocol", "@peac/control"],
-    "3-disc": ["@peac/disc"],
     "3-audit": ["@peac/audit"],
     "3.5-middleware": ["@peac/middleware-core", "@peac/middleware-express"],
     "4-infra": [
@@ -58,6 +57,7 @@
       "@peac/http-signatures",
       "@peac/jwks-cache",
       "@peac/policy-kit",
+      "@peac/disc",
       "@peac/adapter-core"
     ],
     "5-adapters": [


### PR DESCRIPTION
## Summary

`@peac/disc` gained a dependency on `@peac/policy-kit` in v0.12.14 PR1. The publish manifest still listed `@peac/disc` before `@peac/policy-kit`, causing the preflight topological order check to fail when the v0.12.14 tag was pushed.

## Scope

- Move `@peac/disc` after `@peac/policy-kit` in `scripts/publish-manifest.json`
- Update the `layers` map to place `@peac/disc` in `4-infra` (alongside other policy-kit dependents)
- Bump manifest `version` to `0.12.14` and `lastUpdated` to `2026-04-22`

## Validation

`node scripts/check-manifest-topo.mjs` — OK, all 37 packages in valid topological order.