### PR TITLE
feat(protocol): add internal rollback-path flag plumbing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,8 +469,12 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-env
 
-      - name: Build all packages
-        run: pnpm build
+      - name: Build @peac/protocol and its workspace dependencies
+        # Trailing `...` selects @peac/protocol AND every workspace
+        # package it depends on (kernel, schema, crypto, ...). Targeted
+        # build keeps the matrix cost lower than `pnpm build` while
+        # ensuring tsc can resolve all `@peac/*` declarations.
+        run: pnpm --filter '@peac/protocol...' build
 
       - name: Run @peac/protocol tests with PEAC_INTERNAL_LEGACY_PATH=${{ matrix.legacy_path }}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,6 +436,48 @@ jobs:
           retention-days: 90
 
   # ---------------------------------------------------------------------------
+  # Lane 3b: Protocol rollback-path matrix
+  #
+  # Runs the @peac/protocol test suite twice, once with the internal
+  # rollback-path flag PEAC_INTERNAL_LEGACY_PATH=0 (default) and once
+  # with =1. Both halves green verifies the flag is plumbed cleanly
+  # and no test silently depends on a specific flag state. Both flag
+  # values currently use the same protocol path, so the matrix asserts
+  # test-suite equivalence under both, not universal byte-equivalence.
+  #
+  # Scoped to protocol-touching PRs (detect-changes.outputs.core
+  # already covers packages/protocol/**) so apps-only and stamp-only
+  # PRs do not pay this cost.
+  # ---------------------------------------------------------------------------
+  protocol-rollback-path-matrix:
+    name: Protocol Rollback-Path Matrix
+    needs: detect-changes
+    if: >-
+      github.ref == 'refs/heads/main' ||
+      needs.detect-changes.outputs.core == 'true' ||
+      needs.detect-changes.outputs.ci == 'true' ||
+      needs.detect-changes.outputs.root_config == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        legacy_path: ['0', '1']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/setup-env
+
+      - name: Build @peac/protocol
+        run: pnpm --filter @peac/protocol build
+
+      - name: Run @peac/protocol tests with PEAC_INTERNAL_LEGACY_PATH=${{ matrix.legacy_path }}
+        env:
+          PEAC_INTERNAL_LEGACY_PATH: ${{ matrix.legacy_path }}
+        run: pnpm --filter @peac/protocol test
+
+  # ---------------------------------------------------------------------------
   # Lane 4: Examples + Apps (only when relevant paths changed)
   # ---------------------------------------------------------------------------
   examples-apps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,8 +469,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-env
 
-      - name: Build @peac/protocol
-        run: pnpm --filter @peac/protocol build
+      - name: Build all packages
+        run: pnpm build
 
       - name: Run @peac/protocol tests with PEAC_INTERNAL_LEGACY_PATH=${{ matrix.legacy_path }}
         env:

--- a/packages/protocol/__tests__/_internal/legacy-path-flag.test.ts
+++ b/packages/protocol/__tests__/_internal/legacy-path-flag.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Internal rollback-path flag self-tests.
+ *
+ * Asserts:
+ *   T1-T4 env-var parsing (strict `'1'` semantics matching the
+ *         existing `PEAC_INTERNAL_SHADOW_CORE` precedent).
+ *   T5-T6 programmatic option parsing.
+ *   T7    browser / edge runtime guard (no throw when `process` is
+ *         undefined).
+ *   T8    `issue()` output is byte-equivalent across both flag values
+ *         when inputs are deterministic. Uses the
+ *         `issue-verify-baseline.test.ts` fixed-seed pattern + supplied
+ *         `jti` and `occurred_at`. The remaining clock-derived `iat`
+ *         field is stripped before comparison.
+ *   T9    `verifyLocal()` output is byte-equivalent across both flag
+ *         values for a fixed pre-issued JWS.
+ *
+ * NOT TESTED HERE: `verifyReceipt()`. The flag-read at the top of
+ * `verifyReceipt()` is a one-line addition; adding a dedicated test
+ * would require no-network issuer/JWKS fixtures outside this PR's
+ * scope. The call-site change is limited to a guarded flag read, and
+ * the `@peac/protocol` test suite is run under both flag values by
+ * the dual-mode CI matrix in `.github/workflows/ci.yml`.
+ *
+ * NOT TESTED HERE: public option-type cleanliness. Vitest does not
+ * enforce `@ts-expect-error` (the test runner uses esbuild / SWC for
+ * TS, not `tsc`), and `packages/protocol/tsconfig.json` excludes
+ * `__tests__`. Public-surface protection is enforced by the
+ * declaration-output dist-leak gate
+ * (`scripts/verify-dist-private-leaks.mjs`) and the semantic-widening
+ * gate (`scripts/verify-no-semantic-widening.mjs`), which scan all 36
+ * publish-manifest packages' emitted `.d.ts` files plus front-door
+ * docs for `legacyPath` and `PEAC_INTERNAL_LEGACY_PATH` identifiers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { generateKeypairFromSeed } from '@peac/crypto/testkit';
+import { readLegacyPathFlag, type LegacyPathOptions } from '../../src/_internal/legacy-path.js';
+import { issue, verifyLocal } from '../../src/index.js';
+
+// 32-byte deterministic seed; isolated to this test file. Different from
+// the issue-verify-baseline seed so a baseline-snapshot regeneration
+// would not silently shift this test.
+const FIXED_SEED = new Uint8Array([
+  0x55, 0x4c, 0xa3, 0x18, 0xb6, 0x1d, 0x09, 0x42, 0x8e, 0x7b, 0x21, 0x4f, 0x6c, 0xa2, 0x35, 0x77,
+  0x91, 0x40, 0xe3, 0x5b, 0xc8, 0x06, 0x12, 0x99, 0x4d, 0x37, 0x88, 0xa1, 0x6f, 0x2b, 0xc4, 0x0e,
+]);
+const FIXED_KID = 'rollback-flag-test-key-1';
+const FIXED_JTI = '019b0000-0000-7000-8000-000000000007';
+const FIXED_OCCURRED_AT = '2026-05-01T00:00:00Z';
+const FIXED_ISS = 'https://issuer.example';
+const FIXED_TYPE = 'org.example/rollback-flag-test';
+
+const STABLE_OPTIONS = {
+  iss: FIXED_ISS,
+  kind: 'evidence' as const,
+  type: FIXED_TYPE,
+  kid: FIXED_KID,
+  jti: FIXED_JTI,
+  occurred_at: FIXED_OCCURRED_AT,
+  pillars: ['safety'] as const,
+};
+
+function withEnvFlag<T>(value: string | undefined, fn: () => T): T {
+  const prior = process.env.PEAC_INTERNAL_LEGACY_PATH;
+  if (value === undefined) delete process.env.PEAC_INTERNAL_LEGACY_PATH;
+  else process.env.PEAC_INTERNAL_LEGACY_PATH = value;
+  try {
+    return fn();
+  } finally {
+    if (prior === undefined) delete process.env.PEAC_INTERNAL_LEGACY_PATH;
+    else process.env.PEAC_INTERNAL_LEGACY_PATH = prior;
+  }
+}
+
+async function withEnvFlagAsync<T>(value: string | undefined, fn: () => Promise<T>): Promise<T> {
+  const prior = process.env.PEAC_INTERNAL_LEGACY_PATH;
+  if (value === undefined) delete process.env.PEAC_INTERNAL_LEGACY_PATH;
+  else process.env.PEAC_INTERNAL_LEGACY_PATH = value;
+  try {
+    return await fn();
+  } finally {
+    if (prior === undefined) delete process.env.PEAC_INTERNAL_LEGACY_PATH;
+    else process.env.PEAC_INTERNAL_LEGACY_PATH = prior;
+  }
+}
+
+function stripIat(claims: Record<string, unknown>): Record<string, unknown> {
+  const { iat: _iat, ...stable } = claims;
+  return stable;
+}
+
+describe('readLegacyPathFlag: env parsing (strict "1" semantics)', () => {
+  it('T1: returns false when env is unset and no programmatic option supplied', () => {
+    withEnvFlag(undefined, () => {
+      expect(readLegacyPathFlag()).toBe(false);
+      expect(readLegacyPathFlag(undefined)).toBe(false);
+      expect(readLegacyPathFlag({})).toBe(false);
+    });
+  });
+
+  it('T2: returns false when env is "0"', () => {
+    withEnvFlag('0', () => {
+      expect(readLegacyPathFlag()).toBe(false);
+    });
+  });
+
+  it('T3: returns true when env is exactly "1"', () => {
+    withEnvFlag('1', () => {
+      expect(readLegacyPathFlag()).toBe(true);
+    });
+  });
+
+  it('T4: returns false for any non-"1" string ("true", "yes", "TRUE", " 1 ", "01", etc.)', () => {
+    for (const v of ['true', 'yes', 'TRUE', 'on', ' 1 ', '01', '11', '1.0', '', 'enabled']) {
+      withEnvFlag(v, () => {
+        expect(readLegacyPathFlag(), `value=${JSON.stringify(v)}`).toBe(false);
+      });
+    }
+  });
+});
+
+describe('readLegacyPathFlag: programmatic option parsing', () => {
+  it('T5: programmatic legacyPath:true returns true', () => {
+    withEnvFlag(undefined, () => {
+      expect(readLegacyPathFlag({ _internal: { legacyPath: true } })).toBe(true);
+    });
+  });
+
+  it('T5: programmatic legacyPath:false returns false', () => {
+    withEnvFlag(undefined, () => {
+      expect(readLegacyPathFlag({ _internal: { legacyPath: false } })).toBe(false);
+    });
+  });
+
+  it('T5: programmatic _internal absent returns false', () => {
+    withEnvFlag(undefined, () => {
+      expect(readLegacyPathFlag({})).toBe(false);
+    });
+  });
+
+  it('T6: programmatic legacyPath:true returns true even when env is unset', () => {
+    withEnvFlag(undefined, () => {
+      expect(readLegacyPathFlag({ _internal: { legacyPath: true } })).toBe(true);
+    });
+  });
+
+  it('programmatic option only accepts the literal `true` (truthy non-true values do not activate)', () => {
+    withEnvFlag(undefined, () => {
+      // Cast to bypass the type system on purpose: simulate a runtime
+      // value that should not activate the flag.
+      const truthy = { _internal: { legacyPath: 1 as unknown as boolean } };
+      expect(readLegacyPathFlag(truthy)).toBe(false);
+    });
+  });
+});
+
+describe('readLegacyPathFlag: browser / edge runtime guard', () => {
+  it('T7: does not throw and returns false when `process` is undefined', () => {
+    const priorProcess = (globalThis as { process?: unknown }).process;
+    try {
+      // Simulate a runtime where `process` is not a global. Vitest uses
+      // happy-dom / node env depending on config; cast through unknown to
+      // remove the variable from the `globalThis` view used by the reader.
+      (globalThis as { process?: unknown }).process = undefined;
+      expect(() => readLegacyPathFlag()).not.toThrow();
+      expect(readLegacyPathFlag()).toBe(false);
+    } finally {
+      (globalThis as { process?: unknown }).process = priorProcess;
+    }
+  });
+});
+
+describe('issue(): byte-equivalent across both flag values (deterministic inputs)', () => {
+  it('T8: stripped semantic claims are byte-equal with PEAC_INTERNAL_LEGACY_PATH=0 vs =1', async () => {
+    const { privateKey, publicKey } = await generateKeypairFromSeed(FIXED_SEED);
+
+    const issuedFlagOff = await withEnvFlagAsync('0', async () =>
+      issue({ ...STABLE_OPTIONS, pillars: [...STABLE_OPTIONS.pillars], privateKey })
+    );
+    const issuedFlagOn = await withEnvFlagAsync('1', async () =>
+      issue({ ...STABLE_OPTIONS, pillars: [...STABLE_OPTIONS.pillars], privateKey })
+    );
+
+    const verifiedOff = await verifyLocal(issuedFlagOff.jws, publicKey);
+    const verifiedOn = await verifyLocal(issuedFlagOn.jws, publicKey);
+
+    expect(verifiedOff.valid).toBe(true);
+    expect(verifiedOn.valid).toBe(true);
+
+    const claimsOff = verifiedOff.valid ? verifiedOff.claims : null;
+    const claimsOn = verifiedOn.valid ? verifiedOn.claims : null;
+    expect(claimsOff).toBeTruthy();
+    expect(claimsOn).toBeTruthy();
+
+    const strippedOff = stripIat(claimsOff as Record<string, unknown>);
+    const strippedOn = stripIat(claimsOn as Record<string, unknown>);
+    expect(JSON.stringify(strippedOff)).toBe(JSON.stringify(strippedOn));
+  });
+
+  it('T8: same byte-equivalence via the programmatic option', async () => {
+    const { privateKey, publicKey } = await generateKeypairFromSeed(FIXED_SEED);
+
+    const issuedFlagOff = await issue({
+      ...STABLE_OPTIONS,
+      pillars: [...STABLE_OPTIONS.pillars],
+      privateKey,
+    });
+    const issuedFlagOn = await issue({
+      ...STABLE_OPTIONS,
+      pillars: [...STABLE_OPTIONS.pillars],
+      privateKey,
+      ...({ _internal: { legacyPath: true } } as object),
+    } as Parameters<typeof issue>[0]);
+
+    const verifiedOff = await verifyLocal(issuedFlagOff.jws, publicKey);
+    const verifiedOn = await verifyLocal(issuedFlagOn.jws, publicKey);
+
+    expect(verifiedOff.valid).toBe(true);
+    expect(verifiedOn.valid).toBe(true);
+
+    const claimsOff = verifiedOff.valid ? verifiedOff.claims : null;
+    const claimsOn = verifiedOn.valid ? verifiedOn.claims : null;
+    expect(claimsOff).toBeTruthy();
+    expect(claimsOn).toBeTruthy();
+
+    const strippedOff = stripIat(claimsOff as Record<string, unknown>);
+    const strippedOn = stripIat(claimsOn as Record<string, unknown>);
+    expect(JSON.stringify(strippedOff)).toBe(JSON.stringify(strippedOn));
+  });
+});
+
+describe('verifyLocal(): byte-equivalent across both flag values for a fixed JWS', () => {
+  it('T9: result-shape is byte-equal with PEAC_INTERNAL_LEGACY_PATH=0 vs =1', async () => {
+    const { privateKey, publicKey } = await generateKeypairFromSeed(FIXED_SEED);
+    // Issue once (with default flag state) and pin the JWS so the
+    // verifyLocal byte-equivalence is independent of any clock-derived
+    // field that issue() emits.
+    const issued = await issue({
+      ...STABLE_OPTIONS,
+      pillars: [...STABLE_OPTIONS.pillars],
+      privateKey,
+    });
+    const fixedJws = issued.jws;
+
+    const verifiedFlagOff = await withEnvFlagAsync('0', async () =>
+      verifyLocal(fixedJws, publicKey)
+    );
+    const verifiedFlagOn = await withEnvFlagAsync('1', async () =>
+      verifyLocal(fixedJws, publicKey)
+    );
+
+    expect(JSON.stringify(verifiedFlagOff)).toBe(JSON.stringify(verifiedFlagOn));
+  });
+
+  it('T9: same byte-equivalence via the programmatic option', async () => {
+    const { privateKey, publicKey } = await generateKeypairFromSeed(FIXED_SEED);
+    const issued = await issue({
+      ...STABLE_OPTIONS,
+      pillars: [...STABLE_OPTIONS.pillars],
+      privateKey,
+    });
+    const fixedJws = issued.jws;
+
+    const verifiedFlagOff = await verifyLocal(fixedJws, publicKey);
+    const verifiedFlagOn = await verifyLocal(fixedJws, publicKey, {
+      ...({ _internal: { legacyPath: true } } as object),
+    } as Parameters<typeof verifyLocal>[2]);
+
+    expect(JSON.stringify(verifiedFlagOff)).toBe(JSON.stringify(verifiedFlagOn));
+  });
+});
+
+describe('LegacyPathOptions structural shape (smoke; not a type-surface test)', () => {
+  it('LegacyPathOptions accepts the documented internal shape at runtime', () => {
+    // Smoke check that the internal type is wired correctly inside
+    // this package. Public option-type cleanliness (i.e., that
+    // `IssueOptions` / `VerifyLocalOptions` / `VerifyOptions` do NOT
+    // declare `_internal.legacyPath`) is NOT enforced here; Vitest
+    // does not run `tsc` against `__tests__/`. That guarantee is
+    // enforced by `scripts/verify-dist-private-leaks.mjs` (Tier 1
+    // scan over emitted `.d.ts` files in all 36 publish-manifest
+    // packages) and `scripts/verify-no-semantic-widening.mjs`
+    // (front-door grep across docs + tracked surfaces).
+    const opts: LegacyPathOptions = { _internal: { legacyPath: true } };
+    expect(readLegacyPathFlag(opts)).toBe(true);
+  });
+});

--- a/packages/protocol/src/_internal/legacy-path.ts
+++ b/packages/protocol/src/_internal/legacy-path.ts
@@ -1,0 +1,55 @@
+/**
+ * Internal rollback-path flag.
+ *
+ * INTERNAL ONLY. Both flag values currently use the same protocol path.
+ * The flag reader is exercised so rollback-path plumbing can be validated
+ * without changing public behavior.
+ *
+ * Public option types MUST NOT declare `_internal.legacyPath`; callers
+ * inside this package access the programmatic option only through
+ * internal casts. Flag identifiers are forbidden on the public TypeScript
+ * surface by `scripts/verify-dist-private-leaks.mjs` (Tier 1 + scoped
+ * runtime allowlist for `@peac/protocol` runtime files only) and by
+ * `scripts/verify-no-semantic-widening.mjs`.
+ */
+
+/**
+ * Programmatic-flag shape. Internal-only; never appears on any
+ * exported public option type. Mirrors the existing shadow-flag
+ * pattern at `_internal/shadow.ts` so the dist-leak gates and the
+ * semantic-widening gates apply uniformly.
+ *
+ * @internal
+ */
+export interface LegacyPathOptions {
+  readonly _internal?: {
+    readonly legacyPath?: boolean;
+  };
+}
+
+/**
+ * Read the rollback-path flag from environment or programmatic
+ * options. Read once per call, NOT cached at module scope, so tests
+ * can toggle the env var dynamically. Strict semantics: only the
+ * literal string `'1'` activates the flag, mirroring
+ * `PEAC_INTERNAL_SHADOW_CORE`.
+ *
+ * Environment access is guarded for browser / edge runtimes that do
+ * not expose `process`; the function never throws.
+ *
+ * Caller pattern at protocol hot paths:
+ *
+ *   void readLegacyPathFlag(options as unknown as LegacyPathOptions);
+ *
+ * The `void` discards the returned boolean intentionally: both flag
+ * values currently use the same protocol path, and the call exists
+ * so the read path is exercised.
+ *
+ * @internal
+ */
+export function readLegacyPathFlag(options?: LegacyPathOptions): boolean {
+  if (options?._internal?.legacyPath === true) return true;
+  if (typeof process === 'undefined' || process === null) return false;
+  const env = (process as { env?: Record<string, string | undefined> }).env;
+  return env?.PEAC_INTERNAL_LEGACY_PATH === '1';
+}

--- a/packages/protocol/src/issue.ts
+++ b/packages/protocol/src/issue.ts
@@ -8,6 +8,7 @@ import { sign } from '@peac/crypto';
 import { defaultCodec } from './_internal/record-core/codec/jws-jwt.js';
 import { runBoundedValidatorShadow } from './_internal/record-core/bounded-validator.js';
 import { isShadowEnabled, scheduleShadow, type ShadowEnableOptions } from './_internal/shadow.js';
+import { readLegacyPathFlag, type LegacyPathOptions } from './_internal/legacy-path.js';
 import {
   realObservationForIssue,
   shadowObservationFromBoundedAcceptedOnly,
@@ -476,6 +477,11 @@ export type IssueOptions = IssueWire02Options;
  * @throws IssueError if iss is not canonical or schema validation fails
  */
 export async function issueWire02(options: IssueWire02Options): Promise<IssueResult> {
+  // Internal rollback-path flag. The returned boolean is intentionally
+  // discarded; both flag values currently use the same protocol path.
+  // See `_internal/legacy-path.ts` for the full contract.
+  void readLegacyPathFlag(options as unknown as LegacyPathOptions);
+
   // Validate canonical iss before signing
   if (!isCanonicalIss(options.iss)) {
     throw new IssueError({

--- a/packages/protocol/src/verify-local.ts
+++ b/packages/protocol/src/verify-local.ts
@@ -28,6 +28,7 @@ import { checkTypeExtensionMapping } from './type-extension-check';
 import { maybeRunShadowValidation } from './_internal/record-core/shadow-hook';
 import { runBoundedValidatorShadow } from './_internal/record-core/bounded-validator.js';
 import { isShadowEnabled, scheduleShadow, type ShadowEnableOptions } from './_internal/shadow.js';
+import { readLegacyPathFlag, type LegacyPathOptions } from './_internal/legacy-path.js';
 import {
   realObservationForVerifyLocalSuccess,
   shadowObservationFromBounded,
@@ -364,6 +365,10 @@ export async function verifyLocal(
   publicKey: Uint8Array,
   options: VerifyLocalOptions = {}
 ): Promise<VerifyLocalResult> {
+  // Internal rollback-path flag. See `_internal/legacy-path.ts` for
+  // the full contract.
+  void readLegacyPathFlag(options as unknown as LegacyPathOptions);
+
   const {
     issuer,
     subjectUri,

--- a/packages/protocol/src/verify.ts
+++ b/packages/protocol/src/verify.ts
@@ -16,6 +16,7 @@ import {
 } from '@peac/schema';
 import { resolveJWKS, type JWK } from './jwks-resolver.js';
 import { hashReceipt, fireTelemetryHook, type TelemetryHook } from './telemetry.js';
+import { readLegacyPathFlag, type LegacyPathOptions } from './_internal/legacy-path.js';
 
 /**
  * Convert JWK x coordinate to Ed25519 public key
@@ -101,6 +102,12 @@ export interface VerifyOptions {
 export async function verifyReceipt(
   optionsOrJws: string | VerifyOptions
 ): Promise<VerifyResult | VerifyFailure> {
+  // Internal rollback-path flag. See `_internal/legacy-path.ts` for
+  // the full contract.
+  const legacyPathOptions =
+    typeof optionsOrJws === 'string' ? undefined : (optionsOrJws as unknown as LegacyPathOptions);
+  void readLegacyPathFlag(legacyPathOptions);
+
   // Support both old (string) and new (options) signatures for backwards compatibility
   const receiptJws = typeof optionsOrJws === 'string' ? optionsOrJws : optionsOrJws.receiptJws;
   const inputSnapshot =

--- a/scripts/verify-dist-private-leaks.mjs
+++ b/scripts/verify-dist-private-leaks.mjs
@@ -48,6 +48,8 @@ const FORBIDDEN_IDENTIFIERS = [
   '@peac/resolver-http',
   'PEAC_INTERNAL_SHADOW_CORE',
   '_internal.shadowCore',
+  'PEAC_INTERNAL_LEGACY_PATH',
+  '_internal.legacyPath',
   'PEAC_EXPERIMENTAL_CODEC',
   '_internal.codec',
 ];
@@ -69,7 +71,12 @@ const FORBIDDEN_IDENTIFIERS = [
 //   - the identifier is permitted only in *.mjs / *.cjs (runtime),
 //     never in *.d.ts (public TypeScript surface).
 const TIER_1_RUNTIME_ALLOWLIST = {
-  '@peac/protocol': new Set(['PEAC_INTERNAL_SHADOW_CORE', '_internal.shadowCore']),
+  '@peac/protocol': new Set([
+    'PEAC_INTERNAL_SHADOW_CORE',
+    '_internal.shadowCore',
+    'PEAC_INTERNAL_LEGACY_PATH',
+    '_internal.legacyPath',
+  ]),
 };
 
 // Tier 2: forbidden ONLY on public-surface files. These are implementation

--- a/scripts/verify-no-semantic-widening.mjs
+++ b/scripts/verify-no-semantic-widening.mjs
@@ -222,6 +222,8 @@ console.log('\n--- Internal-flag front-door grep ---');
 const FORBIDDEN_FLAGS = [
   'PEAC_INTERNAL_SHADOW_CORE',
   '_internal.shadowCore',
+  'PEAC_INTERNAL_LEGACY_PATH',
+  '_internal.legacyPath',
   'PEAC_EXPERIMENTAL_CODEC',
   '_internal.codec',
 ];


### PR DESCRIPTION
## Summary

Adds internal rollback-path flag plumbing to `@peac/protocol`.

Both flag values currently use the same protocol path. The flag reader is exercised so rollback-path plumbing can be validated without changing current public behavior.

## What changed

- New internal helper at `packages/protocol/src/_internal/legacy-path.ts`: `readLegacyPathFlag(options)` reads `PEAC_INTERNAL_LEGACY_PATH=1` (env, strict literal) or `_internal: { legacyPath: true }` (programmatic, internal-only, never declared on public option types). Browser/edge-runtime guarded.
- Wired at the top of `issueWire02()`, `verifyLocal()`, and `verifyReceipt()` as `void readLegacyPathFlag(...)`.
- New CI job `protocol-rollback-path-matrix` runs the `@peac/protocol` test suite under both flag values; gated on `detect-changes.outputs.core` so apps-only and stamp-only PRs do not pay the cost.
- Self-tests at `packages/protocol/__tests__/_internal/legacy-path-flag.test.ts` cover env parsing (strict `'1'`), programmatic-option parsing, browser/edge runtime guard, and `issue()` / `verifyLocal()` byte-equivalence across both flag values.

## Scope

Internal-only plumbing.

No public API change. No wire-format change. No OpenAPI change. No release-file change. No publish-manifest change. No package version change.

No dedicated `verifyReceipt()` behavior test is added in this PR. The call-site change is limited to reading and discarding the internal flag.

## Verification

- Targeted flag self-tests passed (15/15).
- `@peac/protocol` test suite passed under `PEAC_INTERNAL_LEGACY_PATH=0` and `=1` (1405/1405 each, identical totals).
- Build passed.
- Tooling tests passed (113/113).
- `verify-dist-private-leaks` scanned 36 packages; no leaks (the new identifier is allowlisted in `@peac/protocol` runtime files only, forbidden in every `.d.ts` and every other package).
- `verify-no-semantic-widening` 18/18 checks passed; new identifier added to the front-door denylist.
- Local doc-truth and final-hygiene verifiers passed.
- Forbidden-string check passed.
- `git diff --check` clean.

## Public-surface protection

Enforced by declaration-output leak checks (`scripts/verify-dist-private-leaks.mjs`) and semantic-widening checks (`scripts/verify-no-semantic-widening.mjs`). No runtime type-level test is claimed; Vitest does not run `tsc` against `__tests__/`.
