### PR TITLE
fix(ci): raise Go fuzz budget to 30s

### DIFF
--- a/.github/workflows/go-sdk.yml
+++ b/.github/workflows/go-sdk.yml
@@ -119,6 +119,6 @@ jobs:
           go-version-file: sdks/go/go.mod
           cache-dependency-path: sdks/go/go.sum
 
-      - name: Fuzz evidence validator (10s)
+      - name: Fuzz evidence validator (30s)
         working-directory: sdks/go
-        run: go test ./evidence -run=^$ -fuzz=^FuzzValidate$ -fuzztime=10s
+        run: go test ./evidence -run=^$ -fuzz=^FuzzValidate$ -fuzztime=30s

--- a/sdks/go/scripts/verify.sh
+++ b/sdks/go/scripts/verify.sh
@@ -65,9 +65,9 @@ if [ -d "$SDK_DIR/middleware/gin" ]; then
 fi
 
 # Fuzz test (quick)
-echo "Running fuzz test (10s)..."
+echo "Running fuzz test (30s)..."
 cd "$SDK_DIR"
-go test ./evidence -run=^$ -fuzz=^FuzzValidate$ -fuzztime=10s
+go test ./evidence -run=^$ -fuzz=^FuzzValidate$ -fuzztime=30s
 echo "OK: Fuzz test passed"
 echo ""
 


### PR DESCRIPTION
## Summary

The Go SDK `Fuzz (bounded)` workflow currently runs `FuzzValidate` with a 10-second fuzz budget. A recent main-branch run failed with `context deadline exceeded` shortly after the 10-second budget, without a persisted failing input in the job log.

`sdks/go/evidence/fuzz_test.go` already documents `-fuzztime=30s` as the intended run length for `FuzzValidate`. This PR aligns the GitHub workflow and local Go verification script with that documented budget.

## Scope

- `.github/workflows/go-sdk.yml`: run `FuzzValidate` with `-fuzztime=30s`.
- `sdks/go/scripts/verify.sh`: match the same `30s` budget locally.

No evidence validator logic changes.
No fuzz seed changes.
No job timeout change.

## Validation

- `bash scripts/ci/forbid-strings.sh`: passing
- `cd sdks/go && gofmt -l .`: clean
- `cd sdks/go && go vet ./...`: clean
- Local `go test ./evidence -run=^$ -fuzz=^FuzzValidate$ -fuzztime=30s`: PASS (11.4M execs over 31.4s wall-clock, no failing inputs)