### PR TITLE
docs: align Wire JSDoc on record terminology

### DIFF
--- a/examples/cf-policy-x402-terms/README.md
+++ b/examples/cf-policy-x402-terms/README.md
@@ -11,7 +11,7 @@ x402 PR-1986 `terms`; PEAC does not replace either.
 ## What it shows
 
 1. A `peac-policy/0.1` document is canonicalized via JCS+SHA-256 and
-   bound into a Wire evidence receipt's `policy.digest` field.
+   bound into a signed Wire record's `policy.digest` field.
 2. The same document advertises x402 `terms` in four representations
    (under `terms/`). Each representation envelope produces its own
    binding identity via `computeX402TermsDigest`.

--- a/packages/mappings/a2a/src/auth/evidence.ts
+++ b/packages/mappings/a2a/src/auth/evidence.ts
@@ -41,10 +41,10 @@ export interface A2AAuthEvent {
 }
 
 /**
- * Output structure for the access extension in a Wire 0.2 receipt.
+ * Output structure for the access extension in a Wire 0.2 record.
  *
  * Uses `org.peacprotocol/access` extension group with `auth_event`
- * set to `'observation'` to distinguish from access-decision receipts.
+ * set to `'observation'` to distinguish from access-decision records.
  */
 export interface A2AAuthEvidenceResult {
   /** Extension key for receipt `ext` field */

--- a/packages/mcp-server/src/handlers/issue.ts
+++ b/packages/mcp-server/src/handlers/issue.ts
@@ -1,7 +1,7 @@
 /**
  * Issue handler -- Wire 0.2 only, ZERO MCP SDK imports
  *
- * Signs and returns a Wire 0.2 PEAC receipt JWS (in-memory only, no side-effects).
+ * Signs and returns a Wire 0.2 PEAC record JWS (in-memory only, no side-effects).
  * Requires issuerKey + issuerId on ServerContext.
  */
 

--- a/packages/protocol/src/issue.ts
+++ b/packages/protocol/src/issue.ts
@@ -45,7 +45,7 @@ import {
 import { hashReceipt, fireTelemetryHook, type TelemetryHook } from './telemetry.js';
 
 /**
- * Wire 0.1 receipt options (frozen legacy).
+ * Wire 0.1 record options (frozen legacy).
  *
  * @deprecated Use {@link IssueWire02Options} (or the {@link IssueOptions} alias)
  * for current stable issuance.
@@ -172,12 +172,12 @@ export class IssueError extends Error {
 }
 
 /**
- * Issue a Wire 0.1 PEAC receipt.
+ * Issue a Wire 0.1 PEAC record.
  *
  * @deprecated Wire 0.1 issuance is frozen legacy. Use {@link issue} (current stable format)
- * or {@link issueWire02} (explicit wire-pinned API) for Wire 0.2 receipts.
+ * or {@link issueWire02} (explicit wire-pinned API) for Wire 0.2 records.
  *
- * @param options - Wire 0.1 receipt options
+ * @param options - Wire 0.1 record options
  * @returns Issue result with JWS and optional subject_snapshot
  * @throws IssueError if evidence contains non-JSON-safe values
  */
@@ -363,11 +363,11 @@ export async function issueWire01(options: IssueWire01Options): Promise<IssueRes
 }
 
 /**
- * Issue a Wire 0.1 PEAC receipt and return just the JWS string
+ * Issue a Wire 0.1 PEAC record and return just the JWS string
  *
  * @deprecated Wire 0.1 issuance is frozen legacy. Use {@link issue} for the current stable format.
  *
- * @param options - Wire 0.1 receipt options
+ * @param options - Wire 0.1 record options
  * @returns JWS compact serialization
  */
 export async function issueJws(options: IssueWire01Options): Promise<string> {
@@ -376,13 +376,13 @@ export async function issueJws(options: IssueWire01Options): Promise<string> {
 }
 
 /**
- * Issue a PEAC receipt in the current stable public format.
+ * Issue a PEAC record in the current stable public format.
  *
- * This is the canonical public issuance API. It issues Wire 0.2 receipts
+ * This is the canonical public issuance API. It issues Wire 0.2 records
  * (`typ: interaction-record+jwt`). For an explicit wire-pinned API, use
  * {@link issueWire02} directly.
  *
- * @param options - Receipt options (same as {@link IssueWire02Options})
+ * @param options - Record options (same as {@link IssueWire02Options})
  * @returns Issue result with JWS
  * @throws IssueError if iss is not canonical or schema validation fails
  */
@@ -395,7 +395,7 @@ export async function issue(options: IssueWire02Options): Promise<IssueResult> {
 // ---------------------------------------------------------------------------
 
 /**
- * Options for issuing a Wire 0.2 receipt
+ * Options for issuing a Wire 0.2 record
  */
 export interface IssueWire02Options {
   /**
@@ -462,7 +462,7 @@ export interface IssueWire02Options {
 export type IssueOptions = IssueWire02Options;
 
 /**
- * Issue a Wire 0.2 receipt (explicit wire-pinned API).
+ * Issue a Wire 0.2 record (explicit wire-pinned API).
  *
  * Most callers should use {@link issue} instead, which delegates here.
  * Use `issueWire02` directly for conformance tests, benchmarks, and
@@ -471,7 +471,7 @@ export type IssueOptions = IssueWire02Options;
  * Validates the iss canonical form and Wire02ClaimsSchema before signing.
  * Always sets typ to 'interaction-record+jwt' (WIRE_02_JWS_TYP).
  *
- * @param options - Wire 0.2 receipt options
+ * @param options - Wire 0.2 record options
  * @returns Issue result with JWS
  * @throws IssueError if iss is not canonical or schema validation fails
  */

--- a/packages/protocol/src/policy-binding.ts
+++ b/packages/protocol/src/policy-binding.ts
@@ -27,7 +27,7 @@ import { checkDocumentBinding, computeJsonDocumentDigestJcs } from './document-b
  * `'sha256:<64 lowercase hex>'`.
  *
  * This is the normative digest format for the policy.digest field in
- * Wire 0.2 receipts. The format is stable and identical across
+ * Wire 0.2 records. The format is stable and identical across
  * implementations. Output is byte-identical to
  * `computeJsonDocumentDigestJcs(policy)` from `document-binding.ts`.
  *


### PR DESCRIPTION
## What changed

- `packages/protocol/src/issue.ts` — 10 JSDoc lines (`issueWire01`, `issueJws`, `issue`, `issueWire02`, `IssueWire01Options`, `IssueWire02Options`).
- `packages/protocol/src/policy-binding.ts` — 1 JSDoc line on the `policy.digest` stable digest format description.
- `packages/mappings/a2a/src/auth/evidence.ts` — 1 JSDoc line on the access-extension output structure.
- `packages/mcp-server/src/handlers/issue.ts` — 1 JSDoc line on the issue-handler module summary.
- `examples/cf-policy-x402-terms/README.md` — 1 README prose line.

Total: 14 single-line edits across 5 files. Preserves every Wire 0.1 / Wire 0.2 version qualifier.

## Scope

No public API change.
No wire-format change.
No signing or envelope change.
No discovery behavior change.
No package-surface change.
No npm publish.