### PR TITLE
chore: stamp v0.13.0 dist_tag latest

### DIFF
--- a/docs/releases/current.json
+++ b/docs/releases/current.json
@@ -2,7 +2,7 @@
   "description": "PEAC release manifest: CI-enforceable source of truth for release state",
   "version": "0.13.0",
   "wire_format_version": "0.2",
-  "dist_tag": "next",
+  "dist_tag": "latest",
   "registries_version": "0.6.0",
   "errors_version": "0.13.0"
 }

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -3,7 +3,7 @@
   "schema_version": "1.0.0",
   "version": "0.13.0",
   "wire_format_version": "0.2",
-  "dist_tag": "next",
+  "dist_tag": "latest",
   "release_date": "2026-04-25",
   "metrics": {
     "tests": 7672,


### PR DESCRIPTION
## Summary

Post-promote stamp for v0.13.0. Flips `facts.json.dist_tag` and `current.json.dist_tag` from `next` to `latest` after the `promote-latest` workflow promoted 37 packages on npm.

## Validation

- npm `latest` resolves to `0.13.0`
- `dist_tag` in `docs/releases/facts.json` and `docs/releases/current.json` reflects `latest`