### PR TITLE
docs: align top-level noun on "record" across docs and adapter comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Full loop: [`docs/HOW-IT-WORKS.md`](docs/HOW-IT-WORKS.md). Artifact vocabulary (
 Outcome-led recipes under [`docs/SOLUTIONS/`](docs/SOLUTIONS/):
 
 - [Runtime evidence export](docs/SOLUTIONS/runtime-evidence-export.md)
-- [API receipt issuance](docs/SOLUTIONS/api-receipt-issuance.md)
-- [MCP tool-call receipts](docs/SOLUTIONS/mcp-tool-call-receipts.md)
+- [API record issuance](docs/SOLUTIONS/api-receipt-issuance.md)
+- [MCP tool-call records](docs/SOLUTIONS/mcp-tool-call-receipts.md)
 - [Commerce evidence bundle](docs/SOLUTIONS/commerce-evidence-bundle.md)
 - [Regulatory audit trail](docs/SOLUTIONS/regulatory-audit-trail.md)
 

--- a/apps/api/src/report-format.ts
+++ b/apps/api/src/report-format.ts
@@ -61,7 +61,7 @@ function pseudonymise(value: string): string {
 /**
  * Top-level claim keys whose values are protocol metadata that the
  * redactor MUST preserve verbatim. This set is conservative and
- * reflects PEAC Wire 0.2 surface.
+ * reflects PEAC Wire surface.
  */
 const PROTOCOL_METADATA_KEYS = new Set([
   'iss',

--- a/apps/sandbox-issuer/README.md
+++ b/apps/sandbox-issuer/README.md
@@ -1,6 +1,6 @@
 # Sandbox Issuer
 
-Test receipt issuer for local development and integration testing.
+Test record issuer for local development and integration testing.
 
 Issues signed interaction records with Ed25519 stable keys. Supports `interaction-record+jwt` (Wire 0.2) and `peac-receipt/0.1` (Wire 0.1 legacy).
 Not for production use.
@@ -21,9 +21,9 @@ pnpm start
 | GET    | `/health`                       | Health check         |
 | GET    | `/.well-known/peac-issuer.json` | Issuer configuration |
 | GET    | `/.well-known/jwks.json`        | Public keys (JWKS)   |
-| POST   | `/api/v1/issue`                 | Issue a receipt      |
+| POST   | `/api/v1/issue`                 | Issue a record       |
 
-## Issue a receipt
+## Issue a record
 
 ```bash
 curl -X POST http://127.0.0.1:3100/api/v1/issue \
@@ -58,7 +58,7 @@ to `.local/keys.json`.
 | Variable                   | Default                | Description                                        |
 | -------------------------- | ---------------------- | -------------------------------------------------- |
 | `PORT`                     | `3100`                 | HTTP listen port                                   |
-| `PEAC_ISSUER_URL`          | (derived from request) | Override the `iss` claim in issued receipts        |
+| `PEAC_ISSUER_URL`          | (derived from request) | Override the `iss` claim in issued records         |
 | `PEAC_SANDBOX_PRIVATE_JWK` | (none)                 | Ed25519 private key as JWK JSON string             |
 | `PEAC_TRUST_PROXY`         | (unset)                | Set to `1` to trust X-Forwarded-Proto/Host headers |
 

--- a/apps/sandbox-issuer/package.json
+++ b/apps/sandbox-issuer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@peac/app-sandbox-issuer",
   "version": "0.13.1",
-  "description": "PEAC Protocol Sandbox Issuer - Test receipt issuance for development",
+  "description": "PEAC Protocol Sandbox Issuer - Test record issuance for development",
   "type": "module",
   "main": "dist/node.js",
   "private": true,

--- a/apps/sandbox-issuer/tests/issue.test.ts
+++ b/apps/sandbox-issuer/tests/issue.test.ts
@@ -2,7 +2,7 @@
  * Issue endpoint tests
  *
  * Tests the POST /api/v1/issue flow including request validation,
- * receipt issuance, and round-trip verification.
+ * record issuance, and round-trip verification.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';

--- a/apps/verifier/README.md
+++ b/apps/verifier/README.md
@@ -35,7 +35,7 @@ The verifier uses `verifyLocal()` from `@peac/protocol` to verify receipt signat
 - **File upload**: Drag-and-drop support for .jwt, .jws, .json files
 - **Trust configuration**: Add/remove trusted issuers and public keys via the UI
 - **Offline mode**: Service worker caches the app shell for offline use
-- **Claims display**: Formatted breakdown of all receipt claims
+- **Claims display**: Formatted breakdown of all record claims
 
 ## Trust Store
 

--- a/apps/verifier/src/lib/format-claims.ts
+++ b/apps/verifier/src/lib/format-claims.ts
@@ -1,7 +1,7 @@
 /**
  * Claims Formatting
  *
- * Formats receipt claims for human-readable display.
+ * Formats record claims for human-readable display.
  */
 
 export function formatTimestamp(epoch: number): string {

--- a/docs/README_LONG.md
+++ b/docs/README_LONG.md
@@ -123,7 +123,7 @@ app.get('/data', async (req, res) => {
 
 ### Express middleware
 
-`@peac/middleware-express` provides automatic receipt issuance:
+`@peac/middleware-express` provides automatic record issuance:
 
 ```typescript
 import express from 'express';

--- a/docs/REFERENCE_ARCHITECTURES.md
+++ b/docs/REFERENCE_ARCHITECTURES.md
@@ -82,11 +82,11 @@ MCP Client (Claude, Cursor)     MCP Server (@peac/mcp-server)
 
 ### Packages involved
 
-| Layer | Package              | Role                                                 |
-| ----- | -------------------- | ---------------------------------------------------- |
-| 5     | `@peac/mcp-server`   | MCP tool handlers; receipt issuance and verification |
-| 3     | `@peac/protocol`     | `issue()` and `verifyLocal()`                        |
-| 4     | `@peac/mappings-mcp` | MCP-specific carrier adapter; `_meta` key mapping    |
+| Layer | Package              | Role                                                |
+| ----- | -------------------- | --------------------------------------------------- |
+| 5     | `@peac/mcp-server`   | MCP tool handlers; record issuance and verification |
+| 3     | `@peac/protocol`     | `issue()` and `verifyLocal()`                       |
+| 4     | `@peac/mappings-mcp` | MCP-specific carrier adapter; `_meta` key mapping   |
 
 ## 3. A2A Handoff Evidence Flow
 

--- a/docs/SLO.md
+++ b/docs/SLO.md
@@ -40,7 +40,7 @@ asserts `verifyLocal` p95 MUST be ≤ 10 ms. That gate runs in CI on every PR.
 | `/v1/verify` (Ed25519, ~1 KB record)                          | `release-prep` | `release-prep` | `release-prep` | Loopback; no JWKS resolution                 |
 | `/v1/verify` with JWKS resolution (single issuer, warm cache) | `release-prep` | `release-prep` | `release-prep` | Measured after first request; JWKS cache hot |
 
-## MCP tool-call round-trip with receipt issuance
+## MCP tool-call round-trip with record issuance
 
 | Operation                                                                 | Median (p50)   | p95            | p99            | Notes                 |
 | ------------------------------------------------------------------------- | -------------- | -------------- | -------------- | --------------------- |

--- a/docs/SOLUTIONS/README.md
+++ b/docs/SOLUTIONS/README.md
@@ -5,8 +5,8 @@ Outcome-led recipes. Each one states the real-world problem, the PEAC pieces you
 | Recipe                                                  | Outcome                                                                                                | Audience                    |
 | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | --------------------------- |
 | [Runtime evidence export](runtime-evidence-export.md)   | Export portable evidence from a managed agent runtime for compliance and audit.                        | Runtime / platform operator |
-| [API receipt issuance](api-receipt-issuance.md)         | Issue signed receipts on every HTTP response with Express middleware.                                  | API provider                |
-| [MCP tool-call receipts](mcp-tool-call-receipts.md)     | Attach signed records to MCP tool-call responses.                                                      | MCP server operator         |
+| [API record issuance](api-receipt-issuance.md)          | Issue signed records on every HTTP response with Express middleware.                                   | API provider                |
+| [MCP tool-call records](mcp-tool-call-receipts.md)      | Attach signed records to MCP tool-call responses.                                                      | MCP server operator         |
 | [Commerce evidence bundle](commerce-evidence-bundle.md) | Bundle observational evidence across x402, ACP, and paymentauth without synthesizing payment finality. | Agentic commerce operator   |
 | [Regulatory audit trail](regulatory-audit-trail.md)     | Build a portable, signed audit trail for EU AI Act, NIST AI RMF, and ISO 42001 review.                 | Compliance / audit lead     |
 | [Cloudflare + x402 + PEAC](cloudflare-x402-peac.md)     | Compose Cloudflare delivery surfaces and x402 PR-1986 terms with PEAC policy and terms binding.        | Cloudflare-fronted operator |
@@ -16,7 +16,7 @@ Each recipe follows the same structure:
 1. **The problem** — what real situation this addresses, in plain language.
 2. **What you'll use** — packages, optional adjacent systems, prerequisites.
 3. **Step-by-step** — numbered commands and code.
-4. **Evidence of output** — what the receipt or report looks like.
+4. **Evidence of output** — what the record or report looks like.
 5. **Where to go from here** — deeper specs, compatibility rows, integrator kits.
 
 Every recipe preserves PEAC's boundary: PEAC carries signed records of what another system attested. It does not execute, orchestrate, evaluate, approve, enforce, or determine payment finality. Future releases will add carrier breadth for CLI execution evidence and observational lifecycle records emitted by other systems; that carrier work does not change the boundary.

--- a/docs/SOLUTIONS/api-receipt-issuance.md
+++ b/docs/SOLUTIONS/api-receipt-issuance.md
@@ -1,6 +1,6 @@
-# API receipt issuance
+# API record issuance
 
-> **Outcome:** Your HTTP API emits signed receipts on every response so consumers can verify what terms applied and what happened — offline, with just your public key.
+> **Outcome:** Your HTTP API emits signed records on every response so consumers can verify what terms applied and what happened — offline, with just your public key.
 >
 > **Audience:** API provider.
 >

--- a/docs/SOLUTIONS/mcp-tool-call-receipts.md
+++ b/docs/SOLUTIONS/mcp-tool-call-receipts.md
@@ -1,4 +1,4 @@
-# MCP tool-call receipts
+# MCP tool-call records
 
 > **Outcome:** Your MCP server emits a signed record for every tool call so downstream agents, auditors, or counterparties can verify what tool ran, what arguments were used, and what the result was — offline, with just your public key.
 >

--- a/docs/adapters/x402.md
+++ b/docs/adapters/x402.md
@@ -176,5 +176,5 @@ unsigned `acceptIndex` irrelevant for security.
 
 The distinction:
 
-- **Rail** (`@peac/rails-x402`): Extracts payment information from x402 HTTP headers (`Payment-Required`, `Payment-Response`) and normalizes to PEAC's `NormalizedPayment` format. Used for receipt issuance.
+- **Rail** (`@peac/rails-x402`): Extracts payment information from x402 HTTP headers (`Payment-Required`, `Payment-Response`) and normalizes to PEAC's `NormalizedPayment` format. Used for record issuance.
 - **Adapter** (`@peac/adapter-x402`): Verifies signed x402 offer/receipt artifacts, performs term-matching, and maps to PEAC records with verification status. Used for proof verification and audit.

--- a/docs/adoption/confirmations.md
+++ b/docs/adoption/confirmations.md
@@ -19,7 +19,7 @@ Each confirmation entry MUST include all 6 fields:
 <!-- Example:
 ### Acme Agent Platform
 - **Team/Project:** Acme Agent Platform
-- **Integration Surface:** MCP receipt issuance via `peac_issue` tool
+- **Integration Surface:** MCP record issuance via `peac_issue` tool
 - **Integration Impact:** Replaced custom audit log with structured receipts, reducing compliance integration time.
 - **Date:** 2026-04-01
 - **Public Link:** https://github.com/acme/agent-platform/pull/42

--- a/docs/adoption/integration-evidence.json
+++ b/docs/adoption/integration-evidence.json
@@ -9,7 +9,7 @@
       "pr": 472,
       "pr_commit": "9e5c5dea",
       "dd90_gate": true,
-      "surface": "peac_issue tool produces Wire 0.2 receipts; peac_verify tool verifies them",
+      "surface": "peac_issue tool produces Wire 0.2 records; peac_verify tool verifies them",
       "evidence": "Round-trip issuance and verification via MCP tool calls",
       "wire_version": "0.2",
       "test_files": [
@@ -24,7 +24,7 @@
       "pr": 473,
       "pr_commit": "56fd7047",
       "dd90_gate": true,
-      "surface": "Wire 0.2 receipts carried in A2A metadata[extensionURI] per Evidence Carrier Contract",
+      "surface": "Wire 0.2 records carried in A2A metadata[extensionURI] per Evidence Carrier Contract",
       "evidence": "Round-trip through A2A metadata carrier (issue, embed, extract, verify)",
       "wire_version": "0.2",
       "test_files": ["tests/integration/a2a/wire02-roundtrip.test.ts"],
@@ -38,9 +38,9 @@
       "dd90_gate": false,
       "dd_reference": "DD-154",
       "surface": "COSE_Sign1 (RFC 9052) identity adapter; maps EAT claims to PEAC actor binding",
-      "evidence": "Passport-style identity input; does not produce Wire 0.2 receipts in the EAT ecosystem",
+      "evidence": "Passport-style identity input; does not produce Wire 0.2 records in the EAT ecosystem",
       "wire_version": null,
-      "rationale": "EAT is an identity input surface. It enriches PEAC receipts with external attestations but does not constitute a distinct ecosystem producing Wire 0.2 evidence.",
+      "rationale": "EAT is an identity input surface. It enriches PEAC records with external attestations but does not constitute a distinct ecosystem producing Wire 0.2 evidence.",
       "test_files": [
         "packages/adapters/eat/tests/passport.test.ts",
         "packages/adapters/eat/tests/claim-mapper.test.ts"
@@ -49,8 +49,8 @@
     }
   ],
   "classification_rules": [
-    "An integration counts toward DD-90 if it produces or consumes Wire 0.2 receipts (interaction-record+jwt) in a distinct protocol ecosystem.",
-    "Identity adapters, claim mappers, and format converters that feed into PEAC but do not themselves produce receipts are classified under their own DDs.",
+    "An integration counts toward DD-90 if it produces or consumes Wire 0.2 records (interaction-record+jwt) in a distinct protocol ecosystem.",
+    "Identity adapters, claim mappers, and format converters that feed into PEAC but do not themselves produce records are classified under their own DDs.",
     "Do not inflate the ecosystem count by reclassifying adapters as integrations."
   ]
 }

--- a/docs/adoption/integration-evidence.md
+++ b/docs/adoption/integration-evidence.md
@@ -12,7 +12,7 @@
 - **Surface:** peac_issue tool produces Wire 0.2 records; peac_verify tool verifies them
 - **Evidence:** Round-trip issuance and verification via MCP tool calls
 - **Wire version:** Wire 0.2
-- **DD-90 gate:** YES (distinct ecosystem with Wire 0.2 production)
+- **DD-90 gate:** YES (distinct ecosystem with Wire 0.2 record production)
 - **Test files:** `packages/mcp-server/tests/handlers/issue.test.ts`, `packages/mcp-server/tests/handlers/verify.test.ts`
 - **Spec refs:** `docs/specs/EVIDENCE-CARRIER-CONTRACT.md`
 
@@ -22,7 +22,7 @@
 - **Surface:** Wire 0.2 records carried in A2A metadata[extensionURI] per Evidence Carrier Contract
 - **Evidence:** Round-trip through A2A metadata carrier (issue, embed, extract, verify)
 - **Wire version:** Wire 0.2
-- **DD-90 gate:** YES (distinct ecosystem with Wire 0.2 production)
+- **DD-90 gate:** YES (distinct ecosystem with Wire 0.2 record production)
 - **Test files:** `tests/integration/a2a/wire02-roundtrip.test.ts`
 - **Spec refs:** `docs/specs/EVIDENCE-CARRIER-CONTRACT.md`
 

--- a/docs/adoption/integration-evidence.md
+++ b/docs/adoption/integration-evidence.md
@@ -1,7 +1,7 @@
 # Integration Evidence Catalog
 
 > **Purpose:** Documents which ecosystem integrations count toward DD-90 gates and which do not.
-> **Rule:** Only integrations that produce or consume Wire 0.2 receipts in a distinct ecosystem count.
+> **Rule:** Only integrations that produce or consume Wire 0.2 records in a distinct ecosystem count.
 > **Source:** Generated from `docs/adoption/integration-evidence.json`. Do not edit manually.
 
 ## DD-90 Ecosystem Integrations (Count: 2)
@@ -9,7 +9,7 @@
 ### MCP (Model Context Protocol)
 
 - **PR:** #472 (commit `9e5c5dea`)
-- **Surface:** peac_issue tool produces Wire 0.2 receipts; peac_verify tool verifies them
+- **Surface:** peac_issue tool produces Wire 0.2 records; peac_verify tool verifies them
 - **Evidence:** Round-trip issuance and verification via MCP tool calls
 - **Wire version:** Wire 0.2
 - **DD-90 gate:** YES (distinct ecosystem with Wire 0.2 production)
@@ -19,7 +19,7 @@
 ### A2A (Agent-to-Agent Protocol)
 
 - **PR:** #473 (commit `56fd7047`)
-- **Surface:** Wire 0.2 receipts carried in A2A metadata[extensionURI] per Evidence Carrier Contract
+- **Surface:** Wire 0.2 records carried in A2A metadata[extensionURI] per Evidence Carrier Contract
 - **Evidence:** Round-trip through A2A metadata carrier (issue, embed, extract, verify)
 - **Wire version:** Wire 0.2
 - **DD-90 gate:** YES (distinct ecosystem with Wire 0.2 production)
@@ -32,15 +32,15 @@
 
 - **PR:** #474 (commit `f20e0f61`)
 - **Surface:** COSE_Sign1 (RFC 9052) identity adapter; maps EAT claims to PEAC actor binding
-- **Evidence:** Passport-style identity input; does not produce Wire 0.2 receipts in the EAT ecosystem
-- **Wire version:** N/A (identity input, not receipt output)
+- **Evidence:** Passport-style identity input; does not produce Wire 0.2 records in the EAT ecosystem
+- **Wire version:** N/A (identity input, not record output)
 - **DD-90 gate:** NO (DD-154)
-- **Rationale:** EAT is an identity input surface. It enriches PEAC receipts with external attestations but does not constitute a distinct ecosystem producing Wire 0.2 evidence.
+- **Rationale:** EAT is an identity input surface. It enriches PEAC records with external attestations but does not constitute a distinct ecosystem producing Wire 0.2 evidence.
 - **Test files:** `packages/adapters/eat/tests/passport.test.ts`, `packages/adapters/eat/tests/claim-mapper.test.ts`
 - **Spec refs:** `docs/specs/EVIDENCE-CARRIER-CONTRACT.md`
 
 ## Classification Rules
 
-1. An integration counts toward DD-90 if it produces or consumes Wire 0.2 receipts (interaction-record+jwt) in a distinct protocol ecosystem.
-2. Identity adapters, claim mappers, and format converters that feed into PEAC but do not themselves produce receipts are classified under their own DDs.
+1. An integration counts toward DD-90 if it produces or consumes Wire 0.2 records (interaction-record+jwt) in a distinct protocol ecosystem.
+2. Identity adapters, claim mappers, and format converters that feed into PEAC but do not themselves produce records are classified under their own DDs.
 3. Do not inflate the ecosystem count by reclassifying adapters as integrations.

--- a/docs/adoption/integration-evidence.schema.json
+++ b/docs/adoption/integration-evidence.schema.json
@@ -85,7 +85,7 @@
         },
         "wire_version": {
           "type": ["string", "null"],
-          "description": "Wire format version (e.g. '0.2') or null for non-receipt integrations"
+          "description": "Wire format version (e.g. '0.2') or null for non-record integrations"
         },
         "rationale": {
           "type": "string",

--- a/docs/maintainers/reference-integrations.md
+++ b/docs/maintainers/reference-integrations.md
@@ -8,7 +8,7 @@ Each surface is cataloged in `docs/adoption/integration-evidence.json` with full
 
 ### MCP (Model Context Protocol)
 
-Round-trip receipt issuance and verification via MCP tool calls (`peac_issue`, `peac_verify`). Pack-install smoke verified (ESM, CJS, types).
+Round-trip record issuance and verification via MCP tool calls (`peac_issue`, `peac_verify`). Pack-install smoke verified (ESM, CJS, types).
 
 ### A2A (Agent-to-Agent Protocol)
 

--- a/packages/adapters/eat/src/claim-mapper.ts
+++ b/packages/adapters/eat/src/claim-mapper.ts
@@ -1,9 +1,9 @@
 /**
- * EAT Claim Mapper: maps EAT claims to Wire 0.2 receipt claims
+ * EAT Claim Mapper: maps EAT claims to Wire record claims.
  *
  * Privacy-first: all claim values are SHA-256 hashed by default.
  * Callers opt in to raw value inclusion via `includeRawClaims` option.
- * This prevents accidental PII leakage from EAT attestations into PEAC receipts.
+ * This prevents accidental PII leakage from EAT attestations into PEAC records.
  *
  * References:
  *   - RFC 9711 (Entity Attestation Token)
@@ -55,14 +55,14 @@ function serializeClaimValue(value: unknown): string {
 }
 
 /**
- * Map EAT claims to Wire 0.2 receipt claims.
+ * Map EAT claims to Wire record claims.
  *
  * Privacy-first: claim values are SHA-256 hashed unless their integer key
  * appears in `options.includeRawClaims`. This prevents accidental PII leakage.
  *
  * @param claims - Decoded EAT claims map
  * @param options - Mapper configuration
- * @returns Mapped claims suitable for Wire 0.2 receipt issuance
+ * @returns Mapped claims suitable for Wire record issuance
  */
 export async function mapEatClaims(
   claims: EatClaims,

--- a/packages/adapters/eat/src/index.ts
+++ b/packages/adapters/eat/src/index.ts
@@ -2,10 +2,10 @@
  * @peac/adapter-eat
  *
  * EAT (Entity Attestation Token, RFC 9711) passport decoder and
- * PEAC Wire 0.2 claim mapper.
+ * PEAC Wire record claim mapper.
  *
  * Decodes COSE_Sign1 structures (RFC 9052) with Ed25519 signatures,
- * extracts EAT claims, and maps them to Wire 0.2 receipt claims
+ * extracts EAT claims, and maps them to Wire record claims
  * with privacy-first defaults (SHA-256 hashing of claim values).
  *
  * @packageDocumentation

--- a/packages/adapters/eat/src/types.ts
+++ b/packages/adapters/eat/src/types.ts
@@ -103,13 +103,13 @@ export interface ClaimMapperOptions {
    * List specific integer keys here to include their raw values.
    */
   includeRawClaims?: number[];
-  /** Receipt type (reverse-DNS or URI). Defaults to 'org.peacprotocol/attestation' */
+  /** Record type (reverse-DNS or URI). Defaults to 'org.peacprotocol/attestation' */
   type?: string;
-  /** Pillars to include on the receipt. Defaults to ['identity'] */
+  /** Pillars to include on the record. Defaults to ['identity'] */
   pillars?: string[];
 }
 
-/** Mapped Wire 0.2 claims from an EAT passport */
+/** Mapped Wire record claims from an EAT passport */
 export interface MappedEatClaims {
   kind: 'evidence';
   type: string;

--- a/packages/adapters/eat/tests/claim-mapper.test.ts
+++ b/packages/adapters/eat/tests/claim-mapper.test.ts
@@ -1,7 +1,7 @@
 /**
  * EAT Claim Mapper tests
  *
- * Tests privacy-first claim mapping from EAT to Wire 0.2 receipt claims.
+ * Tests privacy-first claim mapping from EAT to Wire record claims.
  */
 
 import { describe, it, expect } from 'vitest';

--- a/packages/audit/src/dispute-bundle-types.ts
+++ b/packages/audit/src/dispute-bundle-types.ts
@@ -150,7 +150,7 @@ export interface DisputeBundleManifest {
    * sha256:<hex> hash of peac.txt file if included.
    *
    * Enables offline policy binding verification: verifiers can compare this
-   * hash against the policy digest in Wire 0.2 receipts to confirm the policy
+   * hash against the policy digest in Wire records to confirm the policy
    * in effect at issuance time matches what is bundled.
    *
    * Bundle path: policy/peac.txt (locked convention).

--- a/packages/crypto/src/jws.ts
+++ b/packages/crypto/src/jws.ts
@@ -38,7 +38,7 @@ export interface Wire01JWSHeader {
 }
 
 /**
- * JWS header for Wire 0.2 receipts (typ: 'interaction-record+jwt', compact canonical form)
+ * JWS header for Wire 0.2 records (typ: 'interaction-record+jwt', compact canonical form)
  *
  * The full media type 'application/interaction-record+jwt' is accepted by verify()
  * and decode() but normalized to this compact form before returning.

--- a/packages/kernel/src/constants.ts
+++ b/packages/kernel/src/constants.ts
@@ -263,7 +263,7 @@ export const VERIFICATION_MODES = {
 export const WIRE_01_JWS_TYP = 'peac-receipt/0.1' as const;
 
 /**
- * JWS header typ value for Wire 0.2 receipts (compact form).
+ * JWS header typ value for Wire 0.2 records (compact form).
  * Per RFC 7515 Section 4.1.9, the full media type form
  * 'application/interaction-record+jwt' is also accepted by verifiers and
  * normalized to this compact form before returning the header.

--- a/scripts/release/validate-adoption-evidence.mjs
+++ b/scripts/release/validate-adoption-evidence.mjs
@@ -163,7 +163,7 @@ function generateMarkdown(data) {
     '> **Purpose:** Documents which ecosystem integrations count toward DD-90 gates and which do not.'
   );
   lines.push(
-    '> **Rule:** Only integrations that produce or consume Wire 0.2 receipts in a distinct ecosystem count.'
+    '> **Rule:** Only integrations that produce or consume Wire 0.2 records in a distinct ecosystem count.'
   );
   lines.push(
     '> **Source:** Generated from `docs/adoption/integration-evidence.json`. Do not edit manually.'
@@ -179,7 +179,7 @@ function generateMarkdown(data) {
     lines.push(`- **Surface:** ${i.surface}`);
     lines.push(`- **Evidence:** ${i.evidence}`);
     lines.push(`- **Wire version:** Wire ${i.wire_version}`);
-    lines.push('- **DD-90 gate:** YES (distinct ecosystem with Wire 0.2 production)');
+    lines.push('- **DD-90 gate:** YES (distinct ecosystem with Wire 0.2 record production)');
     lines.push(`- **Test files:** ${i.test_files.map((f) => '`' + f + '`').join(', ')}`);
     lines.push(`- **Spec refs:** ${i.spec_refs.map((f) => '`' + f + '`').join(', ')}`);
     lines.push('');
@@ -196,7 +196,7 @@ function generateMarkdown(data) {
       lines.push(`- **Surface:** ${i.surface}`);
       lines.push(`- **Evidence:** ${i.evidence}`);
       lines.push(
-        `- **Wire version:** ${i.wire_version ? 'Wire ' + i.wire_version : 'N/A (identity input, not receipt output)'}`
+        `- **Wire version:** ${i.wire_version ? 'Wire ' + i.wire_version : 'N/A (identity input, not record output)'}`
       );
       lines.push(`- **DD-90 gate:** NO${i.dd_reference ? ` (${i.dd_reference})` : ''}`);
       if (i.rationale) {


### PR DESCRIPTION
## What changed

- Adapter / audit / api JSDoc: `@peac/adapter-eat`, `@peac/audit/dispute-bundle-types`, `apps/api/src/report-format`.
- App prose: sandbox-issuer (`README.md`, `package.json` description, `tests/issue.test.ts`), verifier (`README.md`, `src/lib/format-claims.ts`).
- Adoption / DD-90 evidence catalog: `integration-evidence.md` / `.json` / `.schema.json`. `Wire 0.2` version precision retained; only the noun flipped to `records`. The MD generator template (`scripts/release/validate-adoption-evidence.mjs`) updated so future runs stay in parity.
- `docs/SOLUTIONS/` H1 titles and link text in `README.md` and `docs/SOLUTIONS/README.md`. Filenames unchanged.
- Prose polish around machine identifiers: `packages/crypto/src/jws.ts` and `packages/kernel/src/constants.ts` JSDoc on the JWS `typ` constant; `docs/SLO.md` heading; `docs/REFERENCE_ARCHITECTURES.md` package-role row; `docs/README_LONG.md` middleware-express description; `docs/adapters/x402.md`; `docs/maintainers/reference-integrations.md`; `docs/adoption/confirmations.md` integration surface.

## Scope

No public API change.
No wire-format change.
No signing or envelope change.
No discovery behavior change.
No package-surface change.
No npm publish.