### PR TITLE
chore(release): stamp REPO_SURFACE_STATUS for v0.13.2 publish

### DIFF
--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable surface classification for PEAC Protocol workspace. CI fails if any workspace member is missing. See docs/PACKAGE_STATUS.md for human-readable view.",
   "version": "0.13.0",
-  "updated": "2026-04-26",
+  "updated": "2026-05-01",
   "states": {
     "default": "Current recommended path. Actively maintained, Wire 0.2 native.",
     "supported": "Actively maintained, published, production-ready. May not be on default quickstart path.",

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -2,7 +2,7 @@
 
 Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scripts/generate-surface-status.mjs`.
 
-**Version:** 0.13.0 | **Updated:** 2026-04-26
+**Version:** 0.13.0 | **Updated:** 2026-05-01
 
 ## Layer 1
 


### PR DESCRIPTION
## Summary

Mechanical post-publish stamp for v0.13.2.

Updates `REPO_SURFACE_STATUS.json` from `2026-04-26` to `2026-05-01`

## Scope

- Release-state metadata only.
- No source change.
- No public API change.
- No wire-format change.
- No OpenAPI change.
- No package version change.
- No publish-manifest change.
- No tag, npm publish, GitHub Release, or latest promotion.

## Verification

- Generated by `pnpm release:stamp:publish`.
- `git diff --check` clean.
- Expected to clear the repo-surface-status publish-stage closeout warning.
