### PR TITLE
feat: add private resolver-http composition layer

### DIFF
--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -78,6 +78,14 @@
       "published": false,
       "note": "Workspace-private metadata package. Not published to npm. The canonical codec / record-core implementation lives at packages/protocol/src/_internal/record-core/ and is imported via relative paths from inside @peac/protocol; this package does NOT duplicate that source. Exists for plan-compliance, invisibility-test denylist coverage, and npm-name-reservation drift prevention."
     },
+    "packages/resolver-http": {
+      "npm": "@peac/resolver-http",
+      "state": "internal",
+      "wire": "0.2",
+      "layer": 0,
+      "published": false,
+      "note": "Workspace-private resolver-http shadow package introduced in v0.13.2 PR A per Revision 4 section 7. Holds shadow-only network-bearing resolution logic copied / extracted from packages/protocol/src/{discovery, jwks-resolver, ssrf-safe-fetch, pointer-fetch}.ts for parity testing under a shadow-mode comparison harness. Not published to npm. P0 invariant: @peac/protocol must NOT import / depend on / re-export from / emit reference to this package while it remains workspace-private (denylist seeded by v0.13.1 PR A in tests/tooling/protocol-private-imports.test.ts, private-package-deps.test.ts, protocol-public-surface-stable.test.ts, internal-package-invisibility.test.ts, kernel-public-surface-stable.test.ts; scripts/verify-dist-private-leaks.mjs; scripts/release/pack-install-smoke.mjs). PR A introduces only the package skeleton; resolver source is added in subsequent commits of the same PR."
+    },
     "packages/audit": {
       "npm": "@peac/audit",
       "state": "default",

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -9,7 +9,7 @@
     "tests": 8561,
     "test_files": 346,
     "published_packages": 36,
-    "build_targets": 101,
+    "build_targets": 102,
     "conformance_requirement_ids": 224,
     "conformance_sections": 25
   },

--- a/packages/resolver-http/README.md
+++ b/packages/resolver-http/README.md
@@ -1,0 +1,39 @@
+# @peac/resolver-http (workspace-private)
+
+> Internal-only package. Workspace-private per Revision 4 section 19.
+> Never published. Never referenced by any published package.
+
+## Status
+
+Skeleton-only at v0.13.2 PR A Commit 1. Resolver logic is added in
+subsequent commits of v0.13.2 PR A as a private shadow of
+`packages/protocol/src/{discovery, jwks-resolver, ssrf-safe-fetch,
+pointer-fetch}.ts` for parity testing.
+
+## Why this exists
+
+v0.13.2 reboot extracts network-bearing resolution into a private
+shadow package so the main core path can be exercised in shadow mode by
+PR B without changing public protocol behavior or dependency direction.
+
+## Boundary (P0, LOCKED 2026-04-27)
+
+`@peac/protocol` must NOT import, depend on, re-export from, or emit a
+reference to `@peac/resolver-http`. Verified by:
+
+- `tests/tooling/protocol-private-imports.test.ts`
+- `tests/tooling/private-package-deps.test.ts`
+- `tests/tooling/protocol-public-surface-stable.test.ts`
+- `tests/tooling/internal-package-invisibility.test.ts`
+- `tests/tooling/kernel-public-surface-stable.test.ts`
+- `scripts/verify-dist-private-leaks.mjs`
+- `scripts/release/pack-install-smoke.mjs`
+
+## Reference
+
+- Revision 4 reboot plan section 7 (canonical specification).
+- Revision 4 reboot plan section 7.1P (architecture lock).
+- Revision 4 reboot plan section 7.2 (PR table; corrected wording).
+- Revision 4 reboot plan section 7.2A (PR A acceptance checklist).
+- `~/.claude/plans/tranquil-mirroring-fermat.md` (per-PR execution
+  plan, local-only).

--- a/packages/resolver-http/README.md
+++ b/packages/resolver-http/README.md
@@ -6,20 +6,35 @@
 ## Status
 
 Skeleton-only at v0.13.2 PR A Commit 1. Resolver logic is added in
-subsequent commits of v0.13.2 PR A as a private shadow of
-`packages/protocol/src/{discovery, jwks-resolver, ssrf-safe-fetch,
-pointer-fetch}.ts` for parity testing.
+subsequent commits of v0.13.2 PR A as a private composition layer over
+published primitives (`@peac/net-node`, `@peac/jwks-cache`,
+`@peac/kernel`, `@peac/crypto`, `@peac/schema`) for parity testing
+against `@peac/protocol`'s existing self-contained resolver path on
+shared local fixtures.
 
 ## Why this exists
 
-v0.13.2 reboot extracts network-bearing resolution into a private
-shadow package so the main core path can be exercised in shadow mode by
-PR B without changing public protocol behavior or dependency direction.
+v0.13.2 reboot adds a private composition layer over the existing
+published network and JWKS primitives so the main core path can be
+exercised in shadow mode by PR B without changing public protocol
+behavior or dependency direction. This avoids creating a fourth
+SSRF / JWKS code path: protocol stays self-contained and byte-stable;
+resolver-http composes the two published primitives behind a
+verifier-oriented interface; parity tests compare both paths on shared
+local fixtures.
 
-## Boundary (P0, LOCKED 2026-04-27)
+## Boundary (P0 invariants, LOCKED 2026-04-28)
 
-`@peac/protocol` must NOT import, depend on, re-export from, or emit a
-reference to `@peac/resolver-http`. Verified by:
+- `@peac/protocol` must NOT import, depend on, re-export from, or emit
+  a reference to `@peac/resolver-http`.
+- `@peac/resolver-http` runtime source must NOT import `@peac/protocol`.
+  Parity test files MAY import `@peac/protocol` for behavior comparison.
+- `@peac/jwks-cache` is reused as a published primitive; not modified,
+  not merged, not renamed in v0.13.2.
+- `@peac/net-node` is reused as the canonical network-safety primitive;
+  not modified in PR A.
+
+Verified by:
 
 - `tests/tooling/protocol-private-imports.test.ts`
 - `tests/tooling/private-package-deps.test.ts`
@@ -28,6 +43,9 @@ reference to `@peac/resolver-http`. Verified by:
 - `tests/tooling/kernel-public-surface-stable.test.ts`
 - `scripts/verify-dist-private-leaks.mjs`
 - `scripts/release/pack-install-smoke.mjs`
+- runtime-source isolation gate (added in Commit 2):
+  `git grep -nE '@peac/protocol' packages/resolver-http/src packages/resolver-http/__tests__/_helpers`
+  must be empty.
 
 ## Reference
 

--- a/packages/resolver-http/README.md
+++ b/packages/resolver-http/README.md
@@ -8,11 +8,13 @@
 
 `@peac/resolver-http` is a workspace-private composition layer over
 existing published primitives. v0.13.2 PR A adds the package and its
-runtime modules, parity tests against `@peac/protocol`'s self-contained
-resolver path on shared local fixtures, and SSRF, redirect, timeout,
-cache-isolation, and byte-cap test coverage. No `apps/api` or Hosted
-Verify production-path switch is included in PR A; that wiring is
-deferred to PR B.
+runtime modules, no-network public-API smoke coverage, resolver-http
+local harness coverage, and SSRF, redirect, timeout, cache-isolation,
+and byte-cap test coverage. No `apps/api` or Hosted Verify
+production-path switch is included in PR A; that wiring is deferred to
+PR B. Full fetched-body cross-implementation pointer parity is
+intentionally re-homed to PR B shadow mode (see `## Parity testing`
+below).
 
 ## Why this exists
 
@@ -21,8 +23,8 @@ published network and JWKS primitives so the verifier core path can be
 exercised in shadow mode by PR B without changing public protocol
 behavior or dependency direction. Protocol stays self-contained and
 byte-stable; resolver-http composes the published primitives behind a
-verifier-oriented interface; parity tests compare both paths on shared
-local fixtures.
+verifier-oriented interface; full cross-implementation parity belongs
+to PR B shadow mode.
 
 ## Composition
 

--- a/packages/resolver-http/README.md
+++ b/packages/resolver-http/README.md
@@ -2,37 +2,67 @@
 
 > Internal-only package. Workspace-private per Revision 4 section 19.
 > Never published. Never referenced by any published package.
+> Not a public API. Not part of PEAC's external integration surface.
 
 ## Status
 
-Skeleton-only at v0.13.2 PR A Commit 1. Resolver logic is added in
-subsequent commits of v0.13.2 PR A as a private composition layer over
-published primitives (`@peac/net-node`, `@peac/jwks-cache`,
-`@peac/kernel`, `@peac/crypto`, `@peac/schema`) for parity testing
-against `@peac/protocol`'s existing self-contained resolver path on
-shared local fixtures.
+`@peac/resolver-http` is a workspace-private composition layer over
+existing published primitives. v0.13.2 PR A adds the package and its
+runtime modules, parity tests against `@peac/protocol`'s self-contained
+resolver path on shared local fixtures, and SSRF, redirect, timeout,
+cache-isolation, and byte-cap test coverage. No `apps/api` or Hosted
+Verify production-path switch is included in PR A; that wiring is
+deferred to PR B.
 
 ## Why this exists
 
 v0.13.2 reboot adds a private composition layer over the existing
-published network and JWKS primitives so the main core path can be
+published network and JWKS primitives so the verifier core path can be
 exercised in shadow mode by PR B without changing public protocol
-behavior or dependency direction. This avoids creating a fourth
-SSRF / JWKS code path: protocol stays self-contained and byte-stable;
-resolver-http composes the two published primitives behind a
+behavior or dependency direction. Protocol stays self-contained and
+byte-stable; resolver-http composes the published primitives behind a
 verifier-oriented interface; parity tests compare both paths on shared
 local fixtures.
+
+## Composition
+
+Resolver-http composes only published packages:
+
+- `@peac/net-node`: SSRF-safe network fetches, DNS pinning, redirect
+  policy, and response byte-limit behavior.
+- `@peac/jwks-cache`: package-root URL pre-check, in-memory cache
+  primitives, and Ed25519 JWK import validation
+  (`importJwkAsEd25519`).
+- `@peac/kernel`: `VERIFIER_LIMITS` and `ISSUER_CONFIG` constants.
+- `@peac/crypto`: package-root primitives (`sha256Hex`,
+  `generateKeypair`, `signWire02`, `verify`, `decode`) for digest
+  computation and real-JWS test fixtures.
 
 ## Boundary (P0 invariants, LOCKED 2026-04-28)
 
 - `@peac/protocol` must NOT import, depend on, re-export from, or emit
   a reference to `@peac/resolver-http`.
 - `@peac/resolver-http` runtime source must NOT import `@peac/protocol`.
-  Parity test files MAY import `@peac/protocol` for behavior comparison.
+  Parity test files MAY import `@peac/protocol` for behavior
+  comparison.
 - `@peac/jwks-cache` is reused as a published primitive; not modified,
   not merged, not renamed in v0.13.2.
 - `@peac/net-node` is reused as the canonical network-safety primitive;
   not modified in PR A.
+
+Hard rules carried forward:
+
+- No runtime `@peac/protocol` dependency.
+- No `@peac/schema` dependency (not even type-only imports).
+- No `zod` runtime dependency.
+- No direct `fetch()`, `globalThis.fetch`, `fetchWithTimeout`,
+  `resolveKey()`, or `createResolver()` calls in resolver-http source.
+  All network I/O is mediated by `fetchJsonSafe`, `fetchJwksSafe`, or
+  `fetchRawSafe`.
+- No private package subpaths anywhere under `packages/resolver-http/`.
+- No external network in any test.
+- Absent from `scripts/publish-manifest.json` and from any public
+  documentation, example, integrator kit, or surfaces manifest.
 
 Verified by:
 
@@ -43,15 +73,23 @@ Verified by:
 - `tests/tooling/kernel-public-surface-stable.test.ts`
 - `scripts/verify-dist-private-leaks.mjs`
 - `scripts/release/pack-install-smoke.mjs`
-- runtime-source isolation gate (added in Commit 2):
-  `git grep -nE '@peac/protocol' packages/resolver-http/src packages/resolver-http/__tests__/_helpers`
-  must be empty.
+- runtime-source isolation gate covering resolver-http source and the
+  `_helpers/` test directory.
+
+## Parity testing
+
+PR A includes no-network public-API smoke coverage (`parity.*.test.ts`)
+plus a resolver-http local harness exercising the composed discovery,
+JWKS, and pointer-fetch paths against shared local fixtures. This does
+not claim full fetched-body cross-implementation byte-equal parity
+against protocol's self-contained resolver. Full cross-implementation
+pointer parity is intentionally re-homed to PR B shadow mode, where
+`apps/api` drives both paths through real shadow responses without
+protocol-internal mocking.
 
 ## Reference
 
 - Revision 4 reboot plan section 7 (canonical specification).
 - Revision 4 reboot plan section 7.1P (architecture lock).
-- Revision 4 reboot plan section 7.2 (PR table; corrected wording).
+- Revision 4 reboot plan section 7.2 (PR table).
 - Revision 4 reboot plan section 7.2A (PR A acceptance checklist).
-- `~/.claude/plans/tranquil-mirroring-fermat.md` (per-PR execution
-  plan, local-only).

--- a/packages/resolver-http/SECURITY.md
+++ b/packages/resolver-http/SECURITY.md
@@ -5,16 +5,26 @@ never published and is never referenced by any published package.
 Reporting and disclosure follow the repository SECURITY.md at the
 repository root.
 
-The shadow resolver implementation added in subsequent commits of
-v0.13.2 PR A preserves every existing security invariant from
-`packages/protocol/src/{discovery, jwks-resolver, ssrf-safe-fetch,
-pointer-fetch}.ts`:
+The composition layer added in subsequent commits of v0.13.2 PR A
+delegates network and JWKS policy to existing published primitives
+(`@peac/net-node`, `@peac/jwks-cache`) and pulls verifier-tuned
+defaults from `@peac/kernel.VERIFIER_LIMITS`. Every existing security
+invariant therefore continues to apply, sourced from the underlying
+primitives:
 
 - SSRF prevention (private / loopback / reserved-range block; metadata
-  IP block; HTTPS enforcement).
-- Redirect policy (chain cap; cross-origin rule).
-- Timeout ceiling.
-- Response byte cap.
-- Cache isolation (tenant-keyed; never cross-issuer).
-- No raw secret / URL / header / body bytes in any internal mismatch
-  report.
+  IP block; HTTPS enforcement) — see `@peac/net-node` and
+  `@peac/jwks-cache` security docs.
+- Redirect policy (chain cap; cross-origin rule) — verifier limit from
+  `@peac/kernel.VERIFIER_LIMITS.maxRedirects`.
+- Timeout ceiling — verifier limit from
+  `@peac/kernel.VERIFIER_LIMITS.fetchTimeoutMs`.
+- Response byte cap — verifier limits from
+  `@peac/kernel.VERIFIER_LIMITS.maxResponseBytes` (general) and
+  `maxJwksBytes` (JWKS).
+- Cache isolation (issuer-keyed; never cross-issuer) — provided by
+  `@peac/jwks-cache`.
+- Redaction discipline: no raw URL path / query / headers / body
+  bytes / bearer tokens / cookies / private keys / JWKS body excerpts
+  in any internal mismatch report or error message; bounded numeric
+  counters and enum classes only.

--- a/packages/resolver-http/SECURITY.md
+++ b/packages/resolver-http/SECURITY.md
@@ -5,26 +5,58 @@ never published and is never referenced by any published package.
 Reporting and disclosure follow the repository SECURITY.md at the
 repository root.
 
-The composition layer added in subsequent commits of v0.13.2 PR A
-delegates network and JWKS policy to existing published primitives
-(`@peac/net-node`, `@peac/jwks-cache`) and pulls verifier-tuned
-defaults from `@peac/kernel.VERIFIER_LIMITS`. Every existing security
-invariant therefore continues to apply, sourced from the underlying
-primitives:
+The composition layer delegates network and JWKS policy to existing
+published primitives (`@peac/net-node`, `@peac/jwks-cache`) and pulls
+verifier-tuned defaults from `@peac/kernel.VERIFIER_LIMITS`. Every
+existing security invariant therefore continues to apply, sourced from
+the underlying primitives.
 
-- SSRF prevention (private / loopback / reserved-range block; metadata
-  IP block; HTTPS enforcement) — see `@peac/net-node` and
-  `@peac/jwks-cache` security docs.
-- Redirect policy (chain cap; cross-origin rule) — verifier limit from
-  `@peac/kernel.VERIFIER_LIMITS.maxRedirects`.
-- Timeout ceiling — verifier limit from
-  `@peac/kernel.VERIFIER_LIMITS.fetchTimeoutMs`.
-- Response byte cap — verifier limits from
-  `@peac/kernel.VERIFIER_LIMITS.maxResponseBytes` (general) and
-  `maxJwksBytes` (JWKS).
-- Cache isolation (issuer-keyed; never cross-issuer) — provided by
-  `@peac/jwks-cache`.
-- Redaction discipline: no raw URL path / query / headers / body
-  bytes / bearer tokens / cookies / private keys / JWKS body excerpts
-  in any internal mismatch report or error message; bounded numeric
-  counters and enum classes only.
+## Network safety
+
+- All network I/O is mediated by `fetchJsonSafe`, `fetchJwksSafe`, or
+  `fetchRawSafe`. No call site uses `fetch()`, `globalThis.fetch`, or
+  `fetchWithTimeout` directly.
+- HTTPS-only enforcement at every call site.
+- Verifier limits override broader net-node defaults; redirect chain
+  cap, timeout ceiling, response byte cap, and JWKS byte cap are all
+  read from `@peac/kernel.VERIFIER_LIMITS`.
+- SSRF prevention (private, loopback, and reserved-range block;
+  metadata IP block), DNS pinning, dangerous-port block, and redirect
+  policy are inherited from `@peac/net-node`.
+
+## JWKS safety
+
+- `@peac/jwks-cache.resolveKey()` and `createResolver()` are not
+  called; both use a global fetch path that bypasses verifier limits.
+- JWKS network fetches go through `fetchJwksSafe`.
+- The cache key includes the issuer origin, the normalized `jwks_uri`
+  digest, and the JWK `kid`; cache state is never shared across
+  issuers.
+- The matched Ed25519 JWK is validated via
+  `@peac/jwks-cache.importJwkAsEd25519` before being cached.
+
+## Pointer-fetch safety
+
+- String-mode digest: raw bytes, then UTF-8 decode via
+  `TextDecoder('utf-8', { fatal: false })`, then
+  `sha256Hex(receiptString)`. Raw-bytes-only digest is forbidden.
+- Invalid expected-digest format and malformed compact JWS (non
+  three-segment) produce distinct error classes.
+- Content-type warnings on success are bounded and redaction-safe.
+
+## Redaction
+
+- No raw URL path or query.
+- No headers.
+- No body bytes or excerpts.
+- No bearer tokens, cookies, private key material, or other
+  secret-looking values.
+- Diagnostic output is limited to bounded numeric counters and enum
+  classes.
+
+## Package boundary
+
+- No runtime `@peac/protocol` dependency.
+- No `@peac/schema` dependency.
+- No `zod` dependency.
+- No private package subpaths.

--- a/packages/resolver-http/SECURITY.md
+++ b/packages/resolver-http/SECURITY.md
@@ -1,0 +1,20 @@
+# Security posture
+
+`@peac/resolver-http` is a workspace-private internal package. It is
+never published and is never referenced by any published package.
+Reporting and disclosure follow the repository SECURITY.md at the
+repository root.
+
+The shadow resolver implementation added in subsequent commits of
+v0.13.2 PR A preserves every existing security invariant from
+`packages/protocol/src/{discovery, jwks-resolver, ssrf-safe-fetch,
+pointer-fetch}.ts`:
+
+- SSRF prevention (private / loopback / reserved-range block; metadata
+  IP block; HTTPS enforcement).
+- Redirect policy (chain cap; cross-origin rule).
+- Timeout ceiling.
+- Response byte cap.
+- Cache isolation (tenant-keyed; never cross-issuer).
+- No raw secret / URL / header / body bytes in any internal mismatch
+  report.

--- a/packages/resolver-http/__fixtures__/issuer-config/missing-issuer.json
+++ b/packages/resolver-http/__fixtures__/issuer-config/missing-issuer.json
@@ -1,0 +1,3 @@
+{
+  "jwks_uri": "https://issuer.example.com/.well-known/jwks.json"
+}

--- a/packages/resolver-http/__fixtures__/issuer-config/missing-jwks-uri.json
+++ b/packages/resolver-http/__fixtures__/issuer-config/missing-jwks-uri.json
@@ -1,0 +1,3 @@
+{
+  "issuer": "https://issuer.example.com"
+}

--- a/packages/resolver-http/__fixtures__/issuer-config/valid.json
+++ b/packages/resolver-http/__fixtures__/issuer-config/valid.json
@@ -1,0 +1,5 @@
+{
+  "issuer": "https://issuer.example.com",
+  "jwks_uri": "https://issuer.example.com/.well-known/jwks.json",
+  "version": "peac-issuer/1"
+}

--- a/packages/resolver-http/__fixtures__/jwks/valid.json
+++ b/packages/resolver-http/__fixtures__/jwks/valid.json
@@ -1,0 +1,12 @@
+{
+  "keys": [
+    {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "kid": "k1",
+      "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo",
+      "alg": "EdDSA",
+      "use": "sig"
+    }
+  ]
+}

--- a/packages/resolver-http/__tests__/_helpers/mock-net-node.ts
+++ b/packages/resolver-http/__tests__/_helpers/mock-net-node.ts
@@ -149,10 +149,16 @@ export const mockSafeFetchJson = vi.fn(async (_url: string, opts?: unknown) => {
     return err;
   }
   const { response, bytes } = asResponse(next);
+  // body represents the already-parsed value of result.data (matches real
+  // safeFetchJson semantics: JSON parse happens upstream of resolver-http).
+  // Tests that want to simulate JSON-parse failure should use
+  // { ok: false, code: NET_CODES.E_PARSE_ERROR }. An explicit body field
+  // (including null) is honored verbatim; the empty-object fallback fires
+  // only when body is absent.
   return {
     ok: true,
     response,
-    data: typeof next.body === 'string' ? JSON.parse(next.body) : (next.body ?? {}),
+    data: 'body' in next ? next.body : {},
     evidence: { response_bytes: next.responseBytes ?? bytes.byteLength },
   };
 });
@@ -171,7 +177,10 @@ export const mockSafeFetchJWKS = vi.fn(async (_url: string, opts?: unknown) => {
     return err;
   }
   const { response, bytes } = asResponse(next);
-  const data = typeof next.body === 'string' ? JSON.parse(next.body) : (next.body ?? { keys: [] });
+  // body represents the already-parsed value (matches real safeFetchJWKS
+  // semantics). An explicit body (including null) is honored verbatim; the
+  // { keys: [] } fallback fires only when body is absent.
+  const data = 'body' in next ? next.body : { keys: [] };
   return {
     ok: true,
     response,

--- a/packages/resolver-http/__tests__/_helpers/mock-net-node.ts
+++ b/packages/resolver-http/__tests__/_helpers/mock-net-node.ts
@@ -1,0 +1,203 @@
+// Test helpers for mocking @peac/net-node responses.
+//
+// Each test file does:
+//
+//   import { mockSafeFetchJson, mockSafeFetchJWKS, mockSafeFetchRaw,
+//            enqueue, resetMock, getLastOptions, NET_CODES } from './_helpers/mock-net-node.js';
+//   import { vi } from 'vitest';
+//
+//   vi.mock('@peac/net-node', async () => {
+//     const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+//     return {
+//       ...actual,
+//       safeFetchJson: mockSafeFetchJson,
+//       safeFetchJWKS: mockSafeFetchJWKS,
+//       safeFetchRaw: mockSafeFetchRaw,
+//     };
+//   });
+//
+// This helper deliberately does NOT import @peac/net-node so it is unaffected
+// by the test's vi.mock interception. SAFE_FETCH_ERROR_CODES values are
+// re-declared as string-literal constants below; the actual values are stable
+// public API of net-node and tests assert against them directly.
+//
+// IMPORTANT: this helper MUST NOT import the protocol package. Parity test
+// files (Commit 4) MAY import the protocol package; helpers under _helpers/
+// MUST NOT.
+
+import { vi } from 'vitest';
+
+export const NET_CODES = {
+  E_SSRF_URL_REJECTED: 'E_NET_SSRF_URL_REJECTED',
+  E_SSRF_DNS_RESOLVED_PRIVATE: 'E_NET_SSRF_DNS_RESOLVED_PRIVATE',
+  E_SSRF_ALL_IPS_BLOCKED: 'E_NET_SSRF_ALL_IPS_BLOCKED',
+  E_SSRF_REDIRECT_BLOCKED: 'E_NET_SSRF_REDIRECT_BLOCKED',
+  E_SSRF_TOO_MANY_REDIRECTS: 'E_NET_SSRF_TOO_MANY_REDIRECTS',
+  E_SSRF_ALLOWCIDRS_ACK_REQUIRED: 'E_NET_SSRF_ALLOWCIDRS_ACK_REQUIRED',
+  E_SSRF_IPV6_ZONE_ID: 'E_NET_SSRF_IPV6_ZONE_ID',
+  E_SSRF_INVALID_HOST: 'E_NET_SSRF_INVALID_HOST',
+  E_SSRF_MIXED_DNS_BLOCKED: 'E_NET_SSRF_MIXED_DNS_BLOCKED',
+  E_SSRF_MIXED_DNS_ACK_MISSING: 'E_NET_SSRF_MIXED_DNS_ACK_MISSING',
+  E_SSRF_DANGEROUS_PORT: 'E_NET_SSRF_DANGEROUS_PORT',
+  E_SSRF_DANGEROUS_PORT_ACK_MISSING: 'E_NET_SSRF_DANGEROUS_PORT_ACK_MISSING',
+  E_TENANT_KEY_MISSING: 'E_NET_TENANT_KEY_MISSING',
+  E_DNS_RESOLUTION_FAILED: 'E_NET_DNS_RESOLUTION_FAILED',
+  E_REQUEST_TIMEOUT: 'E_NET_REQUEST_TIMEOUT',
+  E_DNS_TIMEOUT: 'E_NET_DNS_TIMEOUT',
+  E_CONNECT_TIMEOUT: 'E_NET_CONNECT_TIMEOUT',
+  E_HEADERS_TIMEOUT: 'E_NET_HEADERS_TIMEOUT',
+  E_BODY_TIMEOUT: 'E_NET_BODY_TIMEOUT',
+  E_NETWORK_ERROR: 'E_NET_NETWORK_ERROR',
+  E_METHOD_NOT_ALLOWED: 'E_NET_METHOD_NOT_ALLOWED',
+  E_RESPONSE_TOO_LARGE: 'E_NET_RESPONSE_TOO_LARGE',
+  E_PARSE_ERROR: 'E_NET_PARSE_ERROR',
+} as const;
+
+export type NetNodeErrorCode = (typeof NET_CODES)[keyof typeof NET_CODES];
+
+export interface MockSuccess {
+  ok: true;
+  status: number;
+  contentType?: string;
+  body?: unknown;
+  bytes?: Uint8Array;
+  responseBytes?: number;
+}
+
+export interface MockFailure {
+  ok: false;
+  code: NetNodeErrorCode;
+  error?: string;
+  cause?: unknown;
+  stack?: string;
+  upstreamPayload?: unknown;
+}
+
+export type MockResponse = MockSuccess | MockFailure;
+
+type Fn = 'safeFetchJson' | 'safeFetchJWKS' | 'safeFetchRaw';
+
+interface QueueEntry {
+  fn: Fn;
+  response: MockResponse;
+}
+
+const queue: QueueEntry[] = [];
+const lastOptionsRef: { value: unknown } = { value: undefined };
+
+export function resetMock(): void {
+  queue.length = 0;
+  lastOptionsRef.value = undefined;
+}
+
+export function enqueue(fn: Fn, response: MockResponse): void {
+  queue.push({ fn, response });
+}
+
+export function getLastOptions(): unknown {
+  return lastOptionsRef.value;
+}
+
+function buildHeaders(contentType: string | undefined): Headers {
+  const h = new Headers();
+  if (contentType) h.set('content-type', contentType);
+  return h;
+}
+
+function asBytes(input: MockSuccess): Uint8Array {
+  if (input.bytes) return input.bytes;
+  const text = typeof input.body === 'string' ? input.body : JSON.stringify(input.body ?? {});
+  return new TextEncoder().encode(text);
+}
+
+function asResponse(input: MockSuccess): { response: Response; bytes: Uint8Array } {
+  const bytes = asBytes(input);
+  const response = new Response(bytes, {
+    status: input.status,
+    headers: buildHeaders(input.contentType),
+  });
+  return { response, bytes };
+}
+
+function pop(fn: Fn): MockResponse {
+  const next = queue.shift();
+  if (!next) {
+    throw new Error(
+      `[mock-net-node] no queued response for ${fn}; tests must enqueue before invoking fetch`
+    );
+  }
+  if (next.fn !== fn) {
+    throw new Error(
+      `[mock-net-node] queue mismatch: expected ${next.fn} next, but ${fn} was called`
+    );
+  }
+  return next.response;
+}
+
+export const mockSafeFetchJson = vi.fn(async (_url: string, opts?: unknown) => {
+  lastOptionsRef.value = opts;
+  const next = pop('safeFetchJson');
+  if (!next.ok) {
+    const err: Record<string, unknown> = {
+      ok: false,
+      error: next.error ?? 'net-node failure (mock)',
+      code: next.code,
+    };
+    if (next.cause !== undefined) err.cause = next.cause;
+    if (next.stack !== undefined) err.stack = next.stack;
+    if (next.upstreamPayload !== undefined) err.upstreamPayload = next.upstreamPayload;
+    return err;
+  }
+  const { response, bytes } = asResponse(next);
+  return {
+    ok: true,
+    response,
+    data: typeof next.body === 'string' ? JSON.parse(next.body) : (next.body ?? {}),
+    evidence: { response_bytes: next.responseBytes ?? bytes.byteLength },
+  };
+});
+
+export const mockSafeFetchJWKS = vi.fn(async (_url: string, opts?: unknown) => {
+  lastOptionsRef.value = opts;
+  const next = pop('safeFetchJWKS');
+  if (!next.ok) {
+    const err: Record<string, unknown> = {
+      ok: false,
+      error: next.error ?? 'net-node JWKS failure (mock)',
+      code: next.code,
+    };
+    if (next.cause !== undefined) err.cause = next.cause;
+    if (next.stack !== undefined) err.stack = next.stack;
+    return err;
+  }
+  const { response, bytes } = asResponse(next);
+  const data = typeof next.body === 'string' ? JSON.parse(next.body) : (next.body ?? { keys: [] });
+  return {
+    ok: true,
+    response,
+    data,
+    evidence: { response_bytes: next.responseBytes ?? bytes.byteLength },
+  };
+});
+
+export const mockSafeFetchRaw = vi.fn(async (_url: string, opts?: unknown) => {
+  lastOptionsRef.value = opts;
+  const next = pop('safeFetchRaw');
+  if (!next.ok) {
+    const err: Record<string, unknown> = {
+      ok: false,
+      error: next.error ?? 'net-node raw failure (mock)',
+      code: next.code,
+    };
+    if (next.cause !== undefined) err.cause = next.cause;
+    if (next.stack !== undefined) err.stack = next.stack;
+    return err;
+  }
+  const { response } = asResponse(next);
+  return {
+    ok: true,
+    response,
+    close: async () => undefined,
+    evidence: { response_bytes: next.responseBytes ?? asBytes(next).byteLength },
+  };
+});

--- a/packages/resolver-http/__tests__/_helpers/test-jws.ts
+++ b/packages/resolver-http/__tests__/_helpers/test-jws.ts
@@ -3,8 +3,8 @@
 // Uses ONLY package-root @peac/crypto exports (generateKeypair, signWire02,
 // verify, decode, sha256Hex; verified package-root from resolver-http
 // context 2026-04-30). Private crypto subpaths (notably the testkit entry)
-// are forbidden. The protocol package is forbidden in all forms — runtime
-// or test — under packages/resolver-http/__tests__/_helpers/.
+// are forbidden. The protocol package is forbidden in all forms (runtime
+// and test) under packages/resolver-http/__tests__/_helpers/.
 //
 // Hygiene: the private key is kept LOCAL to this helper. signWire02
 // consumes it once; the returned fixture exposes only the public key, the

--- a/packages/resolver-http/__tests__/_helpers/test-jws.ts
+++ b/packages/resolver-http/__tests__/_helpers/test-jws.ts
@@ -1,33 +1,47 @@
 // Test helper: real Ed25519 keypair + real signed compact JWS for resolver-http.
 //
 // Uses ONLY package-root @peac/crypto exports (generateKeypair, signWire02,
-// verify, decode, sha256Hex; all verified package-root from resolver-http
-// context 2026-04-30). No private @peac/crypto/testkit subpath. No
-// @peac/protocol references.
+// verify, decode, sha256Hex; verified package-root from resolver-http
+// context 2026-04-30). Private crypto subpaths (notably the testkit entry)
+// are forbidden. The protocol package is forbidden in all forms — runtime
+// or test — under packages/resolver-http/__tests__/_helpers/.
+//
+// Hygiene: the private key is kept LOCAL to this helper. signWire02
+// consumes it once; the returned fixture exposes only the public key, the
+// JWS, and metadata. Reducing key exposure by default avoids accidental
+// leak surface in failed assertions, snapshots, or future helper reuse.
 //
 // The helper self-validates the generated fixture before returning it:
-// 3 base64url segments, JSON-decodable header + payload, and a successful
-// signature verification via @peac/crypto.verify. If any check fails, the
-// helper throws to fail fast in test setup; callers do not see a partially
-// formed fixture.
+// 3 base64url segments, JSON-decodable header + payload via @peac/crypto.decode,
+// header carries the expected typ + alg + kid, payload carries
+// peac_version: '0.2', and signature verifies via @peac/crypto.verify. If any
+// check fails, the helper throws to fail fast in test setup; callers do not
+// see a partially-formed fixture.
 
 import { generateKeypair, signWire02, verify, decode, sha256Hex } from '@peac/crypto';
 
 const COMPACT_JWS_3_SEGMENTS = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
 
+// Wire 0.2 typ / alg constants. We assert these without importing them from
+// @peac/schema or @peac/crypto's private modules; the values are stable
+// across the Wire 0.2 cycle and locking them here keeps resolver-http test
+// helpers free of additional dependency edges.
+const EXPECTED_TYP = 'interaction-record+jwt';
+const EXPECTED_ALG = 'EdDSA';
+
 export interface SignedJwsFixture {
-  /** Compact JWS serialization (header.payload.signature) — string-mode digest input. */
+  /** Compact JWS serialization (header.payload.signature); string-mode digest input. */
   jws: string;
-  /** sha256Hex(jws) — what resolver-http's pointer-fetch will compute. */
+  /** sha256Hex(jws); what resolver-http's pointer-fetch will compute. */
   expectedDigest: string;
   /** Ed25519 public key (32 bytes). */
   publicKey: Uint8Array;
-  /** Ed25519 private key (32 bytes). Test-only; never logged. */
-  privateKey: Uint8Array;
   /** kid used for signing. */
   kid: string;
   /** Decoded payload (post-verify). */
   payload: Record<string, unknown>;
+  /** Decoded header (post-verify); useful for assertions in tests. */
+  header: { typ?: string; alg?: string; kid?: string };
 }
 
 export interface GenerateSignedJwsOptions {
@@ -40,9 +54,9 @@ export interface GenerateSignedJwsOptions {
 /**
  * Generate a real Ed25519 keypair and a real signed compact JWS at runtime.
  *
- * The returned fixture self-validates: 3 base64url segments, JSON-decodable
- * header + payload, and signature verification via @peac/crypto.verify.
- * Test setup fails fast on any internal inconsistency.
+ * The private key is kept LOCAL to this function and is never returned. The
+ * fixture exposes only the public key, the JWS, and decoded header/payload
+ * metadata.
  */
 export async function generateSignedJws(
   options: GenerateSignedJwsOptions = {}
@@ -81,15 +95,47 @@ export async function generateSignedJws(
   if (typeof decoded.payload !== 'object' || decoded.payload === null) {
     throw new Error('test-jws: decoded payload is not an object');
   }
+  // Self-validation #2a: header carries the expected Wire 0.2 typ
+  if (decoded.header.typ !== EXPECTED_TYP) {
+    throw new Error(`test-jws: header.typ "${decoded.header.typ}" !== expected "${EXPECTED_TYP}"`);
+  }
+  // Self-validation #2b: header alg is EdDSA
+  if (decoded.header.alg !== EXPECTED_ALG) {
+    throw new Error(`test-jws: header.alg "${decoded.header.alg}" !== expected "${EXPECTED_ALG}"`);
+  }
+  // Self-validation #2c: header kid round-trips the requested kid
+  if (decoded.header.kid !== kid) {
+    throw new Error(`test-jws: header.kid "${decoded.header.kid}" !== requested "${kid}"`);
+  }
+  // Self-validation #2d: payload carries peac_version: '0.2'
+  const decodedPayload = decoded.payload as Record<string, unknown>;
+  if (decodedPayload.peac_version !== '0.2') {
+    throw new Error(
+      `test-jws: payload.peac_version "${String(decodedPayload.peac_version)}" !== '0.2'`
+    );
+  }
 
-  // Self-validation #3: signature verifies via @peac/crypto.verify
+  // Self-validation #3: signature verifies via @peac/crypto.verify and
+  // returns a meaningful object with header / payload accessible.
+  let verifyResult: { header?: { typ?: string }; payload?: unknown };
   try {
-    const result = await verify(jws, publicKey);
-    if (typeof result !== 'object' || result === null) {
-      throw new Error('verify returned non-object result');
-    }
+    verifyResult = (await verify(jws, publicKey)) as {
+      header?: { typ?: string };
+      payload?: unknown;
+    };
   } catch (err) {
     throw new Error(`test-jws: signature verify failed: ${(err as Error).message}`);
+  }
+  if (typeof verifyResult !== 'object' || verifyResult === null) {
+    throw new Error('test-jws: verify() returned non-object result');
+  }
+  if (verifyResult.header?.typ !== EXPECTED_TYP) {
+    throw new Error(
+      `test-jws: verify().header.typ "${verifyResult.header?.typ}" !== expected "${EXPECTED_TYP}"`
+    );
+  }
+  if (typeof verifyResult.payload !== 'object' || verifyResult.payload === null) {
+    throw new Error('test-jws: verify().payload is not an object');
   }
 
   // String-mode digest: sha256Hex of the compact JWS string. This is what
@@ -97,12 +143,24 @@ export async function generateSignedJws(
   // path; see packages/resolver-http/src/pointer-fetch.ts).
   const expectedDigest = await sha256Hex(jws);
 
+  // privateKey goes out of scope when this function returns; not exposed
+  // on the fixture object by design (Commit 4.1 hygiene).
   return {
     jws,
     expectedDigest,
     publicKey,
-    privateKey,
     kid,
-    payload: decoded.payload as Record<string, unknown>,
+    payload: decodedPayload,
+    header: decoded.header,
   };
+}
+
+/**
+ * Compute the string-mode digest of a body string. Re-exported here so test
+ * files can compute expected digests without dynamically importing
+ * @peac/crypto inside an `it()` block. Package-root @peac/crypto.sha256Hex
+ * is the only allowed source.
+ */
+export async function digestOfBody(body: string): Promise<string> {
+  return sha256Hex(body);
 }

--- a/packages/resolver-http/__tests__/_helpers/test-jws.ts
+++ b/packages/resolver-http/__tests__/_helpers/test-jws.ts
@@ -1,0 +1,108 @@
+// Test helper: real Ed25519 keypair + real signed compact JWS for resolver-http.
+//
+// Uses ONLY package-root @peac/crypto exports (generateKeypair, signWire02,
+// verify, decode, sha256Hex; all verified package-root from resolver-http
+// context 2026-04-30). No private @peac/crypto/testkit subpath. No
+// @peac/protocol references.
+//
+// The helper self-validates the generated fixture before returning it:
+// 3 base64url segments, JSON-decodable header + payload, and a successful
+// signature verification via @peac/crypto.verify. If any check fails, the
+// helper throws to fail fast in test setup; callers do not see a partially
+// formed fixture.
+
+import { generateKeypair, signWire02, verify, decode, sha256Hex } from '@peac/crypto';
+
+const COMPACT_JWS_3_SEGMENTS = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+
+export interface SignedJwsFixture {
+  /** Compact JWS serialization (header.payload.signature) — string-mode digest input. */
+  jws: string;
+  /** sha256Hex(jws) — what resolver-http's pointer-fetch will compute. */
+  expectedDigest: string;
+  /** Ed25519 public key (32 bytes). */
+  publicKey: Uint8Array;
+  /** Ed25519 private key (32 bytes). Test-only; never logged. */
+  privateKey: Uint8Array;
+  /** kid used for signing. */
+  kid: string;
+  /** Decoded payload (post-verify). */
+  payload: Record<string, unknown>;
+}
+
+export interface GenerateSignedJwsOptions {
+  /** Caller-supplied claims overlay. peac_version: '0.2' is always set. */
+  payload?: Record<string, unknown>;
+  /** kid (default: 'test-key-1'). */
+  kid?: string;
+}
+
+/**
+ * Generate a real Ed25519 keypair and a real signed compact JWS at runtime.
+ *
+ * The returned fixture self-validates: 3 base64url segments, JSON-decodable
+ * header + payload, and signature verification via @peac/crypto.verify.
+ * Test setup fails fast on any internal inconsistency.
+ */
+export async function generateSignedJws(
+  options: GenerateSignedJwsOptions = {}
+): Promise<SignedJwsFixture> {
+  const { privateKey, publicKey } = await generateKeypair();
+  if (privateKey.length !== 32) throw new Error('test-jws: privateKey not 32 bytes');
+  if (publicKey.length !== 32) throw new Error('test-jws: publicKey not 32 bytes');
+
+  const kid = options.kid ?? 'test-key-1';
+  const payload: Record<string, unknown> = {
+    peac_version: '0.2',
+    iss: 'https://issuer.example.com',
+    rid: '01999999-9999-7999-9999-999999999999',
+    iat: 1700000000,
+    occurred_at: 1700000000,
+    ...options.payload,
+  };
+
+  const jws = await signWire02(payload, privateKey, kid);
+
+  // Self-validation #1: 3 base64url segments
+  if (!COMPACT_JWS_3_SEGMENTS.test(jws)) {
+    throw new Error('test-jws: generated JWS is not a 3-segment base64url shape');
+  }
+
+  // Self-validation #2: header + payload decode as JSON via @peac/crypto.decode
+  let decoded: { header: { typ?: string; alg?: string; kid?: string }; payload: unknown };
+  try {
+    decoded = decode<unknown>(jws);
+  } catch (err) {
+    throw new Error(`test-jws: decode failed: ${(err as Error).message}`);
+  }
+  if (typeof decoded.header !== 'object' || decoded.header === null) {
+    throw new Error('test-jws: decoded header is not an object');
+  }
+  if (typeof decoded.payload !== 'object' || decoded.payload === null) {
+    throw new Error('test-jws: decoded payload is not an object');
+  }
+
+  // Self-validation #3: signature verifies via @peac/crypto.verify
+  try {
+    const result = await verify(jws, publicKey);
+    if (typeof result !== 'object' || result === null) {
+      throw new Error('verify returned non-object result');
+    }
+  } catch (err) {
+    throw new Error(`test-jws: signature verify failed: ${(err as Error).message}`);
+  }
+
+  // String-mode digest: sha256Hex of the compact JWS string. This is what
+  // resolver-http's pointer-fetch computes (semantically mirrors protocol's
+  // path; see packages/resolver-http/src/pointer-fetch.ts).
+  const expectedDigest = await sha256Hex(jws);
+
+  return {
+    jws,
+    expectedDigest,
+    publicKey,
+    privateKey,
+    kid,
+    payload: decoded.payload as Record<string, unknown>,
+  };
+}

--- a/packages/resolver-http/__tests__/discovery.fetch-failure.test.ts
+++ b/packages/resolver-http/__tests__/discovery.fetch-failure.test.ts
@@ -1,0 +1,92 @@
+// Discovery fetch-failure pass-through tests.
+// 4xx / 5xx / network / SSRF / timeout failures from fetch-safe must
+// surface unchanged (no double-mapping); discovery-layer mapping only
+// fires for shape failures.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+  NET_CODES,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { fetchIssuerConfig } from '../src/discovery.js';
+
+beforeEach(() => {
+  resetMock();
+});
+
+describe('discovery fetch-failure pass-through', () => {
+  it('4xx surfaces fetch_status_4xx unchanged', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 404,
+      contentType: 'text/html',
+      body: 'not found',
+    });
+    const result = await fetchIssuerConfig('https://issuer.example.com');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('fetch_status_4xx');
+  });
+
+  it('5xx surfaces fetch_status_5xx unchanged', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 503,
+      contentType: 'text/plain',
+      body: 'service unavailable',
+    });
+    const result = await fetchIssuerConfig('https://issuer.example.com');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('fetch_status_5xx');
+  });
+
+  it('network error surfaces fetch_network_error unchanged', async () => {
+    enqueue('safeFetchJson', { ok: false, code: NET_CODES.E_NETWORK_ERROR });
+    const result = await fetchIssuerConfig('https://issuer.example.com');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('fetch_network_error');
+  });
+
+  it('SSRF block surfaces fetch_blocked_ssrf unchanged', async () => {
+    enqueue('safeFetchJson', { ok: false, code: NET_CODES.E_SSRF_DNS_RESOLVED_PRIVATE });
+    const result = await fetchIssuerConfig('https://issuer.example.com');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('fetch_blocked_ssrf');
+  });
+
+  it('timeout surfaces fetch_timeout unchanged', async () => {
+    enqueue('safeFetchJson', { ok: false, code: NET_CODES.E_REQUEST_TIMEOUT });
+    const result = await fetchIssuerConfig('https://issuer.example.com');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('fetch_timeout');
+  });
+
+  it('byte cap surfaces fetch_blocked_byte_cap unchanged (discovery_oversized reserved for future)', async () => {
+    enqueue('safeFetchJson', { ok: false, code: NET_CODES.E_RESPONSE_TOO_LARGE });
+    const result = await fetchIssuerConfig('https://issuer.example.com');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('fetch_blocked_byte_cap');
+  });
+
+  it('non-HTTPS issuer URL is rejected by fetch-safe HTTPS-only pre-check', async () => {
+    // No mock enqueued because the pre-check fires before any net-node call.
+    const result = await fetchIssuerConfig('http://issuer.example.com');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('fetch_blocked_https_only');
+  });
+});

--- a/packages/resolver-http/__tests__/discovery.no-throw.test.ts
+++ b/packages/resolver-http/__tests__/discovery.no-throw.test.ts
@@ -1,0 +1,78 @@
+// Discovery no-throw invariant tests.
+// All malformed input / unexpected upstream errors return discriminated-union
+// failure; never throw to the caller.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+  NET_CODES,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { fetchIssuerConfig } from '../src/discovery.js';
+
+beforeEach(() => {
+  resetMock();
+});
+
+describe('discovery no-throw invariant', () => {
+  it('malformed JSON shape never throws (returns discriminated-union failure)', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { unexpected: 'shape' },
+    });
+    await expect(fetchIssuerConfig('https://issuer.example.com')).resolves.toBeDefined();
+  });
+
+  it('null body never throws', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: null,
+    });
+    await expect(fetchIssuerConfig('https://issuer.example.com')).resolves.toBeDefined();
+  });
+
+  it('non-object body (string) never throws', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: 'not-an-object',
+    });
+    const result = await fetchIssuerConfig('https://issuer.example.com');
+    expect(result.ok).toBe(false);
+  });
+
+  it('upstream timeout never throws', async () => {
+    enqueue('safeFetchJson', { ok: false, code: NET_CODES.E_REQUEST_TIMEOUT });
+    await expect(fetchIssuerConfig('https://issuer.example.com')).resolves.toBeDefined();
+  });
+
+  it('non-HTTPS URL never throws (rejected by fetch-safe pre-check)', async () => {
+    await expect(fetchIssuerConfig('http://issuer.example.com')).resolves.toBeDefined();
+  });
+
+  it('malformed issuer URL surfaces failure, does not throw', async () => {
+    // 'not-a-url' has no scheme; fetch-safe boundary rejects with fetch_blocked_https_only
+    const result = await fetchIssuerConfig('not-a-url');
+    expect(result.ok).toBe(false);
+  });
+});

--- a/packages/resolver-http/__tests__/discovery.shape.test.ts
+++ b/packages/resolver-http/__tests__/discovery.shape.test.ts
@@ -1,0 +1,214 @@
+// Discovery shape validation tests.
+// issuer + jwks_uri must be non-empty strings; jwks_uri must parse as URL;
+// extra fields tolerated; success vector returns the parsed object.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { fetchIssuerConfig } from '../src/discovery.js';
+
+beforeEach(() => {
+  resetMock();
+});
+
+const VALID = {
+  issuer: 'https://issuer.example.com',
+  jwks_uri: 'https://issuer.example.com/.well-known/jwks.json',
+  version: 'peac-issuer/1',
+};
+
+describe('discovery shape validation', () => {
+  it('valid issuer-config returns success with parsed body', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: VALID,
+    });
+    const result = await fetchIssuerConfig('https://issuer.example.com');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.body.issuer).toBe('https://issuer.example.com');
+      expect(result.body.jwks_uri).toBe('https://issuer.example.com/.well-known/jwks.json');
+    }
+  });
+
+  it('extra unknown fields are tolerated', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { ...VALID, extra: 'ignored', another: 42 },
+    });
+    const result = await fetchIssuerConfig('https://issuer.example.com');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.body.issuer).toBe(VALID.issuer);
+      expect(result.body.jwks_uri).toBe(VALID.jwks_uri);
+    }
+  });
+
+  it('missing issuer field surfaces discovery_invalid_shape', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { jwks_uri: VALID.jwks_uri },
+    });
+    const result = await fetchIssuerConfig('https://issuer.example.com');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('discovery_invalid_shape');
+  });
+
+  it('missing jwks_uri field surfaces discovery_invalid_shape', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { issuer: VALID.issuer },
+    });
+    const result = await fetchIssuerConfig('https://issuer.example.com');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('discovery_invalid_shape');
+  });
+
+  it('empty-string issuer surfaces discovery_invalid_shape', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { issuer: '', jwks_uri: VALID.jwks_uri },
+    });
+    const result = await fetchIssuerConfig('https://issuer.example.com');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('discovery_invalid_shape');
+  });
+
+  it('empty-string jwks_uri surfaces discovery_invalid_shape', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { issuer: VALID.issuer, jwks_uri: '' },
+    });
+    const result = await fetchIssuerConfig('https://issuer.example.com');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('discovery_invalid_shape');
+  });
+
+  it('jwks_uri that does not parse as URL surfaces discovery_invalid_shape', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { issuer: VALID.issuer, jwks_uri: 'not a url at all' },
+    });
+    const result = await fetchIssuerConfig('https://issuer.example.com');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('discovery_invalid_shape');
+  });
+
+  it('non-HTTPS jwks_uri is NOT rejected at discovery (deferred to JWKS fetch)', async () => {
+    // Per plan Fix #6: discovery does not pre-reject non-HTTPS jwks_uri;
+    // the eventual JWKS fetch will reject with fetch_blocked_https_only.
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { issuer: VALID.issuer, jwks_uri: 'http://issuer.example.com/jwks' },
+    });
+    const result = await fetchIssuerConfig('https://issuer.example.com');
+    expect(result.ok).toBe(true);
+  });
+
+  it('non-object body surfaces discovery_invalid_shape', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: 'a string body',
+    });
+    const result = await fetchIssuerConfig('https://issuer.example.com');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('discovery_invalid_shape');
+  });
+
+  it('null body surfaces discovery_invalid_shape', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: null,
+    });
+    const result = await fetchIssuerConfig('https://issuer.example.com');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('discovery_invalid_shape');
+  });
+
+  it('array body surfaces discovery_invalid_shape', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: [VALID],
+    });
+    const result = await fetchIssuerConfig('https://issuer.example.com');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('discovery_invalid_shape');
+  });
+
+  it('error message contains origin only, no path/query/secret', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { jwks_uri: VALID.jwks_uri },
+    });
+    const result = await fetchIssuerConfig('https://issuer.example.com?secret=abc&token=def');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain('https://issuer.example.com');
+      expect(result.message).not.toContain('secret');
+      expect(result.message).not.toContain('token');
+      expect(result.message).not.toContain('/.well-known');
+    }
+  });
+
+  it('uses canonical configPath from kernel ISSUER_CONFIG (trailing slash tolerant)', async () => {
+    // Both bare and trailing-slash issuer should produce the same canonical config URL.
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: VALID,
+    });
+    const r1 = await fetchIssuerConfig('https://issuer.example.com');
+    expect(r1.ok).toBe(true);
+
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: VALID,
+    });
+    const r2 = await fetchIssuerConfig('https://issuer.example.com/');
+    expect(r2.ok).toBe(true);
+  });
+});

--- a/packages/resolver-http/__tests__/fetch-safe.api-surface.test.ts
+++ b/packages/resolver-http/__tests__/fetch-safe.api-surface.test.ts
@@ -85,7 +85,7 @@ describe('fetch-safe verifier-oriented option surface', () => {
     if (opts) {
       for (const forbidden of FORBIDDEN_NET_NODE_OPTION_KEYS) {
         // allowedMethods is the one option fetch-safe passes deliberately
-        // (locked to ['GET']) — exclude from this gate.
+        // (locked to ['GET']); exclude from this gate.
         if (forbidden === 'allowedMethods') continue;
         expect(opts[forbidden]).toBeUndefined();
       }

--- a/packages/resolver-http/__tests__/fetch-safe.api-surface.test.ts
+++ b/packages/resolver-http/__tests__/fetch-safe.api-surface.test.ts
@@ -1,0 +1,120 @@
+// API surface guard: resolver-http's verifier-oriented options MUST NOT
+// expose @peac/net-node internal option names. The wrapper exposes only
+// verifier semantics (timeoutMs, maxResponseBytes, maxRedirects,
+// acceptContentTypes); net-node-only / dispatcher-internal names like
+// dispatcher / signal / keepAliveTimeout / bodyTimeout / headersTimeout /
+// allowH2 / connectTimeout MUST NOT appear in the resolver-http surface.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+  getLastOptions,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import {
+  fetchJsonSafe,
+  fetchJwksSafe,
+  fetchRawSafe,
+  type FetchSafeOptions,
+} from '../src/fetch-safe.js';
+
+beforeEach(() => {
+  resetMock();
+});
+
+const ALLOWED_OPTION_KEYS: ReadonlySet<keyof FetchSafeOptions> = new Set([
+  'timeoutMs',
+  'maxResponseBytes',
+  'maxRedirects',
+  'acceptContentTypes',
+]);
+
+const FORBIDDEN_NET_NODE_OPTION_KEYS: readonly string[] = [
+  'dispatcher',
+  'signal',
+  'keepAliveTimeout',
+  'bodyTimeout',
+  'headersTimeout',
+  'connectTimeout',
+  'allowH2',
+  'ssrfPolicy',
+  'evidenceLevel',
+  'redactionKey',
+  'allowedMethods',
+  'timeouts',
+  'allowDangerousPorts',
+  'allowMixedDns',
+  'allowCidrs',
+];
+
+describe('fetch-safe verifier-oriented option surface', () => {
+  it('FetchSafeOptions exposes only the locked four keys (compile-time check encoded as runtime probe)', () => {
+    // Construct an options object that uses every allowed key. If any of
+    // these become invalid, TypeScript errors fail the test build.
+    const probe: FetchSafeOptions = {
+      timeoutMs: 1,
+      maxResponseBytes: 2,
+      maxRedirects: 3,
+      acceptContentTypes: ['application/json'],
+    };
+    for (const k of Object.keys(probe)) {
+      expect(ALLOWED_OPTION_KEYS.has(k as keyof FetchSafeOptions)).toBe(true);
+    }
+  });
+
+  it('wrapper does not pass undici dispatcher / signal / keepAlive / phase-timeouts to net-node by default', async () => {
+    enqueue('safeFetchJson', { ok: true, status: 200, body: {} });
+    await fetchJsonSafe('https://issuer.example.com/x');
+    const opts = getLastOptions() as Record<string, unknown> | undefined;
+    expect(opts).toBeDefined();
+    if (opts) {
+      for (const forbidden of FORBIDDEN_NET_NODE_OPTION_KEYS) {
+        // allowedMethods is the one option fetch-safe passes deliberately
+        // (locked to ['GET']) — exclude from this gate.
+        if (forbidden === 'allowedMethods') continue;
+        expect(opts[forbidden]).toBeUndefined();
+      }
+    }
+  });
+
+  it('wrapper output includes only documented success / failure shapes', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { x: 1 },
+    });
+    const success = await fetchJsonSafe<{ x: number }>('https://issuer.example.com/x');
+    if (success.ok) {
+      const successKeys = Object.keys(success).sort();
+      expect(successKeys).toEqual(['body', 'bytes', 'contentType', 'ok'].sort());
+    } else {
+      throw new Error('expected success');
+    }
+  });
+
+  it('all three entries (json/jwks/raw) accept the same FetchSafeOptions shape', async () => {
+    enqueue('safeFetchJson', { ok: true, status: 200, body: {} });
+    enqueue('safeFetchJWKS', { ok: true, status: 200, body: { keys: [] } });
+    enqueue('safeFetchRaw', { ok: true, status: 200, body: 'x' });
+    const opts: FetchSafeOptions = { timeoutMs: 100, maxResponseBytes: 4096, maxRedirects: 1 };
+    await fetchJsonSafe('https://issuer.example.com/x', opts);
+    await fetchJwksSafe('https://issuer.example.com/jwks', opts);
+    await fetchRawSafe('https://issuer.example.com/raw', opts);
+  });
+});

--- a/packages/resolver-http/__tests__/fetch-safe.byte-cap.test.ts
+++ b/packages/resolver-http/__tests__/fetch-safe.byte-cap.test.ts
@@ -1,0 +1,89 @@
+// Byte caps: asserts verifier maxResponseBytes (256 KiB general; 64 KiB JWKS)
+// is passed to net-node, NOT net-node's broader defaults (2 MiB / 512 KiB).
+// Also asserts E_NET_RESPONSE_TOO_LARGE collapses to fetch_blocked_byte_cap.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+  getLastOptions,
+  NET_CODES,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { VERIFIER_LIMITS } from '@peac/kernel';
+
+import { fetchJsonSafe, fetchJwksSafe, fetchRawSafe } from '../src/fetch-safe.js';
+
+beforeEach(() => {
+  resetMock();
+});
+
+describe('fetch-safe byte cap: verifier override fires, not net-node default', () => {
+  it('JSON path passes VERIFIER_LIMITS.maxResponseBytes (256 KiB) to net-node', async () => {
+    enqueue('safeFetchJson', { ok: true, status: 200, body: {} });
+    await fetchJsonSafe('https://issuer.example.com/x');
+    const opts = getLastOptions() as { maxResponseBytes?: number } | undefined;
+    expect(opts?.maxResponseBytes).toBe(VERIFIER_LIMITS.maxResponseBytes);
+    expect(opts?.maxResponseBytes).toBe(262144);
+    // Net-node default (2 MiB) MUST NOT be what fires
+    expect(opts?.maxResponseBytes).not.toBe(2 * 1024 * 1024);
+  });
+
+  it('JWKS path passes VERIFIER_LIMITS.maxJwksBytes (64 KiB) to net-node', async () => {
+    enqueue('safeFetchJWKS', { ok: true, status: 200, body: { keys: [] } });
+    await fetchJwksSafe('https://issuer.example.com/jwks');
+    const opts = getLastOptions() as { maxResponseBytes?: number } | undefined;
+    expect(opts?.maxResponseBytes).toBe(VERIFIER_LIMITS.maxJwksBytes);
+    expect(opts?.maxResponseBytes).toBe(65536);
+    // Net-node JWKS cap (512 KiB) MUST NOT be what fires
+    expect(opts?.maxResponseBytes).not.toBe(512 * 1024);
+  });
+
+  it('raw path passes VERIFIER_LIMITS.maxResponseBytes (256 KiB)', async () => {
+    enqueue('safeFetchRaw', { ok: true, status: 200, body: 'x' });
+    await fetchRawSafe('https://issuer.example.com/r');
+    const opts = getLastOptions() as { maxResponseBytes?: number } | undefined;
+    expect(opts?.maxResponseBytes).toBe(262144);
+  });
+
+  it('caller override below verifier default is honored', async () => {
+    enqueue('safeFetchJson', { ok: true, status: 200, body: {} });
+    await fetchJsonSafe('https://issuer.example.com/x', { maxResponseBytes: 1024 });
+    const opts = getLastOptions() as { maxResponseBytes?: number } | undefined;
+    expect(opts?.maxResponseBytes).toBe(1024);
+  });
+
+  it('E_NET_RESPONSE_TOO_LARGE maps to fetch_blocked_byte_cap', async () => {
+    enqueue('safeFetchJson', { ok: false, code: NET_CODES.E_RESPONSE_TOO_LARGE });
+    const result = await fetchJsonSafe('https://issuer.example.com/x');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('fetch_blocked_byte_cap');
+  });
+
+  it('raw path enforces byte cap on the post-fetch buffer too', async () => {
+    // Construct an oversized body and pass a tight cap. Tests the
+    // post-fetch verification in fetchRawSafe (defense-in-depth above
+    // net-node's own cap, in case net-node ever reports ok with body
+    // larger than requested).
+    const big = new Uint8Array(2048);
+    big.fill(0x41);
+    enqueue('safeFetchRaw', { ok: true, status: 200, body: '', bytes: big });
+    const result = await fetchRawSafe('https://issuer.example.com/r', { maxResponseBytes: 512 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('fetch_blocked_byte_cap');
+  });
+});

--- a/packages/resolver-http/__tests__/fetch-safe.content-type.test.ts
+++ b/packages/resolver-http/__tests__/fetch-safe.content-type.test.ts
@@ -1,0 +1,91 @@
+// Content-type policy: when caller passes acceptContentTypes, fetch-safe
+// matches case-insensitively against the type/subtype prefix (parameters
+// like charset are stripped).
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { fetchJsonSafe } from '../src/fetch-safe.js';
+
+beforeEach(() => {
+  resetMock();
+});
+
+describe('fetch-safe content-type policy', () => {
+  it('passes when acceptContentTypes is omitted', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'text/html; charset=utf-8',
+      body: {},
+    });
+    const result = await fetchJsonSafe('https://issuer.example.com/x');
+    expect(result.ok).toBe(true);
+  });
+
+  it('passes when content-type matches (case-insensitive, parameter stripped)', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'Application/JSON; charset=utf-8',
+      body: { ok: true },
+    });
+    const result = await fetchJsonSafe<{ ok: boolean }>('https://issuer.example.com/x', {
+      acceptContentTypes: ['application/json'],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('fails fetch_invalid_content_type when content-type does not match', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'text/html; charset=utf-8',
+      body: {},
+    });
+    const result = await fetchJsonSafe('https://issuer.example.com/x', {
+      acceptContentTypes: ['application/json'],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('fetch_invalid_content_type');
+  });
+
+  it('fails fetch_invalid_content_type when content-type header is absent', async () => {
+    enqueue('safeFetchJson', { ok: true, status: 200, body: {} });
+    const result = await fetchJsonSafe('https://issuer.example.com/x', {
+      acceptContentTypes: ['application/json'],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('fetch_invalid_content_type');
+  });
+
+  it('content-type allowlist accepts multiple entries (e.g. JOSE + JSON)', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'application/jose',
+      body: {},
+    });
+    const result = await fetchJsonSafe('https://issuer.example.com/x', {
+      acceptContentTypes: ['application/json', 'application/jose'],
+    });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/packages/resolver-http/__tests__/fetch-safe.dangerous-port.test.ts
+++ b/packages/resolver-http/__tests__/fetch-safe.dangerous-port.test.ts
@@ -1,0 +1,48 @@
+// Dangerous-port: net-node blocks well-known service ports (e.g. 25, 6379).
+// Asserts the upstream codes collapse to fetch_blocked_dangerous_port.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+  NET_CODES,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { fetchJsonSafe } from '../src/fetch-safe.js';
+
+beforeEach(() => {
+  resetMock();
+});
+
+describe('fetch-safe dangerous-port mapping', () => {
+  it('E_NET_SSRF_DANGEROUS_PORT maps to fetch_blocked_dangerous_port', async () => {
+    enqueue('safeFetchJson', { ok: false, code: NET_CODES.E_SSRF_DANGEROUS_PORT });
+    const result = await fetchJsonSafe('https://issuer.example.com:25/x');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('fetch_blocked_dangerous_port');
+  });
+
+  it('E_NET_SSRF_DANGEROUS_PORT_ACK_MISSING maps to fetch_blocked_dangerous_port', async () => {
+    enqueue('safeFetchJson', {
+      ok: false,
+      code: NET_CODES.E_SSRF_DANGEROUS_PORT_ACK_MISSING,
+    });
+    const result = await fetchJsonSafe('https://issuer.example.com:6379/x');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('fetch_blocked_dangerous_port');
+  });
+});

--- a/packages/resolver-http/__tests__/fetch-safe.https.test.ts
+++ b/packages/resolver-http/__tests__/fetch-safe.https.test.ts
@@ -1,0 +1,77 @@
+// HTTPS-only pre-check: non-HTTPS URLs are rejected at the resolver-http
+// boundary BEFORE any net-node fetch dispatch. Asserts the mock is never
+// called.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  resetMock,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { fetchJsonSafe, fetchJwksSafe, fetchRawSafe } from '../src/fetch-safe.js';
+
+beforeEach(() => {
+  resetMock();
+  mockSafeFetchJson.mockClear();
+  mockSafeFetchJWKS.mockClear();
+  mockSafeFetchRaw.mockClear();
+});
+
+const NON_HTTPS = [
+  'http://issuer.example.com/x',
+  'ftp://issuer.example.com/x',
+  'file:///etc/passwd',
+  'gopher://example.com',
+  'data:text/plain,hello',
+  'javascript:alert(1)',
+];
+
+describe('fetch-safe HTTPS-only pre-check', () => {
+  for (const url of NON_HTTPS) {
+    it(`fetchJsonSafe rejects ${url} with fetch_blocked_https_only and never dispatches`, async () => {
+      const result = await fetchJsonSafe(url);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe('fetch_blocked_https_only');
+      }
+      expect(mockSafeFetchJson).not.toHaveBeenCalled();
+    });
+
+    it(`fetchJwksSafe rejects ${url} with fetch_blocked_https_only`, async () => {
+      const result = await fetchJwksSafe(url);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.code).toBe('fetch_blocked_https_only');
+      expect(mockSafeFetchJWKS).not.toHaveBeenCalled();
+    });
+
+    it(`fetchRawSafe rejects ${url} with fetch_blocked_https_only`, async () => {
+      const result = await fetchRawSafe(url);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.code).toBe('fetch_blocked_https_only');
+      expect(mockSafeFetchRaw).not.toHaveBeenCalled();
+    });
+  }
+
+  it('a malformed URL surfaces fetch_blocked_https_only with sanitized origin', async () => {
+    const result = await fetchJsonSafe('not-a-url');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('fetch_blocked_https_only');
+      expect(result.message).toContain('<invalid-url>');
+    }
+    expect(mockSafeFetchJson).not.toHaveBeenCalled();
+  });
+});

--- a/packages/resolver-http/__tests__/fetch-safe.redaction-nested.test.ts
+++ b/packages/resolver-http/__tests__/fetch-safe.redaction-nested.test.ts
@@ -1,0 +1,127 @@
+// Adversarial redaction: a malicious upstream Error embeds secrets across
+// multiple nested fields (cause, cause.cause, stack, custom payload). The
+// resolver-http surfaced failure result MUST NOT carry any of those
+// substrings in any field, including the cause chain.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+  NET_CODES,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { fetchJsonSafe } from '../src/fetch-safe.js';
+
+beforeEach(() => {
+  resetMock();
+});
+
+const SECRETS = [
+  'Bearer abc123',
+  'Cookie: session=secret-xyz',
+  'Authorization: Basic dXNlcjpwYXNz',
+  '-----BEGIN PRIVATE KEY-----MIIBVQIBAD',
+  '"d":"private-jwk-d-field-secret-base64"',
+  'malicious@example.com',
+];
+
+function flattenStrings(value: unknown, depth = 0, acc: string[] = []): string[] {
+  if (depth > 6) return acc;
+  if (typeof value === 'string') {
+    acc.push(value);
+    return acc;
+  }
+  if (value && typeof value === 'object') {
+    for (const v of Object.values(value as Record<string, unknown>)) {
+      flattenStrings(v, depth + 1, acc);
+    }
+  }
+  return acc;
+}
+
+describe('fetch-safe redaction (cause-chain traversal)', () => {
+  it('synthetic upstream error with secrets in message + cause + cause.cause + stack + custom payload', async () => {
+    const innerInner = new Error('Authorization: Basic dXNlcjpwYXNz from inner-inner');
+    const inner: Error & { cause?: unknown } = new Error('Cookie: session=secret-xyz from inner');
+    inner.cause = innerInner;
+    const oneKB = 'A'.repeat(1024);
+
+    enqueue('safeFetchJson', {
+      ok: false,
+      code: NET_CODES.E_NETWORK_ERROR,
+      error: 'Bearer abc123 leaked from upstream',
+      cause: inner,
+      stack:
+        'Error: outer\n    at Object.<anonymous>:1:1\n    at next ' +
+        'Authorization: Basic dXNlcjpwYXNz line\n' +
+        '-----BEGIN PRIVATE KEY-----MIIBVQIBAD wrapped\n',
+      upstreamPayload: { body: oneKB, jwk: '"d":"private-jwk-d-field-secret-base64"' },
+    });
+
+    const result = await fetchJsonSafe('https://issuer.example.com/x');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const allStrings = flattenStrings(result);
+      // No secret may appear in ANY string field of the result, including
+      // any nested cause chain that might have been preserved by mistake.
+      for (const secret of SECRETS) {
+        for (const s of allStrings) {
+          expect(s).not.toContain(secret);
+        }
+      }
+      // The 1 KiB payload body MUST NOT bleed in either
+      for (const s of allStrings) {
+        expect(s.includes(oneKB)).toBe(false);
+      }
+      // Sanity: result is a clean discriminated-union failure
+      expect(result.code).toBe('fetch_network_error');
+      expect(result.message).toBe('fetch_network_error at https://issuer.example.com');
+    }
+  });
+
+  it('resolver-http does not leak upstream cause field even if asked to expose it', async () => {
+    // Construct upstream with a deeply nested cause chain
+    let chain: { message: string; cause?: unknown } = {
+      message: 'Bearer leaf-secret-token',
+    };
+    for (let i = 0; i < 5; i++) {
+      chain = { message: `wrapper-${i}`, cause: chain };
+    }
+    enqueue('safeFetchJson', {
+      ok: false,
+      code: NET_CODES.E_NETWORK_ERROR,
+      error: 'top-level error',
+      cause: chain,
+    });
+
+    const result = await fetchJsonSafe('https://issuer.example.com/x');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // Result must not carry cause / stack / upstreamPayload fields
+      const keys = Object.keys(result).sort();
+      // Allowed keys only: ok, code, message, status?
+      for (const k of keys) {
+        expect(['ok', 'code', 'message', 'status']).toContain(k);
+      }
+      // Safety belt: a flatten of all strings must not contain the leaf secret
+      const allStrings = flattenStrings(result);
+      for (const s of allStrings) {
+        expect(s).not.toContain('leaf-secret-token');
+      }
+    }
+  });
+});

--- a/packages/resolver-http/__tests__/fetch-safe.redaction.test.ts
+++ b/packages/resolver-http/__tests__/fetch-safe.redaction.test.ts
@@ -1,0 +1,105 @@
+// Redaction (basic): error messages MUST NOT contain sensitive material
+// from the URL, request, or response. Allowed: code identifier + sanitized
+// origin (protocol + host).
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+  NET_CODES,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { fetchJsonSafe } from '../src/fetch-safe.js';
+
+beforeEach(() => {
+  resetMock();
+});
+
+const FORBIDDEN_PATTERNS: readonly RegExp[] = [
+  /Bearer\s+\S+/,
+  /Cookie:|Set-Cookie:/i,
+  /Authorization:/i,
+  /-----BEGIN [A-Z ]+PRIVATE KEY-----/,
+  /\?token=/,
+  /\?api_key=/,
+  /password=/i,
+];
+
+describe('fetch-safe redaction (basic)', () => {
+  it('error message contains only code + sanitized origin (no path / query)', async () => {
+    enqueue('safeFetchJson', { ok: false, code: NET_CODES.E_SSRF_URL_REJECTED });
+    const result = await fetchJsonSafe(
+      'https://issuer.example.com/.well-known/peac-issuer.json?token=secret123'
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe('fetch_blocked_ssrf at https://issuer.example.com');
+      // No path
+      expect(result.message).not.toContain('/.well-known');
+      // No query
+      expect(result.message).not.toContain('token=');
+      expect(result.message).not.toContain('secret123');
+    }
+  });
+
+  it('upstream error.message containing secrets does NOT bleed into resolver-http message', async () => {
+    enqueue('safeFetchJson', {
+      ok: false,
+      code: NET_CODES.E_NETWORK_ERROR,
+      error: 'Connection failed Bearer abc123 Cookie: session=xyz',
+    });
+    const result = await fetchJsonSafe('https://issuer.example.com/x');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      for (const re of FORBIDDEN_PATTERNS) {
+        expect(result.message).not.toMatch(re);
+      }
+      expect(result.message).not.toContain('abc123');
+      expect(result.message).not.toContain('session=xyz');
+    }
+  });
+
+  it('HTTP 4xx surfaces only the status + code + origin, not the body', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 401,
+      contentType: 'application/json',
+      body: { error: 'Bearer abc123 invalid' },
+    });
+    const result = await fetchJsonSafe('https://issuer.example.com/x');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('fetch_status_4xx');
+      expect(result.status).toBe(401);
+      for (const re of FORBIDDEN_PATTERNS) {
+        expect(result.message).not.toMatch(re);
+      }
+      expect(result.message).not.toContain('abc123');
+    }
+  });
+
+  it('safe high-level fields ARE present (negative-control)', async () => {
+    enqueue('safeFetchJson', { ok: false, code: NET_CODES.E_REQUEST_TIMEOUT });
+    const result = await fetchJsonSafe('https://issuer.example.com/x');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('fetch_timeout');
+      expect(result.message).toContain('https://issuer.example.com'); // origin allowed
+      expect(result.message).toContain('fetch_timeout'); // code allowed
+    }
+  });
+});

--- a/packages/resolver-http/__tests__/fetch-safe.redirect.test.ts
+++ b/packages/resolver-http/__tests__/fetch-safe.redirect.test.ts
@@ -1,0 +1,73 @@
+// Redirect cap: asserts verifier maxRedirects (3) is passed to net-node,
+// NOT net-node's DEFAULT_MAX_REDIRECTS (5). Also asserts redirect-class
+// upstream codes collapse to fetch_blocked_redirect.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+  getLastOptions,
+  NET_CODES,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { VERIFIER_LIMITS } from '@peac/kernel';
+
+import { fetchJsonSafe, fetchRawSafe } from '../src/fetch-safe.js';
+
+beforeEach(() => {
+  resetMock();
+});
+
+describe('fetch-safe redirect: verifier 3-cap fires, not net-node default 5', () => {
+  it('JSON path passes VERIFIER_LIMITS.maxRedirects (3) to net-node', async () => {
+    enqueue('safeFetchJson', { ok: true, status: 200, body: {} });
+    await fetchJsonSafe('https://issuer.example.com/x');
+    const opts = getLastOptions() as { maxRedirects?: number } | undefined;
+    expect(opts?.maxRedirects).toBe(VERIFIER_LIMITS.maxRedirects);
+    expect(opts?.maxRedirects).toBe(3);
+    // Net-node default (5) MUST NOT be what fires
+    expect(opts?.maxRedirects).not.toBe(5);
+  });
+
+  it('raw path passes VERIFIER_LIMITS.maxRedirects (3)', async () => {
+    enqueue('safeFetchRaw', { ok: true, status: 200, body: 'x' });
+    await fetchRawSafe('https://issuer.example.com/r');
+    const opts = getLastOptions() as { maxRedirects?: number } | undefined;
+    expect(opts?.maxRedirects).toBe(3);
+  });
+
+  it('caller override is honored', async () => {
+    enqueue('safeFetchJson', { ok: true, status: 200, body: {} });
+    await fetchJsonSafe('https://issuer.example.com/x', { maxRedirects: 1 });
+    const opts = getLastOptions() as { maxRedirects?: number } | undefined;
+    expect(opts?.maxRedirects).toBe(1);
+  });
+
+  it('E_NET_SSRF_TOO_MANY_REDIRECTS maps to fetch_blocked_redirect', async () => {
+    enqueue('safeFetchJson', { ok: false, code: NET_CODES.E_SSRF_TOO_MANY_REDIRECTS });
+    const result = await fetchJsonSafe('https://issuer.example.com/x');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('fetch_blocked_redirect');
+  });
+
+  it('E_NET_SSRF_REDIRECT_BLOCKED (cross-origin / private redirect target) maps to fetch_blocked_redirect', async () => {
+    enqueue('safeFetchJson', { ok: false, code: NET_CODES.E_SSRF_REDIRECT_BLOCKED });
+    const result = await fetchJsonSafe('https://issuer.example.com/x');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('fetch_blocked_redirect');
+  });
+});

--- a/packages/resolver-http/__tests__/fetch-safe.redirect.test.ts
+++ b/packages/resolver-http/__tests__/fetch-safe.redirect.test.ts
@@ -26,7 +26,7 @@ vi.mock('@peac/net-node', async () => {
 
 import { VERIFIER_LIMITS } from '@peac/kernel';
 
-import { fetchJsonSafe, fetchRawSafe } from '../src/fetch-safe.js';
+import { fetchJsonSafe, fetchJwksSafe, fetchRawSafe } from '../src/fetch-safe.js';
 
 beforeEach(() => {
   resetMock();
@@ -69,5 +69,39 @@ describe('fetch-safe redirect: verifier 3-cap fires, not net-node default 5', ()
     const result = await fetchJsonSafe('https://issuer.example.com/x');
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.code).toBe('fetch_blocked_redirect');
+  });
+});
+
+describe('fetch-safe JWKS path: deliberate zero-redirect exception (Commit 2.1 Fix #1)', () => {
+  it('JWKS path does NOT pass maxRedirects to upstream safeFetchJWKS (signature Omit<..., maxRedirects>)', async () => {
+    enqueue('safeFetchJWKS', { ok: true, status: 200, body: { keys: [] } });
+    await fetchJwksSafe('https://issuer.example.com/jwks');
+    const opts = getLastOptions() as Record<string, unknown> | undefined;
+    expect(opts).toBeDefined();
+    if (opts) {
+      // Upstream safeFetchJWKS hardcodes maxRedirects: 0; resolver-http MUST
+      // NOT pass a maxRedirects option to it. The key must be absent from
+      // the options object passed across the boundary.
+      expect('maxRedirects' in opts).toBe(false);
+    }
+  });
+
+  it('caller-supplied maxRedirects on FetchSafeOptions is silently ignored on JWKS path', async () => {
+    enqueue('safeFetchJWKS', { ok: true, status: 200, body: { keys: [] } });
+    // Caller asks for 5 redirects; JWKS path forces 0 (upstream hardcode);
+    // resolver-http does not pass the value through.
+    await fetchJwksSafe('https://issuer.example.com/jwks', { maxRedirects: 5 });
+    const opts = getLastOptions() as Record<string, unknown> | undefined;
+    expect(opts).toBeDefined();
+    if (opts) {
+      expect('maxRedirects' in opts).toBe(false);
+    }
+  });
+
+  it('JSON path still honors caller-supplied maxRedirects (control case)', async () => {
+    enqueue('safeFetchJson', { ok: true, status: 200, body: {} });
+    await fetchJsonSafe('https://issuer.example.com/x', { maxRedirects: 5 });
+    const opts = getLastOptions() as { maxRedirects?: number } | undefined;
+    expect(opts?.maxRedirects).toBe(5);
   });
 });

--- a/packages/resolver-http/__tests__/fetch-safe.smoke.test.ts
+++ b/packages/resolver-http/__tests__/fetch-safe.smoke.test.ts
@@ -1,0 +1,85 @@
+// Smoke test for fetch-safe composition.
+// Round-trip JSON success path; happy-path bytes/contentType assertions.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { fetchJsonSafe, fetchJwksSafe, fetchRawSafe } from '../src/fetch-safe.js';
+
+beforeEach(() => {
+  resetMock();
+});
+
+describe('fetch-safe smoke: happy path', () => {
+  it('fetchJsonSafe returns parsed body, byte count, content-type on 200', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json; charset=utf-8',
+      body: { hello: 'world' },
+      responseBytes: 42,
+    });
+    const result = await fetchJsonSafe<{ hello: string }>(
+      'https://issuer.example.com/.well-known/x'
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.body).toEqual({ hello: 'world' });
+      expect(result.bytes).toBe(42);
+      expect(result.contentType).toBe('application/json; charset=utf-8');
+    }
+  });
+
+  it('fetchJwksSafe returns parsed JWKS body', async () => {
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { keys: [{ kty: 'OKP', crv: 'Ed25519', kid: 'k1', x: 'abc' }] },
+      responseBytes: 90,
+    });
+    const result = await fetchJwksSafe('https://issuer.example.com/jwks');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.body).toEqual({
+        keys: [{ kty: 'OKP', crv: 'Ed25519', kid: 'k1', x: 'abc' }],
+      });
+      expect(result.bytes).toBe(90);
+    }
+  });
+
+  it('fetchRawSafe returns raw bytes', async () => {
+    const wireBytes = new TextEncoder().encode('hello.world.signature');
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'application/jose',
+      bytes: wireBytes,
+    });
+    const result = await fetchRawSafe('https://issuer.example.com/receipt');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.body).toBeInstanceOf(Uint8Array);
+      expect(new TextDecoder().decode(result.body)).toBe('hello.world.signature');
+      expect(result.bytes).toBe(wireBytes.byteLength);
+      expect(result.contentType).toBe('application/jose');
+    }
+  });
+});

--- a/packages/resolver-http/__tests__/fetch-safe.ssrf.test.ts
+++ b/packages/resolver-http/__tests__/fetch-safe.ssrf.test.ts
@@ -1,0 +1,116 @@
+// SSRF block class coverage via mocked net-node failures.
+// Asserts every E_NET_SSRF_* class collapses to fetch_blocked_ssrf or
+// (for redirect / dangerous-port / metadata-IP) the appropriate sibling.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+  NET_CODES,
+  type NetNodeErrorCode,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { fetchJsonSafe } from '../src/fetch-safe.js';
+
+beforeEach(() => {
+  resetMock();
+});
+
+const SSRF_CASES: Array<{
+  label: string;
+  upstream: NetNodeErrorCode;
+  expected: 'fetch_blocked_ssrf' | 'fetch_blocked_redirect' | 'fetch_blocked_dangerous_port';
+}> = [
+  {
+    label: 'rfc1918 / private-ip rejected pre-DNS',
+    upstream: NET_CODES.E_SSRF_URL_REJECTED,
+    expected: 'fetch_blocked_ssrf',
+  },
+  {
+    label: 'private IP resolved (DNS rebind class)',
+    upstream: NET_CODES.E_SSRF_DNS_RESOLVED_PRIVATE,
+    expected: 'fetch_blocked_ssrf',
+  },
+  {
+    label: 'all candidate IPs blocked',
+    upstream: NET_CODES.E_SSRF_ALL_IPS_BLOCKED,
+    expected: 'fetch_blocked_ssrf',
+  },
+  {
+    label: 'IPv6 zone identifier present',
+    upstream: NET_CODES.E_SSRF_IPV6_ZONE_ID,
+    expected: 'fetch_blocked_ssrf',
+  },
+  {
+    label: 'invalid host string',
+    upstream: NET_CODES.E_SSRF_INVALID_HOST,
+    expected: 'fetch_blocked_ssrf',
+  },
+  {
+    label: 'mixed-DNS audit blocked',
+    upstream: NET_CODES.E_SSRF_MIXED_DNS_BLOCKED,
+    expected: 'fetch_blocked_ssrf',
+  },
+  {
+    label: 'mixed-DNS ack missing',
+    upstream: NET_CODES.E_SSRF_MIXED_DNS_ACK_MISSING,
+    expected: 'fetch_blocked_ssrf',
+  },
+  {
+    label: 'allowCIDRs ack required but missing',
+    upstream: NET_CODES.E_SSRF_ALLOWCIDRS_ACK_REQUIRED,
+    expected: 'fetch_blocked_ssrf',
+  },
+  {
+    label: 'tenant key missing (treat as ssrf-class block)',
+    upstream: NET_CODES.E_TENANT_KEY_MISSING,
+    expected: 'fetch_blocked_ssrf',
+  },
+  {
+    label: 'redirect to blocked target',
+    upstream: NET_CODES.E_SSRF_REDIRECT_BLOCKED,
+    expected: 'fetch_blocked_redirect',
+  },
+  {
+    label: 'too many redirects',
+    upstream: NET_CODES.E_SSRF_TOO_MANY_REDIRECTS,
+    expected: 'fetch_blocked_redirect',
+  },
+  {
+    label: 'dangerous port (e.g. 25, 6379)',
+    upstream: NET_CODES.E_SSRF_DANGEROUS_PORT,
+    expected: 'fetch_blocked_dangerous_port',
+  },
+  {
+    label: 'dangerous port ack missing',
+    upstream: NET_CODES.E_SSRF_DANGEROUS_PORT_ACK_MISSING,
+    expected: 'fetch_blocked_dangerous_port',
+  },
+];
+
+describe('fetch-safe SSRF mapping', () => {
+  for (const tc of SSRF_CASES) {
+    it(`maps ${tc.upstream} -> ${tc.expected} (${tc.label})`, async () => {
+      enqueue('safeFetchJson', { ok: false, code: tc.upstream });
+      const result = await fetchJsonSafe('https://issuer.example.com/x');
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe(tc.expected);
+      }
+    });
+  }
+});

--- a/packages/resolver-http/__tests__/fetch-safe.status-vs-content-type.test.ts
+++ b/packages/resolver-http/__tests__/fetch-safe.status-vs-content-type.test.ts
@@ -1,0 +1,170 @@
+// Status precedence over content-type (Commit 2.1 Fix #2).
+//
+// For a successful upstream response, classify HTTP status BEFORE enforcing
+// acceptContentTypes. A 4xx with text/html body is more usefully reported as
+// fetch_status_4xx than as fetch_invalid_content_type. The control case
+// (status 2xx with mismatched content-type) still surfaces
+// fetch_invalid_content_type.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { fetchJsonSafe, fetchJwksSafe, fetchRawSafe } from '../src/fetch-safe.js';
+
+beforeEach(() => {
+  resetMock();
+});
+
+describe('fetch-safe status precedence over content-type (JSON path)', () => {
+  it('401 text/html surfaces fetch_status_4xx, not fetch_invalid_content_type', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 401,
+      contentType: 'text/html; charset=utf-8',
+      body: { ignored: true },
+    });
+    const result = await fetchJsonSafe('https://issuer.example.com/x', {
+      acceptContentTypes: ['application/json'],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('fetch_status_4xx');
+      expect(result.code).not.toBe('fetch_invalid_content_type');
+      expect(result.status).toBe(401);
+    }
+  });
+
+  it('500 text/plain surfaces fetch_status_5xx, not fetch_invalid_content_type', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 500,
+      contentType: 'text/plain',
+      body: { ignored: true },
+    });
+    const result = await fetchJsonSafe('https://issuer.example.com/x', {
+      acceptContentTypes: ['application/json'],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('fetch_status_5xx');
+      expect(result.code).not.toBe('fetch_invalid_content_type');
+      expect(result.status).toBe(500);
+    }
+  });
+
+  it('200 text/html with acceptContentTypes:[application/json] STILL surfaces fetch_invalid_content_type (control case)', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'text/html',
+      body: { x: 1 },
+    });
+    const result = await fetchJsonSafe('https://issuer.example.com/x', {
+      acceptContentTypes: ['application/json'],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('fetch_invalid_content_type');
+    }
+  });
+
+  it('200 application/json with matching acceptContentTypes succeeds (control case)', async () => {
+    enqueue('safeFetchJson', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { x: 1 },
+    });
+    const result = await fetchJsonSafe<{ x: number }>('https://issuer.example.com/x', {
+      acceptContentTypes: ['application/json'],
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('fetch-safe status precedence over content-type (JWKS path)', () => {
+  it('401 text/html on JWKS path surfaces fetch_status_4xx, not fetch_invalid_content_type', async () => {
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 401,
+      contentType: 'text/html',
+      body: { keys: [] },
+    });
+    const result = await fetchJwksSafe('https://issuer.example.com/jwks', {
+      acceptContentTypes: ['application/json'],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('fetch_status_4xx');
+      expect(result.code).not.toBe('fetch_invalid_content_type');
+    }
+  });
+
+  it('500 text/plain on JWKS path surfaces fetch_status_5xx, not fetch_invalid_content_type', async () => {
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 503,
+      contentType: 'text/plain',
+      body: { keys: [] },
+    });
+    const result = await fetchJwksSafe('https://issuer.example.com/jwks', {
+      acceptContentTypes: ['application/json'],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('fetch_status_5xx');
+    }
+  });
+});
+
+describe('fetch-safe status precedence over content-type (raw path)', () => {
+  it('401 text/html on raw path surfaces fetch_status_4xx, not fetch_invalid_content_type', async () => {
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 404,
+      contentType: 'text/html',
+      body: 'not found',
+    });
+    const result = await fetchRawSafe('https://issuer.example.com/r', {
+      acceptContentTypes: ['application/jose'],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('fetch_status_4xx');
+      expect(result.code).not.toBe('fetch_invalid_content_type');
+    }
+  });
+
+  it('500 text/plain on raw path surfaces fetch_status_5xx', async () => {
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 502,
+      contentType: 'text/plain',
+      body: 'bad gateway',
+    });
+    const result = await fetchRawSafe('https://issuer.example.com/r', {
+      acceptContentTypes: ['application/jose'],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('fetch_status_5xx');
+    }
+  });
+});

--- a/packages/resolver-http/__tests__/fetch-safe.timeout.test.ts
+++ b/packages/resolver-http/__tests__/fetch-safe.timeout.test.ts
@@ -1,0 +1,81 @@
+// Timeout: asserts the verifier 5000ms cap is what fetch-safe passes to
+// net-node, NOT net-node's own DEFAULT_TIMEOUT_MS (30000ms). Also asserts
+// the upstream timeout codes (E_REQUEST_TIMEOUT, E_DNS_TIMEOUT, etc.) all
+// collapse to fetch_timeout.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+  getLastOptions,
+  NET_CODES,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { VERIFIER_LIMITS } from '@peac/kernel';
+
+import { fetchJsonSafe, fetchJwksSafe, fetchRawSafe } from '../src/fetch-safe.js';
+
+beforeEach(() => {
+  resetMock();
+});
+
+describe('fetch-safe timeout: verifier cap fires, not net-node default', () => {
+  it('verifier timeout (5000ms) is passed to net-node when caller omits timeoutMs', async () => {
+    enqueue('safeFetchJson', { ok: true, status: 200, body: {} });
+    await fetchJsonSafe('https://issuer.example.com/x');
+    const opts = getLastOptions() as { timeoutMs?: number } | undefined;
+    expect(opts?.timeoutMs).toBe(VERIFIER_LIMITS.fetchTimeoutMs);
+    expect(opts?.timeoutMs).toBe(5000);
+    // Hard assertion: net-node default (30000) MUST NOT be what fired
+    expect(opts?.timeoutMs).not.toBe(30000);
+  });
+
+  it('caller-supplied tighter timeout overrides verifier default', async () => {
+    enqueue('safeFetchJson', { ok: true, status: 200, body: {} });
+    await fetchJsonSafe('https://issuer.example.com/x', { timeoutMs: 1500 });
+    const opts = getLastOptions() as { timeoutMs?: number } | undefined;
+    expect(opts?.timeoutMs).toBe(1500);
+  });
+
+  it('all upstream timeout error codes collapse to fetch_timeout', async () => {
+    const timeoutCodes = [
+      NET_CODES.E_REQUEST_TIMEOUT,
+      NET_CODES.E_DNS_TIMEOUT,
+      NET_CODES.E_CONNECT_TIMEOUT,
+      NET_CODES.E_HEADERS_TIMEOUT,
+      NET_CODES.E_BODY_TIMEOUT,
+    ];
+    for (const code of timeoutCodes) {
+      enqueue('safeFetchJson', { ok: false, code });
+      const result = await fetchJsonSafe('https://issuer.example.com/x');
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe('fetch_timeout');
+      }
+    }
+  });
+
+  it('verifier timeout also fires through fetchJwksSafe and fetchRawSafe', async () => {
+    enqueue('safeFetchJWKS', { ok: true, status: 200, body: { keys: [] } });
+    await fetchJwksSafe('https://issuer.example.com/jwks');
+    expect((getLastOptions() as { timeoutMs?: number } | undefined)?.timeoutMs).toBe(5000);
+
+    enqueue('safeFetchRaw', { ok: true, status: 200, body: 'x' });
+    await fetchRawSafe('https://issuer.example.com/r');
+    expect((getLastOptions() as { timeoutMs?: number } | undefined)?.timeoutMs).toBe(5000);
+  });
+});

--- a/packages/resolver-http/__tests__/fetch-safe.upstream-code-drift.test.ts
+++ b/packages/resolver-http/__tests__/fetch-safe.upstream-code-drift.test.ts
@@ -1,0 +1,109 @@
+// Upstream-code drift coverage (Commit 2.1 Fix #4).
+//
+// Imports the actual @peac/net-node SAFE_FETCH_ERROR_CODES via vi.importActual
+// (NOT the mocked module — see vi.unmock at the top scope) and asserts every
+// current upstream code is either:
+//   - mapped by fetch-safe (MAPPED_UPSTREAM_CODES); or
+//   - explicitly listed as an internal-only / never-reaches-resolver-http
+//     exception (EXPLICITLY_INTERNAL_ONLY_CODES).
+//
+// If upstream net-node adds a new E_NET_* code, this test fails loudly so the
+// fetch-safe mapping table gets a conscious extension before merge.
+
+import { describe, it, expect } from 'vitest';
+
+// This test does NOT mock @peac/net-node. We import the real codes module
+// directly so the assertion runs against the actual current public enum.
+import { SAFE_FETCH_ERROR_CODES } from '@peac/net-node';
+
+// Codes that fetch-safe.ts mapNetNodeCode() switch handles. The order
+// mirrors the switch in src/fetch-safe.ts; if the switch changes, this
+// set must change too.
+const MAPPED_UPSTREAM_CODES: ReadonlySet<string> = new Set([
+  // -> fetch_timeout
+  'E_NET_REQUEST_TIMEOUT',
+  'E_NET_DNS_TIMEOUT',
+  'E_NET_CONNECT_TIMEOUT',
+  'E_NET_HEADERS_TIMEOUT',
+  'E_NET_BODY_TIMEOUT',
+  // -> fetch_network_error
+  'E_NET_NETWORK_ERROR',
+  'E_NET_DNS_RESOLUTION_FAILED',
+  'E_NET_PARSE_ERROR',
+  // -> fetch_blocked_ssrf
+  'E_NET_SSRF_URL_REJECTED',
+  'E_NET_SSRF_DNS_RESOLVED_PRIVATE',
+  'E_NET_SSRF_ALL_IPS_BLOCKED',
+  'E_NET_SSRF_IPV6_ZONE_ID',
+  'E_NET_SSRF_INVALID_HOST',
+  'E_NET_SSRF_MIXED_DNS_BLOCKED',
+  'E_NET_SSRF_MIXED_DNS_ACK_MISSING',
+  'E_NET_SSRF_ALLOWCIDRS_ACK_REQUIRED',
+  'E_NET_TENANT_KEY_MISSING',
+  // -> fetch_blocked_redirect
+  'E_NET_SSRF_REDIRECT_BLOCKED',
+  'E_NET_SSRF_TOO_MANY_REDIRECTS',
+  // -> fetch_blocked_byte_cap
+  'E_NET_RESPONSE_TOO_LARGE',
+  // -> fetch_blocked_dangerous_port
+  'E_NET_SSRF_DANGEROUS_PORT',
+  'E_NET_SSRF_DANGEROUS_PORT_ACK_MISSING',
+  // -> resolver_internal_error (programmer error in resolver-http; never expected
+  //    in production because resolver-http only issues GET / HEAD via allowedMethods).
+  'E_NET_METHOD_NOT_ALLOWED',
+]);
+
+// Codes that net-node may emit but that resolver-http intentionally does NOT
+// surface as a distinct mapped class. Listed here so that "every upstream
+// code is consciously decided" is a hard test rather than a soft default.
+//
+// (Currently empty — every upstream code is mapped. Future net-node codes
+// that are evidence-emission-only or telemetry-only should be added here
+// with a one-line rationale comment.)
+const EXPLICITLY_INTERNAL_ONLY_CODES: ReadonlySet<string> = new Set([
+  // (none today)
+]);
+
+describe('fetch-safe upstream-code drift', () => {
+  it('every actual @peac/net-node SAFE_FETCH_ERROR_CODES value is either mapped or explicitly internal', () => {
+    const actualCodes = Object.values(SAFE_FETCH_ERROR_CODES);
+    expect(actualCodes.length).toBeGreaterThan(0);
+
+    const undecided: string[] = [];
+    for (const code of actualCodes) {
+      const decided = MAPPED_UPSTREAM_CODES.has(code) || EXPLICITLY_INTERNAL_ONLY_CODES.has(code);
+      if (!decided) undecided.push(code);
+    }
+
+    expect(
+      undecided,
+      `New upstream @peac/net-node code(s) without a conscious mapping decision: ${undecided.join(', ')}. ` +
+        `Add to MAPPED_UPSTREAM_CODES (and update fetch-safe.ts mapNetNodeCode switch) or ` +
+        `EXPLICITLY_INTERNAL_ONLY_CODES with a rationale comment.`
+    ).toEqual([]);
+  });
+
+  it('every code in MAPPED_UPSTREAM_CODES exists in the actual upstream enum (no stale entries)', () => {
+    const actualValues = new Set(Object.values(SAFE_FETCH_ERROR_CODES) as string[]);
+    const stale: string[] = [];
+    for (const mapped of MAPPED_UPSTREAM_CODES) {
+      if (!actualValues.has(mapped)) stale.push(mapped);
+    }
+    expect(
+      stale,
+      `Stale entries in MAPPED_UPSTREAM_CODES (no longer in upstream): ${stale.join(', ')}`
+    ).toEqual([]);
+  });
+
+  it('every code in EXPLICITLY_INTERNAL_ONLY_CODES exists in the actual upstream enum (no stale entries)', () => {
+    const actualValues = new Set(Object.values(SAFE_FETCH_ERROR_CODES) as string[]);
+    const stale: string[] = [];
+    for (const internal of EXPLICITLY_INTERNAL_ONLY_CODES) {
+      if (!actualValues.has(internal)) stale.push(internal);
+    }
+    expect(
+      stale,
+      `Stale entries in EXPLICITLY_INTERNAL_ONLY_CODES (no longer in upstream): ${stale.join(', ')}`
+    ).toEqual([]);
+  });
+});

--- a/packages/resolver-http/__tests__/fetch-safe.upstream-code-drift.test.ts
+++ b/packages/resolver-http/__tests__/fetch-safe.upstream-code-drift.test.ts
@@ -1,7 +1,7 @@
 // Upstream-code drift coverage (Commit 2.1 Fix #4).
 //
 // Imports the actual @peac/net-node SAFE_FETCH_ERROR_CODES via vi.importActual
-// (NOT the mocked module — see vi.unmock at the top scope) and asserts every
+// (NOT the mocked module; this file does not call vi.mock) and asserts every
 // current upstream code is either:
 //   - mapped by fetch-safe (MAPPED_UPSTREAM_CODES); or
 //   - explicitly listed as an internal-only / never-reaches-resolver-http
@@ -57,7 +57,7 @@ const MAPPED_UPSTREAM_CODES: ReadonlySet<string> = new Set([
 // surface as a distinct mapped class. Listed here so that "every upstream
 // code is consciously decided" is a hard test rather than a soft default.
 //
-// (Currently empty — every upstream code is mapped. Future net-node codes
+// (Currently empty: every upstream code is mapped. Future net-node codes
 // that are evidence-emission-only or telemetry-only should be added here
 // with a one-line rationale comment.)
 const EXPLICITLY_INTERNAL_ONLY_CODES: ReadonlySet<string> = new Set([

--- a/packages/resolver-http/__tests__/fetch-safe.url-redaction.test.ts
+++ b/packages/resolver-http/__tests__/fetch-safe.url-redaction.test.ts
@@ -1,0 +1,81 @@
+// Deterministic URL stripping: surfaced messages contain ONLY the origin
+// (protocol + host) plus the resolver-http error code. No path, no query,
+// no fragment, no token-looking substrings ever appear.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+  NET_CODES,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { fetchJsonSafe } from '../src/fetch-safe.js';
+
+beforeEach(() => {
+  resetMock();
+});
+
+interface Case {
+  url: string;
+  expectedMessage: string;
+}
+
+const CASES: readonly Case[] = [
+  {
+    url: 'https://issuer.example.com/.well-known/jwks.json',
+    expectedMessage: 'fetch_blocked_ssrf at https://issuer.example.com',
+  },
+  {
+    url: 'https://issuer.example.com/.well-known/peac-issuer.json?token=secret&kid=abc',
+    expectedMessage: 'fetch_blocked_ssrf at https://issuer.example.com',
+  },
+  {
+    url: 'https://issuer.example.com/path#fragment-with-token',
+    expectedMessage: 'fetch_blocked_ssrf at https://issuer.example.com',
+  },
+  {
+    url: 'https://api.example.com:8443/v1/keys/path/segments',
+    expectedMessage: 'fetch_blocked_ssrf at https://api.example.com:8443',
+  },
+  {
+    url: 'https://issuer.example.com/path%20with%20spaces?q=secret%21',
+    expectedMessage: 'fetch_blocked_ssrf at https://issuer.example.com',
+  },
+];
+
+describe('fetch-safe URL stripping (deterministic, exact-equality)', () => {
+  for (const tc of CASES) {
+    it(`strips path/query/fragment from ${tc.url}`, async () => {
+      enqueue('safeFetchJson', { ok: false, code: NET_CODES.E_SSRF_URL_REJECTED });
+      const result = await fetchJsonSafe(tc.url);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        // Exact-string-equality, not regex; prevents accidentally-stripped
+        // variants from passing.
+        expect(result.message).toBe(tc.expectedMessage);
+        // Forbidden-substring checks (defense-in-depth)
+        expect(result.message).not.toContain('?');
+        expect(result.message).not.toContain('#');
+        expect(result.message).not.toContain('token');
+        expect(result.message).not.toContain('secret');
+        expect(result.message).not.toContain('jwks.json');
+        expect(result.message).not.toContain('peac-issuer.json');
+        expect(result.message).not.toContain('/v1/keys');
+      }
+    });
+  }
+});

--- a/packages/resolver-http/__tests__/jwks-resolver.cache-isolation.test.ts
+++ b/packages/resolver-http/__tests__/jwks-resolver.cache-isolation.test.ts
@@ -110,6 +110,60 @@ describe('jwks-resolver cache isolation', () => {
     expect(r2.cacheSize).toBe(1);
   });
 
+  it('same issuer + same kid + different jwksUri returns distinct keys (Commit 3.1 Fix #2)', async () => {
+    // Cache key includes a sha256 digest of the normalized jwksUri so
+    // an issuer with multiple JWKS endpoints (e.g. tenant-specific paths)
+    // does not collide on (origin, kid).
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { keys: [{ kty: 'OKP', crv: 'Ed25519', kid: 'k1', x: ALPHA_X }] },
+    });
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { keys: [{ kty: 'OKP', crv: 'Ed25519', kid: 'k1', x: BETA_X }] },
+    });
+
+    const resolver = new IssuerJwksResolver();
+    const a = await resolver.resolve(
+      'https://issuer.example.com',
+      'https://issuer.example.com/tenant-a/jwks',
+      'k1'
+    );
+    const b = await resolver.resolve(
+      'https://issuer.example.com',
+      'https://issuer.example.com/tenant-b/jwks',
+      'k1'
+    );
+    expect(a.ok && a.jwk.x).toBe(ALPHA_X);
+    expect(b.ok && b.jwk.x).toBe(BETA_X);
+    expect(mockSafeFetchJWKS).toHaveBeenCalledTimes(2);
+    // Cache populated for both jwksUri variants
+    expect(resolver.cacheSize).toBe(2);
+  });
+
+  it('error messages do not leak the raw jwksUri path/query', async () => {
+    // Use a metadata-IP URL with secrets in the path/query ; pre-check
+    // rejects before any fetch, but the surfaced message must not echo
+    // the raw URI components.
+    const resolver = new IssuerJwksResolver();
+    const result = await resolver.resolve(
+      'https://issuer.example.com',
+      'https://169.254.169.254/jwks?token=secret&tenant=a',
+      'k1'
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).not.toContain('token=');
+      expect(result.message).not.toContain('secret');
+      expect(result.message).not.toContain('tenant=');
+      expect(result.message).not.toContain('/jwks?');
+    }
+  });
+
   it('clearCache empties the resolver', async () => {
     enqueue('safeFetchJWKS', {
       ok: true,

--- a/packages/resolver-http/__tests__/jwks-resolver.cache-isolation.test.ts
+++ b/packages/resolver-http/__tests__/jwks-resolver.cache-isolation.test.ts
@@ -1,0 +1,135 @@
+// Cache isolation: two issuers with overlapping kids resolve to distinct keys.
+// Cache key is keyed by issuer origin via buildCacheKey.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { IssuerJwksResolver } from '../src/jwks-resolver.js';
+
+beforeEach(() => {
+  resetMock();
+  mockSafeFetchJWKS.mockClear();
+});
+
+const ALPHA_X = '11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo';
+const BETA_X = '0CkahJv_36-58FvSBTLkQ8nAcBd5lMJpaH4yj7BD5Hk';
+
+describe('jwks-resolver cache isolation', () => {
+  it('two issuers with overlapping kid k1 resolve to distinct keys', async () => {
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { keys: [{ kty: 'OKP', crv: 'Ed25519', kid: 'k1', x: ALPHA_X }] },
+    });
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { keys: [{ kty: 'OKP', crv: 'Ed25519', kid: 'k1', x: BETA_X }] },
+    });
+
+    const resolver = new IssuerJwksResolver();
+    const a = await resolver.resolve(
+      'https://alpha.example.com',
+      'https://alpha.example.com/jwks',
+      'k1'
+    );
+    const b = await resolver.resolve(
+      'https://beta.example.com',
+      'https://beta.example.com/jwks',
+      'k1'
+    );
+
+    expect(a.ok && a.jwk.x).toBe(ALPHA_X);
+    expect(b.ok && b.jwk.x).toBe(BETA_X);
+    expect(mockSafeFetchJWKS).toHaveBeenCalledTimes(2);
+    // Cache is populated for both
+    expect(resolver.cacheSize).toBe(2);
+  });
+
+  it('repeated resolve for the same (issuer, kid) hits cache', async () => {
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { keys: [{ kty: 'OKP', crv: 'Ed25519', kid: 'k1', x: ALPHA_X }] },
+    });
+    const resolver = new IssuerJwksResolver();
+    const r1 = await resolver.resolve(
+      'https://alpha.example.com',
+      'https://alpha.example.com/jwks',
+      'k1'
+    );
+    const r2 = await resolver.resolve(
+      'https://alpha.example.com',
+      'https://alpha.example.com/jwks',
+      'k1'
+    );
+    expect(r1.ok && r1.jwk.x).toBe(ALPHA_X);
+    expect(r2.ok && r2.jwk.x).toBe(ALPHA_X);
+    expect(mockSafeFetchJWKS).toHaveBeenCalledTimes(1);
+  });
+
+  it('different resolver instances do not share cache state', async () => {
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { keys: [{ kty: 'OKP', crv: 'Ed25519', kid: 'k1', x: ALPHA_X }] },
+    });
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { keys: [{ kty: 'OKP', crv: 'Ed25519', kid: 'k1', x: ALPHA_X }] },
+    });
+    const r1 = new IssuerJwksResolver();
+    const r2 = new IssuerJwksResolver();
+    await r1.resolve('https://alpha.example.com', 'https://alpha.example.com/jwks', 'k1');
+    await r2.resolve('https://alpha.example.com', 'https://alpha.example.com/jwks', 'k1');
+    expect(mockSafeFetchJWKS).toHaveBeenCalledTimes(2); // each resolver fetched
+    expect(r1.cacheSize).toBe(1);
+    expect(r2.cacheSize).toBe(1);
+  });
+
+  it('clearCache empties the resolver', async () => {
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { keys: [{ kty: 'OKP', crv: 'Ed25519', kid: 'k1', x: ALPHA_X }] },
+    });
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { keys: [{ kty: 'OKP', crv: 'Ed25519', kid: 'k1', x: ALPHA_X }] },
+    });
+    const resolver = new IssuerJwksResolver();
+    await resolver.resolve('https://alpha.example.com', 'https://alpha.example.com/jwks', 'k1');
+    expect(resolver.cacheSize).toBe(1);
+    resolver.clearCache();
+    expect(resolver.cacheSize).toBe(0);
+    // Next resolve fires another fetch
+    await resolver.resolve('https://alpha.example.com', 'https://alpha.example.com/jwks', 'k1');
+    expect(mockSafeFetchJWKS).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/resolver-http/__tests__/jwks-resolver.errors.test.ts
+++ b/packages/resolver-http/__tests__/jwks-resolver.errors.test.ts
@@ -1,0 +1,185 @@
+// JWKS resolver error mapping tests.
+// Covers: pre-fetch URL pre-check failures (validateUrl / isMetadataIp);
+// fetch-safe pass-through; local body-validator failures; kid-not-found.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+  NET_CODES,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { fetchAndValidateJwks, IssuerJwksResolver } from '../src/jwks-resolver.js';
+
+beforeEach(() => {
+  resetMock();
+});
+
+describe('jwks-resolver pre-fetch URL pre-checks', () => {
+  it('non-HTTPS jwks_uri rejected (jwks-cache validateUrl + fetch-safe both block)', async () => {
+    const result = await fetchAndValidateJwks('http://issuer.example.com/jwks');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // jwks-cache validateUrl rejects http:// -> fetch_blocked_ssrf
+      // (alternatively could surface fetch_blocked_https_only; both are
+      // acceptable defenses)
+      expect(['fetch_blocked_ssrf', 'fetch_blocked_https_only']).toContain(result.code);
+    }
+  });
+
+  it('metadata-IP URL rejected with fetch_blocked_metadata_ip', async () => {
+    const result = await fetchAndValidateJwks('https://169.254.169.254/jwks');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('fetch_blocked_metadata_ip');
+  });
+
+  it('malformed URL rejected', async () => {
+    const result = await fetchAndValidateJwks('not-a-url');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(['fetch_blocked_https_only', 'fetch_blocked_ssrf']).toContain(result.code);
+    }
+  });
+});
+
+describe('jwks-resolver fetch-safe pass-through', () => {
+  it('SSRF pass-through preserves fetch_blocked_ssrf', async () => {
+    enqueue('safeFetchJWKS', { ok: false, code: NET_CODES.E_SSRF_DNS_RESOLVED_PRIVATE });
+    const result = await fetchAndValidateJwks('https://issuer.example.com/jwks');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('fetch_blocked_ssrf');
+  });
+
+  it('byte cap pass-through preserves fetch_blocked_byte_cap', async () => {
+    enqueue('safeFetchJWKS', { ok: false, code: NET_CODES.E_RESPONSE_TOO_LARGE });
+    const result = await fetchAndValidateJwks('https://issuer.example.com/jwks');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('fetch_blocked_byte_cap');
+  });
+
+  it('timeout pass-through preserves fetch_timeout', async () => {
+    enqueue('safeFetchJWKS', { ok: false, code: NET_CODES.E_REQUEST_TIMEOUT });
+    const result = await fetchAndValidateJwks('https://issuer.example.com/jwks');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('fetch_timeout');
+  });
+
+  it('4xx pass-through preserves fetch_status_4xx', async () => {
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 404,
+      contentType: 'application/json',
+      body: {},
+    });
+    const result = await fetchAndValidateJwks('https://issuer.example.com/jwks');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('fetch_status_4xx');
+  });
+});
+
+describe('jwks-resolver local body validation', () => {
+  it('body without keys array surfaces jwks_invalid_shape', async () => {
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { not_keys: [] },
+    });
+    const result = await fetchAndValidateJwks('https://issuer.example.com/jwks');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('jwks_invalid_shape');
+  });
+
+  it('keys array exceeding maxJwksKeys (20) surfaces jwks_invalid_shape', async () => {
+    const tooMany = {
+      keys: Array.from({ length: 25 }, (_, i) => ({
+        kty: 'OKP',
+        crv: 'Ed25519',
+        kid: `k${i}`,
+        x: '11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo',
+      })),
+    };
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: tooMany,
+    });
+    const result = await fetchAndValidateJwks('https://issuer.example.com/jwks');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('jwks_invalid_shape');
+  });
+
+  it('key missing required fields surfaces jwks_invalid_shape', async () => {
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { keys: [{ kty: 'OKP' /* missing crv, x */ }] },
+    });
+    const result = await fetchAndValidateJwks('https://issuer.example.com/jwks');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('jwks_invalid_shape');
+  });
+
+  it('null body surfaces jwks_invalid_shape', async () => {
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: null,
+    });
+    const result = await fetchAndValidateJwks('https://issuer.example.com/jwks');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('jwks_invalid_shape');
+  });
+});
+
+describe('jwks-resolver kid lookup', () => {
+  it('kid not found in JWKS surfaces jwks_kid_not_found', async () => {
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: {
+        keys: [
+          {
+            kty: 'OKP',
+            crv: 'Ed25519',
+            kid: 'k1',
+            x: '11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo',
+          },
+        ],
+      },
+    });
+    const resolver = new IssuerJwksResolver();
+    const result = await resolver.resolve(
+      'https://issuer.example.com',
+      'https://issuer.example.com/jwks',
+      'absent-kid'
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('jwks_kid_not_found');
+  });
+
+  it('malformed issuer URL surfaces discovery_invalid_shape', async () => {
+    const resolver = new IssuerJwksResolver();
+    const result = await resolver.resolve('not-a-url', 'https://issuer.example.com/jwks', 'k1');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('discovery_invalid_shape');
+  });
+});

--- a/packages/resolver-http/__tests__/jwks-resolver.fetch-path.test.ts
+++ b/packages/resolver-http/__tests__/jwks-resolver.fetch-path.test.ts
@@ -1,0 +1,86 @@
+// JWKS fetch-path test (Plan Fix #3).
+// Asserts the network fetch goes through fetchJwksSafe (net-node-backed),
+// NOT through @peac/jwks-cache.resolveKey (which uses global fetch).
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { IssuerJwksResolver, fetchAndValidateJwks } from '../src/jwks-resolver.js';
+
+beforeEach(() => {
+  resetMock();
+  mockSafeFetchJWKS.mockClear();
+});
+
+const VALID_JWKS = {
+  keys: [
+    { kty: 'OKP', crv: 'Ed25519', kid: 'k1', x: '11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo' },
+  ],
+};
+
+describe('jwks-resolver fetch-path: routes through fetchJwksSafe (Plan Fix #3)', () => {
+  it('safeFetchJWKS mock is called once per cache miss', async () => {
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: VALID_JWKS,
+    });
+    const resolver = new IssuerJwksResolver();
+    await resolver.resolve('https://issuer.example.com', 'https://issuer.example.com/jwks', 'k1');
+    expect(mockSafeFetchJWKS).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetchAndValidateJwks calls safeFetchJWKS, not safeFetchJson or safeFetchRaw', async () => {
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: VALID_JWKS,
+    });
+    await fetchAndValidateJwks('https://issuer.example.com/jwks');
+    expect(mockSafeFetchJWKS).toHaveBeenCalledTimes(1);
+    expect(mockSafeFetchJson).not.toHaveBeenCalled();
+    expect(mockSafeFetchRaw).not.toHaveBeenCalled();
+  });
+
+  it('jwks-resolver source does NOT import resolveKey or createResolver from @peac/jwks-cache', async () => {
+    // Read the source file and assert no resolveKey / createResolver references.
+    // (Defense-in-depth: the build-time isolation gate covers @peac/protocol;
+    // this test catches accidental jwks-cache.resolveKey usage in resolver-http source.)
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const url = await import('node:url');
+    const here = path.dirname(url.fileURLToPath(import.meta.url));
+    const src = fs.readFileSync(path.resolve(here, '../src/jwks-resolver.ts'), 'utf8');
+    // Strip comments before scanning so doctrine prose like "MUST NOT call resolveKey"
+    // doesn't false-flag.
+    const stripped = src
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .split('\n')
+      .map((line) => line.replace(/\/\/.*$/, ''))
+      .join('\n');
+    // Match actual function calls only.
+    expect(/\bresolveKey\s*\(/.test(stripped), 'resolveKey() should not be called').toBe(false);
+    expect(/\bcreateResolver\s*\(/.test(stripped), 'createResolver() should not be called').toBe(
+      false
+    );
+  });
+});

--- a/packages/resolver-http/__tests__/jwks-resolver.key-validation.test.ts
+++ b/packages/resolver-http/__tests__/jwks-resolver.key-validation.test.ts
@@ -1,0 +1,118 @@
+// JWKS key validation tests (Commit 3.1 Fix #1).
+//
+// resolver-http now calls importJwkAsEd25519 on the matched JWK before
+// caching/returning it. Structurally plausible but cryptographically
+// invalid keys are rejected with jwks_invalid_shape and NOT cached.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { IssuerJwksResolver } from '../src/jwks-resolver.js';
+
+beforeEach(() => {
+  resetMock();
+  mockSafeFetchJWKS.mockClear();
+});
+
+// A real Ed25519 public-key x value (32 bytes base64url-encoded; no padding).
+// 'AAAA...' decodes to 32 zero bytes ; crypto.subtle accepts this as a JWK
+// shape, which is sufficient to confirm the import path validates the key
+// material structurally.
+const VALID_ED25519_X = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+
+describe('jwks-resolver key validation (Commit 3.1 Fix #1)', () => {
+  it('valid Ed25519 JWK succeeds and is cached', async () => {
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: {
+        keys: [{ kty: 'OKP', crv: 'Ed25519', kid: 'k1', x: VALID_ED25519_X }],
+      },
+    });
+    const resolver = new IssuerJwksResolver();
+    const result = await resolver.resolve(
+      'https://issuer.example.com',
+      'https://issuer.example.com/jwks',
+      'k1'
+    );
+    expect(result.ok).toBe(true);
+    expect(resolver.cacheSize).toBe(1);
+  });
+
+  it('structurally plausible but cryptographically invalid Ed25519 key (wrong x length) is rejected', async () => {
+    // x must be 32 bytes (~43 base64url chars). 'short' decodes to 3 bytes.
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { keys: [{ kty: 'OKP', crv: 'Ed25519', kid: 'k1', x: 'short' }] },
+    });
+    const resolver = new IssuerJwksResolver();
+    const result = await resolver.resolve(
+      'https://issuer.example.com',
+      'https://issuer.example.com/jwks',
+      'k1'
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('jwks_invalid_shape');
+    // Critically: the invalid key was NOT cached
+    expect(resolver.cacheSize).toBe(0);
+  });
+
+  it('wrong curve (Ed448 in OKP) is rejected by importJwkAsEd25519', async () => {
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: {
+        keys: [{ kty: 'OKP', crv: 'Ed448', kid: 'k1', x: VALID_ED25519_X }],
+      },
+    });
+    const resolver = new IssuerJwksResolver();
+    const result = await resolver.resolve(
+      'https://issuer.example.com',
+      'https://issuer.example.com/jwks',
+      'k1'
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('jwks_invalid_shape');
+    expect(resolver.cacheSize).toBe(0);
+  });
+
+  it('wrong key type (RSA shape with kty=OKP) is rejected', async () => {
+    // Garbage x with wrong padding/length. crypto.subtle.importKey('jwk', ...)
+    // throws on shape mismatch.
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { keys: [{ kty: 'OKP', crv: 'Ed25519', kid: 'k1', x: '!!!@@@###' }] },
+    });
+    const resolver = new IssuerJwksResolver();
+    const result = await resolver.resolve(
+      'https://issuer.example.com',
+      'https://issuer.example.com/jwks',
+      'k1'
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('jwks_invalid_shape');
+  });
+});

--- a/packages/resolver-http/__tests__/jwks-resolver.no-throw.test.ts
+++ b/packages/resolver-http/__tests__/jwks-resolver.no-throw.test.ts
@@ -1,0 +1,83 @@
+// jwks-resolver no-throw invariant.
+// Missing kid / malformed JWKS / network failure / pre-check rejection
+// NEVER throw; always discriminated-union failure.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+  NET_CODES,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { fetchAndValidateJwks, IssuerJwksResolver, findKeyByKid } from '../src/jwks-resolver.js';
+
+beforeEach(() => {
+  resetMock();
+});
+
+describe('jwks-resolver no-throw invariant', () => {
+  it('missing kid never throws', async () => {
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { keys: [] },
+    });
+    const resolver = new IssuerJwksResolver();
+    await expect(
+      resolver.resolve('https://issuer.example.com', 'https://issuer.example.com/jwks', 'absent')
+    ).resolves.toBeDefined();
+  });
+
+  it('malformed JWKS body never throws', async () => {
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: { not_keys: 'malformed' },
+    });
+    await expect(fetchAndValidateJwks('https://issuer.example.com/jwks')).resolves.toBeDefined();
+  });
+
+  it('network failure never throws', async () => {
+    enqueue('safeFetchJWKS', { ok: false, code: NET_CODES.E_NETWORK_ERROR });
+    await expect(fetchAndValidateJwks('https://issuer.example.com/jwks')).resolves.toBeDefined();
+  });
+
+  it('pre-fetch URL rejection (metadata-IP) never throws', async () => {
+    await expect(fetchAndValidateJwks('https://169.254.169.254/jwks')).resolves.toBeDefined();
+  });
+
+  it('non-HTTPS URL never throws', async () => {
+    await expect(fetchAndValidateJwks('http://issuer.example.com/jwks')).resolves.toBeDefined();
+  });
+
+  it('malformed jwks_uri never throws', async () => {
+    await expect(fetchAndValidateJwks('not-a-url')).resolves.toBeDefined();
+  });
+
+  it('malformed issuer URL in resolve() never throws', async () => {
+    const resolver = new IssuerJwksResolver();
+    await expect(
+      resolver.resolve('not-a-url', 'https://issuer.example.com/jwks', 'k1')
+    ).resolves.toBeDefined();
+  });
+
+  it('findKeyByKid with empty JWKS returns null, does not throw', () => {
+    expect(findKeyByKid({ keys: [] }, 'k1')).toBeNull();
+  });
+});

--- a/packages/resolver-http/__tests__/jwks-resolver.smoke.test.ts
+++ b/packages/resolver-http/__tests__/jwks-resolver.smoke.test.ts
@@ -104,7 +104,7 @@ describe('jwks-resolver smoke', () => {
       'k1'
     );
     expect(b.ok).toBe(true);
-    // Still 1 — second call served from cache.
+    // Still 1 ; second call served from cache.
     expect(mockSafeFetchJWKS).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/resolver-http/__tests__/jwks-resolver.smoke.test.ts
+++ b/packages/resolver-http/__tests__/jwks-resolver.smoke.test.ts
@@ -1,0 +1,127 @@
+// JWKS resolver smoke test.
+// Issuer URL + jwks_uri + kid → resolves to a JWK; second call hits cache.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { IssuerJwksResolver, fetchAndValidateJwks, findKeyByKid } from '../src/jwks-resolver.js';
+
+beforeEach(() => {
+  resetMock();
+  mockSafeFetchJWKS.mockClear();
+});
+
+const VALID_JWKS = {
+  keys: [
+    {
+      kty: 'OKP',
+      crv: 'Ed25519',
+      kid: 'k1',
+      x: '11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo',
+      alg: 'EdDSA',
+      use: 'sig',
+    },
+  ],
+};
+
+describe('jwks-resolver smoke', () => {
+  it('fetchAndValidateJwks returns parsed JWKS on happy path', async () => {
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: VALID_JWKS,
+    });
+    const result = await fetchAndValidateJwks('https://issuer.example.com/jwks');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.jwks.keys).toHaveLength(1);
+      expect(result.jwks.keys[0].kid).toBe('k1');
+    }
+  });
+
+  it('findKeyByKid returns the right key', () => {
+    const found = findKeyByKid(VALID_JWKS, 'k1');
+    expect(found?.kid).toBe('k1');
+    expect(findKeyByKid(VALID_JWKS, 'absent')).toBeNull();
+  });
+
+  it('IssuerJwksResolver.resolve returns the matched JWK on first call', async () => {
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: VALID_JWKS,
+    });
+    const resolver = new IssuerJwksResolver();
+    const result = await resolver.resolve(
+      'https://issuer.example.com',
+      'https://issuer.example.com/jwks',
+      'k1'
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.jwk.kid).toBe('k1');
+    }
+  });
+
+  it('second call hits cache (no second upstream fetch)', async () => {
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: VALID_JWKS,
+    });
+    const resolver = new IssuerJwksResolver();
+    const a = await resolver.resolve(
+      'https://issuer.example.com',
+      'https://issuer.example.com/jwks',
+      'k1'
+    );
+    expect(a.ok).toBe(true);
+    expect(mockSafeFetchJWKS).toHaveBeenCalledTimes(1);
+
+    const b = await resolver.resolve(
+      'https://issuer.example.com',
+      'https://issuer.example.com/jwks',
+      'k1'
+    );
+    expect(b.ok).toBe(true);
+    // Still 1 — second call served from cache.
+    expect(mockSafeFetchJWKS).toHaveBeenCalledTimes(1);
+  });
+
+  it('kid-not-found surfaces jwks_kid_not_found', async () => {
+    enqueue('safeFetchJWKS', {
+      ok: true,
+      status: 200,
+      contentType: 'application/json',
+      body: VALID_JWKS,
+    });
+    const resolver = new IssuerJwksResolver();
+    const result = await resolver.resolve(
+      'https://issuer.example.com',
+      'https://issuer.example.com/jwks',
+      'absent-kid'
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('jwks_kid_not_found');
+  });
+});

--- a/packages/resolver-http/__tests__/jwks-resolver.upstream-code-drift.test.ts
+++ b/packages/resolver-http/__tests__/jwks-resolver.upstream-code-drift.test.ts
@@ -1,0 +1,102 @@
+// Upstream-code drift coverage for @peac/jwks-cache (Plan Fix #4 mirror).
+//
+// Imports the actual @peac/jwks-cache.ErrorCodes via vi.importActual and
+// asserts every current upstream JWKS error code is either:
+//   - mapped by resolver-http (MAPPED_JWKS_CODES); or
+//   - explicitly listed as internal-only / unreachable in our composed
+//     path because we do NOT call resolveKey/createResolver
+//     (EXPLICITLY_INTERNAL_ONLY_JWKS_CODES).
+//
+// If @peac/jwks-cache adds a new E_JWKS_* / E_SSRF_* / E_KEY_NOT_FOUND code,
+// this test fails loudly so the resolver-http error mapping gets a conscious
+// extension before merge.
+
+import { describe, it, expect } from 'vitest';
+
+// This test does NOT mock @peac/jwks-cache. We import the real codes directly
+// so the assertion runs against the actual current public enum.
+import { ErrorCodes } from '@peac/jwks-cache';
+
+// Codes that resolver-http surfaces directly (via either pre-fetch validateUrl
+// throwing a JwksError or local body-validator emitting a derived code).
+const MAPPED_JWKS_CODES: ReadonlySet<string> = new Set([
+  // Pre-fetch URL pre-check via validateUrl throws JwksError({code: SSRF_BLOCKED, ...})
+  // which resolver-http maps to fetch_blocked_ssrf or fetch_blocked_metadata_ip.
+  'E_SSRF_BLOCKED',
+  // Local body-validator surfaces this via jwks_invalid_shape on the resolver-http
+  // boundary; jwks-cache's own E_JWKS_INVALID is the symbol class match.
+  'E_JWKS_INVALID',
+  // Local body-validator surfaces this via jwks_invalid_shape (max-keys cap fires).
+  'E_JWKS_TOO_MANY_KEYS',
+  // resolver-http does NOT call resolveKey, so E_KEY_NOT_FOUND from jwks-cache
+  // never surfaces from jwks-cache directly. resolver-http emits its OWN
+  // jwks_kid_not_found from its local kid-lookup; the symbol class from
+  // jwks-cache is a stable identifier that resolver-http's mapping plan
+  // references as "the equivalent class".
+  'E_KEY_NOT_FOUND',
+]);
+
+// Codes that jwks-cache may emit but that resolver-http intentionally does
+// NOT surface from jwks-cache directly because resolver-http does its OWN
+// network fetch via fetchJwksSafe (NOT through jwks-cache's resolveKey).
+// These would only surface if resolver-http called resolveKey/createResolver
+// (which is forbidden per plan Fix #3).
+const EXPLICITLY_INTERNAL_ONLY_JWKS_CODES: ReadonlySet<string> = new Set([
+  // Network errors come from fetchJwksSafe (net-node-backed), NOT from
+  // jwks-cache's internal fetchWithTimeout. The codes below are unreachable
+  // from resolver-http's composed path.
+  'E_JWKS_FETCH_FAILED',
+  'E_JWKS_TIMEOUT',
+  // Body-too-large is enforced upstream by net-node's response_too_large
+  // (which fetch-safe maps to fetch_blocked_byte_cap). jwks-cache's own
+  // E_JWKS_TOO_LARGE only fires from its internal fetch path, which we
+  // do not call.
+  'E_JWKS_TOO_LARGE',
+  // E_ALL_PATHS_FAILED is multi-path discovery; resolver-http does not
+  // multi-path. Unreachable from our composed path.
+  'E_ALL_PATHS_FAILED',
+]);
+
+describe('jwks-resolver upstream-code drift (@peac/jwks-cache)', () => {
+  it('every actual @peac/jwks-cache.ErrorCodes value is either mapped or explicitly internal', () => {
+    const actualCodes = Object.values(ErrorCodes) as string[];
+    expect(actualCodes.length).toBeGreaterThan(0);
+
+    const undecided: string[] = [];
+    for (const code of actualCodes) {
+      const decided = MAPPED_JWKS_CODES.has(code) || EXPLICITLY_INTERNAL_ONLY_JWKS_CODES.has(code);
+      if (!decided) undecided.push(code);
+    }
+
+    expect(
+      undecided,
+      `New upstream @peac/jwks-cache code(s) without a conscious mapping decision: ${undecided.join(', ')}. ` +
+        `Add to MAPPED_JWKS_CODES (and update resolver-http error mapping) or ` +
+        `EXPLICITLY_INTERNAL_ONLY_JWKS_CODES with a rationale comment.`
+    ).toEqual([]);
+  });
+
+  it('every code in MAPPED_JWKS_CODES exists in the actual upstream enum (no stale entries)', () => {
+    const actualValues = new Set(Object.values(ErrorCodes) as string[]);
+    const stale: string[] = [];
+    for (const mapped of MAPPED_JWKS_CODES) {
+      if (!actualValues.has(mapped)) stale.push(mapped);
+    }
+    expect(
+      stale,
+      `Stale entries in MAPPED_JWKS_CODES (no longer in upstream): ${stale.join(', ')}`
+    ).toEqual([]);
+  });
+
+  it('every code in EXPLICITLY_INTERNAL_ONLY_JWKS_CODES exists in the actual upstream enum', () => {
+    const actualValues = new Set(Object.values(ErrorCodes) as string[]);
+    const stale: string[] = [];
+    for (const internal of EXPLICITLY_INTERNAL_ONLY_JWKS_CODES) {
+      if (!actualValues.has(internal)) stale.push(internal);
+    }
+    expect(
+      stale,
+      `Stale entries in EXPLICITLY_INTERNAL_ONLY_JWKS_CODES (no longer in upstream): ${stale.join(', ')}`
+    ).toEqual([]);
+  });
+});

--- a/packages/resolver-http/__tests__/parity.pointer-fetch.test.ts
+++ b/packages/resolver-http/__tests__/parity.pointer-fetch.test.ts
@@ -1,0 +1,147 @@
+// Real public-API parity test against @peac/protocol's pointer-fetch.
+//
+// Imports ONLY public @peac/protocol exports (`fetchPointerWithDigest` and
+// public types). Compares NORMALIZED behavior classes only — not internal
+// error code strings or implementation internals. The full cross-
+// implementation byte-equal harness over fetched bodies belongs to Commit 4
+// (which adds dispatcher-mock infrastructure to drive both code paths
+// through synthetic responses).
+//
+// This test exercises the no-network cases (non-HTTPS URL pre-check;
+// invalid expected-digest format) where both paths short-circuit before any
+// network attempt. That is sufficient for "real parity" as a starting
+// point. Body-fetch parity is Commit 4 scope.
+//
+// Parity test files are the ONLY allowed location for @peac/protocol
+// imports under packages/resolver-http/. Runtime source and shared helpers
+// MUST NOT import @peac/protocol.
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  fetchPointerWithDigest as protocolFetchPointer,
+  type PointerFetchResult as ProtocolPointerResult,
+} from '@peac/protocol';
+
+import {
+  fetchPointerWithDigest as resolverHttpFetchPointer,
+  type PointerFetchResult as ResolverPointerResult,
+} from '../src/pointer-fetch.js';
+
+/**
+ * Normalized behavior class. Both implementations use different specific
+ * error codes; the parity test compares classes only.
+ */
+type NormalizedClass =
+  | 'success'
+  | 'url_blocked'
+  | 'invalid_digest_input'
+  | 'malformed_body'
+  | 'digest_mismatch'
+  | 'fetch_failure';
+
+function normalizeProtocol(result: ProtocolPointerResult): NormalizedClass {
+  if (result.ok) return 'success';
+  switch (result.reason) {
+    case 'pointer_fetch_blocked':
+      return 'url_blocked';
+    case 'pointer_digest_mismatch':
+      return 'digest_mismatch';
+    case 'malformed_receipt':
+      return 'malformed_body';
+    case 'pointer_fetch_failed':
+    case 'pointer_fetch_timeout':
+    case 'pointer_fetch_too_large':
+      return 'fetch_failure';
+    default:
+      return 'fetch_failure';
+  }
+}
+
+function normalizeResolver(result: ResolverPointerResult): NormalizedClass {
+  if (result.ok) return 'success';
+  switch (result.code) {
+    case 'pointer_fetch_blocked':
+      return 'url_blocked';
+    case 'pointer_digest_mismatch':
+      return 'digest_mismatch';
+    case 'pointer_malformed_jws':
+      return 'malformed_body';
+    case 'fetch_blocked_https_only':
+      return 'url_blocked';
+    case 'fetch_blocked_ssrf':
+    case 'fetch_blocked_metadata_ip':
+    case 'fetch_blocked_redirect':
+    case 'fetch_blocked_dangerous_port':
+      return 'url_blocked';
+    case 'fetch_timeout':
+    case 'fetch_network_error':
+    case 'fetch_blocked_byte_cap':
+    case 'fetch_status_4xx':
+    case 'fetch_status_5xx':
+    case 'fetch_invalid_content_type':
+    case 'resolver_internal_error':
+      return 'fetch_failure';
+    default:
+      return 'fetch_failure';
+  }
+}
+
+const VALID_HEX_64 = '0'.repeat(64);
+
+describe('parity: pointer-fetch normalized class agreement (no-network cases)', () => {
+  it('non-HTTPS URL: both surface url_blocked', async () => {
+    const url = 'http://issuer.example.com/r';
+    const proto = await protocolFetchPointer({ url, expectedDigest: VALID_HEX_64 });
+    const ours = await resolverHttpFetchPointer(url, VALID_HEX_64);
+    expect(normalizeProtocol(proto)).toBe('url_blocked');
+    expect(normalizeResolver(ours)).toBe('url_blocked');
+    // Class agreement
+    expect(normalizeResolver(ours)).toBe(normalizeProtocol(proto));
+  });
+
+  it('javascript: scheme URL: both surface url_blocked', async () => {
+    const url = 'javascript:alert(1)';
+    const proto = await protocolFetchPointer({ url, expectedDigest: VALID_HEX_64 });
+    const ours = await resolverHttpFetchPointer(url, VALID_HEX_64);
+    expect(normalizeProtocol(proto)).toBe('url_blocked');
+    expect(normalizeResolver(ours)).toBe('url_blocked');
+    expect(normalizeResolver(ours)).toBe(normalizeProtocol(proto));
+  });
+
+  it('invalid expected-digest format: both surface a non-success failure', async () => {
+    // Protocol uses pointer_fetch_failed for invalid digest input;
+    // resolver-http uses pointer_fetch_blocked. Both are non-success
+    // discriminated-union failures at the boundary. Normalized class
+    // agreement: both are pre-fetch failures (not 'success').
+    const url = 'https://issuer.example.com/r';
+    const proto = await protocolFetchPointer({ url, expectedDigest: 'not-a-digest' });
+    const ours = await resolverHttpFetchPointer(url, 'not-a-digest');
+    expect(proto.ok).toBe(false);
+    expect(ours.ok).toBe(false);
+    // Both implementations short-circuit at the boundary without network
+    // access — class agreement on "not success".
+    const protoClass = normalizeProtocol(proto);
+    const oursClass = normalizeResolver(ours);
+    expect(protoClass).not.toBe('success');
+    expect(oursClass).not.toBe('success');
+  });
+
+  it('uppercase hex digest: both reject (lowercase rule)', async () => {
+    const url = 'https://issuer.example.com/r';
+    const upper = 'A'.repeat(64);
+    const proto = await protocolFetchPointer({ url, expectedDigest: upper });
+    const ours = await resolverHttpFetchPointer(url, upper);
+    expect(proto.ok).toBe(false);
+    expect(ours.ok).toBe(false);
+  });
+
+  it('parity test imports only public @peac/protocol exports', () => {
+    // Self-test: assert the imports above are the only @peac/protocol
+    // references in this file. (Source-level discipline; shell isolation
+    // gate scopes only src + __tests__/_helpers, so this file's imports
+    // are intentionally allowed.)
+    expect(typeof protocolFetchPointer).toBe('function');
+    expect(typeof resolverHttpFetchPointer).toBe('function');
+  });
+});

--- a/packages/resolver-http/__tests__/parity.pointer-fetch.test.ts
+++ b/packages/resolver-http/__tests__/parity.pointer-fetch.test.ts
@@ -1,13 +1,19 @@
-// Public-API no-network parity SMOKE test against @peac/protocol.
+// Public-API no-network smoke against @peac/protocol's pointer-fetch.
 //
 // Imports ONLY public @peac/protocol exports (`fetchPointerWithDigest` and
-// public types). Compares NORMALIZED behavior classes only ; not internal
-// error code strings or implementation internals. This is an explicit
-// SMOKE-level test, not full parity: it covers only the no-network short-
-// circuit cases (non-HTTPS URL; invalid expected-digest format) where both
-// paths fail before any network attempt. Body-fetch parity, byte-equal
-// digest parity, and full error-class parity are Commit 4's harness scope
-// (dispatcher mocks drive both implementations through synthetic responses).
+// public types). Compares NORMALIZED behavior classes only; not internal
+// error code strings or implementation internals.
+//
+// Scope: explicit SMOKE-level test, NOT full parity. Covers only the
+// no-network short-circuit cases (non-HTTPS URL; invalid expected-digest
+// format) where both paths fail before any network attempt.
+//
+// True cross-implementation pointer parity (body-fetch, byte-equal digest,
+// full error-class agreement, redaction parity, content-type warning class
+// agreement) is RE-HOMED to PR B's apps/api shadow-mode harness, where both
+// implementations naturally run side by side against the same fetched
+// response set. See plan PR B section "Cross-implementation pointer parity
+// gate (RE-HOMED from Commit 4 of PR A)".
 //
 // Parity test files are the ONLY allowed location for @peac/protocol
 // imports under packages/resolver-http/. Runtime source and shared helpers
@@ -108,7 +114,7 @@ function normalizeResolver(result: ResolverPointerResult): NormalizedClass {
 
 const VALID_HEX_64 = '0'.repeat(64);
 
-describe('parity smoke: pointer-fetch normalized class agreement (no-network cases)', () => {
+describe('public-API no-network smoke: pointer-fetch normalized class agreement (true parity is PR B shadow-mode scope)', () => {
   it('non-HTTPS URL: both surface url_blocked', async () => {
     const url = 'http://issuer.example.com/r';
     const proto = await protocolFetchPointer({ url, expectedDigest: VALID_HEX_64 });

--- a/packages/resolver-http/__tests__/parity.pointer-fetch.test.ts
+++ b/packages/resolver-http/__tests__/parity.pointer-fetch.test.ts
@@ -1,16 +1,13 @@
-// Real public-API parity test against @peac/protocol's pointer-fetch.
+// Public-API no-network parity SMOKE test against @peac/protocol.
 //
 // Imports ONLY public @peac/protocol exports (`fetchPointerWithDigest` and
-// public types). Compares NORMALIZED behavior classes only — not internal
-// error code strings or implementation internals. The full cross-
-// implementation byte-equal harness over fetched bodies belongs to Commit 4
-// (which adds dispatcher-mock infrastructure to drive both code paths
-// through synthetic responses).
-//
-// This test exercises the no-network cases (non-HTTPS URL pre-check;
-// invalid expected-digest format) where both paths short-circuit before any
-// network attempt. That is sufficient for "real parity" as a starting
-// point. Body-fetch parity is Commit 4 scope.
+// public types). Compares NORMALIZED behavior classes only ; not internal
+// error code strings or implementation internals. This is an explicit
+// SMOKE-level test, not full parity: it covers only the no-network short-
+// circuit cases (non-HTTPS URL; invalid expected-digest format) where both
+// paths fail before any network attempt. Body-fetch parity, byte-equal
+// digest parity, and full error-class parity are Commit 4's harness scope
+// (dispatcher mocks drive both implementations through synthetic responses).
 //
 // Parity test files are the ONLY allowed location for @peac/protocol
 // imports under packages/resolver-http/. Runtime source and shared helpers
@@ -30,7 +27,7 @@ import {
 
 /**
  * Normalized behavior class. Both implementations use different specific
- * error codes; the parity test compares classes only.
+ * error codes; this smoke test compares the broader class only.
  */
 type NormalizedClass =
   | 'success'
@@ -40,6 +37,16 @@ type NormalizedClass =
   | 'digest_mismatch'
   | 'fetch_failure';
 
+/**
+ * Map protocol's pointer-fetch result to a normalized class.
+ *
+ * Protocol uses `pointer_fetch_failed` for invalid digest input (per
+ * `packages/protocol/src/pointer-fetch.ts:155-160`). When the message
+ * contains "Invalid expected digest" we treat the failure as
+ * `invalid_digest_input` rather than the generic `fetch_failure` bucket so
+ * that resolver-http's dedicated `pointer_invalid_expected_digest` code
+ * normalizes to the same class.
+ */
 function normalizeProtocol(result: ProtocolPointerResult): NormalizedClass {
   if (result.ok) return 'success';
   switch (result.reason) {
@@ -50,6 +57,16 @@ function normalizeProtocol(result: ProtocolPointerResult): NormalizedClass {
     case 'malformed_receipt':
       return 'malformed_body';
     case 'pointer_fetch_failed':
+      // Protocol re-uses pointer_fetch_failed for invalid digest input
+      // (a programmer-error class) AND for generic fetch failures. Use
+      // the message string as the normalization signal.
+      if (
+        typeof result.message === 'string' &&
+        result.message.toLowerCase().includes('invalid expected digest')
+      ) {
+        return 'invalid_digest_input';
+      }
+      return 'fetch_failure';
     case 'pointer_fetch_timeout':
     case 'pointer_fetch_too_large':
       return 'fetch_failure';
@@ -61,6 +78,8 @@ function normalizeProtocol(result: ProtocolPointerResult): NormalizedClass {
 function normalizeResolver(result: ResolverPointerResult): NormalizedClass {
   if (result.ok) return 'success';
   switch (result.code) {
+    case 'pointer_invalid_expected_digest':
+      return 'invalid_digest_input';
     case 'pointer_fetch_blocked':
       return 'url_blocked';
     case 'pointer_digest_mismatch':
@@ -89,7 +108,7 @@ function normalizeResolver(result: ResolverPointerResult): NormalizedClass {
 
 const VALID_HEX_64 = '0'.repeat(64);
 
-describe('parity: pointer-fetch normalized class agreement (no-network cases)', () => {
+describe('parity smoke: pointer-fetch normalized class agreement (no-network cases)', () => {
   it('non-HTTPS URL: both surface url_blocked', async () => {
     const url = 'http://issuer.example.com/r';
     const proto = await protocolFetchPointer({ url, expectedDigest: VALID_HEX_64 });
@@ -109,22 +128,17 @@ describe('parity: pointer-fetch normalized class agreement (no-network cases)', 
     expect(normalizeResolver(ours)).toBe(normalizeProtocol(proto));
   });
 
-  it('invalid expected-digest format: both surface a non-success failure', async () => {
+  it('invalid expected-digest format: both surface invalid_digest_input', async () => {
     // Protocol uses pointer_fetch_failed for invalid digest input;
-    // resolver-http uses pointer_fetch_blocked. Both are non-success
-    // discriminated-union failures at the boundary. Normalized class
-    // agreement: both are pre-fetch failures (not 'success').
+    // resolver-http uses pointer_invalid_expected_digest (Commit 3.1
+    // Plan Fix #3). The normalization function maps both to the
+    // invalid_digest_input class.
     const url = 'https://issuer.example.com/r';
     const proto = await protocolFetchPointer({ url, expectedDigest: 'not-a-digest' });
     const ours = await resolverHttpFetchPointer(url, 'not-a-digest');
-    expect(proto.ok).toBe(false);
-    expect(ours.ok).toBe(false);
-    // Both implementations short-circuit at the boundary without network
-    // access — class agreement on "not success".
-    const protoClass = normalizeProtocol(proto);
-    const oursClass = normalizeResolver(ours);
-    expect(protoClass).not.toBe('success');
-    expect(oursClass).not.toBe('success');
+    expect(normalizeProtocol(proto)).toBe('invalid_digest_input');
+    expect(normalizeResolver(ours)).toBe('invalid_digest_input');
+    expect(normalizeResolver(ours)).toBe(normalizeProtocol(proto));
   });
 
   it('uppercase hex digest: both reject (lowercase rule)', async () => {

--- a/packages/resolver-http/__tests__/pointer-fetch.content-type-warn.test.ts
+++ b/packages/resolver-http/__tests__/pointer-fetch.content-type-warn.test.ts
@@ -30,7 +30,14 @@ vi.mock('@peac/net-node', async () => {
 
 import { fetchPointerWithDigest } from '../src/pointer-fetch.js';
 
-const VALID_JWS = 'aGVhZGVy.cGF5bG9hZA.c2lnbmF0dXJl';
+// Compact-like JWS string: 3 base64url segments (matches COMPACT_JWS_REGEX)
+// but NOT a real signed JWS. The protected header decodes to 'header' (not
+// JSON) and the signature is not real Ed25519 material. resolver-http's
+// pointer-fetch only validates 3-segment base64url shape before computing
+// the digest, so this fixture is sufficient for digest / content-type /
+// redaction tests. Commit 4 will introduce real signed-JWS fixtures for
+// cross-implementation byte-equal parity.
+const COMPACT_LIKE_JWS = 'aGVhZGVy.cGF5bG9hZA.c2lnbmF0dXJl';
 
 beforeEach(() => {
   resetMock();
@@ -43,11 +50,11 @@ describe('pointer-fetch content-type warn', () => {
         ok: true,
         status: 200,
         contentType: accepted,
-        body: VALID_JWS,
+        body: COMPACT_LIKE_JWS,
       });
       const result = await fetchPointerWithDigest(
         'https://issuer.example.com/r',
-        await sha256Hex(VALID_JWS)
+        await sha256Hex(COMPACT_LIKE_JWS)
       );
       expect(result.ok).toBe(true);
       if (result.ok) expect(result.contentTypeWarning).toBeUndefined();
@@ -59,11 +66,11 @@ describe('pointer-fetch content-type warn', () => {
       ok: true,
       status: 200,
       contentType: 'text/html; charset=utf-8',
-      body: VALID_JWS,
+      body: COMPACT_LIKE_JWS,
     });
     const result = await fetchPointerWithDigest(
       'https://issuer.example.com/r',
-      await sha256Hex(VALID_JWS)
+      await sha256Hex(COMPACT_LIKE_JWS)
     );
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -78,11 +85,11 @@ describe('pointer-fetch content-type warn', () => {
       ok: true,
       status: 200,
       contentType: longCT,
-      body: VALID_JWS,
+      body: COMPACT_LIKE_JWS,
     });
     const result = await fetchPointerWithDigest(
       'https://issuer.example.com/r',
-      await sha256Hex(VALID_JWS)
+      await sha256Hex(COMPACT_LIKE_JWS)
     );
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -94,7 +101,7 @@ describe('pointer-fetch content-type warn', () => {
   it('warning contains NO body bytes / URL path / headers / secrets', async () => {
     // Server returns text/html body (still a valid 3-segment JWS string for digest).
     // The warning must not pull body bytes or URL path/query into its string.
-    const sensitiveBody = VALID_JWS; // valid JWS so digest succeeds
+    const sensitiveBody = COMPACT_LIKE_JWS; // valid JWS so digest succeeds
     enqueue('safeFetchRaw', {
       ok: true,
       status: 200,
@@ -127,11 +134,11 @@ describe('pointer-fetch content-type warn', () => {
       ok: true,
       status: 200,
       contentType: 'application/jose; charset=utf-8',
-      body: VALID_JWS,
+      body: COMPACT_LIKE_JWS,
     });
     const result = await fetchPointerWithDigest(
       'https://issuer.example.com/r',
-      await sha256Hex(VALID_JWS)
+      await sha256Hex(COMPACT_LIKE_JWS)
     );
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -145,11 +152,11 @@ describe('pointer-fetch content-type warn', () => {
       ok: true,
       status: 200,
       // no contentType set
-      body: VALID_JWS,
+      body: COMPACT_LIKE_JWS,
     });
     const result = await fetchPointerWithDigest(
       'https://issuer.example.com/r',
-      await sha256Hex(VALID_JWS)
+      await sha256Hex(COMPACT_LIKE_JWS)
     );
     expect(result.ok).toBe(true);
     if (result.ok) {

--- a/packages/resolver-http/__tests__/pointer-fetch.content-type-warn.test.ts
+++ b/packages/resolver-http/__tests__/pointer-fetch.content-type-warn.test.ts
@@ -1,0 +1,159 @@
+// pointer-fetch content-type warn (Plan Fix #4 + Commit 3.0.1 Fix #5 safety).
+//
+// Mirror protocol behavior: content-type outside the expected set is NOT a
+// failure; success result carries a bounded contentTypeWarning string.
+// resolver-http MUST NOT pass acceptContentTypes to fetchRawSafe on this
+// path. Warning is bounded ≤ 200 chars; contains only the upstream
+// content-type value (already public response metadata) plus a stable class
+// label. No body bytes / URL path / query / headers / secrets in warning.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { sha256Hex } from '@peac/crypto';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { fetchPointerWithDigest } from '../src/pointer-fetch.js';
+
+const VALID_JWS = 'aGVhZGVy.cGF5bG9hZA.c2lnbmF0dXJl';
+
+beforeEach(() => {
+  resetMock();
+});
+
+describe('pointer-fetch content-type warn', () => {
+  for (const accepted of ['application/jose', 'application/json', 'text/plain']) {
+    it(`${accepted} succeeds with NO warning`, async () => {
+      enqueue('safeFetchRaw', {
+        ok: true,
+        status: 200,
+        contentType: accepted,
+        body: VALID_JWS,
+      });
+      const result = await fetchPointerWithDigest(
+        'https://issuer.example.com/r',
+        await sha256Hex(VALID_JWS)
+      );
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.contentTypeWarning).toBeUndefined();
+    });
+  }
+
+  it('text/html content-type with correct digest succeeds (warn, do not reject)', async () => {
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'text/html; charset=utf-8',
+      body: VALID_JWS,
+    });
+    const result = await fetchPointerWithDigest(
+      'https://issuer.example.com/r',
+      await sha256Hex(VALID_JWS)
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.contentTypeWarning).toBeDefined();
+      expect(result.contentTypeWarning).toMatch(/unexpected_content_type/);
+    }
+  });
+
+  it('warning is bounded (<=200 chars)', async () => {
+    const longCT = `application/x-` + 'a'.repeat(500); // 514 chars
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: longCT,
+      body: VALID_JWS,
+    });
+    const result = await fetchPointerWithDigest(
+      'https://issuer.example.com/r',
+      await sha256Hex(VALID_JWS)
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.contentTypeWarning).toBeDefined();
+      expect(result.contentTypeWarning!.length).toBeLessThanOrEqual(200);
+    }
+  });
+
+  it('warning contains NO body bytes / URL path / headers / secrets', async () => {
+    // Server returns text/html body (still a valid 3-segment JWS string for digest).
+    // The warning must not pull body bytes or URL path/query into its string.
+    const sensitiveBody = VALID_JWS; // valid JWS so digest succeeds
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'text/xml',
+      body: sensitiveBody,
+    });
+    const result = await fetchPointerWithDigest(
+      'https://issuer.example.com/path/with/secrets?token=abc&kid=def',
+      await sha256Hex(sensitiveBody)
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok && result.contentTypeWarning) {
+      const warning = result.contentTypeWarning;
+      expect(warning).not.toContain('Bearer');
+      expect(warning).not.toContain('Cookie');
+      expect(warning).not.toContain('Authorization');
+      expect(warning).not.toContain('token=');
+      expect(warning).not.toContain('kid=');
+      expect(warning).not.toContain('/path/with/secrets');
+      expect(warning).not.toContain(sensitiveBody);
+      // Warning DOES contain the safe stable class label and the upstream
+      // content-type value (already public response metadata).
+      expect(warning).toContain('unexpected_content_type');
+      expect(warning).toContain('text/xml');
+    }
+  });
+
+  it('content-type pre-check tolerates parameters (charset)', async () => {
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'application/jose; charset=utf-8',
+      body: VALID_JWS,
+    });
+    const result = await fetchPointerWithDigest(
+      'https://issuer.example.com/r',
+      await sha256Hex(VALID_JWS)
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // application/jose; charset=utf-8 should NOT trigger the warning.
+      expect(result.contentTypeWarning).toBeUndefined();
+    }
+  });
+
+  it('absent content-type does NOT trigger warning', async () => {
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      // no contentType set
+      body: VALID_JWS,
+    });
+    const result = await fetchPointerWithDigest(
+      'https://issuer.example.com/r',
+      await sha256Hex(VALID_JWS)
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.contentTypeWarning).toBeUndefined();
+    }
+  });
+});

--- a/packages/resolver-http/__tests__/pointer-fetch.digest.test.ts
+++ b/packages/resolver-http/__tests__/pointer-fetch.digest.test.ts
@@ -28,16 +28,23 @@ beforeEach(() => {
   resetMock();
 });
 
-const VALID_JWS = 'aGVhZGVy.cGF5bG9hZA.c2lnbmF0dXJl';
+// Compact-like JWS string: 3 base64url segments (matches COMPACT_JWS_REGEX)
+// but NOT a real signed JWS. The protected header decodes to 'header' (not
+// JSON) and the signature is not real Ed25519 material. resolver-http's
+// pointer-fetch only validates 3-segment base64url shape before computing
+// the digest, so this fixture is sufficient for digest / content-type /
+// redaction tests. Commit 4 will introduce real signed-JWS fixtures for
+// cross-implementation byte-equal parity.
+const COMPACT_LIKE_JWS = 'aGVhZGVy.cGF5bG9hZA.c2lnbmF0dXJl';
 
 describe('pointer-fetch digest semantics (string-mode)', () => {
   it('ASCII compact JWS body: digest matches', async () => {
-    const expected = await sha256Hex(VALID_JWS);
+    const expected = await sha256Hex(COMPACT_LIKE_JWS);
     enqueue('safeFetchRaw', {
       ok: true,
       status: 200,
       contentType: 'application/jose',
-      body: VALID_JWS,
+      body: COMPACT_LIKE_JWS,
     });
     const result = await fetchPointerWithDigest('https://issuer.example.com/r', expected);
     expect(result.ok).toBe(true);
@@ -65,7 +72,7 @@ describe('pointer-fetch digest semantics (string-mode)', () => {
   });
 
   it('trailing newline in valid compact JWS surfaces pointer_malformed_jws (newline is not base64url)', async () => {
-    const withNewline = `${VALID_JWS}\n`;
+    const withNewline = `${COMPACT_LIKE_JWS}\n`;
     enqueue('safeFetchRaw', {
       ok: true,
       status: 200,

--- a/packages/resolver-http/__tests__/pointer-fetch.digest.test.ts
+++ b/packages/resolver-http/__tests__/pointer-fetch.digest.test.ts
@@ -1,0 +1,107 @@
+// pointer-fetch digest: string-mode digest (TextDecoder UTF-8 then sha256Hex).
+// (Plan Fix #5: pointer-fetch target is a compact JWS string, not JSON.)
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { sha256Hex } from '@peac/crypto';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { fetchPointerWithDigest } from '../src/pointer-fetch.js';
+
+beforeEach(() => {
+  resetMock();
+});
+
+const VALID_JWS = 'aGVhZGVy.cGF5bG9hZA.c2lnbmF0dXJl';
+
+describe('pointer-fetch digest semantics (string-mode)', () => {
+  it('ASCII compact JWS body: digest matches', async () => {
+    const expected = await sha256Hex(VALID_JWS);
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'application/jose',
+      body: VALID_JWS,
+    });
+    const result = await fetchPointerWithDigest('https://issuer.example.com/r', expected);
+    expect(result.ok).toBe(true);
+  });
+
+  it('non-ASCII UTF-8 body decodes through TextDecoder before sha256Hex', async () => {
+    // Build a synthetic body that's still a valid 3-segment compact-JWS
+    // shape but contains a non-ASCII char in one of the segments... wait,
+    // compact JWS is base64url which is ASCII-only. So we test that if the
+    // server happens to return non-ASCII bytes we still surface
+    // pointer_malformed_jws (compact-JWS regex rejects non-base64url chars)
+    // rather than crashing on the decode.
+    const nonAscii = new TextEncoder().encode('héllo.wörld.signaturé');
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'application/jose',
+      bytes: nonAscii,
+    });
+    const result = await fetchPointerWithDigest('https://issuer.example.com/r', 'a'.repeat(64));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('pointer_malformed_jws');
+    }
+  });
+
+  it('trailing newline in valid compact JWS surfaces pointer_malformed_jws (newline is not base64url)', async () => {
+    const withNewline = `${VALID_JWS}\n`;
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'application/jose',
+      body: withNewline,
+    });
+    const result = await fetchPointerWithDigest(
+      'https://issuer.example.com/r',
+      await sha256Hex(withNewline)
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // The trailing-newline body is no longer a valid compact-JWS shape
+      // because '\n' is not base64url. resolver-http rejects with
+      // pointer_malformed_jws BEFORE the digest comparison. This matches
+      // protocol's malformed_receipt branch (newline outside the 3-segment
+      // base64url shape).
+      expect(result.code).toBe('pointer_malformed_jws');
+    }
+  });
+
+  it('digest input is the decoded UTF-8 string (sha256Hex of TextEncoder.encode of the string)', async () => {
+    // Construct a compact JWS, fetch its bytes, and assert the actualDigest
+    // matches sha256Hex(decoded-string) byte-for-byte.
+    const bodyStr = 'aGVhZGVyMg.cGF5bG9hZDI.c2lnbmF0dXJlMg';
+    const expectedFromString = await sha256Hex(bodyStr);
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'application/jose',
+      body: bodyStr,
+    });
+    const result = await fetchPointerWithDigest('https://issuer.example.com/r', expectedFromString);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.actualDigest).toBe(expectedFromString);
+    }
+  });
+});

--- a/packages/resolver-http/__tests__/pointer-fetch.malformed.test.ts
+++ b/packages/resolver-http/__tests__/pointer-fetch.malformed.test.ts
@@ -1,0 +1,120 @@
+// pointer-fetch malformed-body cases (Plan Fix #1: pointer_malformed_jws).
+// Empty body / non-3-segment / non-base64url all surface pointer_malformed_jws,
+// NOT pointer_digest_mismatch and NOT discovery_invalid_shape.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { fetchPointerWithDigest } from '../src/pointer-fetch.js';
+
+const ANY_DIGEST = '0'.repeat(64);
+
+beforeEach(() => {
+  resetMock();
+});
+
+describe('pointer-fetch malformed body', () => {
+  it('empty body surfaces pointer_malformed_jws', async () => {
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'application/jose',
+      bytes: new Uint8Array(0),
+    });
+    const result = await fetchPointerWithDigest('https://issuer.example.com/r', ANY_DIGEST);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('pointer_malformed_jws');
+  });
+
+  it('one-segment body surfaces pointer_malformed_jws (not 3-segment)', async () => {
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'application/jose',
+      body: 'oneSegment',
+    });
+    const result = await fetchPointerWithDigest('https://issuer.example.com/r', ANY_DIGEST);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('pointer_malformed_jws');
+  });
+
+  it('two-segment body surfaces pointer_malformed_jws', async () => {
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'application/jose',
+      body: 'seg1.seg2',
+    });
+    const result = await fetchPointerWithDigest('https://issuer.example.com/r', ANY_DIGEST);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('pointer_malformed_jws');
+  });
+
+  it('four-segment body surfaces pointer_malformed_jws', async () => {
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'application/jose',
+      body: 'seg1.seg2.seg3.seg4',
+    });
+    const result = await fetchPointerWithDigest('https://issuer.example.com/r', ANY_DIGEST);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('pointer_malformed_jws');
+  });
+
+  it('non-base64url chars in segments surfaces pointer_malformed_jws', async () => {
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'application/jose',
+      body: 'seg!1.seg@2.seg#3',
+    });
+    const result = await fetchPointerWithDigest('https://issuer.example.com/r', ANY_DIGEST);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('pointer_malformed_jws');
+  });
+
+  it('whitespace-only body surfaces pointer_malformed_jws', async () => {
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'application/jose',
+      body: '   ',
+    });
+    const result = await fetchPointerWithDigest('https://issuer.example.com/r', ANY_DIGEST);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('pointer_malformed_jws');
+  });
+
+  it('malformed body codes are NOT discovery_invalid_shape (Plan Fix #1)', async () => {
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'application/jose',
+      body: 'seg1.seg2',
+    });
+    const result = await fetchPointerWithDigest('https://issuer.example.com/r', ANY_DIGEST);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).not.toBe('discovery_invalid_shape');
+      expect(result.code).not.toBe('pointer_digest_mismatch');
+    }
+  });
+});

--- a/packages/resolver-http/__tests__/pointer-fetch.network-path.test.ts
+++ b/packages/resolver-http/__tests__/pointer-fetch.network-path.test.ts
@@ -1,0 +1,229 @@
+// Consolidated network-path failure-mode coverage for pointer-fetch (Commit 4).
+//
+// Each test pairs an upstream net-node failure code with the EXPECTED
+// resolver-http error code, plus asserts redaction discipline (no body /
+// URL path / query / headers / secrets in any surfaced field).
+//
+// Existing pointer-fetch.ssrf.test.ts covers SSRF + redirect classes; this
+// file adds the broader timeout / network-error / byte-cap / status / non-
+// HTTPS / redaction matrix in one place so the failure-mode contract is easy
+// to read in one diff.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+  NET_CODES,
+  type NetNodeErrorCode,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { fetchPointerWithDigest } from '../src/pointer-fetch.js';
+
+const ANY_DIGEST = '0'.repeat(64);
+
+beforeEach(() => {
+  resetMock();
+});
+
+const FORBIDDEN_PATTERNS: readonly RegExp[] = [
+  /Bearer\s+\S+/,
+  /Cookie:|Set-Cookie:/i,
+  /Authorization:/i,
+  /-----BEGIN [A-Z ]+PRIVATE KEY-----/,
+  /\?token=/,
+  /\?api_key=/,
+  /password=/i,
+];
+
+function flattenStrings(value: unknown, depth = 0, acc: string[] = []): string[] {
+  if (depth > 6) return acc;
+  if (typeof value === 'string') {
+    acc.push(value);
+    return acc;
+  }
+  if (value && typeof value === 'object') {
+    for (const v of Object.values(value as Record<string, unknown>)) {
+      flattenStrings(v, depth + 1, acc);
+    }
+  }
+  return acc;
+}
+
+function assertRedacted(result: unknown): void {
+  const allStrings = flattenStrings(result);
+  for (const s of allStrings) {
+    for (const re of FORBIDDEN_PATTERNS) {
+      expect(s).not.toMatch(re);
+    }
+    expect(s).not.toContain('/path/with/secrets');
+    expect(s).not.toContain('?token=');
+    expect(s).not.toContain('kid-of-secret');
+  }
+}
+
+const SENSITIVE_URL = 'https://issuer.example.com/path/with/secrets?token=abc&kid=kid-of-secret';
+
+interface NetworkCase {
+  label: string;
+  upstream: NetNodeErrorCode;
+  expected:
+    | 'fetch_timeout'
+    | 'fetch_network_error'
+    | 'fetch_blocked_byte_cap'
+    | 'fetch_blocked_redirect'
+    | 'fetch_blocked_ssrf';
+}
+
+const NETWORK_CASES: readonly NetworkCase[] = [
+  // Timeouts
+  { label: 'request timeout', upstream: NET_CODES.E_REQUEST_TIMEOUT, expected: 'fetch_timeout' },
+  { label: 'DNS timeout', upstream: NET_CODES.E_DNS_TIMEOUT, expected: 'fetch_timeout' },
+  { label: 'connect timeout', upstream: NET_CODES.E_CONNECT_TIMEOUT, expected: 'fetch_timeout' },
+  { label: 'headers timeout', upstream: NET_CODES.E_HEADERS_TIMEOUT, expected: 'fetch_timeout' },
+  { label: 'body timeout', upstream: NET_CODES.E_BODY_TIMEOUT, expected: 'fetch_timeout' },
+  // Network errors
+  {
+    label: 'generic network error',
+    upstream: NET_CODES.E_NETWORK_ERROR,
+    expected: 'fetch_network_error',
+  },
+  {
+    label: 'DNS resolution failed',
+    upstream: NET_CODES.E_DNS_RESOLUTION_FAILED,
+    expected: 'fetch_network_error',
+  },
+  // Byte cap
+  {
+    label: 'response too large',
+    upstream: NET_CODES.E_RESPONSE_TOO_LARGE,
+    expected: 'fetch_blocked_byte_cap',
+  },
+  // Redirect
+  {
+    label: 'too many redirects',
+    upstream: NET_CODES.E_SSRF_TOO_MANY_REDIRECTS,
+    expected: 'fetch_blocked_redirect',
+  },
+  {
+    label: 'redirect blocked (cross-origin)',
+    upstream: NET_CODES.E_SSRF_REDIRECT_BLOCKED,
+    expected: 'fetch_blocked_redirect',
+  },
+  // SSRF
+  {
+    label: 'SSRF URL rejected',
+    upstream: NET_CODES.E_SSRF_URL_REJECTED,
+    expected: 'fetch_blocked_ssrf',
+  },
+  {
+    label: 'SSRF DNS resolved private',
+    upstream: NET_CODES.E_SSRF_DNS_RESOLVED_PRIVATE,
+    expected: 'fetch_blocked_ssrf',
+  },
+  {
+    label: 'SSRF all IPs blocked',
+    upstream: NET_CODES.E_SSRF_ALL_IPS_BLOCKED,
+    expected: 'fetch_blocked_ssrf',
+  },
+];
+
+describe('pointer-fetch network-path failure modes', () => {
+  for (const tc of NETWORK_CASES) {
+    it(`${tc.upstream} -> ${tc.expected} (${tc.label}); message redacted`, async () => {
+      enqueue('safeFetchRaw', {
+        ok: false,
+        code: tc.upstream,
+        error: 'Bearer abc123 leaked in upstream message',
+        cause: { message: 'Cookie: session=secret-xyz' },
+      });
+      const result = await fetchPointerWithDigest(SENSITIVE_URL, ANY_DIGEST);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe(tc.expected);
+        assertRedacted(result);
+      }
+    });
+  }
+
+  it('non-HTTPS URL pre-check (mapped to pointer_fetch_blocked); message redacted', async () => {
+    const result = await fetchPointerWithDigest(
+      'http://issuer.example.com/path/with/secrets?token=abc',
+      ANY_DIGEST
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('pointer_fetch_blocked');
+      assertRedacted(result);
+    }
+  });
+
+  it('HTTP 404 (4xx class); message redacted', async () => {
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 404,
+      contentType: 'text/html',
+      body: 'not found Bearer abc123',
+    });
+    const result = await fetchPointerWithDigest(SENSITIVE_URL, ANY_DIGEST);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('fetch_status_4xx');
+      expect(result.status).toBe(404);
+      assertRedacted(result);
+    }
+  });
+
+  it('HTTP 503 (5xx class); message redacted', async () => {
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 503,
+      contentType: 'text/plain',
+      body: 'service unavailable Cookie: session=secret',
+    });
+    const result = await fetchPointerWithDigest(SENSITIVE_URL, ANY_DIGEST);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('fetch_status_5xx');
+      expect(result.status).toBe(503);
+      assertRedacted(result);
+    }
+  });
+
+  it('upstream cause chain with secrets does not bleed through (resolver-http boundary redaction)', async () => {
+    enqueue('safeFetchRaw', {
+      ok: false,
+      code: NET_CODES.E_NETWORK_ERROR,
+      error: 'Bearer abc123 connection failed',
+      cause: {
+        message: '-----BEGIN PRIVATE KEY-----secret-material',
+        stack: 'Authorization: Basic dXNlcjpwYXNz',
+      },
+      upstreamPayload: { body: 'A'.repeat(512), token: 'leaked-token-value' },
+    });
+    const result = await fetchPointerWithDigest(SENSITIVE_URL, ANY_DIGEST);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('fetch_network_error');
+      assertRedacted(result);
+      // Defense-in-depth: result keys are restricted to the discriminated-union shape
+      const keys = Object.keys(result).sort();
+      for (const k of keys) {
+        expect(['ok', 'code', 'message', 'status']).toContain(k);
+      }
+    }
+  });
+});

--- a/packages/resolver-http/__tests__/pointer-fetch.no-throw.test.ts
+++ b/packages/resolver-http/__tests__/pointer-fetch.no-throw.test.ts
@@ -95,6 +95,6 @@ describe('pointer-fetch no-throw invariant', () => {
     const upper = 'A'.repeat(64);
     const result = await fetchPointerWithDigest('https://issuer.example.com/r', upper);
     expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.code).toBe('pointer_fetch_blocked');
+    if (!result.ok) expect(result.code).toBe('pointer_invalid_expected_digest');
   });
 });

--- a/packages/resolver-http/__tests__/pointer-fetch.no-throw.test.ts
+++ b/packages/resolver-http/__tests__/pointer-fetch.no-throw.test.ts
@@ -1,0 +1,100 @@
+// pointer-fetch no-throw invariant.
+// Empty body / malformed / digest mismatch / network failure / unexpected
+// upstream errors NEVER throw; always discriminated-union failure.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+  NET_CODES,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { fetchPointerWithDigest } from '../src/pointer-fetch.js';
+
+const ANY_DIGEST = '0'.repeat(64);
+
+beforeEach(() => {
+  resetMock();
+});
+
+describe('pointer-fetch no-throw invariant', () => {
+  it('empty body never throws', async () => {
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'application/jose',
+      bytes: new Uint8Array(0),
+    });
+    await expect(
+      fetchPointerWithDigest('https://issuer.example.com/r', ANY_DIGEST)
+    ).resolves.toBeDefined();
+  });
+
+  it('malformed body never throws', async () => {
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'application/jose',
+      body: 'not-a-valid-jws',
+    });
+    await expect(
+      fetchPointerWithDigest('https://issuer.example.com/r', ANY_DIGEST)
+    ).resolves.toBeDefined();
+  });
+
+  it('digest mismatch never throws', async () => {
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'application/jose',
+      body: 'aGVhZGVy.cGF5bG9hZA.c2lnbmF0dXJl',
+    });
+    await expect(
+      fetchPointerWithDigest('https://issuer.example.com/r', ANY_DIGEST)
+    ).resolves.toBeDefined();
+  });
+
+  it('network failure never throws', async () => {
+    enqueue('safeFetchRaw', { ok: false, code: NET_CODES.E_NETWORK_ERROR });
+    await expect(
+      fetchPointerWithDigest('https://issuer.example.com/r', ANY_DIGEST)
+    ).resolves.toBeDefined();
+  });
+
+  it('non-HTTPS URL never throws', async () => {
+    await expect(
+      fetchPointerWithDigest('http://issuer.example.com/r', ANY_DIGEST)
+    ).resolves.toBeDefined();
+  });
+
+  it('malformed URL never throws', async () => {
+    await expect(fetchPointerWithDigest('not-a-url', ANY_DIGEST)).resolves.toBeDefined();
+  });
+
+  it('invalid expected-digest format never throws', async () => {
+    await expect(
+      fetchPointerWithDigest('https://issuer.example.com/r', 'bad')
+    ).resolves.toBeDefined();
+  });
+
+  it('uppercase hex expected digest is rejected (lowercase rule) without throwing', async () => {
+    const upper = 'A'.repeat(64);
+    const result = await fetchPointerWithDigest('https://issuer.example.com/r', upper);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('pointer_fetch_blocked');
+  });
+});

--- a/packages/resolver-http/__tests__/pointer-fetch.real-jws.test.ts
+++ b/packages/resolver-http/__tests__/pointer-fetch.real-jws.test.ts
@@ -1,0 +1,156 @@
+// Real-JWS pointer harness (Commit 4).
+//
+// Drives resolver-http's pointer-fetch through real Ed25519-signed compact
+// JWS fixtures generated at runtime via package-root @peac/crypto exports.
+// No external network. No protocol-side mocking. No fake "byte-equal
+// cross-implementation parity" claims; cross-implementation pointer parity
+// is PR B's shadow-mode harness scope (see plan §"Cross-implementation
+// pointer parity gate" in PR B).
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { fetchPointerWithDigest } from '../src/pointer-fetch.js';
+import { generateSignedJws } from './_helpers/test-jws.js';
+
+beforeEach(() => {
+  resetMock();
+});
+
+describe('pointer-fetch real-JWS harness', () => {
+  it('real signed compact JWS succeeds with digest match', async () => {
+    const fixture = await generateSignedJws();
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'application/jose',
+      body: fixture.jws,
+    });
+    const result = await fetchPointerWithDigest(
+      'https://issuer.example.com/receipt',
+      fixture.expectedDigest
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.receipt).toBe(fixture.jws);
+      expect(result.actualDigest).toBe(fixture.expectedDigest);
+      expect(result.expectedDigest).toBe(fixture.expectedDigest);
+      expect(result.contentType).toBe('application/jose');
+      expect(result.contentTypeWarning).toBeUndefined();
+    }
+  });
+
+  it('digest mismatch fails with pointer_digest_mismatch and surfaces both digests', async () => {
+    const fixture = await generateSignedJws();
+    const wrongDigest = '0'.repeat(64);
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'application/jose',
+      body: fixture.jws,
+    });
+    const result = await fetchPointerWithDigest('https://issuer.example.com/receipt', wrongDigest);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('pointer_digest_mismatch');
+      expect(result.actualDigest).toBe(fixture.expectedDigest);
+      expect(result.expectedDigest).toBe(wrongDigest);
+    }
+  });
+
+  it('Unicode claims are signed into a real compact JWS; pointer-fetch hashes the resulting compact JWS string after UTF-8 decode', async () => {
+    // The compact JWS itself is ASCII (base64url + dots), even though its
+    // payload claims contain non-ASCII characters. pointer-fetch fetches the
+    // raw bytes, decodes them via TextDecoder('utf-8', { fatal: false }), and
+    // hashes the resulting string. For ASCII bodies the decode round-trip is
+    // a no-op and digest math is byte-identical. The Unicode claim only lives
+    // inside the signed payload, not in the wire bytes.
+    const fixture = await generateSignedJws({
+      payload: {
+        purpose: 'café',
+        notes: '日本語テスト',
+        emoji: 'rocket',
+      },
+    });
+    // Sanity: the JWS itself is ASCII (base64url + dots) regardless of the
+    // non-ASCII claims it carries.
+    expect(/^[\x20-\x7e]+$/.test(fixture.jws)).toBe(true);
+
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'application/jose',
+      body: fixture.jws,
+    });
+    const result = await fetchPointerWithDigest(
+      'https://issuer.example.com/receipt',
+      fixture.expectedDigest
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.actualDigest).toBe(fixture.expectedDigest);
+    }
+  });
+
+  it('trailing newline body is rejected by the compact-JWS shape check (parser order: shape before digest)', async () => {
+    // Documented parser order in resolver-http's pointer-fetch:
+    //   1. fetchRawSafe -> raw bytes
+    //   2. TextDecoder UTF-8 -> string
+    //   3. compact-JWS regex shape check -> reject as pointer_malformed_jws if not 3 base64url segments
+    //   4. sha256Hex -> compare to expected digest
+    // A trailing newline breaks the regex shape check at step 3; the test
+    // never reaches the digest comparison. This is asserted explicitly per
+    // the Commit 4.0.1 fixture rule "trailing newline fails as malformed or
+    // digest mismatch, depending on exact parser order, but must be explicit
+    // and tested".
+    const fixture = await generateSignedJws();
+    const bodyWithNewline = `${fixture.jws}\n`;
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'application/jose',
+      body: bodyWithNewline,
+    });
+    // Even if caller passes the digest of the newline-terminated body, the
+    // shape check rejects first.
+    const expectedOfNewlineBody = (await import('@peac/crypto')).sha256Hex
+      ? await (await import('@peac/crypto')).sha256Hex(bodyWithNewline)
+      : '';
+    const result = await fetchPointerWithDigest(
+      'https://issuer.example.com/receipt',
+      expectedOfNewlineBody
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('pointer_malformed_jws');
+    }
+  });
+
+  it('helper self-validation: generated fixture verifies via @peac/crypto.verify (no private subpath)', async () => {
+    // The helper itself runs verify() before returning; this test makes the
+    // self-validation visible at the test boundary.
+    const fixture = await generateSignedJws();
+    expect(fixture.jws.split('.')).toHaveLength(3);
+    expect(fixture.publicKey).toBeInstanceOf(Uint8Array);
+    expect(fixture.publicKey.length).toBe(32);
+    expect(fixture.privateKey.length).toBe(32);
+    expect(fixture.expectedDigest).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/packages/resolver-http/__tests__/pointer-fetch.real-jws.test.ts
+++ b/packages/resolver-http/__tests__/pointer-fetch.real-jws.test.ts
@@ -1,4 +1,4 @@
-// Real-JWS pointer harness (Commit 4).
+// Real-JWS pointer harness (Commit 4; tightened in Commit 4.1).
 //
 // Drives resolver-http's pointer-fetch through real Ed25519-signed compact
 // JWS fixtures generated at runtime via package-root @peac/crypto exports.
@@ -6,6 +6,9 @@
 // cross-implementation parity" claims; cross-implementation pointer parity
 // is PR B's shadow-mode harness scope (see plan §"Cross-implementation
 // pointer parity gate" in PR B).
+//
+// Hygiene: the fixture helper does NOT expose the private signing key.
+// Tests assert behavior on the public surface only.
 
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 
@@ -28,7 +31,7 @@ vi.mock('@peac/net-node', async () => {
 });
 
 import { fetchPointerWithDigest } from '../src/pointer-fetch.js';
-import { generateSignedJws } from './_helpers/test-jws.js';
+import { generateSignedJws, digestOfBody } from './_helpers/test-jws.js';
 
 beforeEach(() => {
   resetMock();
@@ -75,13 +78,14 @@ describe('pointer-fetch real-JWS harness', () => {
     }
   });
 
-  it('Unicode claims are signed into a real compact JWS; pointer-fetch hashes the resulting compact JWS string after UTF-8 decode', async () => {
-    // The compact JWS itself is ASCII (base64url + dots), even though its
-    // payload claims contain non-ASCII characters. pointer-fetch fetches the
-    // raw bytes, decodes them via TextDecoder('utf-8', { fatal: false }), and
-    // hashes the resulting string. For ASCII bodies the decode round-trip is
-    // a no-op and digest math is byte-identical. The Unicode claim only lives
-    // inside the signed payload, not in the wire bytes.
+  it('Unicode claims live inside the signed payload; pointer-fetch hashes the resulting compact JWS string (which is ASCII)', async () => {
+    // Wire-level shape: a compact JWS is base64url + dots, so the JWS string
+    // itself is ASCII regardless of the Unicode characters in its payload
+    // claims. pointer-fetch fetches the raw bytes of the compact JWS,
+    // decodes them via TextDecoder('utf-8', { fatal: false }) (a no-op for
+    // ASCII bytes), and hashes the resulting string. The Unicode claim only
+    // exists inside the signed payload; pointer-fetch never receives raw
+    // non-ASCII JSON as the body.
     const fixture = await generateSignedJws({
       payload: {
         purpose: 'café',
@@ -89,8 +93,7 @@ describe('pointer-fetch real-JWS harness', () => {
         emoji: 'rocket',
       },
     });
-    // Sanity: the JWS itself is ASCII (base64url + dots) regardless of the
-    // non-ASCII claims it carries.
+    // Sanity: the compact JWS itself is ASCII-only.
     expect(/^[\x20-\x7e]+$/.test(fixture.jws)).toBe(true);
 
     enqueue('safeFetchRaw', {
@@ -116,10 +119,7 @@ describe('pointer-fetch real-JWS harness', () => {
     //   3. compact-JWS regex shape check -> reject as pointer_malformed_jws if not 3 base64url segments
     //   4. sha256Hex -> compare to expected digest
     // A trailing newline breaks the regex shape check at step 3; the test
-    // never reaches the digest comparison. This is asserted explicitly per
-    // the Commit 4.0.1 fixture rule "trailing newline fails as malformed or
-    // digest mismatch, depending on exact parser order, but must be explicit
-    // and tested".
+    // never reaches the digest comparison.
     const fixture = await generateSignedJws();
     const bodyWithNewline = `${fixture.jws}\n`;
     enqueue('safeFetchRaw', {
@@ -128,11 +128,10 @@ describe('pointer-fetch real-JWS harness', () => {
       contentType: 'application/jose',
       body: bodyWithNewline,
     });
-    // Even if caller passes the digest of the newline-terminated body, the
-    // shape check rejects first.
-    const expectedOfNewlineBody = (await import('@peac/crypto')).sha256Hex
-      ? await (await import('@peac/crypto')).sha256Hex(bodyWithNewline)
-      : '';
+    // Even if the caller passes the digest of the newline-terminated body,
+    // the shape check rejects first. Compute via digestOfBody helper to
+    // avoid dynamic imports inside the test body.
+    const expectedOfNewlineBody = await digestOfBody(bodyWithNewline);
     const result = await fetchPointerWithDigest(
       'https://issuer.example.com/receipt',
       expectedOfNewlineBody
@@ -143,14 +142,23 @@ describe('pointer-fetch real-JWS harness', () => {
     }
   });
 
-  it('helper self-validation: generated fixture verifies via @peac/crypto.verify (no private subpath)', async () => {
-    // The helper itself runs verify() before returning; this test makes the
-    // self-validation visible at the test boundary.
+  it('fixture self-validation surface: helper returns public material only (no private key)', async () => {
+    // The helper runs decode + verify + typ/alg/kid/peac_version checks
+    // before returning. This test makes the public-only surface visible at
+    // the test boundary.
     const fixture = await generateSignedJws();
     expect(fixture.jws.split('.')).toHaveLength(3);
     expect(fixture.publicKey).toBeInstanceOf(Uint8Array);
     expect(fixture.publicKey.length).toBe(32);
-    expect(fixture.privateKey.length).toBe(32);
     expect(fixture.expectedDigest).toMatch(/^[0-9a-f]{64}$/);
+    // Header round-trip: helper asserts these, but we surface them so a
+    // failed assertion gives reviewer signal at the test boundary.
+    expect(fixture.header.typ).toBe('interaction-record+jwt');
+    expect(fixture.header.alg).toBe('EdDSA');
+    expect(fixture.header.kid).toBe('test-key-1');
+    // Payload round-trip
+    expect(fixture.payload.peac_version).toBe('0.2');
+    // Hygiene: the fixture object MUST NOT expose privateKey.
+    expect((fixture as Record<string, unknown>).privateKey).toBeUndefined();
   });
 });

--- a/packages/resolver-http/__tests__/pointer-fetch.redaction.test.ts
+++ b/packages/resolver-http/__tests__/pointer-fetch.redaction.test.ts
@@ -1,0 +1,126 @@
+// pointer-fetch redaction: digest-mismatch error path leaks no body / URL /
+// header / secret content. Only public hashes (sha256 hex) and bounded
+// numeric counters are surfaced.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { sha256Hex } from '@peac/crypto';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { fetchPointerWithDigest } from '../src/pointer-fetch.js';
+
+const VALID_JWS = 'aGVhZGVy.cGF5bG9hZA.c2lnbmF0dXJl';
+
+beforeEach(() => {
+  resetMock();
+});
+
+const FORBIDDEN_PATTERNS: readonly RegExp[] = [
+  /Bearer\s+\S+/,
+  /Cookie:|Set-Cookie:/i,
+  /Authorization:/i,
+  /-----BEGIN [A-Z ]+PRIVATE KEY-----/,
+  /\?token=/,
+  /\?api_key=/,
+];
+
+function flattenStrings(value: unknown, depth = 0, acc: string[] = []): string[] {
+  if (depth > 6) return acc;
+  if (typeof value === 'string') {
+    acc.push(value);
+    return acc;
+  }
+  if (value && typeof value === 'object') {
+    for (const v of Object.values(value as Record<string, unknown>)) {
+      flattenStrings(v, depth + 1, acc);
+    }
+  }
+  return acc;
+}
+
+describe('pointer-fetch redaction', () => {
+  it('digest-mismatch error contains only origin + code + public hashes', async () => {
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'application/jose',
+      body: VALID_JWS,
+    });
+    const wrongExpected = '0'.repeat(64);
+    const result = await fetchPointerWithDigest(
+      'https://issuer.example.com/path/with/secrets?token=abc&kid=def',
+      wrongExpected
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('pointer_digest_mismatch');
+      // message contains only origin + code; no path / query / token
+      expect(result.message).toContain('https://issuer.example.com');
+      expect(result.message).not.toContain('/path/with/secrets');
+      expect(result.message).not.toContain('token=');
+      expect(result.message).not.toContain('abc');
+      expect(result.message).not.toContain('kid=');
+      // Both digests are public hashes — safe to surface
+      expect(result.actualDigest).toMatch(/^[0-9a-f]{64}$/);
+      expect(result.expectedDigest).toBe(wrongExpected);
+      // No body content in any field
+      const allStrings = flattenStrings(result);
+      for (const s of allStrings) {
+        expect(s).not.toContain(VALID_JWS);
+      }
+    }
+  });
+
+  it('upstream cause from fetchRawSafe with secrets does not bleed through', async () => {
+    enqueue('safeFetchRaw', {
+      ok: false,
+      code: 'E_NET_NETWORK_ERROR' as const,
+      error: 'Connection failed Bearer abc123 Cookie: session=xyz',
+      cause: {
+        message: '-----BEGIN PRIVATE KEY-----secret',
+        stack: 'Authorization: Basic dXNlcg==',
+      },
+    });
+    const result = await fetchPointerWithDigest('https://issuer.example.com/r', '0'.repeat(64));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const allStrings = flattenStrings(result);
+      for (const s of allStrings) {
+        for (const re of FORBIDDEN_PATTERNS) {
+          expect(s).not.toMatch(re);
+        }
+        expect(s).not.toContain('abc123');
+        expect(s).not.toContain('session=xyz');
+      }
+    }
+  });
+
+  it('expected-digest format failure (pointer_fetch_blocked) does NOT leak the bad digest text', async () => {
+    const badInput = 'totally-not-a-digest';
+    const result = await fetchPointerWithDigest(
+      'https://issuer.example.com/r?token=secret',
+      badInput
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).not.toContain(badInput);
+      expect(result.message).not.toContain('token');
+    }
+  });
+});

--- a/packages/resolver-http/__tests__/pointer-fetch.redaction.test.ts
+++ b/packages/resolver-http/__tests__/pointer-fetch.redaction.test.ts
@@ -3,7 +3,6 @@
 // numeric counters are surfaced.
 
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { sha256Hex } from '@peac/crypto';
 
 import {
   mockSafeFetchJson,

--- a/packages/resolver-http/__tests__/pointer-fetch.redaction.test.ts
+++ b/packages/resolver-http/__tests__/pointer-fetch.redaction.test.ts
@@ -25,7 +25,14 @@ vi.mock('@peac/net-node', async () => {
 
 import { fetchPointerWithDigest } from '../src/pointer-fetch.js';
 
-const VALID_JWS = 'aGVhZGVy.cGF5bG9hZA.c2lnbmF0dXJl';
+// Compact-like JWS string: 3 base64url segments (matches COMPACT_JWS_REGEX)
+// but NOT a real signed JWS. The protected header decodes to 'header' (not
+// JSON) and the signature is not real Ed25519 material. resolver-http's
+// pointer-fetch only validates 3-segment base64url shape before computing
+// the digest, so this fixture is sufficient for digest / content-type /
+// redaction tests. Commit 4 will introduce real signed-JWS fixtures for
+// cross-implementation byte-equal parity.
+const COMPACT_LIKE_JWS = 'aGVhZGVy.cGF5bG9hZA.c2lnbmF0dXJl';
 
 beforeEach(() => {
   resetMock();
@@ -60,7 +67,7 @@ describe('pointer-fetch redaction', () => {
       ok: true,
       status: 200,
       contentType: 'application/jose',
-      body: VALID_JWS,
+      body: COMPACT_LIKE_JWS,
     });
     const wrongExpected = '0'.repeat(64);
     const result = await fetchPointerWithDigest(
@@ -76,13 +83,13 @@ describe('pointer-fetch redaction', () => {
       expect(result.message).not.toContain('token=');
       expect(result.message).not.toContain('abc');
       expect(result.message).not.toContain('kid=');
-      // Both digests are public hashes — safe to surface
+      // Both digests are public hashes ; safe to surface
       expect(result.actualDigest).toMatch(/^[0-9a-f]{64}$/);
       expect(result.expectedDigest).toBe(wrongExpected);
       // No body content in any field
       const allStrings = flattenStrings(result);
       for (const s of allStrings) {
-        expect(s).not.toContain(VALID_JWS);
+        expect(s).not.toContain(COMPACT_LIKE_JWS);
       }
     }
   });
@@ -111,7 +118,7 @@ describe('pointer-fetch redaction', () => {
     }
   });
 
-  it('expected-digest format failure (pointer_fetch_blocked) does NOT leak the bad digest text', async () => {
+  it('expected-digest format failure (pointer_invalid_expected_digest) does NOT leak the bad digest text', async () => {
     const badInput = 'totally-not-a-digest';
     const result = await fetchPointerWithDigest(
       'https://issuer.example.com/r?token=secret',
@@ -119,6 +126,7 @@ describe('pointer-fetch redaction', () => {
     );
     expect(result.ok).toBe(false);
     if (!result.ok) {
+      expect(result.code).toBe('pointer_invalid_expected_digest');
       expect(result.message).not.toContain(badInput);
       expect(result.message).not.toContain('token');
     }

--- a/packages/resolver-http/__tests__/pointer-fetch.smoke.test.ts
+++ b/packages/resolver-http/__tests__/pointer-fetch.smoke.test.ts
@@ -1,0 +1,77 @@
+// pointer-fetch smoke: happy path + clean digest mismatch.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { sha256Hex } from '@peac/crypto';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { fetchPointerWithDigest } from '../src/pointer-fetch.js';
+
+beforeEach(() => {
+  resetMock();
+});
+
+const VALID_JWS = 'aGVhZGVy.cGF5bG9hZA.c2lnbmF0dXJl';
+
+describe('pointer-fetch smoke', () => {
+  it('happy-path returns receipt + actualDigest matching expected', async () => {
+    const expected = await sha256Hex(VALID_JWS);
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'application/jose',
+      body: VALID_JWS,
+    });
+    const result = await fetchPointerWithDigest('https://issuer.example.com/receipt', expected);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.receipt).toBe(VALID_JWS);
+      expect(result.actualDigest).toBe(expected);
+      expect(result.expectedDigest).toBe(expected);
+      expect(result.contentType).toBe('application/jose');
+      expect(result.contentTypeWarning).toBeUndefined();
+    }
+  });
+
+  it('digest mismatch surfaces pointer_digest_mismatch with both digests', async () => {
+    enqueue('safeFetchRaw', {
+      ok: true,
+      status: 200,
+      contentType: 'application/jose',
+      body: VALID_JWS,
+    });
+    const wrong = '0'.repeat(64);
+    const result = await fetchPointerWithDigest('https://issuer.example.com/receipt', wrong);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('pointer_digest_mismatch');
+      expect(result.actualDigest).toBe(await sha256Hex(VALID_JWS));
+      expect(result.expectedDigest).toBe(wrong);
+    }
+  });
+
+  it('invalid expected-digest format (not 64 lowercase hex) surfaces pointer_fetch_blocked', async () => {
+    const result = await fetchPointerWithDigest(
+      'https://issuer.example.com/receipt',
+      'not a digest'
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('pointer_fetch_blocked');
+  });
+});

--- a/packages/resolver-http/__tests__/pointer-fetch.smoke.test.ts
+++ b/packages/resolver-http/__tests__/pointer-fetch.smoke.test.ts
@@ -27,21 +27,28 @@ beforeEach(() => {
   resetMock();
 });
 
-const VALID_JWS = 'aGVhZGVy.cGF5bG9hZA.c2lnbmF0dXJl';
+// Compact-like JWS string: 3 base64url segments (matches COMPACT_JWS_REGEX)
+// but NOT a real signed JWS. The protected header decodes to 'header' (not
+// JSON) and the signature is not real Ed25519 material. resolver-http's
+// pointer-fetch only validates 3-segment base64url shape before computing
+// the digest, so this fixture is sufficient for digest / content-type /
+// redaction tests. Commit 4 will introduce real signed-JWS fixtures for
+// cross-implementation byte-equal parity.
+const COMPACT_LIKE_JWS = 'aGVhZGVy.cGF5bG9hZA.c2lnbmF0dXJl';
 
 describe('pointer-fetch smoke', () => {
   it('happy-path returns receipt + actualDigest matching expected', async () => {
-    const expected = await sha256Hex(VALID_JWS);
+    const expected = await sha256Hex(COMPACT_LIKE_JWS);
     enqueue('safeFetchRaw', {
       ok: true,
       status: 200,
       contentType: 'application/jose',
-      body: VALID_JWS,
+      body: COMPACT_LIKE_JWS,
     });
     const result = await fetchPointerWithDigest('https://issuer.example.com/receipt', expected);
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.receipt).toBe(VALID_JWS);
+      expect(result.receipt).toBe(COMPACT_LIKE_JWS);
       expect(result.actualDigest).toBe(expected);
       expect(result.expectedDigest).toBe(expected);
       expect(result.contentType).toBe('application/jose');
@@ -54,24 +61,37 @@ describe('pointer-fetch smoke', () => {
       ok: true,
       status: 200,
       contentType: 'application/jose',
-      body: VALID_JWS,
+      body: COMPACT_LIKE_JWS,
     });
     const wrong = '0'.repeat(64);
     const result = await fetchPointerWithDigest('https://issuer.example.com/receipt', wrong);
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.code).toBe('pointer_digest_mismatch');
-      expect(result.actualDigest).toBe(await sha256Hex(VALID_JWS));
+      expect(result.actualDigest).toBe(await sha256Hex(COMPACT_LIKE_JWS));
       expect(result.expectedDigest).toBe(wrong);
     }
   });
 
-  it('invalid expected-digest format (not 64 lowercase hex) surfaces pointer_fetch_blocked', async () => {
+  it('invalid expected-digest format (not 64 lowercase hex) surfaces pointer_invalid_expected_digest', async () => {
     const result = await fetchPointerWithDigest(
       'https://issuer.example.com/receipt',
       'not a digest'
     );
     expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.code).toBe('pointer_fetch_blocked');
+    if (!result.ok) expect(result.code).toBe('pointer_invalid_expected_digest');
+  });
+
+  it('invalid digest class is distinct from URL-blocked class (Commit 3.1 Fix #3)', async () => {
+    const a = await fetchPointerWithDigest('https://issuer.example.com/r', 'bad-digest');
+    const b = await fetchPointerWithDigest('http://issuer.example.com/r', '0'.repeat(64));
+    expect(a.ok).toBe(false);
+    expect(b.ok).toBe(false);
+    if (!a.ok && !b.ok) {
+      expect(a.code).toBe('pointer_invalid_expected_digest');
+      expect(b.code).toBe('pointer_fetch_blocked');
+      // The two classes are distinct
+      expect(a.code).not.toBe(b.code);
+    }
   });
 });

--- a/packages/resolver-http/__tests__/pointer-fetch.ssrf.test.ts
+++ b/packages/resolver-http/__tests__/pointer-fetch.ssrf.test.ts
@@ -1,0 +1,68 @@
+// pointer-fetch SSRF / non-HTTPS / redirect coverage.
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  mockSafeFetchJson,
+  mockSafeFetchJWKS,
+  mockSafeFetchRaw,
+  enqueue,
+  resetMock,
+  NET_CODES,
+} from './_helpers/mock-net-node.js';
+
+vi.mock('@peac/net-node', async () => {
+  const actual = await vi.importActual<typeof import('@peac/net-node')>('@peac/net-node');
+  return {
+    ...actual,
+    safeFetchJson: mockSafeFetchJson,
+    safeFetchJWKS: mockSafeFetchJWKS,
+    safeFetchRaw: mockSafeFetchRaw,
+  };
+});
+
+import { fetchPointerWithDigest } from '../src/pointer-fetch.js';
+
+const ANY_DIGEST = '0'.repeat(64);
+
+beforeEach(() => {
+  resetMock();
+});
+
+describe('pointer-fetch SSRF blocks', () => {
+  it('non-HTTPS URL surfaces pointer_fetch_blocked (mirrors protocol)', async () => {
+    const result = await fetchPointerWithDigest('http://issuer.example.com/r', ANY_DIGEST);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('pointer_fetch_blocked');
+  });
+
+  it('private-IP rejected by net-node SSRF -> fetch_blocked_ssrf', async () => {
+    enqueue('safeFetchRaw', {
+      ok: false,
+      code: NET_CODES.E_SSRF_DNS_RESOLVED_PRIVATE,
+    });
+    const result = await fetchPointerWithDigest('https://issuer.example.com/r', ANY_DIGEST);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('fetch_blocked_ssrf');
+  });
+
+  it('redirect-blocked surfaces fetch_blocked_redirect', async () => {
+    enqueue('safeFetchRaw', {
+      ok: false,
+      code: NET_CODES.E_SSRF_TOO_MANY_REDIRECTS,
+    });
+    const result = await fetchPointerWithDigest('https://issuer.example.com/r', ANY_DIGEST);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('fetch_blocked_redirect');
+  });
+
+  it('cross-origin redirect surfaces fetch_blocked_redirect', async () => {
+    enqueue('safeFetchRaw', {
+      ok: false,
+      code: NET_CODES.E_SSRF_REDIRECT_BLOCKED,
+    });
+    const result = await fetchPointerWithDigest('https://issuer.example.com/r', ANY_DIGEST);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('fetch_blocked_redirect');
+  });
+});

--- a/packages/resolver-http/__tests__/runtime-source-isolation.test.ts
+++ b/packages/resolver-http/__tests__/runtime-source-isolation.test.ts
@@ -1,0 +1,83 @@
+// Layer 1 (test gate) of the runtime-source isolation invariant.
+//
+// resolver-http runtime source MUST NOT import @peac/protocol. Parity
+// test files (Commit 4) MAY import protocol; helpers under _helpers/
+// MUST NOT. This test reads each runtime / helper file via the filesystem
+// and asserts no @peac/protocol reference appears anywhere.
+//
+// Layer 2 is the shell gate `git grep -nE '@peac/protocol'
+// packages/resolver-http/src packages/resolver-http/__tests__/_helpers`,
+// run from the repo CI; both layers must agree.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOTS = [
+  // resolver-http runtime source (production code path)
+  '../src',
+  // resolver-http shared test helpers (parity tests excluded by design)
+  '../__tests__/_helpers',
+];
+
+function walk(dir: string): string[] {
+  let files: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return files;
+  }
+  for (const e of entries) {
+    const p = join(dir, e);
+    const s = statSync(p);
+    if (s.isDirectory()) {
+      files = files.concat(walk(p));
+    } else if (/\.(ts|tsx|mts|cts|js|mjs|cjs)$/.test(p)) {
+      files.push(p);
+    }
+  }
+  return files;
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+describe('runtime-source-isolation: resolver-http MUST NOT import @peac/protocol', () => {
+  for (const rel of ROOTS) {
+    const root = resolve(here, rel);
+    const files = walk(root);
+    if (files.length === 0) {
+      it(`${rel}: directory has no .ts/.js files yet (skipped)`, () => {
+        expect(true).toBe(true);
+      });
+      continue;
+    }
+    for (const f of files) {
+      it(`${f.replace(here, '.')} does not import @peac/protocol`, () => {
+        const src = readFileSync(f, 'utf8');
+        // Strip block comments (greedy single-pass) and line comments before
+        // scanning. Documentation comments mentioning @peac/protocol (e.g.
+        // P0-invariant prose) are intentional and must not be flagged; only
+        // actual import / require statements are forbidden.
+        const stripped = src
+          .replace(/\/\*[\s\S]*?\*\//g, '')
+          .split('\n')
+          .map((line) => line.replace(/\/\/.*$/, ''))
+          .join('\n');
+
+        const importStatement =
+          /\bimport\b[^;]*?(?:from\s*['"]|['"])(@peac\/protocol(?:\/[^'"\s)]*)?)['"]/g;
+        const requireCall = /\brequire\s*\(\s*['"](@peac\/protocol(?:\/[^'"\s)]*)?)['"]/g;
+        const dynamicImport = /\bimport\s*\(\s*['"](@peac\/protocol(?:\/[^'"\s)]*)?)['"]/g;
+
+        const hits: string[] = [];
+        for (const re of [importStatement, requireCall, dynamicImport]) {
+          let m: RegExpExecArray | null;
+          while ((m = re.exec(stripped)) !== null) hits.push(m[1]);
+        }
+        expect(hits, `forbidden @peac/protocol imports: ${hits.join(', ')}`).toEqual([]);
+      });
+    }
+  }
+});

--- a/packages/resolver-http/package.json
+++ b/packages/resolver-http/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@peac/resolver-http",
+  "version": "0.13.1",
+  "private": true,
+  "description": "PEAC Protocol - workspace-private resolver-http shadow package introduced in v0.13.2 PR A per Revision 4 §7. Holds shadow-only network-bearing resolution logic (issuer-config fetch, JWKS resolution, SSRF-safe fetch, redirect / timeout / cache isolation / byte-cap enforcement) copied from packages/protocol/src/{discovery,jwks-resolver,ssrf-safe-fetch,pointer-fetch}.ts for parity testing. NEVER published. NEVER referenced by published packages. P0 invariant: @peac/protocol must NOT import / depend on / re-export from / emit reference to this package while it remains workspace-private (denylist seeded by v0.13.1 PR A in tests/tooling/protocol-private-imports.test.ts and friends).",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "scripts": {
+    "prebuild": "rm -rf dist",
+    "build": "pnpm run build:js && pnpm run build:types",
+    "build:js": "tsup",
+    "build:types": "rm -f dist/.tsbuildinfo && tsc && rm -f dist/.tsbuildinfo",
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^4.0.0"
+  }
+}

--- a/packages/resolver-http/package.json
+++ b/packages/resolver-http/package.json
@@ -25,10 +25,13 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@peac/crypto": "workspace:*",
+    "@peac/jwks-cache": "workspace:*",
     "@peac/kernel": "workspace:*",
     "@peac/net-node": "workspace:*"
   },
   "devDependencies": {
+    "@peac/protocol": "workspace:*",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^4.0.0"

--- a/packages/resolver-http/package.json
+++ b/packages/resolver-http/package.json
@@ -24,7 +24,10 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@peac/kernel": "workspace:*",
+    "@peac/net-node": "workspace:*"
+  },
   "devDependencies": {
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",

--- a/packages/resolver-http/package.json
+++ b/packages/resolver-http/package.json
@@ -2,7 +2,7 @@
   "name": "@peac/resolver-http",
   "version": "0.13.1",
   "private": true,
-  "description": "PEAC Protocol - workspace-private resolver-http shadow package introduced in v0.13.2 PR A per Revision 4 §7. Holds shadow-only network-bearing resolution logic (issuer-config fetch, JWKS resolution, SSRF-safe fetch, redirect / timeout / cache isolation / byte-cap enforcement) copied from packages/protocol/src/{discovery,jwks-resolver,ssrf-safe-fetch,pointer-fetch}.ts for parity testing. NEVER published. NEVER referenced by published packages. P0 invariant: @peac/protocol must NOT import / depend on / re-export from / emit reference to this package while it remains workspace-private (denylist seeded by v0.13.1 PR A in tests/tooling/protocol-private-imports.test.ts and friends).",
+  "description": "PEAC Protocol - workspace-private resolver-http composition layer introduced in v0.13.2 PR A per Revision 4 §7. Composes published primitives (@peac/net-node, @peac/jwks-cache, @peac/kernel, @peac/crypto, @peac/schema) behind a private verifier-oriented interface for parity testing against @peac/protocol's existing self-contained resolver path on shared local fixtures. NEVER published. NEVER referenced by published packages. P0 invariants: @peac/protocol must NOT import / depend on / re-export from / emit reference to this package; @peac/resolver-http runtime source must NOT import @peac/protocol (parity test files MAY). @peac/jwks-cache and @peac/net-node are reused as published primitives, not modified, not merged, not renamed in v0.13.2 (denylist seeded by v0.13.1 PR A in tests/tooling/protocol-private-imports.test.ts and friends).",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/resolver-http/src/discovery.ts
+++ b/packages/resolver-http/src/discovery.ts
@@ -1,0 +1,124 @@
+// Issuer-config discovery composed over fetch-safe.
+//
+// Fetches the canonical issuer-config endpoint at
+// `<issuer>/.well-known/peac-issuer.json` (path constant from
+// `@peac/kernel.ISSUER_CONFIG.configPath`), validates a minimal local
+// shape, and returns a discriminated-union result with redacted error
+// messages. Hand-rolled shape check; no Zod runtime dep, no @peac/schema
+// import.
+//
+// Composition layer over a published primitive. Does not import the
+// protocol package.
+
+import { ISSUER_CONFIG } from '@peac/kernel';
+
+import type { FetchSafeOptions, FetchSafeResult } from './types.js';
+import { fetchJsonSafe } from './fetch-safe.js';
+
+export interface IssuerConfig {
+  issuer: string;
+  jwks_uri: string;
+  [key: string]: unknown;
+}
+
+export type DiscoveryResult = FetchSafeResult<IssuerConfig>;
+
+export interface DiscoveryOptions extends Pick<
+  FetchSafeOptions,
+  'timeoutMs' | 'maxResponseBytes'
+> {}
+
+function safeOrigin(url: string): string {
+  try {
+    const u = new URL(url);
+    return `${u.protocol}//${u.host}`;
+  } catch {
+    return '<invalid-url>';
+  }
+}
+
+function buildConfigUrl(issuer: string): string {
+  // Strip a single trailing slash from the issuer base before joining the
+  // canonical configPath ("/.well-known/peac-issuer.json"). Both
+  // "https://issuer.example.com" and "https://issuer.example.com/" must
+  // map to the same canonical URL.
+  const base = issuer.endsWith('/') ? issuer.slice(0, -1) : issuer;
+  return `${base}${ISSUER_CONFIG.configPath}`;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isParseableUrl(value: string): boolean {
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function validateIssuerConfigShape(body: unknown): IssuerConfig | null {
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    return null;
+  }
+  const obj = body as Record<string, unknown>;
+  if (!isNonEmptyString(obj.issuer)) return null;
+  if (!isNonEmptyString(obj.jwks_uri)) return null;
+  if (!isParseableUrl(obj.jwks_uri)) return null;
+  return obj as IssuerConfig;
+}
+
+/**
+ * Fetch and validate an issuer's `peac-issuer.json` discovery document.
+ *
+ * The `issuer` argument is the issuer base URL (e.g.
+ * `https://issuer.example.com`). The canonical configuration path
+ * (`/.well-known/peac-issuer.json`) comes from
+ * `@peac/kernel.ISSUER_CONFIG.configPath`.
+ *
+ * Validation: `issuer` and `jwks_uri` MUST be non-empty strings;
+ * `jwks_uri` MUST parse as a URL. Unknown extra fields are tolerated.
+ * Non-HTTPS `jwks_uri` is NOT rejected at the discovery layer; the
+ * downstream JWKS fetch (via `fetchJwksSafe`) will reject with
+ * `fetch_blocked_https_only` when the actual fetch is attempted.
+ */
+export async function fetchIssuerConfig(
+  issuer: string,
+  options?: DiscoveryOptions
+): Promise<DiscoveryResult> {
+  const url = buildConfigUrl(issuer);
+  const origin = safeOrigin(url);
+
+  let result;
+  try {
+    result = await fetchJsonSafe<unknown>(url, options);
+  } catch {
+    return {
+      ok: false,
+      code: 'resolver_internal_error',
+      message: `resolver_internal_error at ${origin}`,
+    };
+  }
+
+  if (!result.ok) {
+    return result as DiscoveryResult;
+  }
+
+  const validated = validateIssuerConfigShape(result.body);
+  if (validated === null) {
+    return {
+      ok: false,
+      code: 'discovery_invalid_shape',
+      message: `discovery_invalid_shape at ${origin}`,
+    };
+  }
+
+  return {
+    ok: true,
+    body: validated,
+    bytes: result.bytes,
+    contentType: result.contentType,
+  };
+}

--- a/packages/resolver-http/src/fetch-safe.ts
+++ b/packages/resolver-http/src/fetch-safe.ts
@@ -1,0 +1,249 @@
+// Verifier-oriented fetch composition over @peac/net-node.
+//
+// Pulls verifier defaults from @peac/kernel.VERIFIER_LIMITS and overrides
+// net-node's broader defaults (5000ms vs 30000ms; 256 KiB vs 2 MiB; 64 KiB
+// JWKS vs 512 KiB; 3 redirects vs 5). Maps SAFE_FETCH_ERROR_CODES to a
+// closed local FetchSafeErrorCode set. Returns discriminated-union results;
+// failure messages are redacted (origin host only; no path / query / headers
+// / body / secrets / upstream cause text).
+//
+// Composition layer over a published primitive. Does not import the protocol package.
+
+import { safeFetchJson, safeFetchJWKS, safeFetchRaw, SAFE_FETCH_ERROR_CODES } from '@peac/net-node';
+import { VERIFIER_LIMITS } from '@peac/kernel';
+
+import type {
+  FetchSafeErrorCode,
+  FetchSafeFailure,
+  FetchSafeOptions,
+  FetchSafeResult,
+} from './types.js';
+
+function safeOrigin(url: string): string {
+  try {
+    const u = new URL(url);
+    return `${u.protocol}//${u.host}`;
+  } catch {
+    return '<invalid-url>';
+  }
+}
+
+function isHttpsUrl(url: string): boolean {
+  try {
+    return new URL(url).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function fail(code: FetchSafeErrorCode, origin: string, status?: number): FetchSafeFailure {
+  const base: FetchSafeFailure = {
+    ok: false,
+    code,
+    message: `${code} at ${origin}`,
+  };
+  return status === undefined ? base : { ...base, status };
+}
+
+function mapNetNodeCode(code: string): FetchSafeErrorCode {
+  switch (code) {
+    case SAFE_FETCH_ERROR_CODES.E_REQUEST_TIMEOUT:
+    case SAFE_FETCH_ERROR_CODES.E_DNS_TIMEOUT:
+    case SAFE_FETCH_ERROR_CODES.E_CONNECT_TIMEOUT:
+    case SAFE_FETCH_ERROR_CODES.E_HEADERS_TIMEOUT:
+    case SAFE_FETCH_ERROR_CODES.E_BODY_TIMEOUT:
+      return 'fetch_timeout';
+    case SAFE_FETCH_ERROR_CODES.E_NETWORK_ERROR:
+    case SAFE_FETCH_ERROR_CODES.E_DNS_RESOLUTION_FAILED:
+    case SAFE_FETCH_ERROR_CODES.E_PARSE_ERROR:
+      return 'fetch_network_error';
+    case SAFE_FETCH_ERROR_CODES.E_SSRF_URL_REJECTED:
+    case SAFE_FETCH_ERROR_CODES.E_SSRF_DNS_RESOLVED_PRIVATE:
+    case SAFE_FETCH_ERROR_CODES.E_SSRF_ALL_IPS_BLOCKED:
+    case SAFE_FETCH_ERROR_CODES.E_SSRF_IPV6_ZONE_ID:
+    case SAFE_FETCH_ERROR_CODES.E_SSRF_INVALID_HOST:
+    case SAFE_FETCH_ERROR_CODES.E_SSRF_MIXED_DNS_BLOCKED:
+    case SAFE_FETCH_ERROR_CODES.E_SSRF_MIXED_DNS_ACK_MISSING:
+    case SAFE_FETCH_ERROR_CODES.E_SSRF_ALLOWCIDRS_ACK_REQUIRED:
+    case SAFE_FETCH_ERROR_CODES.E_TENANT_KEY_MISSING:
+      return 'fetch_blocked_ssrf';
+    case SAFE_FETCH_ERROR_CODES.E_SSRF_REDIRECT_BLOCKED:
+    case SAFE_FETCH_ERROR_CODES.E_SSRF_TOO_MANY_REDIRECTS:
+      return 'fetch_blocked_redirect';
+    case SAFE_FETCH_ERROR_CODES.E_RESPONSE_TOO_LARGE:
+      return 'fetch_blocked_byte_cap';
+    case SAFE_FETCH_ERROR_CODES.E_SSRF_DANGEROUS_PORT:
+    case SAFE_FETCH_ERROR_CODES.E_SSRF_DANGEROUS_PORT_ACK_MISSING:
+      return 'fetch_blocked_dangerous_port';
+    case SAFE_FETCH_ERROR_CODES.E_METHOD_NOT_ALLOWED:
+      return 'resolver_internal_error';
+    default:
+      return 'resolver_internal_error';
+  }
+}
+
+interface BuiltOptions {
+  timeoutMs: number;
+  maxResponseBytes: number;
+  maxRedirects: number;
+}
+
+function buildOptions(opts: FetchSafeOptions | undefined, kind: 'json' | 'jwks'): BuiltOptions {
+  const maxResponseBytes =
+    opts?.maxResponseBytes ??
+    (kind === 'jwks' ? VERIFIER_LIMITS.maxJwksBytes : VERIFIER_LIMITS.maxResponseBytes);
+  return {
+    timeoutMs: opts?.timeoutMs ?? VERIFIER_LIMITS.fetchTimeoutMs,
+    maxResponseBytes,
+    maxRedirects: opts?.maxRedirects ?? VERIFIER_LIMITS.maxRedirects,
+  };
+}
+
+function classifyStatus(status: number): FetchSafeErrorCode | null {
+  if (status >= 400 && status < 500) return 'fetch_status_4xx';
+  if (status >= 500) return 'fetch_status_5xx';
+  return null;
+}
+
+function checkContentType(
+  contentType: string | null,
+  accept: readonly string[] | undefined
+): boolean {
+  if (!accept || accept.length === 0) return true;
+  if (!contentType) return false;
+  const lower = contentType.toLowerCase().split(';')[0].trim();
+  return accept.some((allowed) => lower === allowed.toLowerCase());
+}
+
+export async function fetchJsonSafe<T = unknown>(
+  url: string,
+  options?: FetchSafeOptions
+): Promise<FetchSafeResult<T>> {
+  const origin = safeOrigin(url);
+  if (!isHttpsUrl(url)) {
+    return fail('fetch_blocked_https_only', origin);
+  }
+  const built = buildOptions(options, 'json');
+  let result;
+  try {
+    result = await safeFetchJson<T>(url, {
+      timeoutMs: built.timeoutMs,
+      maxResponseBytes: built.maxResponseBytes,
+      maxRedirects: built.maxRedirects,
+      allowedMethods: ['GET'],
+    });
+  } catch {
+    return fail('resolver_internal_error', origin);
+  }
+  if (!result.ok) {
+    return fail(mapNetNodeCode(result.code), origin);
+  }
+  const contentType = result.response.headers.get('content-type') ?? undefined;
+  if (!checkContentType(contentType ?? null, options?.acceptContentTypes)) {
+    return fail('fetch_invalid_content_type', origin);
+  }
+  const statusFailure = classifyStatus(result.response.status);
+  if (statusFailure !== null) {
+    return fail(statusFailure, origin, result.response.status);
+  }
+  return {
+    ok: true,
+    body: result.data,
+    bytes: result.evidence?.response_bytes ?? 0,
+    contentType,
+  };
+}
+
+export async function fetchJwksSafe<T = { keys: unknown[] }>(
+  url: string,
+  options?: FetchSafeOptions
+): Promise<FetchSafeResult<T>> {
+  const origin = safeOrigin(url);
+  if (!isHttpsUrl(url)) {
+    return fail('fetch_blocked_https_only', origin);
+  }
+  const built = buildOptions(options, 'jwks');
+  let result;
+  try {
+    result = await safeFetchJWKS(url, {
+      timeoutMs: built.timeoutMs,
+      maxResponseBytes: built.maxResponseBytes,
+      allowedMethods: ['GET'],
+    });
+  } catch {
+    return fail('resolver_internal_error', origin);
+  }
+  if (!result.ok) {
+    return fail(mapNetNodeCode(result.code), origin);
+  }
+  const contentType = result.response.headers.get('content-type') ?? undefined;
+  if (!checkContentType(contentType ?? null, options?.acceptContentTypes)) {
+    return fail('fetch_invalid_content_type', origin);
+  }
+  const statusFailure = classifyStatus(result.response.status);
+  if (statusFailure !== null) {
+    return fail(statusFailure, origin, result.response.status);
+  }
+  return {
+    ok: true,
+    body: result.data as T,
+    bytes: result.evidence?.response_bytes ?? 0,
+    contentType,
+  };
+}
+
+export async function fetchRawSafe(
+  url: string,
+  options?: FetchSafeOptions
+): Promise<FetchSafeResult<Uint8Array>> {
+  const origin = safeOrigin(url);
+  if (!isHttpsUrl(url)) {
+    return fail('fetch_blocked_https_only', origin);
+  }
+  const built = buildOptions(options, 'json');
+  let raw;
+  try {
+    raw = await safeFetchRaw(url, {
+      timeoutMs: built.timeoutMs,
+      maxResponseBytes: built.maxResponseBytes,
+      maxRedirects: built.maxRedirects,
+      allowedMethods: ['GET'],
+    });
+  } catch {
+    return fail('resolver_internal_error', origin);
+  }
+  if (!raw.ok) {
+    return fail(mapNetNodeCode(raw.code), origin);
+  }
+  try {
+    const contentType = raw.response.headers.get('content-type') ?? undefined;
+    if (!checkContentType(contentType ?? null, options?.acceptContentTypes)) {
+      return fail('fetch_invalid_content_type', origin);
+    }
+    const statusFailure = classifyStatus(raw.response.status);
+    if (statusFailure !== null) {
+      return fail(statusFailure, origin, raw.response.status);
+    }
+    const buf = await raw.response.arrayBuffer();
+    if (buf.byteLength > built.maxResponseBytes) {
+      return fail('fetch_blocked_byte_cap', origin);
+    }
+    const bytes = new Uint8Array(buf);
+    return {
+      ok: true,
+      body: bytes,
+      bytes: bytes.byteLength,
+      contentType,
+    };
+  } catch {
+    return fail('resolver_internal_error', origin);
+  } finally {
+    try {
+      await raw.close();
+    } catch {
+      // close failures are not surfaced; raw fetch already returned a body
+    }
+  }
+}
+
+export type { FetchSafeOptions, FetchSafeResult, FetchSafeErrorCode } from './types.js';

--- a/packages/resolver-http/src/fetch-safe.ts
+++ b/packages/resolver-http/src/fetch-safe.ts
@@ -3,7 +3,7 @@
 // Pulls verifier defaults from @peac/kernel.VERIFIER_LIMITS and overrides
 // net-node's broader defaults (5000ms vs 30000ms; 256 KiB vs 2 MiB; 64 KiB
 // JWKS vs 512 KiB; 3 redirects vs 5). Maps SAFE_FETCH_ERROR_CODES to a
-// closed local FetchSafeErrorCode set. Returns discriminated-union results;
+// closed local ResolverHttpErrorCode set. Returns discriminated-union results;
 // failure messages are redacted (origin host only; no path / query / headers
 // / body / secrets / upstream cause text).
 //
@@ -13,10 +13,10 @@ import { safeFetchJson, safeFetchJWKS, safeFetchRaw, SAFE_FETCH_ERROR_CODES } fr
 import { VERIFIER_LIMITS } from '@peac/kernel';
 
 import type {
-  FetchSafeErrorCode,
   FetchSafeFailure,
   FetchSafeOptions,
   FetchSafeResult,
+  ResolverHttpErrorCode,
 } from './types.js';
 
 function safeOrigin(url: string): string {
@@ -36,7 +36,7 @@ function isHttpsUrl(url: string): boolean {
   }
 }
 
-function fail(code: FetchSafeErrorCode, origin: string, status?: number): FetchSafeFailure {
+function fail(code: ResolverHttpErrorCode, origin: string, status?: number): FetchSafeFailure {
   const base: FetchSafeFailure = {
     ok: false,
     code,
@@ -45,7 +45,7 @@ function fail(code: FetchSafeErrorCode, origin: string, status?: number): FetchS
   return status === undefined ? base : { ...base, status };
 }
 
-function mapNetNodeCode(code: string): FetchSafeErrorCode {
+function mapNetNodeCode(code: string): ResolverHttpErrorCode {
   switch (code) {
     case SAFE_FETCH_ERROR_CODES.E_REQUEST_TIMEOUT:
     case SAFE_FETCH_ERROR_CODES.E_DNS_TIMEOUT:
@@ -99,7 +99,7 @@ function buildOptions(opts: FetchSafeOptions | undefined, kind: 'json' | 'jwks')
   };
 }
 
-function classifyStatus(status: number): FetchSafeErrorCode | null {
+function classifyStatus(status: number): ResolverHttpErrorCode | null {
   if (status >= 400 && status < 500) return 'fetch_status_4xx';
   if (status >= 500) return 'fetch_status_5xx';
   return null;
@@ -138,13 +138,16 @@ export async function fetchJsonSafe<T = unknown>(
   if (!result.ok) {
     return fail(mapNetNodeCode(result.code), origin);
   }
-  const contentType = result.response.headers.get('content-type') ?? undefined;
-  if (!checkContentType(contentType ?? null, options?.acceptContentTypes)) {
-    return fail('fetch_invalid_content_type', origin);
-  }
+  // Status precedence: classify HTTP status BEFORE content-type. A 4xx with
+  // text/html body is more usefully reported as fetch_status_4xx than as
+  // fetch_invalid_content_type. (Commit 2.1 Fix #2.)
   const statusFailure = classifyStatus(result.response.status);
   if (statusFailure !== null) {
     return fail(statusFailure, origin, result.response.status);
+  }
+  const contentType = result.response.headers.get('content-type') ?? undefined;
+  if (!checkContentType(contentType ?? null, options?.acceptContentTypes)) {
+    return fail('fetch_invalid_content_type', origin);
   }
   return {
     ok: true,
@@ -165,6 +168,11 @@ export async function fetchJwksSafe<T = { keys: unknown[] }>(
   const built = buildOptions(options, 'jwks');
   let result;
   try {
+    // JWKS endpoints are forced to zero redirects by upstream safeFetchJWKS
+    // (deliberate stricter case for key-material URLs); resolver-http's
+    // FetchSafeOptions.maxRedirects is silently ignored on this path because
+    // safeFetchJWKS has signature Omit<SafeFetchOptions, 'maxRedirects'>.
+    // Documented in plan "Commit 2.1, Fix #1".
     result = await safeFetchJWKS(url, {
       timeoutMs: built.timeoutMs,
       maxResponseBytes: built.maxResponseBytes,
@@ -176,13 +184,14 @@ export async function fetchJwksSafe<T = { keys: unknown[] }>(
   if (!result.ok) {
     return fail(mapNetNodeCode(result.code), origin);
   }
-  const contentType = result.response.headers.get('content-type') ?? undefined;
-  if (!checkContentType(contentType ?? null, options?.acceptContentTypes)) {
-    return fail('fetch_invalid_content_type', origin);
-  }
+  // Status precedence (Commit 2.1 Fix #2).
   const statusFailure = classifyStatus(result.response.status);
   if (statusFailure !== null) {
     return fail(statusFailure, origin, result.response.status);
+  }
+  const contentType = result.response.headers.get('content-type') ?? undefined;
+  if (!checkContentType(contentType ?? null, options?.acceptContentTypes)) {
+    return fail('fetch_invalid_content_type', origin);
   }
   return {
     ok: true,
@@ -216,13 +225,14 @@ export async function fetchRawSafe(
     return fail(mapNetNodeCode(raw.code), origin);
   }
   try {
-    const contentType = raw.response.headers.get('content-type') ?? undefined;
-    if (!checkContentType(contentType ?? null, options?.acceptContentTypes)) {
-      return fail('fetch_invalid_content_type', origin);
-    }
+    // Status precedence (Commit 2.1 Fix #2).
     const statusFailure = classifyStatus(raw.response.status);
     if (statusFailure !== null) {
       return fail(statusFailure, origin, raw.response.status);
+    }
+    const contentType = raw.response.headers.get('content-type') ?? undefined;
+    if (!checkContentType(contentType ?? null, options?.acceptContentTypes)) {
+      return fail('fetch_invalid_content_type', origin);
     }
     const buf = await raw.response.arrayBuffer();
     if (buf.byteLength > built.maxResponseBytes) {
@@ -246,4 +256,4 @@ export async function fetchRawSafe(
   }
 }
 
-export type { FetchSafeOptions, FetchSafeResult, FetchSafeErrorCode } from './types.js';
+export type { FetchSafeOptions, FetchSafeResult, ResolverHttpErrorCode } from './types.js';

--- a/packages/resolver-http/src/index.ts
+++ b/packages/resolver-http/src/index.ts
@@ -24,3 +24,27 @@ export type {
   FetchSafeSuccess,
   ResolverHttpErrorCode,
 } from './types.js';
+
+export { fetchIssuerConfig } from './discovery.js';
+export type { DiscoveryOptions, DiscoveryResult, IssuerConfig } from './discovery.js';
+
+export {
+  IssuerJwksResolver,
+  fetchAndValidateJwks,
+  findKeyByKid,
+  validateJwksShape,
+} from './jwks-resolver.js';
+export type {
+  JwksResolveFailure,
+  JwksResolveResult,
+  JwksResolveSuccess,
+  JwksResolverOptions,
+} from './jwks-resolver.js';
+
+export { fetchPointerWithDigest } from './pointer-fetch.js';
+export type {
+  PointerFetchFailure,
+  PointerFetchOptions,
+  PointerFetchResult,
+  PointerFetchSuccess,
+} from './pointer-fetch.js';

--- a/packages/resolver-http/src/index.ts
+++ b/packages/resolver-http/src/index.ts
@@ -18,9 +18,9 @@
 
 export { fetchJsonSafe, fetchJwksSafe, fetchRawSafe } from './fetch-safe.js';
 export type {
-  FetchSafeErrorCode,
   FetchSafeFailure,
   FetchSafeOptions,
   FetchSafeResult,
   FetchSafeSuccess,
+  ResolverHttpErrorCode,
 } from './types.js';

--- a/packages/resolver-http/src/index.ts
+++ b/packages/resolver-http/src/index.ts
@@ -1,20 +1,26 @@
-// @peac/resolver-http (workspace-private)
+// resolver-http (workspace-private)
 //
 // Internal-only barrel. This package is workspace-private per Revision 4
 // section 19; never published; never referenced by any published
-// package. Resolver logic is added in subsequent commits of v0.13.2 PR
-// A as a private composition layer over published primitives
-// (@peac/net-node, @peac/jwks-cache, @peac/kernel, @peac/crypto,
-// @peac/schema) for parity testing against @peac/protocol's existing
-// self-contained resolver path on shared local fixtures.
+// package. Composition layer over published primitives (@peac/net-node,
+// @peac/jwks-cache, @peac/kernel, @peac/crypto, @peac/schema) for parity
+// testing against the protocol package's existing self-contained
+// resolver path on shared local fixtures.
 //
-// P0 invariants (LOCKED): @peac/protocol must NOT import, depend on,
-// re-export from, or emit a reference to @peac/resolver-http;
-// @peac/resolver-http runtime source must NOT import @peac/protocol
-// (parity test files MAY import protocol for behavior comparison).
-// @peac/jwks-cache and @peac/net-node are reused as published
-// primitives; they are not modified, merged, or renamed in v0.13.2.
-// Verified by tests/tooling/protocol-private-imports.test.ts and
-// adjacent gates.
+// P0 invariants (LOCKED): the protocol package must NOT import, depend
+// on, re-export from, or emit a reference to this package; this
+// package's runtime source must NOT import the protocol package
+// (parity test files MAY import the protocol package for behavior
+// comparison). @peac/jwks-cache and @peac/net-node are reused as
+// published primitives; they are not modified, merged, or renamed in
+// v0.13.2. Verified by tests/tooling/protocol-private-imports.test.ts
+// and adjacent gates.
 
-export {};
+export { fetchJsonSafe, fetchJwksSafe, fetchRawSafe } from './fetch-safe.js';
+export type {
+  FetchSafeErrorCode,
+  FetchSafeFailure,
+  FetchSafeOptions,
+  FetchSafeResult,
+  FetchSafeSuccess,
+} from './types.js';

--- a/packages/resolver-http/src/index.ts
+++ b/packages/resolver-http/src/index.ts
@@ -1,0 +1,14 @@
+// @peac/resolver-http (workspace-private)
+//
+// Internal-only barrel. This package is workspace-private per Revision 4
+// section 19; never published; never referenced by any published
+// package. Resolver logic is added in subsequent commits of v0.13.2 PR
+// A as a private shadow of packages/protocol/src/{discovery, jwks-
+// resolver, ssrf-safe-fetch, pointer-fetch}.ts for parity testing.
+//
+// P0 invariant (LOCKED): @peac/protocol must NOT import, depend on,
+// re-export from, or emit a reference to @peac/resolver-http. Verified
+// by tests/tooling/protocol-private-imports.test.ts and adjacent
+// gates.
+
+export {};

--- a/packages/resolver-http/src/index.ts
+++ b/packages/resolver-http/src/index.ts
@@ -3,12 +3,18 @@
 // Internal-only barrel. This package is workspace-private per Revision 4
 // section 19; never published; never referenced by any published
 // package. Resolver logic is added in subsequent commits of v0.13.2 PR
-// A as a private shadow of packages/protocol/src/{discovery, jwks-
-// resolver, ssrf-safe-fetch, pointer-fetch}.ts for parity testing.
+// A as a private composition layer over published primitives
+// (@peac/net-node, @peac/jwks-cache, @peac/kernel, @peac/crypto,
+// @peac/schema) for parity testing against @peac/protocol's existing
+// self-contained resolver path on shared local fixtures.
 //
-// P0 invariant (LOCKED): @peac/protocol must NOT import, depend on,
-// re-export from, or emit a reference to @peac/resolver-http. Verified
-// by tests/tooling/protocol-private-imports.test.ts and adjacent
-// gates.
+// P0 invariants (LOCKED): @peac/protocol must NOT import, depend on,
+// re-export from, or emit a reference to @peac/resolver-http;
+// @peac/resolver-http runtime source must NOT import @peac/protocol
+// (parity test files MAY import protocol for behavior comparison).
+// @peac/jwks-cache and @peac/net-node are reused as published
+// primitives; they are not modified, merged, or renamed in v0.13.2.
+// Verified by tests/tooling/protocol-private-imports.test.ts and
+// adjacent gates.
 
 export {};

--- a/packages/resolver-http/src/jwks-resolver.ts
+++ b/packages/resolver-http/src/jwks-resolver.ts
@@ -1,0 +1,235 @@
+// Issuer-keyed JWKS resolution composed over jwks-cache primitives + fetch-safe.
+//
+// Network goes through `fetchJwksSafe` (net-node-backed; verifier-grade DNS
+// pinning + redirect policy + verifier limits). `@peac/jwks-cache` is used
+// for: (a) string-level URL pre-check (`validateUrl`, `isMetadataIp`),
+// (b) cache primitives (`InMemoryCache`, `buildCacheKey`), and (c) key
+// material conversion (`importJwkAsEd25519`, `createJwkVerifier`).
+//
+// `resolveKey` and `createResolver` from `@peac/jwks-cache` are NOT called:
+// they use global `fetch()` internally (verified at
+// `packages/jwks-cache/src/resolver.ts:284`) which lacks net-node's DNS
+// pinning. Routing JWKS network through them would bypass the verifier
+// boundary.
+
+import {
+  InMemoryCache,
+  type InMemoryCacheOptions,
+  type JWK,
+  type JWKS,
+  buildCacheKey,
+  isMetadataIp,
+  validateUrl,
+} from '@peac/jwks-cache';
+import { VERIFIER_LIMITS } from '@peac/kernel';
+
+import { fetchJwksSafe } from './fetch-safe.js';
+import type { FetchSafeOptions, FetchSafeFailure, ResolverHttpErrorCode } from './types.js';
+
+export type JwksResolveSuccess = {
+  ok: true;
+  jwk: JWK;
+};
+
+export type JwksResolveFailure = FetchSafeFailure;
+
+export type JwksResolveResult = JwksResolveSuccess | JwksResolveFailure;
+
+export interface JwksResolverOptions extends Pick<
+  FetchSafeOptions,
+  'timeoutMs' | 'maxResponseBytes'
+> {
+  /** TTL in seconds for cached keys (defaults to ISSUER_CONFIG.cacheTtlSeconds-style 3600). */
+  ttlSeconds?: number;
+  /** InMemoryCache options (maxEntries, etc.). */
+  cacheOptions?: InMemoryCacheOptions;
+}
+
+const DEFAULT_TTL_SECONDS = 3600;
+
+function safeOrigin(url: string): string {
+  try {
+    const u = new URL(url);
+    return `${u.protocol}//${u.host}`;
+  } catch {
+    return '<invalid-url>';
+  }
+}
+
+function fail(code: ResolverHttpErrorCode, origin: string): JwksResolveFailure {
+  return {
+    ok: false,
+    code,
+    message: `${code} at ${origin}`,
+  };
+}
+
+function isJwk(value: unknown): value is JWK {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return typeof obj.kty === 'string' && typeof obj.crv === 'string' && typeof obj.x === 'string';
+}
+
+/**
+ * Validate JWKS body shape locally. `@peac/jwks-cache` does not export a
+ * standalone validator; the relevant logic is internal to `resolveKey`.
+ *
+ * Rules: object with a `keys` array; `keys.length` <= `VERIFIER_LIMITS.maxJwksKeys`;
+ * each key has `kty`, `crv`, `x` strings.
+ */
+export function validateJwksShape(body: unknown): JWKS | null {
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) return null;
+  const obj = body as Record<string, unknown>;
+  if (!Array.isArray(obj.keys)) return null;
+  if (obj.keys.length > VERIFIER_LIMITS.maxJwksKeys) return null;
+  for (const key of obj.keys) {
+    if (!isJwk(key)) return null;
+  }
+  return { keys: obj.keys as JWK[] };
+}
+
+/**
+ * Pre-check JWKS URL before fetch dispatch. Returns null if URL is acceptable;
+ * a discriminated-union failure otherwise. Defense-in-depth: net-node also
+ * enforces SSRF; this catches obviously bad URLs at the resolver-http
+ * boundary so callers see a stable error class earlier in the call chain.
+ */
+function preCheckJwksUrl(jwksUri: string): JwksResolveFailure | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(jwksUri);
+  } catch {
+    return fail('fetch_blocked_https_only', '<invalid-url>');
+  }
+  // Metadata-IP pre-check via jwks-cache helper. resolver-http surfaces a
+  // dedicated `fetch_blocked_metadata_ip` code (Step 3 mapping table).
+  if (isMetadataIp(parsed.hostname)) {
+    return fail('fetch_blocked_metadata_ip', `${parsed.protocol}//${parsed.host}`);
+  }
+  // Generic SSRF / scheme / host pre-check via jwks-cache validateUrl.
+  // Throws JwksError on failure; treat any failure as fetch_blocked_ssrf
+  // (HTTPS-only enforcement is also covered by fetchJwksSafe downstream).
+  try {
+    validateUrl(jwksUri);
+  } catch {
+    return fail('fetch_blocked_ssrf', `${parsed.protocol}//${parsed.host}`);
+  }
+  return null;
+}
+
+/**
+ * Stateless JWKS fetch + body validation.
+ *
+ * Network goes through `fetchJwksSafe`. Body shape is validated by
+ * `validateJwksShape`. No caching (callers can layer caching via
+ * `IssuerJwksResolver` below).
+ */
+export async function fetchAndValidateJwks(
+  jwksUri: string,
+  options?: JwksResolverOptions
+): Promise<{ ok: true; jwks: JWKS; bytes: number } | JwksResolveFailure> {
+  const preCheckFailure = preCheckJwksUrl(jwksUri);
+  if (preCheckFailure !== null) return preCheckFailure;
+
+  const fetchResult = await fetchJwksSafe<unknown>(jwksUri, {
+    timeoutMs: options?.timeoutMs,
+    maxResponseBytes: options?.maxResponseBytes,
+  });
+
+  if (!fetchResult.ok) {
+    return fetchResult;
+  }
+
+  const validated = validateJwksShape(fetchResult.body);
+  if (validated === null) {
+    return fail('jwks_invalid_shape', safeOrigin(jwksUri));
+  }
+
+  return { ok: true, jwks: validated, bytes: fetchResult.bytes };
+}
+
+/**
+ * Find a JWK in a JWKS by `kid`. Returns null if not found.
+ */
+export function findKeyByKid(jwks: JWKS, kid: string): JWK | null {
+  for (const key of jwks.keys) {
+    if (key.kid === kid) return key;
+  }
+  return null;
+}
+
+/**
+ * Issuer-keyed JWKS resolver with per-key caching.
+ *
+ * Owns an `InMemoryCache` (from `@peac/jwks-cache`) keyed by
+ * `buildCacheKey(issuerOrigin, kid)`. Two issuers with overlapping `kid`
+ * values resolve to distinct cache entries because the cache key includes
+ * the issuer origin.
+ */
+export class IssuerJwksResolver {
+  private readonly cache: InMemoryCache;
+  private readonly ttlSeconds: number;
+
+  constructor(options?: JwksResolverOptions) {
+    this.cache = new InMemoryCache(options?.cacheOptions);
+    this.ttlSeconds = options?.ttlSeconds ?? DEFAULT_TTL_SECONDS;
+  }
+
+  /**
+   * Resolve a single key by `(issuer, kid)`.
+   *
+   * Cache hit: returns the cached JWK without any network call.
+   * Cache miss: pre-checks `jwksUri` via jwks-cache `validateUrl` /
+   * `isMetadataIp`, fetches JWKS via `fetchJwksSafe`, validates body
+   * shape, finds the key by `kid`, caches it with `ttlSeconds`, returns.
+   * If `kid` is not present in the fetched JWKS, returns `jwks_kid_not_found`.
+   */
+  async resolve(
+    issuer: string,
+    jwksUri: string,
+    kid: string,
+    options?: JwksResolverOptions
+  ): Promise<JwksResolveResult> {
+    let issuerOrigin: string;
+    try {
+      issuerOrigin = new URL(issuer).origin;
+    } catch {
+      return fail('discovery_invalid_shape', '<invalid-url>');
+    }
+
+    const cacheKey = buildCacheKey(issuerOrigin, kid);
+    const cached = await this.cache.get(cacheKey);
+    if (cached !== null) {
+      return { ok: true, jwk: cached.jwk };
+    }
+
+    const fetchResult = await fetchAndValidateJwks(jwksUri, options);
+    if (!fetchResult.ok) {
+      return fetchResult;
+    }
+
+    const matched = findKeyByKid(fetchResult.jwks, kid);
+    if (matched === null) {
+      return fail('jwks_kid_not_found', issuerOrigin);
+    }
+
+    const expiresAt = Math.floor(Date.now() / 1000) + this.ttlSeconds;
+    await this.cache.set(cacheKey, { jwk: matched, expiresAt });
+
+    return { ok: true, jwk: matched };
+  }
+
+  /**
+   * Clear cache (for tests).
+   */
+  clearCache(): void {
+    this.cache.clear();
+  }
+
+  /**
+   * Cache size (for tests).
+   */
+  get cacheSize(): number {
+    return this.cache.size;
+  }
+}

--- a/packages/resolver-http/src/jwks-resolver.ts
+++ b/packages/resolver-http/src/jwks-resolver.ts
@@ -3,8 +3,10 @@
 // Network goes through `fetchJwksSafe` (net-node-backed; verifier-grade DNS
 // pinning + redirect policy + verifier limits). `@peac/jwks-cache` is used
 // for: (a) string-level URL pre-check (`validateUrl`, `isMetadataIp`),
-// (b) cache primitives (`InMemoryCache`, `buildCacheKey`), and (c) key
-// material conversion (`importJwkAsEd25519`, `createJwkVerifier`).
+// (b) cache primitives (`InMemoryCache`, `buildCacheKey`), and (c) crypto
+// validation of the matched JWK before caching (`importJwkAsEd25519`).
+// `@peac/crypto.sha256Hex` derives the per-`jwksUri` cache-key fragment so
+// the same issuer with different JWKS endpoints does not collide on `kid`.
 //
 // `resolveKey` and `createResolver` from `@peac/jwks-cache` are NOT called:
 // they use global `fetch()` internally (verified at
@@ -18,9 +20,11 @@ import {
   type JWK,
   type JWKS,
   buildCacheKey,
+  importJwkAsEd25519,
   isMetadataIp,
   validateUrl,
 } from '@peac/jwks-cache';
+import { sha256Hex } from '@peac/crypto';
 import { VERIFIER_LIMITS } from '@peac/kernel';
 
 import { fetchJwksSafe } from './fetch-safe.js';
@@ -53,6 +57,23 @@ function safeOrigin(url: string): string {
     return `${u.protocol}//${u.host}`;
   } catch {
     return '<invalid-url>';
+  }
+}
+
+/**
+ * Normalize a `jwksUri` for cache-key derivation. Lowercases the host;
+ * keeps the rest of the URL byte-for-byte (path / query / fragment matter
+ * for cache identity). Returns the original string unchanged if URL parse
+ * fails (the cache lookup will simply miss for a malformed URI; this code
+ * path is reached only after the pre-fetch validateUrl pre-check).
+ */
+function normalizeJwksUri(jwksUri: string): string {
+  try {
+    const u = new URL(jwksUri);
+    u.host = u.host.toLowerCase();
+    return u.toString();
+  } catch {
+    return jwksUri;
   }
 }
 
@@ -176,13 +197,21 @@ export class IssuerJwksResolver {
   }
 
   /**
-   * Resolve a single key by `(issuer, kid)`.
+   * Resolve a single key by `(issuer, jwksUri, kid)`.
+   *
+   * Cache key includes a sha256 digest of the normalized `jwksUri` so that
+   * the same issuer with different JWKS endpoints (e.g. tenant-specific
+   * paths under one origin) does not collide on `kid`.
    *
    * Cache hit: returns the cached JWK without any network call.
    * Cache miss: pre-checks `jwksUri` via jwks-cache `validateUrl` /
    * `isMetadataIp`, fetches JWKS via `fetchJwksSafe`, validates body
-   * shape, finds the key by `kid`, caches it with `ttlSeconds`, returns.
-   * If `kid` is not present in the fetched JWKS, returns `jwks_kid_not_found`.
+   * shape, finds the key by `kid`, validates the JWK's cryptographic
+   * shape via `importJwkAsEd25519` (rejects structurally plausible but
+   * not actually Ed25519-loadable keys), caches it with `ttlSeconds`,
+   * returns. If `kid` is not present in the fetched JWKS, returns
+   * `jwks_kid_not_found`. If the matched JWK fails crypto-import,
+   * returns `jwks_invalid_shape` and the JWK is NOT cached.
    */
   async resolve(
     issuer: string,
@@ -197,7 +226,9 @@ export class IssuerJwksResolver {
       return fail('discovery_invalid_shape', '<invalid-url>');
     }
 
-    const cacheKey = buildCacheKey(issuerOrigin, kid);
+    const normalizedJwksUri = normalizeJwksUri(jwksUri);
+    const jwksUriDigest = await sha256Hex(normalizedJwksUri);
+    const cacheKey = buildCacheKey(`${issuerOrigin}#${jwksUriDigest}`, kid);
     const cached = await this.cache.get(cacheKey);
     if (cached !== null) {
       return { ok: true, jwk: cached.jwk };
@@ -211,6 +242,16 @@ export class IssuerJwksResolver {
     const matched = findKeyByKid(fetchResult.jwks, kid);
     if (matched === null) {
       return fail('jwks_kid_not_found', issuerOrigin);
+    }
+
+    // Crypto-validate the matched JWK before caching. importJwkAsEd25519
+    // calls crypto.subtle.importKey('jwk', ..., { name: 'Ed25519' }, ...)
+    // which throws on non-Ed25519 / malformed-x JWKs. A structurally
+    // plausible JWK with bad crypto material MUST NOT be cached.
+    try {
+      await importJwkAsEd25519(matched);
+    } catch {
+      return fail('jwks_invalid_shape', issuerOrigin);
     }
 
     const expiresAt = Math.floor(Date.now() / 1000) + this.ttlSeconds;

--- a/packages/resolver-http/src/pointer-fetch.ts
+++ b/packages/resolver-http/src/pointer-fetch.ts
@@ -1,17 +1,21 @@
 // Pointer-fetch: fetch a compact-JWS receipt by URL, verify SHA-256 digest.
 //
-// Mirrors the protocol package's call sequence at
-// `packages/protocol/src/pointer-fetch.ts:202-235` byte-for-byte:
+// Semantically mirrors the protocol package's call sequence at
+// `packages/protocol/src/pointer-fetch.ts:202-235` (string-mode digest path):
 //   1. fetch raw bytes via fetchRawSafe (verifier-grade DNS pinning + caps)
 //   2. decode bytes to UTF-8 string via TextDecoder('utf-8', { fatal: false })
 //   3. compute sha256Hex(receiptString) -- string-mode digest
 //   4. compare to expected digest (lowercase hex, 64 chars)
-// Raw-bytes-only digest is forbidden (would diverge from protocol on the
-// theoretical malformed-UTF-8 edge case; parity is the rule).
+// Raw-bytes-only digest is forbidden because the parity rule mirrors
+// protocol's actual call sequence. Byte-equal parity over fetched bodies is
+// proven by Commit 4's full harness; this commit asserts class-level parity
+// only (Commit 3 parity smoke).
 //
-// Content-type behavior matches protocol exactly: do NOT reject on mismatch;
-// surface a bounded contentTypeWarning string on success when the upstream
-// content-type is outside the expected set.
+// Content-type behavior matches protocol's normalized warning behavior: do
+// NOT reject on mismatch; surface a bounded contentTypeWarning string on
+// success when the upstream content-type is outside the expected set. The
+// resolver-http warning string is its own (bounded, redaction-safe) ; it is
+// not byte-equal to protocol's warning string.
 //
 // Composition layer over a published primitive. Does not import the
 // protocol package.
@@ -100,7 +104,7 @@ function isValidCompactJws(s: string): boolean {
  *
  * Pre-checks:
  *   - HTTPS-only (delegated to fetchRawSafe; surfaces fetch_blocked_https_only)
- *   - expectedDigest format (64 lowercase hex chars; pointer_fetch_blocked otherwise)
+ *   - expectedDigest format (64 lowercase hex chars; pointer_invalid_expected_digest otherwise)
  *
  * Post-fetch checks:
  *   - empty body or non-3-segment compact JWS surfaces pointer_malformed_jws
@@ -117,7 +121,10 @@ export async function fetchPointerWithDigest(
   const origin = safeOrigin(url);
 
   if (!EXPECTED_DIGEST_REGEX.test(expectedDigest)) {
-    return fail('pointer_fetch_blocked', origin);
+    // Invalid digest input is a programmer error / API misuse class, not
+    // a URL-block / SSRF / policy block. Distinct code per Commit 3.1
+    // Plan Fix #3.
+    return fail('pointer_invalid_expected_digest', origin);
   }
 
   const fetchResult = await fetchRawSafe(url, {

--- a/packages/resolver-http/src/pointer-fetch.ts
+++ b/packages/resolver-http/src/pointer-fetch.ts
@@ -1,0 +1,180 @@
+// Pointer-fetch: fetch a compact-JWS receipt by URL, verify SHA-256 digest.
+//
+// Mirrors the protocol package's call sequence at
+// `packages/protocol/src/pointer-fetch.ts:202-235` byte-for-byte:
+//   1. fetch raw bytes via fetchRawSafe (verifier-grade DNS pinning + caps)
+//   2. decode bytes to UTF-8 string via TextDecoder('utf-8', { fatal: false })
+//   3. compute sha256Hex(receiptString) -- string-mode digest
+//   4. compare to expected digest (lowercase hex, 64 chars)
+// Raw-bytes-only digest is forbidden (would diverge from protocol on the
+// theoretical malformed-UTF-8 edge case; parity is the rule).
+//
+// Content-type behavior matches protocol exactly: do NOT reject on mismatch;
+// surface a bounded contentTypeWarning string on success when the upstream
+// content-type is outside the expected set.
+//
+// Composition layer over a published primitive. Does not import the
+// protocol package.
+
+import { sha256Hex } from '@peac/crypto';
+
+import { fetchRawSafe } from './fetch-safe.js';
+import type { FetchSafeOptions, FetchSafeFailure, ResolverHttpErrorCode } from './types.js';
+
+const ACCEPTED_CONTENT_TYPES = ['application/jose', 'application/json', 'text/plain'] as const;
+const CONTENT_TYPE_WARNING_MAX_LEN = 200;
+const EXPECTED_DIGEST_REGEX = /^[0-9a-f]{64}$/;
+const COMPACT_JWS_REGEX = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+
+export interface PointerFetchOptions extends Pick<
+  FetchSafeOptions,
+  'timeoutMs' | 'maxResponseBytes' | 'maxRedirects'
+> {}
+
+export interface PointerFetchSuccess {
+  ok: true;
+  /** Fetched receipt (compact JWS string). */
+  receipt: string;
+  /** Actual SHA-256 digest of the decoded UTF-8 string (lowercase hex). */
+  actualDigest: string;
+  /** Expected SHA-256 digest (echo of the caller's input). */
+  expectedDigest: string;
+  /** Content-Type header (if present). */
+  contentType?: string;
+  /**
+   * Warning string when content-type is outside the expected set. Bounded
+   * length; contains only the upstream content-type value (already public
+   * response metadata) plus a stable warning class label. Mirrors protocol's
+   * contentTypeWarning behavior at packages/protocol/src/pointer-fetch.ts:208-211.
+   */
+  contentTypeWarning?: string;
+}
+
+export interface PointerFetchFailure extends FetchSafeFailure {
+  /** Actual digest if computed (only present for digest-mismatch errors). */
+  actualDigest?: string;
+  /** Expected digest (only present for digest-mismatch errors). */
+  expectedDigest?: string;
+}
+
+export type PointerFetchResult = PointerFetchSuccess | PointerFetchFailure;
+
+function safeOrigin(url: string): string {
+  try {
+    const u = new URL(url);
+    return `${u.protocol}//${u.host}`;
+  } catch {
+    return '<invalid-url>';
+  }
+}
+
+function fail(code: ResolverHttpErrorCode, origin: string, status?: number): PointerFetchFailure {
+  const base: PointerFetchFailure = {
+    ok: false,
+    code,
+    message: `${code} at ${origin}`,
+  };
+  return status === undefined ? base : { ...base, status };
+}
+
+function buildContentTypeWarning(contentType: string): string {
+  // Mirror protocol's wording shape but bounded: stable class label +
+  // upstream content-type value (public response metadata). Length-capped.
+  const safe = contentType.slice(0, CONTENT_TYPE_WARNING_MAX_LEN - 80);
+  const warning = `unexpected_content_type: ${safe}; expected application/jose, application/json, or text/plain`;
+  return warning.slice(0, CONTENT_TYPE_WARNING_MAX_LEN);
+}
+
+function isValidCompactJws(s: string): boolean {
+  if (s.length === 0) return false;
+  if (s.length > 1024 * 1024) return false; // sanity: bound at 1 MiB
+  return COMPACT_JWS_REGEX.test(s);
+}
+
+/**
+ * Fetch a pointer URL and verify the digest matches the expected value.
+ *
+ * @param url - HTTPS URL pointing to a compact-JWS receipt
+ * @param expectedDigest - Lowercase hex SHA-256 (64 chars) of the receipt
+ * @param options - Optional verifier overrides (timeoutMs / maxResponseBytes / maxRedirects)
+ *
+ * Pre-checks:
+ *   - HTTPS-only (delegated to fetchRawSafe; surfaces fetch_blocked_https_only)
+ *   - expectedDigest format (64 lowercase hex chars; pointer_fetch_blocked otherwise)
+ *
+ * Post-fetch checks:
+ *   - empty body or non-3-segment compact JWS surfaces pointer_malformed_jws
+ *   - sha256Hex(decoded_utf8_string) compared to expected digest;
+ *     mismatch surfaces pointer_digest_mismatch with both digests echoed
+ *   - content-type outside accepted set surfaces a bounded contentTypeWarning
+ *     on success (not a failure)
+ */
+export async function fetchPointerWithDigest(
+  url: string,
+  expectedDigest: string,
+  options?: PointerFetchOptions
+): Promise<PointerFetchResult> {
+  const origin = safeOrigin(url);
+
+  if (!EXPECTED_DIGEST_REGEX.test(expectedDigest)) {
+    return fail('pointer_fetch_blocked', origin);
+  }
+
+  const fetchResult = await fetchRawSafe(url, {
+    timeoutMs: options?.timeoutMs,
+    maxResponseBytes: options?.maxResponseBytes,
+    maxRedirects: options?.maxRedirects,
+    // Deliberately do NOT pass acceptContentTypes -- pointer-fetch warns on
+    // mismatch instead of rejecting (mirrors protocol).
+  });
+
+  if (!fetchResult.ok) {
+    // SSRF / non-HTTPS / redirect / timeout / network / status pass-through.
+    // Map non-HTTPS to pointer_fetch_blocked to match protocol's
+    // pointer_fetch_blocked branch semantics for blocked URLs.
+    if (fetchResult.code === 'fetch_blocked_https_only') {
+      return fail('pointer_fetch_blocked', origin);
+    }
+    return fetchResult as PointerFetchFailure;
+  }
+
+  // Decode raw bytes to UTF-8 string. fatal:false matches protocol's
+  // TextDecoder default and tolerates malformed UTF-8 by replacement
+  // characters (impossible on a valid JWS but we mirror protocol).
+  const decoder = new TextDecoder('utf-8', { fatal: false });
+  const receipt = decoder.decode(fetchResult.body);
+
+  if (!isValidCompactJws(receipt)) {
+    return fail('pointer_malformed_jws', origin);
+  }
+
+  // String-mode digest: sha256Hex(receipt) where receipt is the decoded
+  // UTF-8 string. Inside sha256Hex, TextEncoder.encode(receipt) is what
+  // gets hashed. For valid UTF-8 (always true on a valid JWS) this is
+  // byte-identical to hashing the original wire bytes.
+  const actualDigest = await sha256Hex(receipt);
+
+  if (actualDigest !== expectedDigest) {
+    return {
+      ok: false,
+      code: 'pointer_digest_mismatch',
+      message: `pointer_digest_mismatch at ${origin}`,
+      actualDigest,
+      expectedDigest,
+    };
+  }
+
+  const contentType = fetchResult.contentType;
+  const warningNeeded =
+    contentType !== undefined &&
+    !ACCEPTED_CONTENT_TYPES.some((expected) => contentType.toLowerCase().startsWith(expected));
+
+  return {
+    ok: true,
+    receipt,
+    actualDigest,
+    expectedDigest,
+    contentType,
+    ...(warningNeeded ? { contentTypeWarning: buildContentTypeWarning(contentType) } : {}),
+  };
+}

--- a/packages/resolver-http/src/types.ts
+++ b/packages/resolver-http/src/types.ts
@@ -1,0 +1,49 @@
+// Workspace-internal types for @peac/resolver-http.
+//
+// Discriminated-union result shape for verifier-oriented fetch primitives.
+// Closed local error-code set; mapping from upstream @peac/net-node and
+// @peac/jwks-cache codes lives in fetch-safe.ts and (later) jwks-resolver.ts.
+
+export type FetchSafeErrorCode =
+  | 'fetch_timeout'
+  | 'fetch_network_error'
+  | 'fetch_blocked_ssrf'
+  | 'fetch_blocked_metadata_ip'
+  | 'fetch_blocked_redirect'
+  | 'fetch_blocked_byte_cap'
+  | 'fetch_blocked_https_only'
+  | 'fetch_blocked_dangerous_port'
+  | 'fetch_status_4xx'
+  | 'fetch_status_5xx'
+  | 'fetch_invalid_content_type'
+  | 'discovery_invalid_shape'
+  | 'discovery_oversized'
+  | 'jwks_invalid_shape'
+  | 'jwks_oversized'
+  | 'jwks_kid_not_found'
+  | 'pointer_digest_mismatch'
+  | 'pointer_fetch_blocked'
+  | 'resolver_internal_error';
+
+export interface FetchSafeOptions {
+  timeoutMs?: number;
+  maxResponseBytes?: number;
+  maxRedirects?: number;
+  acceptContentTypes?: readonly string[];
+}
+
+export interface FetchSafeSuccess<T> {
+  ok: true;
+  body: T;
+  bytes: number;
+  contentType: string | undefined;
+}
+
+export interface FetchSafeFailure {
+  ok: false;
+  code: FetchSafeErrorCode;
+  message: string;
+  status?: number;
+}
+
+export type FetchSafeResult<T> = FetchSafeSuccess<T> | FetchSafeFailure;

--- a/packages/resolver-http/src/types.ts
+++ b/packages/resolver-http/src/types.ts
@@ -25,6 +25,7 @@ export type ResolverHttpErrorCode =
   | 'jwks_kid_not_found'
   | 'pointer_digest_mismatch'
   | 'pointer_fetch_blocked'
+  | 'pointer_malformed_jws'
   | 'resolver_internal_error';
 
 export interface FetchSafeOptions {

--- a/packages/resolver-http/src/types.ts
+++ b/packages/resolver-http/src/types.ts
@@ -26,6 +26,7 @@ export type ResolverHttpErrorCode =
   | 'pointer_digest_mismatch'
   | 'pointer_fetch_blocked'
   | 'pointer_malformed_jws'
+  | 'pointer_invalid_expected_digest'
   | 'resolver_internal_error';
 
 export interface FetchSafeOptions {

--- a/packages/resolver-http/src/types.ts
+++ b/packages/resolver-http/src/types.ts
@@ -1,10 +1,12 @@
-// Workspace-internal types for @peac/resolver-http.
+// Workspace-internal types for resolver-http.
 //
-// Discriminated-union result shape for verifier-oriented fetch primitives.
-// Closed local error-code set; mapping from upstream @peac/net-node and
-// @peac/jwks-cache codes lives in fetch-safe.ts and (later) jwks-resolver.ts.
+// Discriminated-union result shape for verifier-oriented fetch primitives
+// and the closed local error-code set for the whole private package
+// (fetch-safe today; discovery / jwks-resolver / pointer-fetch in Commit 3).
+// Mapping from upstream @peac/net-node and @peac/jwks-cache codes lives in
+// fetch-safe.ts and (later) jwks-resolver.ts.
 
-export type FetchSafeErrorCode =
+export type ResolverHttpErrorCode =
   | 'fetch_timeout'
   | 'fetch_network_error'
   | 'fetch_blocked_ssrf'
@@ -28,6 +30,14 @@ export type FetchSafeErrorCode =
 export interface FetchSafeOptions {
   timeoutMs?: number;
   maxResponseBytes?: number;
+  /**
+   * Caller-supplied redirect cap. Honored on the JSON and raw paths
+   * (default: VERIFIER_LIMITS.maxRedirects = 3). IGNORED on the JWKS
+   * path because upstream `@peac/net-node.safeFetchJWKS` has signature
+   * `Omit<SafeFetchOptions, 'maxRedirects'>` and hardcodes 0 redirects
+   * for key-material URLs (deliberate stricter case; documented in
+   * tranquil-mirroring-fermat.md "Commit 2.1, Fix #1").
+   */
   maxRedirects?: number;
   acceptContentTypes?: readonly string[];
 }
@@ -41,7 +51,7 @@ export interface FetchSafeSuccess<T> {
 
 export interface FetchSafeFailure {
   ok: false;
-  code: FetchSafeErrorCode;
+  code: ResolverHttpErrorCode;
   message: string;
   status?: number;
 }

--- a/packages/resolver-http/tsconfig.json
+++ b/packages/resolver-http/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false,
+    "module": "ESNext",
+    "emitDeclarationOnly": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "__tests__"]
+}

--- a/packages/resolver-http/tsup.config.ts
+++ b/packages/resolver-http/tsup.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: false,
+  outDir: 'dist',
+  sourcemap: true,
+  clean: false,
+  splitting: false,
+  treeshake: true,
+  minify: false,
+  target: 'es2022',
+  platform: 'neutral',
+  external: [/^[^./]/],
+  outExtension({ format }) {
+    return { js: format === 'cjs' ? '.cjs' : '.mjs' };
+  },
+});

--- a/packages/resolver-http/vitest.config.ts
+++ b/packages/resolver-http/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['__tests__/**/*.test.ts'],
+    environment: 'node',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1923,6 +1923,12 @@ importers:
 
   packages/resolver-http:
     dependencies:
+      '@peac/crypto':
+        specifier: workspace:*
+        version: link:../crypto
+      '@peac/jwks-cache':
+        specifier: workspace:*
+        version: link:../jwks-cache
       '@peac/kernel':
         specifier: workspace:*
         version: link:../kernel
@@ -1930,6 +1936,9 @@ importers:
         specifier: workspace:*
         version: link:../net/node
     devDependencies:
+      '@peac/protocol':
+        specifier: workspace:*
+        version: link:../protocol
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1921,6 +1921,18 @@ importers:
         specifier: ^5.0.0
         version: 5.9.3
 
+  packages/resolver-http:
+    devDependencies:
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.0
+        version: 4.1.0(@types/node@22.19.11)(vite@6.4.1)
+
   packages/schema:
     dependencies:
       '@peac/kernel':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1922,6 +1922,13 @@ importers:
         version: 5.9.3
 
   packages/resolver-http:
+    dependencies:
+      '@peac/kernel':
+        specifier: workspace:*
+        version: link:../kernel
+      '@peac/net-node':
+        specifier: workspace:*
+        version: link:../net/node
     devDependencies:
       tsup:
         specifier: ^8.0.0

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -28,6 +28,7 @@
       "@peac/cli": ["./packages/cli/src"],
       "@peac/net-node": ["./packages/net/node/src"],
       "@peac/registries": ["./packages/registries/src"],
+      "@peac/resolver-http": ["./packages/resolver-http/src"],
       "@peac/pay402": ["./packages/pay402/src"],
       "@peac/rails-stripe": ["./packages/rails/stripe/src"],
       "@peac/rails-x402": ["./packages/rails/x402/src"],


### PR DESCRIPTION
## Summary

Adds `@peac/resolver-http` as a workspace-private composition package for verifier-side HTTP resolver paths.

This PR does not change public protocol behavior, does not change `apps/api`, and does not publish a new package. `packages/protocol` remains self-contained and byte-stable.

## What changed

- Added private `packages/resolver-http`
- Composed network fetches over `@peac/net-node`
- Composed JWKS handling over package-root `@peac/jwks-cache` primitives
- Used `@peac/kernel` verifier limits and issuer config constants
- Used `@peac/crypto` package-root primitives for digest and real-JWS test fixtures
- Added discovery, JWKS, pointer-fetch, redaction, cache-isolation, and real-JWS tests
- Added internal README and SECURITY notes for package boundaries

## Boundaries

- No runtime dependency from `@peac/protocol` to `@peac/resolver-http`
- No resolver-http runtime import of `@peac/protocol`
- No `@peac/schema` or zod dependency
- No direct fetch calls in resolver-http source
- No private package subpath imports
- No `apps/api` wiring in this PR
- No public documentation or publish-manifest exposure

## Test coverage

- resolver-http: 227 tests across 35 files
- repo-root tooling tests pass
- private-package leak checks pass
- resolver-http absent from publish dry-run
- protocol and apps/api diffs are empty

## Not in this PR

- Production app wiring
- End-to-end shadow-mode comparison through app-level flows
- Release preparation
