### PR TITLE
test(protocol): add no-network diagnostic parity taxonomy

### DIFF
--- a/packages/protocol/__tests__/_internal/parity-corpus-accounting.test.ts
+++ b/packages/protocol/__tests__/_internal/parity-corpus-accounting.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Parity-corpus accounting.
+ *
+ * Locks the schema-validated parity corpus shape so the diagnostic
+ * comparison taxonomy cannot silently shift. Two failure modes this
+ * prevents:
+ *
+ *   1. A new family added without a `vectors.schema.json` and not
+ *      enrolled in `PARITY_FAMILIES` would go unloaded by
+ *      `loadAllFamilies()` and silently drop out of any cross-family
+ *      coverage assertion.
+ *
+ *   2. The 31-vector floor (12 + 8 + 7 + 4) is the schema-validated
+ *      corpus that supports parity-vector comparison
+ *      (`{ id, description, input: { payload, header? }, expected: { accepted, errors?, warnings? } }`).
+ *      The `jcs-extended/` directory exists alongside but uses a
+ *      different shape (`{ id, description, input, canonical }`) for
+ *      JCS canonicalization parity; it is NOT a parity-vector source
+ *      and is exercised by separate cross-language JCS tests.
+ *
+ * The accounting test asserts the EXACT shape, the EXACT family list,
+ * and the EXACT floor totals. It is the single place a contributor
+ * must consult before declaring "the parity corpus is N vectors".
+ */
+
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  PARITY_FAMILIES,
+  PARITY_FLOOR_COUNTS,
+  loadAllFamilies,
+  loadFamily,
+  resolveCorpusRoot,
+} from '../../src/_internal/test-helpers/corpus-loader';
+
+const CORPUS_ROOT = resolveCorpusRoot();
+const SCHEMA_VALIDATED_TOTAL = 31;
+
+describe('parity-corpus accounting (schema-validated families)', () => {
+  it('PARITY_FAMILIES enrolls exactly 4 schema-validated families', () => {
+    expect([...PARITY_FAMILIES].sort()).toEqual([
+      'commerce-bridges',
+      'default-flows',
+      'jose-hardening',
+      'runtime-governance',
+    ]);
+  });
+
+  it('PARITY_FLOOR_COUNTS matches per-family floor: 12 + 8 + 7 + 4 = 31', () => {
+    expect(PARITY_FLOOR_COUNTS['default-flows']).toBe(12);
+    expect(PARITY_FLOOR_COUNTS['jose-hardening']).toBe(8);
+    expect(PARITY_FLOOR_COUNTS['runtime-governance']).toBe(7);
+    expect(PARITY_FLOOR_COUNTS['commerce-bridges']).toBe(4);
+
+    const sum = Object.values(PARITY_FLOOR_COUNTS).reduce((a, b) => a + b, 0);
+    expect(sum).toBe(SCHEMA_VALIDATED_TOTAL);
+  });
+
+  it('loadAllFamilies() returns exactly 4 families', () => {
+    const families = loadAllFamilies();
+    expect(families).toHaveLength(4);
+    const names = families.map((f) => f.family).sort();
+    expect(names).toEqual([
+      'commerce-bridges',
+      'default-flows',
+      'jose-hardening',
+      'runtime-governance',
+    ]);
+  });
+
+  it('loadAllFamilies() vector counts meet floor (>= 31 total)', () => {
+    const families = loadAllFamilies();
+    const total = families.reduce((acc, f) => acc + f.vectors.length, 0);
+    expect(total).toBeGreaterThanOrEqual(SCHEMA_VALIDATED_TOTAL);
+  });
+
+  it('every schema-validated family has both vectors.json and vectors.schema.json on disk', () => {
+    for (const family of PARITY_FAMILIES) {
+      const familyDir = resolve(CORPUS_ROOT, family);
+      expect(existsSync(resolve(familyDir, 'vectors.json')), `${family} missing vectors.json`).toBe(
+        true
+      );
+      expect(
+        existsSync(resolve(familyDir, 'vectors.schema.json')),
+        `${family} missing vectors.schema.json`
+      ).toBe(true);
+    }
+  });
+
+  it('every schema-validated vector carries the parity-vector shape (id + description + input.payload + expected.accepted)', () => {
+    for (const family of PARITY_FAMILIES) {
+      const loaded = loadFamily(family);
+      for (const v of loaded.vectors) {
+        expect(typeof v.id, `${family}/${v.id ?? '<no-id>'}: id`).toBe('string');
+        expect(typeof v.description, `${family}/${v.id}: description`).toBe('string');
+        expect(typeof v.input, `${family}/${v.id}: input`).toBe('object');
+        expect(typeof v.input.payload, `${family}/${v.id}: input.payload`).toBe('object');
+        expect(typeof v.expected, `${family}/${v.id}: expected`).toBe('object');
+        expect(typeof v.expected.accepted, `${family}/${v.id}: expected.accepted`).toBe('boolean');
+      }
+    }
+  });
+});
+
+describe('parity-corpus accounting (jcs-extended is excluded by design)', () => {
+  it('jcs-extended directory exists alongside schema-validated families', () => {
+    const jcsDir = resolve(CORPUS_ROOT, 'jcs-extended');
+    expect(existsSync(jcsDir)).toBe(true);
+    expect(statSync(jcsDir).isDirectory()).toBe(true);
+  });
+
+  it('jcs-extended is NOT enrolled in PARITY_FAMILIES (intentionally excluded)', () => {
+    const families = PARITY_FAMILIES as readonly string[];
+    expect(families).not.toContain('jcs-extended');
+  });
+
+  it('jcs-extended is NOT loaded by loadAllFamilies()', () => {
+    const families = loadAllFamilies();
+    const names = families.map((f) => f.family as string);
+    expect(names).not.toContain('jcs-extended');
+  });
+
+  it('jcs-extended uses JCS canonicalization shape (input + canonical), not parity-vector shape', () => {
+    const vectorsPath = resolve(CORPUS_ROOT, 'jcs-extended', 'vectors.json');
+    expect(existsSync(vectorsPath)).toBe(true);
+
+    const vectorsJson = JSON.parse(readFileSync(vectorsPath, 'utf8')) as {
+      vectors: ReadonlyArray<Record<string, unknown>>;
+    };
+    expect(Array.isArray(vectorsJson.vectors)).toBe(true);
+    expect(vectorsJson.vectors.length).toBeGreaterThan(0);
+
+    for (const v of vectorsJson.vectors) {
+      // JCS canonicalization shape carries `input` + `canonical` per vector.
+      expect(v).toHaveProperty('id');
+      expect(v).toHaveProperty('description');
+      expect(v).toHaveProperty('input');
+      expect(v).toHaveProperty('canonical');
+      // It does NOT carry the parity-vector `expected.accepted` field.
+      expect(v).not.toHaveProperty('expected');
+    }
+  });
+
+  it('jcs-extended has no vectors.schema.json (not schema-validated as a parity family)', () => {
+    const schemaPath = resolve(CORPUS_ROOT, 'jcs-extended', 'vectors.schema.json');
+    expect(existsSync(schemaPath)).toBe(false);
+  });
+});
+
+describe('parity-corpus accounting (no silent extra families)', () => {
+  it('every directory under parity-corpus/ is either schema-validated and enrolled, or jcs-extended (the documented exception)', () => {
+    const entries = readdirSync(CORPUS_ROOT, { withFileTypes: true });
+    const dirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
+    const enrolled = new Set<string>([...(PARITY_FAMILIES as readonly string[]), 'jcs-extended']);
+    const unaccounted = dirs.filter((d) => !enrolled.has(d));
+    expect(unaccounted, `unaccounted parity-corpus directories: ${unaccounted.join(', ')}`).toEqual(
+      []
+    );
+  });
+});

--- a/packages/protocol/__tests__/_internal/parity-verdict-self.test.ts
+++ b/packages/protocol/__tests__/_internal/parity-verdict-self.test.ts
@@ -19,7 +19,12 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { makeVerdict, verdictKey } from '../../src/_internal/test-helpers/parity-verdict';
+import {
+  makeVerdict,
+  verdictKey,
+  verdictKeyErrorClass,
+  type ParityVerdict,
+} from '../../src/_internal/test-helpers/parity-verdict';
 import { runEnvelopeCanonical } from '../../src/_internal/test-helpers/canonical-runner';
 
 describe('parity verdict comparator: negative harness tests', () => {
@@ -188,5 +193,104 @@ describe('parity verdict comparator: negative harness tests', () => {
     const left = makeVerdict(false, [{ code: 'A' }, { code: 'Z' }]);
     const right = makeVerdict(false, [{ code: 'Z' }, { code: 'A' }]);
     expect(verdictKey(left)).toBe(verdictKey(right));
+  });
+});
+
+describe('verdictKeyErrorClass: error-class-equivalent comparison semantics', () => {
+  // Construct verdicts literally (bypassing makeVerdict's dedup) so the
+  // multiset semantics are preserved through the comparator. The helper
+  // operates on the verdict's `.errors` array as given.
+  function rawVerdict(
+    accepted: boolean,
+    errors: Array<{ code: string; path?: string }> = [],
+    warnings: Array<{ code: string; path?: string }> = [],
+    canonicalClaimsDigest?: string
+  ): ParityVerdict {
+    const verdict: ParityVerdict = {
+      accepted,
+      errors,
+      warnings,
+    };
+    if (canonicalClaimsDigest !== undefined) {
+      return { ...verdict, canonicalClaimsDigest };
+    }
+    return verdict;
+  }
+
+  it('same error codes in different order: equal key', () => {
+    const left = rawVerdict(false, [{ code: 'E_ALPHA' }, { code: 'E_BETA' }, { code: 'E_GAMMA' }]);
+    const right = rawVerdict(false, [{ code: 'E_GAMMA' }, { code: 'E_ALPHA' }, { code: 'E_BETA' }]);
+    expect(verdictKeyErrorClass(left)).toBe(verdictKeyErrorClass(right));
+  });
+
+  it('duplicate code counts are preserved (multiset, no dedup)', () => {
+    const single = rawVerdict(false, [{ code: 'E_DUP' }]);
+    const triple = rawVerdict(false, [{ code: 'E_DUP' }, { code: 'E_DUP' }, { code: 'E_DUP' }]);
+    expect(verdictKeyErrorClass(single)).not.toBe(verdictKeyErrorClass(triple));
+
+    const tripleReordered = rawVerdict(false, [
+      { code: 'E_DUP' },
+      { code: 'E_DUP' },
+      { code: 'E_DUP' },
+    ]);
+    expect(verdictKeyErrorClass(triple)).toBe(verdictKeyErrorClass(tripleReordered));
+  });
+
+  it('different duplicate counts of the same code: divergence', () => {
+    const two = rawVerdict(false, [{ code: 'E_X' }, { code: 'E_X' }]);
+    const three = rawVerdict(false, [{ code: 'E_X' }, { code: 'E_X' }, { code: 'E_X' }]);
+    expect(verdictKeyErrorClass(two)).not.toBe(verdictKeyErrorClass(three));
+  });
+
+  it('different accepted value: divergence even with identical error sets', () => {
+    const accepted = rawVerdict(true, [{ code: 'E_Y' }]);
+    const rejected = rawVerdict(false, [{ code: 'E_Y' }]);
+    expect(verdictKeyErrorClass(accepted)).not.toBe(verdictKeyErrorClass(rejected));
+  });
+
+  it('path differences do not affect the key (path is ignored)', () => {
+    const left = rawVerdict(false, [{ code: 'E_PATH', path: '/a' }]);
+    const right = rawVerdict(false, [{ code: 'E_PATH', path: '/b' }]);
+    expect(verdictKeyErrorClass(left)).toBe(verdictKeyErrorClass(right));
+
+    const noPath = rawVerdict(false, [{ code: 'E_PATH' }]);
+    expect(verdictKeyErrorClass(left)).toBe(verdictKeyErrorClass(noPath));
+  });
+
+  it('warning differences do not affect the key (warnings are ignored)', () => {
+    const noWarn = rawVerdict(true, [], []);
+    const oneWarn = rawVerdict(true, [], [{ code: 'W_X' }]);
+    const manyWarn = rawVerdict(true, [], [{ code: 'W_X' }, { code: 'W_Y', path: '/p' }]);
+    expect(verdictKeyErrorClass(noWarn)).toBe(verdictKeyErrorClass(oneWarn));
+    expect(verdictKeyErrorClass(noWarn)).toBe(verdictKeyErrorClass(manyWarn));
+  });
+
+  it('canonicalClaimsDigest does not affect the key (digest is ignored)', () => {
+    const noDigest = rawVerdict(true, [], []);
+    const withDigest = rawVerdict(true, [], [], 'sha256:aaaaaa');
+    const otherDigest = rawVerdict(true, [], [], 'sha256:bbbbbb');
+    expect(verdictKeyErrorClass(noDigest)).toBe(verdictKeyErrorClass(withDigest));
+    expect(verdictKeyErrorClass(withDigest)).toBe(verdictKeyErrorClass(otherDigest));
+  });
+
+  it('different error codes: divergence', () => {
+    const left = rawVerdict(false, [{ code: 'E_ALPHA' }]);
+    const right = rawVerdict(false, [{ code: 'E_BETA' }]);
+    expect(verdictKeyErrorClass(left)).not.toBe(verdictKeyErrorClass(right));
+  });
+
+  it('output is stable JSON with sorted errorCodes field', () => {
+    const v = rawVerdict(false, [{ code: 'C' }, { code: 'A' }, { code: 'B' }, { code: 'A' }]);
+    const key = verdictKeyErrorClass(v);
+    expect(key).toBe(JSON.stringify({ accepted: false, errorCodes: ['A', 'A', 'B', 'C'] }));
+  });
+
+  it('empty errors: stable encoding', () => {
+    const accepted = rawVerdict(true, [], []);
+    const rejected = rawVerdict(false, [], []);
+    expect(verdictKeyErrorClass(accepted)).toBe(JSON.stringify({ accepted: true, errorCodes: [] }));
+    expect(verdictKeyErrorClass(rejected)).toBe(
+      JSON.stringify({ accepted: false, errorCodes: [] })
+    );
   });
 });

--- a/packages/protocol/src/_internal/test-helpers/parity-verdict.ts
+++ b/packages/protocol/src/_internal/test-helpers/parity-verdict.ts
@@ -92,3 +92,46 @@ export function verdictKey(v: ParityVerdict): string {
 export function verdictKeyShape(v: ParityVerdict): string {
   return JSON.stringify(verdictBase(v));
 }
+
+/**
+ * Stringify a ParityVerdict using error-class-equivalent semantics.
+ *
+ * Encodes ONLY:
+ *   - `accepted` boolean
+ *   - sorted error-code MULTISET preserving counts
+ *
+ * Ignores:
+ *   - error path
+ *   - warnings (codes and paths)
+ *   - canonicalClaimsDigest
+ *   - any other field
+ *
+ * Does NOT dedupe duplicate codes. Two errors emitted with the same
+ * `code` are encoded as two entries; this preserves multiset semantics
+ * because duplicate counts may carry meaningful diagnostic signal that
+ * dedup would erase.
+ *
+ * Use for diagnostic overlap comparisons where the goal is to assert
+ * agreement on what error CLASS was raised, independent of where it
+ * was emitted, what message it carried, or what warnings accompanied
+ * it. Path comparison is intentionally too strict for this gate;
+ * callers needing path-aware comparison should use `verdictKey` or
+ * `verdictKeyShape`.
+ *
+ * NOTE on input construction: `makeVerdict()` deduplicates errors by
+ * `(code, path)` before normalization. To preserve a true multiset of
+ * same-code entries through `verdictKeyErrorClass`, callers MUST
+ * construct the `ParityVerdict` literally (without `makeVerdict`) or
+ * supply errors with distinct `path` values that survive dedup. The
+ * function operates on the verdict's `.errors` array as given; it is
+ * the caller's responsibility to ensure that array carries the
+ * intended multiset shape.
+ */
+export function verdictKeyErrorClass(v: ParityVerdict): string {
+  const errorCodes = v.errors.map((e) => e.code);
+  const sorted = [...errorCodes].sort();
+  return JSON.stringify({
+    accepted: v.accepted,
+    errorCodes: sorted,
+  });
+}


### PR DESCRIPTION
## Summary

Adds an internal diagnostic comparison helper and corpus-accounting tests for the schema-validated parity corpus.

## What changed

- Adds `verdictKeyErrorClass(v: ParityVerdict)`, which encodes:
  - `accepted`
  - sorted error-code multiset preserving duplicate counts

- Extends `parity-verdict-self.test.ts` to verify that the error-class key:
  - is order-insensitive for equivalent error-code multisets
  - preserves duplicate-code counts
  - differs when `accepted` differs
  - ignores message text
  - ignores path differences
  - ignores warning differences
  - ignores canonical digest differences

- Adds `parity-corpus-accounting.test.ts` to lock the schema-validated parity corpus at:
  - `default-flows`: 12
  - `jose-hardening`: 8
  - `runtime-governance`: 7
  - `commerce-bridges`: 4
  - total: 31 vectors

- Documents in test coverage that `jcs-extended` is intentionally excluded because it is a JCS canonicalization corpus with `input + canonical` shape, not a parity-vector source with `input + expected`.

## Scope

Internal protocol test helper and internal tests only.

No public API change. No wire-format change. No OpenAPI change. No route shadowing. No package version change. No publish-manifest change. No release-file change.

## Verification

- Targeted parity tests passed.
- `@peac/protocol` tests passed.
- `@peac/protocol` build passed.
- Tooling tests passed.
- Public declaration surface checked for helper leaks.
- `verify-dist-private-leaks` passed across the 36-package publish surface.
- Local doc-truth and final-hygiene verifiers passed.
- Forbidden-string check passed.
- `git diff --check` clean.
