### PR TITLE
chore: stamp v0.12.14 release_date

### DIFF
--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable surface classification for PEAC Protocol workspace. CI fails if any workspace member is missing. See docs/PACKAGE_STATUS.md for human-readable view.",
   "version": "0.12.14",
-  "updated": "PENDING",
+  "updated": "2026-04-22",
   "states": {
     "default": "Current recommended path. Actively maintained, Wire 0.2 native.",
     "supported": "Actively maintained, published, production-ready. May not be on default quickstart path.",

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -2,7 +2,7 @@
 
 Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scripts/generate-surface-status.mjs`.
 
-**Version:** 0.12.14 | **Updated:** PENDING
+**Version:** 0.12.14 | **Updated:** 2026-04-22
 
 ## Layer 1
 


### PR DESCRIPTION
Stamps release_date for v0.12.14 in REPO_SURFACE_STATUS.json and regenerates derived docs.

Post-publish stamp micro-PR per docs/RELEASING.md Mode 2 flow.