### PR TITLE
chore(release): stamp REPO_SURFACE_STATUS

### DIFF
--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable surface classification for PEAC Protocol workspace. CI fails if any workspace member is missing. See docs/PACKAGE_STATUS.md for human-readable view.",
   "version": "0.13.0",
-  "updated": "2026-04-25",
+  "updated": "2026-04-26",
   "states": {
     "default": "Current recommended path. Actively maintained, Wire 0.2 native.",
     "supported": "Actively maintained, published, production-ready. May not be on default quickstart path.",

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -2,7 +2,7 @@
 
 Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scripts/generate-surface-status.mjs`.
 
-**Version:** 0.13.0 | **Updated:** 2026-04-25
+**Version:** 0.13.0 | **Updated:** 2026-04-26
 
 ## Layer 1
 


### PR DESCRIPTION
## Summary

Stamp-only release-state micro-PR. Bumps `REPO_SURFACE_STATUS.updated` from `2026-04-25` to `2026-04-26` so the release-closeout reconciler reads the surface-status file as fresh on the v0.13.1 publish window.

## Scope

Generated by `pnpm release:stamp:publish`:

- `REPO_SURFACE_STATUS.json` — single-line `updated` field bump.
- `docs/SURFACE_STATUS.md` — regenerated from `REPO_SURFACE_STATUS.json` (single-line `Updated:` field bump).

No content classification change. No package added or removed. No public surface change.

## Validation

- `pnpm release:stamp:check:publish`: PASS after the bump.
- Stamp-only PR guard accepts the change set (only allowlisted files modified).
