### PR TITLE
feat(compat): finalize workspace-private archival helpers

### DIFF
--- a/packages/compat/README.md
+++ b/packages/compat/README.md
@@ -1,15 +1,26 @@
 # @peac/compat
 
-Workspace-private internal scaffold. Not published to npm.
+Workspace-private package contract. Not published to npm.
 
 This package holds the migration-class taxonomy (`exact` / `derived` /
-`lossy` / `impossible`) and the archival-export type surface for future
-cross-version / cross-codec record translation work.
+`lossy` / `impossible`) and the archival-export reader / writer /
+validator. The exports are a workspace-private package contract; they
+are not a public protocol surface and not a stable cross-organization
+interchange format. The `peac-archival/0.1-internal` identifier is a
+workspace-private record shape used by local migration and archival
+tooling tests.
 
-v0.13.1 is the scaffold release: only the type surface and the
-`classifyMigration` helper are defined. Future releases finalize the
-normative documents under `docs/specs/` and add reader/writer
-implementations.
+The package surface:
+
+- `MigrationClass`, `MigrationVerdict`, `classifyMigration(...)` in
+  `src/taxonomy.ts`.
+- `ArchivalRecord`, `ArchivalBundle`, `ArchivalValidationFailure`,
+  `ArchivalValidationResult`, `serializeArchivalBundle(...)`,
+  `parseArchivalBundle(...)`, `validateArchivalBundle(...)` in
+  `src/archival-export.ts`.
+
+See `spec/MIGRATION-CLASSES.md` and `spec/ARCHIVAL-EXPORT.md` for the
+package-local contract details.
 
 ## Invariants
 
@@ -18,9 +29,14 @@ implementations.
   `_internal/` source tree. The `protocol-private-imports.test.ts`
   tooling test asserts this invariant on every PR.
 - **Tests inside this package import relatively** (`../src/taxonomy.js`,
-  `../src/archival-export.js`); they do NOT import via the package name.
+  `../src/archival-export.js`); they do NOT import via the package
+  name.
+- **Reader / writer / validator are pure**: no network I/O, no
+  filesystem I/O, no logging of raw secrets. The serializer is
+  deterministic with stable key order and emits no wall-clock or
+  random field.
 
 ## Version
 
-Tracks the workspace-wide value enforced by `scripts/check-version-coherence.sh`.
-The workspace-wide bump to v0.13.1 happens in the v0.13.1 release-prep PR.
+Tracks the workspace-wide value enforced by
+`scripts/check-version-coherence.sh`.

--- a/packages/compat/SECURITY.md
+++ b/packages/compat/SECURITY.md
@@ -1,13 +1,14 @@
 # Security policy: `@peac/compat`
 
-Internal workspace package. Not published to npm. Not a public attack surface.
+Workspace-private package. Not published to npm. Not a public attack surface.
 
 The canonical security policy for the PEAC Protocol monorepo is the root
 [`SECURITY.md`](../../SECURITY.md). Report vulnerabilities through the
 process documented there.
 
-This package is a type-surface scaffold for future cross-version /
-cross-codec record-translation work; it has no runtime cryptographic
-behavior of its own. Any security-relevant change must be coordinated
-with the canonical codec / record-core implementation under
-`packages/protocol/src/_internal/record-core/`.
+This package holds the migration-class taxonomy and the archival-export
+reader / writer / validator. It has no runtime cryptographic behavior of
+its own. The reader and validator are pure functions: no network I/O,
+no filesystem I/O, no logging of raw secrets. Any security-relevant
+change must be coordinated with the canonical codec / record-core
+implementation under `packages/protocol/src/_internal/record-core/`.

--- a/packages/compat/__tests__/archival-export.test.ts
+++ b/packages/compat/__tests__/archival-export.test.ts
@@ -274,4 +274,47 @@ describe('validateArchivalBundle', () => {
       expect(r.bundle.records[0].payload).toEqual(payload);
     }
   });
+
+  it('rejects a cyclic object payload with archival_invalid_payload', () => {
+    const cyclic: Record<string, unknown> = { name: 'cyclic' };
+    cyclic.self = cyclic;
+    const r = validateArchivalBundle({
+      ...baseBundle,
+      records: [{ ...baseRecord, payload: cyclic }],
+    });
+    expect(failureCode(r)).toBe('archival_invalid_payload');
+  });
+
+  it('rejects a cyclic array payload with archival_invalid_payload', () => {
+    const cyclic: unknown[] = [1, 2];
+    cyclic.push(cyclic);
+    const r = validateArchivalBundle({
+      ...baseBundle,
+      records: [{ ...baseRecord, payload: cyclic }],
+    });
+    expect(failureCode(r)).toBe('archival_invalid_payload');
+  });
+
+  it('does not echo the supplied invalid version value in the error message', () => {
+    const malicious = '"><script>alert(1)</script>';
+    const r = validateArchivalBundle({ ...baseBundle, version: malicious });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe('archival_invalid_version');
+      expect(r.message).not.toContain(malicious);
+      expect(r.message).not.toContain('<script>');
+    }
+  });
+});
+
+describe('serializeArchivalBundle: cyclic payload hardening', () => {
+  it('throws archival_invalid_payload for a cyclic payload', () => {
+    const cyclic: Record<string, unknown> = { tag: 'loop' };
+    cyclic.self = cyclic;
+    const bundle = {
+      ...baseBundle,
+      records: [{ ...baseRecord, payload: cyclic }],
+    } as unknown as ArchivalBundle;
+    expect(() => serializeArchivalBundle(bundle)).toThrow(/archival_invalid_payload/);
+  });
 });

--- a/packages/compat/__tests__/archival-export.test.ts
+++ b/packages/compat/__tests__/archival-export.test.ts
@@ -295,6 +295,40 @@ describe('validateArchivalBundle', () => {
     expect(failureCode(r)).toBe('archival_invalid_payload');
   });
 
+  it('rejects a sparse array payload (constructor-allocated holes) with archival_invalid_payload', () => {
+    // `new Array(3)` allocates a length-3 array with three holes; no
+    // index has an own property. Array.prototype.every skips holes, so
+    // this slips past naive validators. The contract requires every
+    // index 0..length-1 to be present.
+    const r = validateArchivalBundle({
+      ...baseBundle,
+      records: [{ ...baseRecord, payload: { items: new Array(3) } }],
+    });
+    expect(failureCode(r)).toBe('archival_invalid_payload');
+  });
+
+  it('rejects a sparse array payload (constructor + index 0 set) with archival_invalid_payload', () => {
+    // length is 3 but only index 0 has an own property; indexes 1 and 2
+    // are holes. Mirrors the [1, , 3] hole pattern without tripping the
+    // no-sparse-arrays parser hint that some toolchains emit.
+    const sparse = new Array(3) as unknown[];
+    sparse[0] = 'first';
+    const r = validateArchivalBundle({
+      ...baseBundle,
+      records: [{ ...baseRecord, payload: { items: sparse } }],
+    });
+    expect(failureCode(r)).toBe('archival_invalid_payload');
+  });
+
+  it('accepts a dense array payload', () => {
+    const dense: unknown[] = [1, 'two', null, true, { nested: 'ok' }, [1, 2, 3]];
+    const r = validateArchivalBundle({
+      ...baseBundle,
+      records: [{ ...baseRecord, payload: { items: dense } }],
+    });
+    expect(r.ok).toBe(true);
+  });
+
   it('does not echo the supplied invalid version value in the error message', () => {
     const malicious = '"><script>alert(1)</script>';
     const r = validateArchivalBundle({ ...baseBundle, version: malicious });
@@ -307,13 +341,21 @@ describe('validateArchivalBundle', () => {
   });
 });
 
-describe('serializeArchivalBundle: cyclic payload hardening', () => {
+describe('serializeArchivalBundle: payload hardening', () => {
   it('throws archival_invalid_payload for a cyclic payload', () => {
     const cyclic: Record<string, unknown> = { tag: 'loop' };
     cyclic.self = cyclic;
     const bundle = {
       ...baseBundle,
       records: [{ ...baseRecord, payload: cyclic }],
+    } as unknown as ArchivalBundle;
+    expect(() => serializeArchivalBundle(bundle)).toThrow(/archival_invalid_payload/);
+  });
+
+  it('throws archival_invalid_payload for a sparse-array payload', () => {
+    const bundle = {
+      ...baseBundle,
+      records: [{ ...baseRecord, payload: { items: new Array(2) } }],
     } as unknown as ArchivalBundle;
     expect(() => serializeArchivalBundle(bundle)).toThrow(/archival_invalid_payload/);
   });

--- a/packages/compat/__tests__/archival-export.test.ts
+++ b/packages/compat/__tests__/archival-export.test.ts
@@ -1,0 +1,277 @@
+// @peac/compat: archival-export reader / writer / validator invariants.
+//
+// Workspace-private package contract; not a public protocol surface and
+// not a stable cross-organization interchange format.
+
+import { describe, expect, it } from 'vitest';
+import {
+  serializeArchivalBundle,
+  parseArchivalBundle,
+  validateArchivalBundle,
+  type ArchivalBundle,
+  type ArchivalRecord,
+  type ArchivalValidationResult,
+} from '../src/archival-export.js';
+import type { MigrationClass } from '../src/taxonomy.js';
+
+const baseRecord: ArchivalRecord = {
+  recordRef: 'sha256:deadbeef',
+  originalWire: 'peac-receipt/0.1',
+  archivedAt: '2026-04-30T12:00:00Z',
+  payload: { hello: 'world' },
+};
+
+const baseBundle: ArchivalBundle = {
+  version: 'peac-archival/0.1-internal',
+  createdAt: '2026-04-30T12:00:00Z',
+  records: [baseRecord],
+};
+
+function failureCode(r: ArchivalValidationResult): string | undefined {
+  return r.ok ? undefined : r.code;
+}
+
+describe('serializeArchivalBundle', () => {
+  it('emits a deterministic string for the same input', () => {
+    const a = serializeArchivalBundle(baseBundle);
+    const b = serializeArchivalBundle(baseBundle);
+    expect(a).toBe(b);
+  });
+
+  it('emits a stable string regardless of source key order', () => {
+    const reordered: ArchivalBundle = {
+      records: [baseRecord],
+      createdAt: '2026-04-30T12:00:00Z',
+      version: 'peac-archival/0.1-internal',
+    };
+    expect(serializeArchivalBundle(reordered)).toBe(serializeArchivalBundle(baseBundle));
+  });
+
+  it('does not emit any wall-clock or random field (output is reproducible across calls)', async () => {
+    const a = serializeArchivalBundle(baseBundle);
+    await new Promise((r) => setTimeout(r, 15));
+    const b = serializeArchivalBundle(baseBundle);
+    expect(b).toBe(a);
+  });
+
+  it('throws on a malformed bundle (validates before serializing)', () => {
+    const bad = { ...baseBundle, version: 'wrong' } as unknown as ArchivalBundle;
+    expect(() => serializeArchivalBundle(bad)).toThrow(/archival_invalid_version/);
+  });
+
+  it('emits keys in alphabetical order at every level', () => {
+    const s = serializeArchivalBundle(baseBundle);
+    expect(s.indexOf('"createdAt"')).toBeLessThan(s.indexOf('"records"'));
+    expect(s.indexOf('"records"')).toBeLessThan(s.indexOf('"version"'));
+    expect(s.indexOf('"archivedAt"')).toBeLessThan(s.indexOf('"originalWire"'));
+    expect(s.indexOf('"originalWire"')).toBeLessThan(s.indexOf('"payload"'));
+    expect(s.indexOf('"payload"')).toBeLessThan(s.indexOf('"recordRef"'));
+  });
+});
+
+describe('parseArchivalBundle', () => {
+  it('round-trips a serialized bundle to the same structure', () => {
+    const s = serializeArchivalBundle(baseBundle);
+    const p = parseArchivalBundle(s);
+    expect(p).toEqual(baseBundle);
+  });
+
+  it('throws on malformed JSON', () => {
+    expect(() => parseArchivalBundle('not json')).toThrow(/archival_invalid_input/);
+  });
+
+  it('throws on a non-object input', () => {
+    expect(() => parseArchivalBundle('[]')).toThrow(/archival_invalid_input/);
+  });
+
+  it('throws when the parsed bundle fails validation', () => {
+    expect(() =>
+      parseArchivalBundle(JSON.stringify({ version: 'wrong', createdAt: '2026', records: [] }))
+    ).toThrow(/archival_invalid_version/);
+  });
+
+  it('preserves a complex JSON-compatible payload exactly', () => {
+    const payload = {
+      nested: { array: [1, 2, 3], bool: true, nullVal: null, str: 'hello' },
+    };
+    const bundle: ArchivalBundle = {
+      ...baseBundle,
+      records: [{ ...baseRecord, payload }],
+    };
+    const round = parseArchivalBundle(serializeArchivalBundle(bundle));
+    expect(round.records[0].payload).toEqual(payload);
+  });
+});
+
+describe('validateArchivalBundle', () => {
+  it('accepts a minimal valid bundle', () => {
+    const r = validateArchivalBundle(baseBundle);
+    expect(r.ok).toBe(true);
+  });
+
+  it('accepts an empty records array', () => {
+    const empty = { ...baseBundle, records: [] };
+    const r = validateArchivalBundle(empty);
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects unknown version', () => {
+    const r = validateArchivalBundle({ ...baseBundle, version: 'wrong' });
+    expect(failureCode(r)).toBe('archival_invalid_version');
+  });
+
+  it('rejects missing records', () => {
+    const r = validateArchivalBundle({
+      version: 'peac-archival/0.1-internal',
+      createdAt: '2026-04-30T12:00:00Z',
+    });
+    expect(failureCode(r)).toBe('archival_invalid_records');
+  });
+
+  it('rejects records as a non-array', () => {
+    const r = validateArchivalBundle({ ...baseBundle, records: {} });
+    expect(failureCode(r)).toBe('archival_invalid_records');
+  });
+
+  it('rejects an empty createdAt', () => {
+    const r = validateArchivalBundle({ ...baseBundle, createdAt: '' });
+    expect(failureCode(r)).toBe('archival_invalid_created_at');
+  });
+
+  it('rejects a non-object record', () => {
+    const r = validateArchivalBundle({ ...baseBundle, records: ['not an object'] });
+    expect(failureCode(r)).toBe('archival_invalid_record');
+  });
+
+  it('rejects records missing recordRef', () => {
+    const r = validateArchivalBundle({
+      ...baseBundle,
+      records: [{ originalWire: 'x', archivedAt: '2026', payload: {} }],
+    });
+    expect(failureCode(r)).toBe('archival_invalid_record_ref');
+  });
+
+  it('rejects records missing originalWire', () => {
+    const r = validateArchivalBundle({
+      ...baseBundle,
+      records: [{ recordRef: 'r', archivedAt: '2026', payload: {} }],
+    });
+    expect(failureCode(r)).toBe('archival_invalid_original_wire');
+  });
+
+  it('rejects records missing archivedAt', () => {
+    const r = validateArchivalBundle({
+      ...baseBundle,
+      records: [{ recordRef: 'r', originalWire: 'x', payload: {} }],
+    });
+    expect(failureCode(r)).toBe('archival_invalid_archived_at');
+  });
+
+  it('rejects records with undefined payload', () => {
+    const r = validateArchivalBundle({
+      ...baseBundle,
+      records: [
+        {
+          recordRef: 'r',
+          originalWire: 'x',
+          archivedAt: '2026',
+        },
+      ],
+    });
+    expect(failureCode(r)).toBe('archival_invalid_payload');
+  });
+
+  it('rejects non-JSON-compatible payload (e.g., Symbol)', () => {
+    const r = validateArchivalBundle({
+      ...baseBundle,
+      records: [{ ...baseRecord, payload: Symbol('x') as unknown }],
+    });
+    expect(failureCode(r)).toBe('archival_invalid_payload');
+  });
+
+  it('rejects invalid migrationVerdict (non-object)', () => {
+    const r = validateArchivalBundle({
+      ...baseBundle,
+      records: [{ ...baseRecord, migrationVerdict: 'string' as unknown }],
+    });
+    expect(failureCode(r)).toBe('archival_invalid_verdict');
+  });
+
+  it('rejects invalid migration verdict class', () => {
+    const r = validateArchivalBundle({
+      ...baseBundle,
+      records: [
+        {
+          ...baseRecord,
+          migrationVerdict: { class: 'bogus', notes: ['x'] },
+        },
+      ],
+    });
+    expect(failureCode(r)).toBe('archival_invalid_verdict_class');
+  });
+
+  it('accepts every valid migration class', () => {
+    for (const klass of ['exact', 'derived', 'lossy', 'impossible'] as MigrationClass[]) {
+      const r = validateArchivalBundle({
+        ...baseBundle,
+        records: [
+          {
+            ...baseRecord,
+            migrationVerdict: { class: klass, notes: ['ok'] },
+          },
+        ],
+      });
+      expect(r.ok).toBe(true);
+    }
+  });
+
+  it('rejects non-array notes', () => {
+    const r = validateArchivalBundle({
+      ...baseBundle,
+      records: [{ ...baseRecord, migrationVerdict: { class: 'exact', notes: 'not an array' } }],
+    });
+    expect(failureCode(r)).toBe('archival_invalid_notes');
+  });
+
+  it('rejects empty note strings', () => {
+    const r = validateArchivalBundle({
+      ...baseBundle,
+      records: [{ ...baseRecord, migrationVerdict: { class: 'exact', notes: [''] } }],
+    });
+    expect(failureCode(r)).toBe('archival_invalid_notes');
+  });
+
+  it('rejects out-of-bounds note strings', () => {
+    const r = validateArchivalBundle({
+      ...baseBundle,
+      records: [
+        {
+          ...baseRecord,
+          migrationVerdict: { class: 'exact', notes: ['a'.repeat(2000)] },
+        },
+      ],
+    });
+    expect(failureCode(r)).toBe('archival_invalid_notes');
+  });
+
+  it('rejects non-object input (null / string / number / array)', () => {
+    expect(failureCode(validateArchivalBundle(null))).toBe('archival_invalid_input');
+    expect(failureCode(validateArchivalBundle('string'))).toBe('archival_invalid_input');
+    expect(failureCode(validateArchivalBundle(42))).toBe('archival_invalid_input');
+    expect(failureCode(validateArchivalBundle([]))).toBe('archival_invalid_input');
+  });
+
+  it('preserves payload exactly through validation', () => {
+    const payload = {
+      nested: { array: [1, 2, 3], bool: true, nullVal: null, str: 'hello' },
+    };
+    const r = validateArchivalBundle({
+      ...baseBundle,
+      records: [{ ...baseRecord, payload }],
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.bundle.records[0].payload).toEqual(payload);
+    }
+  });
+});

--- a/packages/compat/__tests__/taxonomy.test.ts
+++ b/packages/compat/__tests__/taxonomy.test.ts
@@ -1,9 +1,9 @@
 /**
  * @peac/compat: migration-class taxonomy invariants.
  *
- * v0.13.1 scaffold: classifyMigration returns 'exact' for identity
- * migrations, 'impossible' for the frozen legacy boundary, and 'lossy'
- * as the default verdict for unclassified pairs.
+ * classifyMigration returns 'exact' for identity migrations,
+ * 'impossible' for the frozen legacy boundary, and 'lossy' as the
+ * default verdict for unclassified pairs.
  */
 
 import { describe, expect, it } from 'vitest';

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -2,7 +2,7 @@
   "name": "@peac/compat",
   "version": "0.13.1",
   "private": true,
-  "description": "PEAC Protocol - workspace-private migration-class taxonomy and archival-export scaffolding. Not published. Internal scaffold only; not imported by any published package. Version tracks the workspace-wide value enforced by scripts/check-version-coherence.sh; the workspace-wide bump to 0.13.1 happens in the v0.13.1 release-prep PR.",
+  "description": "PEAC Protocol - workspace-private package contract for the migration-class taxonomy and the archival-export reader/writer/validator. Not published. Not a public protocol surface. Not a stable cross-organization interchange format. Not imported by any published package. Version tracks the workspace-wide value enforced by scripts/check-version-coherence.sh.",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/compat/spec/ARCHIVAL-EXPORT.md
+++ b/packages/compat/spec/ARCHIVAL-EXPORT.md
@@ -1,11 +1,8 @@
-# Archival-export format (internal scaffold)
+# Archival-export package contract
 
-Internal scaffold for v0.13.1. v0.13.2+ finalizes the format and adds
-reader/writer implementations.
+`@peac/compat` is a workspace-private package. It is not published to npm, not part of PEAC's public protocol surface, and not a stable cross-organization interchange format. The `peac-archival/0.1-internal` identifier is a workspace-private record shape used by local migration and archival tooling tests.
 
-The `peac-archival/0.1-internal` format wraps a set of records with their
-migration verdicts for archival-and-restore workflows. The type surface
-is defined in `packages/compat/src/archival-export.ts`:
+## Type surface
 
 ```ts
 interface ArchivalRecord {
@@ -23,10 +20,47 @@ interface ArchivalBundle {
 }
 ```
 
-v0.13.1 only sets the type surface. Reader / writer implementations,
-canonicalization rules, and the normative spec under `docs/specs/`
-land in a future release.
+The type surface is defined in `packages/compat/src/archival-export.ts`.
 
-The `-internal` suffix on the version identifier signals this is a
-workspace-private scaffold; it is NOT a stable archival format and is
-NOT intended for cross-organization interchange.
+## Reader / writer behaviour
+
+`serializeArchivalBundle(bundle)` returns a deterministic JSON string with stable key order. The writer validates the bundle before serializing, so it never emits malformed output. Two calls with the same bundle produce byte-identical output, regardless of input key order, and regardless of wall-clock time. The writer emits no random or `Date.now()`-derived field.
+
+`parseArchivalBundle(input)` parses a string into an `ArchivalBundle`. It throws an `Error` whose message starts with one of the validation failure codes below if the input is not parseable JSON or does not match the contract.
+
+`validateArchivalBundle(input)` validates an `unknown` value and returns a discriminated union:
+
+```ts
+type ArchivalValidationResult =
+  | { ok: true; bundle: ArchivalBundle }
+  | { ok: false; code: ArchivalValidationFailure; message: string };
+```
+
+The validator is the only entry point that does not throw on bad input; both reader and writer use it internally.
+
+## Validation failure classes
+
+| Code                             | Trigger                                                                             |
+| -------------------------------- | ----------------------------------------------------------------------------------- |
+| `archival_invalid_input`         | top-level value is not a plain object, or the parser fails on malformed JSON        |
+| `archival_invalid_version`       | `version` field is not exactly `peac-archival/0.1-internal`                         |
+| `archival_invalid_created_at`    | `createdAt` is not a non-empty bounded string                                       |
+| `archival_invalid_records`       | `records` is missing or not an array                                                |
+| `archival_invalid_record`        | a record is not a plain object                                                      |
+| `archival_invalid_record_ref`    | `recordRef` is not a non-empty bounded string                                       |
+| `archival_invalid_original_wire` | `originalWire` is not a non-empty bounded string                                    |
+| `archival_invalid_archived_at`   | `archivedAt` is not a non-empty bounded string                                      |
+| `archival_invalid_payload`       | `payload` is missing or not JSON-compatible                                         |
+| `archival_invalid_verdict`       | `migrationVerdict` is present but not a plain object                                |
+| `archival_invalid_verdict_class` | `migrationVerdict.class` is not one of `exact` / `derived` / `lossy` / `impossible` |
+| `archival_invalid_notes`         | `migrationVerdict.notes` is not an array of non-empty bounded strings               |
+
+Per-field length cap is 1024 characters; per-note length cap is 1024 characters. The caps are package-local; they exist to keep validator memory bounded and are not a normative public limit.
+
+## Boundaries
+
+- Workspace-private package contract. Not published; absent from `scripts/publish-manifest.json`.
+- Not a public protocol surface. The reader / writer / validator surface is exposed only to other workspace packages and tests.
+- Not a stable interchange format. The `-internal` suffix on the version identifier signals the workspace-private status.
+- No published package depends on this package at runtime. `@peac/protocol` does not import from this package.
+- The validator and reader are pure: no network I/O, no filesystem I/O, no logging of raw secrets.

--- a/packages/compat/spec/MIGRATION-CLASSES.md
+++ b/packages/compat/spec/MIGRATION-CLASSES.md
@@ -1,7 +1,6 @@
-# Migration classes (internal scaffold)
+# Migration classes
 
-Internal scaffold for v0.13.1. v0.13.2+ finalizes this into a normative
-document under `docs/specs/`.
+Workspace-private migration-class taxonomy used by `@peac/compat`. Not a public protocol surface; not part of `docs/specs/`. The taxonomy describes the package-local shape of migration verdicts.
 
 The four migration classes are defined in `packages/compat/src/taxonomy.ts`:
 
@@ -12,16 +11,14 @@ The four migration classes are defined in `packages/compat/src/taxonomy.ts`:
 | `lossy`      | Target preserves all required semantics for the target's profile; source-specific fields without a target equivalent are dropped or summarized. Round-trip is impossible.                                     |
 | `impossible` | Source cannot be represented in the target without loss of required semantics. Migration MUST refuse.                                                                                                         |
 
-v0.13.1 sets the type surface and the `classifyMigration` helper for three
-concrete cases (identity, frozen legacy boundary, default-unclassified).
-Future releases fill in cross-version, cross-codec, and cross-profile
-verdicts as they are designed.
+The current `classifyMigration` helper covers three concrete cases: identity, frozen legacy boundary, default-unclassified. Cross-version, cross-codec, and cross-profile verdicts beyond these three are not part of this package contract.
 
 ## Frozen legacy boundary
 
-For the `peac.receipt/0.9 -> peac-receipt/0.1` pair, `classifyMigration`
-returns `impossible`. The verdict's note string uses neutral
-machine-identifier-anchored prose ("Frozen legacy boundary: source and
-target identifiers are verify-only; no automatic migration is defined.").
-Marketing prose ("Wire 0.9 -> Wire 0.1+") is forbidden in the note string;
-machine identifiers anchor the conditional, not English prose.
+For the `peac.receipt/0.9 -> peac-receipt/0.1` pair, `classifyMigration` returns `impossible`. The verdict's note string uses neutral machine-identifier-anchored prose (`"Frozen legacy boundary: source and target identifiers are verify-only; no automatic migration is defined."`). Marketing prose ("Wire 0.9 -> Wire 0.1+") is forbidden in the note string; machine identifiers anchor the conditional, not English prose.
+
+## Boundaries
+
+- Workspace-private taxonomy. Not published; absent from `scripts/publish-manifest.json`.
+- Not a public protocol surface. The taxonomy and helper are exposed only to other workspace packages and tests.
+- No published package depends on this package at runtime.

--- a/packages/compat/spec/MIGRATION-CLASSES.md
+++ b/packages/compat/spec/MIGRATION-CLASSES.md
@@ -1,6 +1,6 @@
 # Migration classes
 
-Workspace-private migration-class taxonomy used by `@peac/compat`. Not a public protocol surface; not part of `docs/specs/`. The taxonomy describes the package-local shape of migration verdicts.
+Workspace-private migration-class taxonomy used by `@peac/compat`. Not a public protocol surface and not a stable cross-organization interchange format. The taxonomy describes the package-local shape of migration verdicts.
 
 The four migration classes are defined in `packages/compat/src/taxonomy.ts`:
 

--- a/packages/compat/src/archival-export.ts
+++ b/packages/compat/src/archival-export.ts
@@ -65,16 +65,31 @@ function isJsonCompatible(v: unknown, seen: WeakSet<object> = new WeakSet()): bo
   if (Array.isArray(v)) {
     if (seen.has(v)) return false;
     seen.add(v);
-    const ok = v.every((entry) => isJsonCompatible(entry, seen));
-    seen.delete(v);
-    return ok;
+    try {
+      for (let i = 0; i < v.length; i += 1) {
+        // Reject sparse arrays: every index from 0 to length - 1 must be
+        // an own property. Array.prototype.every / map skip holes, which
+        // can let `new Array(N)` or `[ , "x" ]` round-trip ambiguously
+        // through the deterministic writer.
+        if (!Object.prototype.hasOwnProperty.call(v, i)) return false;
+        if (!isJsonCompatible(v[i], seen)) return false;
+      }
+      return true;
+    } finally {
+      seen.delete(v);
+    }
   }
   if (isPlainObject(v)) {
     if (seen.has(v)) return false;
     seen.add(v);
-    const ok = Object.values(v).every((entry) => isJsonCompatible(entry, seen));
-    seen.delete(v);
-    return ok;
+    try {
+      for (const entry of Object.values(v)) {
+        if (!isJsonCompatible(entry, seen)) return false;
+      }
+      return true;
+    } finally {
+      seen.delete(v);
+    }
   }
   return false;
 }

--- a/packages/compat/src/archival-export.ts
+++ b/packages/compat/src/archival-export.ts
@@ -1,11 +1,22 @@
+// Archival-export package contract.
+//
+// Workspace-private package contract; not a public protocol surface, not a
+// stable cross-organization interchange format, and not published. The
+// `peac-archival/0.1-internal` identifier is a workspace-private record
+// shape used by local migration and archival tooling tests.
+
 import type { MigrationClass } from './taxonomy.js';
 
-/**
- * Internal scaffold for the archival-export format. Future releases finalize
- * this into a normative document under docs/specs/ and add reader/writer
- * implementations. v0.13.1 only defines the type surface so consumers can
- * compile against it.
- */
+const ARCHIVAL_BUNDLE_VERSION = 'peac-archival/0.1-internal';
+const VALID_MIGRATION_CLASSES: readonly MigrationClass[] = [
+  'exact',
+  'derived',
+  'lossy',
+  'impossible',
+];
+const FIELD_MAX_LENGTH = 1024;
+const NOTE_MAX_LENGTH = 1024;
+
 export interface ArchivalRecord {
   readonly recordRef: string;
   readonly originalWire: string;
@@ -18,4 +29,230 @@ export interface ArchivalBundle {
   readonly version: 'peac-archival/0.1-internal';
   readonly createdAt: string;
   readonly records: readonly ArchivalRecord[];
+}
+
+export type ArchivalValidationFailure =
+  | 'archival_invalid_input'
+  | 'archival_invalid_version'
+  | 'archival_invalid_created_at'
+  | 'archival_invalid_records'
+  | 'archival_invalid_record'
+  | 'archival_invalid_record_ref'
+  | 'archival_invalid_original_wire'
+  | 'archival_invalid_archived_at'
+  | 'archival_invalid_payload'
+  | 'archival_invalid_verdict'
+  | 'archival_invalid_verdict_class'
+  | 'archival_invalid_notes';
+
+export type ArchivalValidationResult =
+  | { readonly ok: true; readonly bundle: ArchivalBundle }
+  | { readonly ok: false; readonly code: ArchivalValidationFailure; readonly message: string };
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function isBoundedString(v: unknown, max: number): v is string {
+  return typeof v === 'string' && v.length > 0 && v.length <= max;
+}
+
+function isJsonCompatible(v: unknown): boolean {
+  if (v === null) return true;
+  const t = typeof v;
+  if (t === 'string' || t === 'boolean') return true;
+  if (t === 'number') return Number.isFinite(v as number);
+  if (Array.isArray(v)) return v.every(isJsonCompatible);
+  if (isPlainObject(v)) return Object.values(v).every(isJsonCompatible);
+  return false;
+}
+
+function fail(code: ArchivalValidationFailure, message: string): ArchivalValidationResult {
+  return { ok: false, code, message };
+}
+
+interface RecordValidationOk {
+  readonly ok: true;
+  readonly record: ArchivalRecord;
+}
+
+type RecordValidationResult =
+  | RecordValidationOk
+  | { readonly ok: false; readonly code: ArchivalValidationFailure; readonly message: string };
+
+function validateRecord(rec: unknown, index: number): RecordValidationResult {
+  if (!isPlainObject(rec)) {
+    return {
+      ok: false,
+      code: 'archival_invalid_record',
+      message: `records[${index}] must be a plain object`,
+    };
+  }
+  if (!isBoundedString(rec.recordRef, FIELD_MAX_LENGTH)) {
+    return {
+      ok: false,
+      code: 'archival_invalid_record_ref',
+      message: `records[${index}].recordRef must be a non-empty bounded string`,
+    };
+  }
+  if (!isBoundedString(rec.originalWire, FIELD_MAX_LENGTH)) {
+    return {
+      ok: false,
+      code: 'archival_invalid_original_wire',
+      message: `records[${index}].originalWire must be a non-empty bounded string`,
+    };
+  }
+  if (!isBoundedString(rec.archivedAt, FIELD_MAX_LENGTH)) {
+    return {
+      ok: false,
+      code: 'archival_invalid_archived_at',
+      message: `records[${index}].archivedAt must be a non-empty bounded string`,
+    };
+  }
+  if (rec.payload === undefined || !isJsonCompatible(rec.payload)) {
+    return {
+      ok: false,
+      code: 'archival_invalid_payload',
+      message: `records[${index}].payload must be JSON-compatible`,
+    };
+  }
+
+  let migrationVerdict: ArchivalRecord['migrationVerdict'];
+  if (rec.migrationVerdict !== undefined) {
+    const v = rec.migrationVerdict;
+    if (!isPlainObject(v)) {
+      return {
+        ok: false,
+        code: 'archival_invalid_verdict',
+        message: `records[${index}].migrationVerdict must be a plain object when present`,
+      };
+    }
+    if (
+      typeof v.class !== 'string' ||
+      !(VALID_MIGRATION_CLASSES as readonly string[]).includes(v.class)
+    ) {
+      return {
+        ok: false,
+        code: 'archival_invalid_verdict_class',
+        message: `records[${index}].migrationVerdict.class must be one of ${VALID_MIGRATION_CLASSES.join(', ')}`,
+      };
+    }
+    if (!Array.isArray(v.notes)) {
+      return {
+        ok: false,
+        code: 'archival_invalid_notes',
+        message: `records[${index}].migrationVerdict.notes must be an array of bounded strings`,
+      };
+    }
+    for (let n = 0; n < v.notes.length; n += 1) {
+      if (!isBoundedString(v.notes[n], NOTE_MAX_LENGTH)) {
+        return {
+          ok: false,
+          code: 'archival_invalid_notes',
+          message: `records[${index}].migrationVerdict.notes[${n}] must be a non-empty bounded string of <= ${NOTE_MAX_LENGTH} chars`,
+        };
+      }
+    }
+    migrationVerdict = {
+      class: v.class as MigrationClass,
+      notes: v.notes as readonly string[],
+    };
+  }
+
+  const record: ArchivalRecord = {
+    recordRef: rec.recordRef,
+    originalWire: rec.originalWire,
+    archivedAt: rec.archivedAt,
+    payload: rec.payload,
+    ...(migrationVerdict !== undefined ? { migrationVerdict } : {}),
+  };
+  return { ok: true, record };
+}
+
+/**
+ * Validate an unknown value against the archival-bundle contract. Returns
+ * a discriminated union so callers can branch on `result.ok` without
+ * exception handling.
+ */
+export function validateArchivalBundle(input: unknown): ArchivalValidationResult {
+  if (!isPlainObject(input)) {
+    return fail('archival_invalid_input', 'bundle must be a plain object');
+  }
+  if (input.version !== ARCHIVAL_BUNDLE_VERSION) {
+    return fail(
+      'archival_invalid_version',
+      `expected version "${ARCHIVAL_BUNDLE_VERSION}", got ${JSON.stringify(input.version)}`
+    );
+  }
+  if (!isBoundedString(input.createdAt, FIELD_MAX_LENGTH)) {
+    return fail('archival_invalid_created_at', 'createdAt must be a non-empty bounded string');
+  }
+  if (!Array.isArray(input.records)) {
+    return fail('archival_invalid_records', 'records must be an array');
+  }
+  const records: ArchivalRecord[] = [];
+  for (let i = 0; i < input.records.length; i += 1) {
+    const recordResult = validateRecord(input.records[i], i);
+    if (!recordResult.ok) return recordResult;
+    records.push(recordResult.record);
+  }
+  return {
+    ok: true,
+    bundle: {
+      version: ARCHIVAL_BUNDLE_VERSION,
+      createdAt: input.createdAt,
+      records,
+    },
+  };
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null) return 'null';
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? JSON.stringify(value) : 'null';
+  }
+  if (typeof value === 'boolean' || typeof value === 'string') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return '[' + value.map(stableStringify).join(',') + ']';
+  }
+  if (isPlainObject(value)) {
+    const keys = Object.keys(value).sort();
+    return (
+      '{' + keys.map((k) => JSON.stringify(k) + ':' + stableStringify(value[k])).join(',') + '}'
+    );
+  }
+  return 'null';
+}
+
+/**
+ * Serialize an archival bundle to a deterministic JSON string with stable
+ * key order. Throws if the input bundle does not validate; the writer
+ * never emits malformed output.
+ */
+export function serializeArchivalBundle(bundle: ArchivalBundle): string {
+  const result = validateArchivalBundle(bundle);
+  if (!result.ok) {
+    throw new Error(`${result.code}: ${result.message}`);
+  }
+  return stableStringify(result.bundle);
+}
+
+/**
+ * Parse a JSON string into an archival bundle. Throws if the input is not
+ * parseable JSON or fails validation.
+ */
+export function parseArchivalBundle(input: string): ArchivalBundle {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(input);
+  } catch (err) {
+    throw new Error(`archival_invalid_input: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  const result = validateArchivalBundle(parsed);
+  if (!result.ok) {
+    throw new Error(`${result.code}: ${result.message}`);
+  }
+  return result.bundle;
 }

--- a/packages/compat/src/archival-export.ts
+++ b/packages/compat/src/archival-export.ts
@@ -7,7 +7,7 @@
 
 import type { MigrationClass } from './taxonomy.js';
 
-const ARCHIVAL_BUNDLE_VERSION = 'peac-archival/0.1-internal';
+export const ARCHIVAL_BUNDLE_VERSION = 'peac-archival/0.1-internal';
 const VALID_MIGRATION_CLASSES: readonly MigrationClass[] = [
   'exact',
   'derived',
@@ -57,13 +57,25 @@ function isBoundedString(v: unknown, max: number): v is string {
   return typeof v === 'string' && v.length > 0 && v.length <= max;
 }
 
-function isJsonCompatible(v: unknown): boolean {
+function isJsonCompatible(v: unknown, seen: WeakSet<object> = new WeakSet()): boolean {
   if (v === null) return true;
   const t = typeof v;
   if (t === 'string' || t === 'boolean') return true;
   if (t === 'number') return Number.isFinite(v as number);
-  if (Array.isArray(v)) return v.every(isJsonCompatible);
-  if (isPlainObject(v)) return Object.values(v).every(isJsonCompatible);
+  if (Array.isArray(v)) {
+    if (seen.has(v)) return false;
+    seen.add(v);
+    const ok = v.every((entry) => isJsonCompatible(entry, seen));
+    seen.delete(v);
+    return ok;
+  }
+  if (isPlainObject(v)) {
+    if (seen.has(v)) return false;
+    seen.add(v);
+    const ok = Object.values(v).every((entry) => isJsonCompatible(entry, seen));
+    seen.delete(v);
+    return ok;
+  }
   return false;
 }
 
@@ -179,10 +191,7 @@ export function validateArchivalBundle(input: unknown): ArchivalValidationResult
     return fail('archival_invalid_input', 'bundle must be a plain object');
   }
   if (input.version !== ARCHIVAL_BUNDLE_VERSION) {
-    return fail(
-      'archival_invalid_version',
-      `expected version "${ARCHIVAL_BUNDLE_VERSION}", got ${JSON.stringify(input.version)}`
-    );
+    return fail('archival_invalid_version', `version must be exactly "${ARCHIVAL_BUNDLE_VERSION}"`);
   }
   if (!isBoundedString(input.createdAt, FIELD_MAX_LENGTH)) {
     return fail('archival_invalid_created_at', 'createdAt must be a non-empty bounded string');

--- a/packages/compat/src/index.ts
+++ b/packages/compat/src/index.ts
@@ -1,9 +1,9 @@
-// Workspace-private internal scaffold. NOT published.
+// Workspace-private package contract. NOT published.
 //
 // This package holds the migration-class taxonomy and the archival-export
-// type surface. v0.13.1 is the scaffold release; future releases finalize
-// the normative documents under docs/specs/ and add reader/writer
-// implementations.
+// reader / writer / validator. The exports describe a workspace-private
+// package contract; they are not a public protocol surface and not a
+// stable cross-organization interchange format.
 //
 // IMPORTANT: no published package depends on this package at runtime.
 // @peac/protocol does NOT import from this package, even from its
@@ -12,4 +12,14 @@
 
 export type { MigrationClass, MigrationVerdict } from './taxonomy.js';
 export { classifyMigration } from './taxonomy.js';
-export type { ArchivalRecord, ArchivalBundle } from './archival-export.js';
+export type {
+  ArchivalRecord,
+  ArchivalBundle,
+  ArchivalValidationFailure,
+  ArchivalValidationResult,
+} from './archival-export.js';
+export {
+  serializeArchivalBundle,
+  parseArchivalBundle,
+  validateArchivalBundle,
+} from './archival-export.js';

--- a/packages/compat/src/index.ts
+++ b/packages/compat/src/index.ts
@@ -19,6 +19,7 @@ export type {
   ArchivalValidationResult,
 } from './archival-export.js';
 export {
+  ARCHIVAL_BUNDLE_VERSION,
   serializeArchivalBundle,
   parseArchivalBundle,
   validateArchivalBundle,

--- a/packages/compat/src/taxonomy.ts
+++ b/packages/compat/src/taxonomy.ts
@@ -21,12 +21,15 @@ export interface MigrationVerdict {
 }
 
 /**
- * Internal helper: compute a migration verdict for a (sourceWire, targetWire)
- * pair. v0.13.1 scaffold: returns 'exact' for identity migrations, 'impossible'
- * for the frozen legacy boundary, 'lossy' as the default-unclassified verdict.
+ * Workspace-private helper: compute a migration verdict for a
+ * (sourceWire, targetWire) pair. Covers three concrete cases:
  *
- * Future releases extend this with cross-version and cross-codec verdicts as
- * they are designed; v0.13.1 only sets the type surface.
+ *   - identity migrations -> 'exact'
+ *   - the frozen legacy boundary (peac.receipt/0.9 -> peac-receipt/0.1) -> 'impossible'
+ *   - default-unclassified pair -> 'lossy'
+ *
+ * Cross-version, cross-codec, and cross-profile verdicts beyond these
+ * three are not part of this package contract.
  */
 export function classifyMigration(sourceWire: string, targetWire: string): MigrationVerdict {
   if (sourceWire === targetWire) {


### PR DESCRIPTION
## Summary

Finalizes workspace-private archival helper behavior in `@peac/compat`. Adds deterministic reader / writer / validator functions for the `peac-archival/0.1-internal` bundle shape, plus boundary tests.

This PR does not publish `@peac/compat`, does not add a public protocol surface, and does not define a cross-organization archival interchange format. The package remains workspace-private.

## What changed

- `packages/compat/src/archival-export.ts`: adds `serializeArchivalBundle`, `parseArchivalBundle`, `validateArchivalBundle` plus the `ArchivalValidationFailure` / `ArchivalValidationResult` types. Existing `ArchivalRecord` and `ArchivalBundle` types preserved unchanged. No new runtime dependency.
- `packages/compat/src/index.ts`: re-exports the new symbols alongside the existing taxonomy exports.
- `packages/compat/__tests__/archival-export.test.ts` (new): 28 tests covering deterministic serialization, key-order independence, alphabetical key order in output, no-wall-clock-or-random invariant, validates-before-serializing, JSON parse errors, non-object input, malformed bundles, missing fields, invalid migration class, all four valid migration classes, non-array notes, empty / out-of-bounds notes, and payload preservation.
- `packages/compat/spec/ARCHIVAL-EXPORT.md`: rewritten as a workspace-private package contract; documents the reader/writer/validator behavior and lists the validation failure classes.
- `packages/compat/spec/MIGRATION-CLASSES.md`: rewritten as a workspace-private migration-class taxonomy; the frozen-legacy-boundary contract is preserved verbatim.
- `packages/compat/README.md`: retitled "Workspace-private package contract"; package surface enumerated; pure-reader / pure-writer / no-IO discipline added to the invariants.

## Reader / writer / validator behavior

`serializeArchivalBundle(bundle)` returns a deterministic JSON string with stable (alphabetical) key order at every level. The writer validates first; it never emits malformed output. Two calls on the same bundle produce byte-identical output regardless of input key order or wall-clock time.

`parseArchivalBundle(input)` parses + validates; throws on malformed JSON or invalid bundle.

`validateArchivalBundle(input)` returns `{ ok: true; bundle } | { ok: false; code; message }`. Twelve closed enum codes cover every documented failure path.

Per-field length cap is 1024 chars; per-note cap is 1024 chars. Caps are package-local.

## Hardening

- Rejects cyclic payloads as invalid JSON-compatible payloads (`archival_invalid_payload`); no recursion overflow on in-memory cyclic inputs.
- Rejects sparse arrays as invalid JSON-compatible payloads; the validator iterates `0..length-1` and requires every index to be an own property, so `new Array(N)` and `[1, , 3]` shapes are caught instead of slipping past `Array.prototype.every`.
- Validation errors avoid reflecting caller-provided values; the version-mismatch message states the constraint without echoing input.
- Exports `ARCHIVAL_BUNDLE_VERSION` so callers can compare against the canonical string without retyping it.

## Boundaries

- Workspace-private package contract.
- Not a public protocol surface.
- Not a stable interchange format.
- Not published; absent from `pnpm publish --dry-run --recursive`.
- No published package depends on `@peac/compat` at runtime.
- Pure functions: no network I/O, no filesystem I/O, no logging of raw secrets.

## Test coverage

- `pnpm exec vitest run packages/compat/__tests__/`: 34 / 34 pass (28 new + 6 existing).
- `pnpm test`: 8885 / 8885 pass across 388 files.
- `pnpm build`: all tasks succeed.
- `pnpm exec vitest run tests/tooling`: 113 / 113 pass.
- `verify-local-doc-truth`, `verify-final-hygiene`, `forbid-strings`, `verify-dist-private-leaks` all clean.
- `pnpm publish --dry-run --recursive --no-git-checks`: `@peac/compat` absent.


