### PR TITLE
feat(protocol): expand internal validation parity coverage in shadow mode

### DIFF
--- a/packages/protocol/__tests__/_internal/bounded-validator-expanded-layers.test.ts
+++ b/packages/protocol/__tests__/_internal/bounded-validator-expanded-layers.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Layer-activation proof for the canonical-composed shadow validation.
+ *
+ * Each new sync optional-input layer must be reachable through
+ * `runBoundedValidatorShadow(...)` when its inputs are present.
+ * Per-layer activation is asserted by exercising the bounded
+ * validator with inputs designed to fire that layer's surface, then
+ * checking the layer tag appears on the resulting `violations` or
+ * `warnings` list.
+ *
+ * The signature wrapper is intentionally NOT in scope here. It is a
+ * standalone async export and is exercised by
+ * `canonical-composed-validators.test.ts`. This file covers only
+ * the six sync layers wired into the bounded validator.
+ *
+ * Layer-by-layer activation (one assertion per layer):
+ *   - schema-parse
+ *   - jose-typ-strictness
+ *   - iat-not-yet-valid
+ *   - policy-binding
+ *   - unknown-extension-grammar
+ *   - type-extension-enforcement
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  runBoundedValidatorShadow,
+  type BoundedLayer,
+} from '../../src/_internal/record-core/bounded-validator.js';
+
+const FIXED_NOW = 1735689600;
+const VALID_ISS = 'https://issuer.example';
+const REGISTERED_TYPE = 'org.peacprotocol/payment';
+const FIXED_DIGEST_A = 'sha256:0000000000000000000000000000000000000000000000000000000000000001';
+const FIXED_DIGEST_B = 'sha256:0000000000000000000000000000000000000000000000000000000000000002';
+
+function assertLayerFires(
+  result: ReturnType<typeof runBoundedValidatorShadow>,
+  layer: BoundedLayer
+): void {
+  const violationFired = result.violations.some((v) => v.layer === layer);
+  const warningFired = result.warnings.some((w) => w.layer === layer);
+  expect(violationFired || warningFired, `expected layer "${layer}" to fire`).toBe(true);
+}
+
+describe('bounded validator: sync optional-input layer activation', () => {
+  it('schema-parse fires when fullClaims is supplied and the payload fails parse', () => {
+    const r = runBoundedValidatorShadow({
+      claims: {
+        kind: 'evidence',
+        type: REGISTERED_TYPE,
+        iss: VALID_ISS,
+        iat: FIXED_NOW,
+      },
+      now: FIXED_NOW,
+      // Empty payload fails canonical parseReceiptClaims.
+      fullClaims: {},
+    });
+    assertLayerFires(r, 'schema-parse');
+  });
+
+  it('jose-typ-strictness fires under strict mode when typ is absent in the header', () => {
+    const r = runBoundedValidatorShadow({
+      claims: {
+        kind: 'evidence',
+        type: REGISTERED_TYPE,
+        iss: VALID_ISS,
+        iat: FIXED_NOW,
+      },
+      header: { alg: 'EdDSA', kid: 'k1' },
+      now: FIXED_NOW,
+      strictness: 'strict',
+    });
+    assertLayerFires(r, 'jose-typ-strictness');
+  });
+
+  it('iat-not-yet-valid fires when iat is past now+maxClockSkew', () => {
+    const r = runBoundedValidatorShadow({
+      claims: {
+        kind: 'evidence',
+        type: REGISTERED_TYPE,
+        iss: VALID_ISS,
+        iat: FIXED_NOW + 1000,
+      },
+      now: FIXED_NOW,
+      maxClockSkew: 0,
+    });
+    assertLayerFires(r, 'iat-not-yet-valid');
+  });
+
+  it('policy-binding fires when receipt and local digests are present and unequal', () => {
+    const r = runBoundedValidatorShadow({
+      claims: {
+        kind: 'evidence',
+        type: REGISTERED_TYPE,
+        iss: VALID_ISS,
+        iat: FIXED_NOW,
+      },
+      now: FIXED_NOW,
+      receiptPolicyDigest: FIXED_DIGEST_A,
+      localPolicyDigest: FIXED_DIGEST_B,
+    });
+    assertLayerFires(r, 'policy-binding');
+  });
+
+  it('unknown-extension-grammar fires when an unregistered well-formed extension key is present', () => {
+    const r = runBoundedValidatorShadow({
+      claims: {
+        kind: 'evidence',
+        type: REGISTERED_TYPE,
+        iss: VALID_ISS,
+        iat: FIXED_NOW,
+        extensions: { 'org.example/custom': { x: 1 } },
+      },
+      now: FIXED_NOW,
+    });
+    assertLayerFires(r, 'unknown-extension-grammar');
+  });
+
+  it('type-extension-enforcement fires when strict mode is requested and the expected extension group is absent', () => {
+    const r = runBoundedValidatorShadow({
+      claims: {
+        kind: 'evidence',
+        type: REGISTERED_TYPE,
+        iss: VALID_ISS,
+        iat: FIXED_NOW,
+      },
+      now: FIXED_NOW,
+      strictness: 'strict',
+    });
+    assertLayerFires(r, 'type-extension-enforcement');
+  });
+});
+
+describe('bounded validator: optional-input layers skip when their inputs are absent', () => {
+  it('schema-parse skips when fullClaims is absent', () => {
+    const r = runBoundedValidatorShadow({
+      claims: {
+        kind: 'evidence',
+        type: 'org.example/custom',
+        iss: VALID_ISS,
+        iat: FIXED_NOW,
+      },
+      now: FIXED_NOW,
+    });
+    const fired =
+      r.violations.some((v) => v.layer === 'schema-parse') ||
+      r.warnings.some((w) => w.layer === 'schema-parse');
+    expect(fired).toBe(false);
+  });
+
+  it('jose-typ-strictness skips when no header or no strictness is supplied', () => {
+    const r = runBoundedValidatorShadow({
+      claims: {
+        kind: 'evidence',
+        type: 'org.example/custom',
+        iss: VALID_ISS,
+        iat: FIXED_NOW,
+      },
+      now: FIXED_NOW,
+    });
+    expect(r.violations.some((v) => v.layer === 'jose-typ-strictness')).toBe(false);
+  });
+
+  it('iat-not-yet-valid skips when maxClockSkew is absent', () => {
+    const r = runBoundedValidatorShadow({
+      claims: {
+        kind: 'evidence',
+        type: 'org.example/custom',
+        iss: VALID_ISS,
+        iat: FIXED_NOW + 1_000_000,
+      },
+      now: FIXED_NOW,
+    });
+    expect(r.violations.some((v) => v.layer === 'iat-not-yet-valid')).toBe(false);
+  });
+
+  it('policy-binding skips when either digest is absent', () => {
+    const r = runBoundedValidatorShadow({
+      claims: {
+        kind: 'evidence',
+        type: 'org.example/custom',
+        iss: VALID_ISS,
+        iat: FIXED_NOW,
+      },
+      now: FIXED_NOW,
+      receiptPolicyDigest: FIXED_DIGEST_A,
+    });
+    expect(r.violations.some((v) => v.layer === 'policy-binding')).toBe(false);
+  });
+
+  it('type-extension-enforcement skips when strictness is absent', () => {
+    const r = runBoundedValidatorShadow({
+      claims: {
+        kind: 'evidence',
+        type: REGISTERED_TYPE,
+        iss: VALID_ISS,
+        iat: FIXED_NOW,
+      },
+      now: FIXED_NOW,
+    });
+    expect(r.violations.some((v) => v.layer === 'type-extension-enforcement')).toBe(false);
+    expect(r.warnings.some((w) => w.layer === 'type-extension-enforcement')).toBe(false);
+  });
+});

--- a/packages/protocol/__tests__/_internal/canonical-composed-validators.test.ts
+++ b/packages/protocol/__tests__/_internal/canonical-composed-validators.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Per-validator unit tests for the canonical-composed validator
+ * modules used by the bounded validation harness.
+ *
+ * Covers seven canonical-composed validators:
+ *   - schema-parse (delegates to `parseReceiptClaims`)
+ *   - jose-typ-strictness (mirrors `verify-local` strictness routing)
+ *   - iat-not-yet-valid (mirrors `iat > now + maxClockSkew`)
+ *   - policy-binding (delegates to `verifyPolicyBinding`)
+ *   - unknown-extension-grammar (delegates to `isValidExtensionKey` +
+ *     `REGISTERED_EXTENSION_GROUP_KEYS`)
+ *   - type-extension-enforcement (delegates to
+ *     `checkTypeExtensionMapping` + strictness routing)
+ *   - signature (delegates to `@peac/crypto.verify`; standalone async
+ *     export, not composed into `runBoundedValidatorShadow`)
+ *
+ * Each section asserts the wrapper's projection logic. Cross-fixture
+ * byte-equality with the canonical path is asserted by the broader
+ * canonical-vs-candidate differential test
+ * (`parity-canonical-vs-candidate.test.ts`); these tests are focused
+ * unit checks on the projection / dispatch logic.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { generateKeypairFromSeed } from '@peac/crypto/testkit';
+import { issue } from '../../src/index.js';
+import {
+  validateIatNotYetValidInternal,
+  validateJoseTypStrictnessInternal,
+  validatePolicyBindingInternal,
+  validateSchemaParseInternal,
+  validateSignatureInternal,
+  validateTypeExtensionEnforcementInternal,
+  validateUnknownExtensionGrammarInternal,
+} from '../../src/_internal/record-core/validators/index.js';
+
+// Deterministic seed for signature tests; isolated to this file.
+const FIXED_SEED = new Uint8Array([
+  0x42, 0x9c, 0x1d, 0x76, 0xe3, 0x4f, 0x82, 0x55, 0x18, 0xab, 0x07, 0x60, 0xd4, 0x39, 0xc5, 0x77,
+  0x21, 0x68, 0xf3, 0x4a, 0x09, 0x80, 0xee, 0x6c, 0x14, 0x95, 0x33, 0xa1, 0x47, 0x2b, 0x6e, 0xc8,
+]);
+
+// ---------------------------------------------------------------------------
+// schema-parse
+// ---------------------------------------------------------------------------
+
+describe('validateSchemaParseInternal', () => {
+  it('accepts a minimally-valid Wire 0.2 evidence record', () => {
+    const r = validateSchemaParseInternal({
+      peac_version: '0.2',
+      kind: 'evidence',
+      type: 'org.example/test',
+      iss: 'https://issuer.example',
+      iat: 1735689600,
+      jti: '019b0000-0000-7000-8000-000000000abc',
+    });
+    expect(r.accepted).toBe(true);
+    expect(r.claims).toBeDefined();
+  });
+
+  it('rejects a payload missing required fields with a canonical error code', () => {
+    const r = validateSchemaParseInternal({ kind: 'evidence' });
+    expect(r.accepted).toBe(false);
+    expect(typeof r.errorCode).toBe('string');
+    expect((r.errorCode ?? '').length).toBeGreaterThan(0);
+  });
+
+  it('rejects a non-Wire-0.2 payload with a stable error code', () => {
+    const r = validateSchemaParseInternal({
+      iss: 'https://issuer.example',
+      aud: 'https://aud.example',
+      iat: 1735689600,
+      rid: '01-old-rid',
+      amt: 1,
+      cur: 'USD',
+      payment: {
+        rail: 'card',
+        reference: 'r1',
+        amount: 1,
+        currency: 'USD',
+        asset: 'USD',
+        env: 'test',
+        evidence: {},
+      },
+    });
+    expect(r.accepted).toBe(false);
+    expect(typeof r.errorCode).toBe('string');
+    expect((r.errorCode ?? '').length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// jose-typ-strictness
+// ---------------------------------------------------------------------------
+
+describe('validateJoseTypStrictnessInternal', () => {
+  it('typ present (any string) -> accepted with no warning', () => {
+    expect(validateJoseTypStrictnessInternal('interaction-record+jwt', 'strict')).toEqual({
+      accepted: true,
+    });
+    expect(validateJoseTypStrictnessInternal('arbitrary', 'interop')).toEqual({ accepted: true });
+  });
+
+  it('typ absent + strict -> rejected with E_INVALID_FORMAT', () => {
+    expect(validateJoseTypStrictnessInternal(undefined, 'strict')).toEqual({
+      accepted: false,
+      errorCode: 'E_INVALID_FORMAT',
+    });
+    expect(validateJoseTypStrictnessInternal(null, 'strict')).toEqual({
+      accepted: false,
+      errorCode: 'E_INVALID_FORMAT',
+    });
+    expect(validateJoseTypStrictnessInternal('', 'strict')).toEqual({
+      accepted: false,
+      errorCode: 'E_INVALID_FORMAT',
+    });
+  });
+
+  it('typ absent + interop -> accepted with typ_missing warning', () => {
+    expect(validateJoseTypStrictnessInternal(undefined, 'interop')).toEqual({
+      accepted: true,
+      warnings: [{ code: 'typ_missing' }],
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// iat-not-yet-valid
+// ---------------------------------------------------------------------------
+
+describe('validateIatNotYetValidInternal', () => {
+  const NOW = 1735689600;
+  const SKEW = 300;
+
+  it('iat at or before now+skew -> accepted', () => {
+    expect(validateIatNotYetValidInternal(NOW, NOW, SKEW)).toEqual({ accepted: true });
+    expect(validateIatNotYetValidInternal(NOW + SKEW, NOW, SKEW)).toEqual({ accepted: true });
+    expect(validateIatNotYetValidInternal(NOW - 100, NOW, SKEW)).toEqual({ accepted: true });
+  });
+
+  it('iat one second past now+skew -> rejected with E_NOT_YET_VALID', () => {
+    expect(validateIatNotYetValidInternal(NOW + SKEW + 1, NOW, SKEW)).toEqual({
+      accepted: false,
+      errorCode: 'E_NOT_YET_VALID',
+    });
+  });
+
+  it('zero skew enforces strict iat <= now', () => {
+    expect(validateIatNotYetValidInternal(NOW, NOW, 0)).toEqual({ accepted: true });
+    expect(validateIatNotYetValidInternal(NOW + 1, NOW, 0)).toEqual({
+      accepted: false,
+      errorCode: 'E_NOT_YET_VALID',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// policy-binding
+// ---------------------------------------------------------------------------
+
+describe('validatePolicyBindingInternal', () => {
+  const D1 = 'sha256:0000000000000000000000000000000000000000000000000000000000000001';
+  const D2 = 'sha256:0000000000000000000000000000000000000000000000000000000000000002';
+
+  it('matching digests -> accepted with status verified', () => {
+    expect(validatePolicyBindingInternal(D1, D1)).toEqual({
+      accepted: true,
+      status: 'verified',
+    });
+  });
+
+  it('mismatched digests -> rejected with E_POLICY_BINDING_FAILED', () => {
+    expect(validatePolicyBindingInternal(D1, D2)).toEqual({
+      accepted: false,
+      errorCode: 'E_POLICY_BINDING_FAILED',
+      status: 'failed',
+    });
+  });
+
+  it('either digest absent -> accepted with status unavailable', () => {
+    expect(validatePolicyBindingInternal(undefined, D1)).toEqual({
+      accepted: true,
+      status: 'unavailable',
+    });
+    expect(validatePolicyBindingInternal(D1, undefined)).toEqual({
+      accepted: true,
+      status: 'unavailable',
+    });
+    expect(validatePolicyBindingInternal(undefined, undefined)).toEqual({
+      accepted: true,
+      status: 'unavailable',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unknown-extension-grammar
+// ---------------------------------------------------------------------------
+
+describe('validateUnknownExtensionGrammarInternal', () => {
+  it('extensions undefined -> accepted, no warnings', () => {
+    expect(validateUnknownExtensionGrammarInternal(undefined)).toEqual({
+      accepted: true,
+      warnings: [],
+    });
+  });
+
+  it('empty extensions object -> accepted, no warnings', () => {
+    expect(validateUnknownExtensionGrammarInternal({})).toEqual({
+      accepted: true,
+      warnings: [],
+    });
+  });
+
+  it('well-formed but unregistered key -> warning with JSON-pointer escaped path', () => {
+    const r = validateUnknownExtensionGrammarInternal({ 'org.example/custom': { x: 1 } });
+    expect(r.accepted).toBe(true);
+    expect(r.warnings).toHaveLength(1);
+    expect(r.warnings[0]).toEqual({
+      code: 'unknown_extension_preserved',
+      pointer: '/extensions/org.example~1custom',
+    });
+  });
+
+  it('multiple unregistered keys produce one warning each', () => {
+    const r = validateUnknownExtensionGrammarInternal({
+      'org.example/a': { x: 1 },
+      'org.example/b': { y: 2 },
+    });
+    expect(r.warnings).toHaveLength(2);
+    const pointers = r.warnings.map((w) => w.pointer).sort();
+    expect(pointers).toEqual(['/extensions/org.example~1a', '/extensions/org.example~1b']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// type-extension-enforcement
+// ---------------------------------------------------------------------------
+
+describe('validateTypeExtensionEnforcementInternal', () => {
+  it('challenge kind always skips (accepted, no warning)', () => {
+    expect(
+      validateTypeExtensionEnforcementInternal('challenge', 'org.example/test', undefined, 'strict')
+    ).toEqual({ accepted: true });
+  });
+
+  it('unmapped type always skips (accepted, no warning)', () => {
+    expect(
+      validateTypeExtensionEnforcementInternal('evidence', 'org.example/unmapped', {}, 'strict')
+    ).toEqual({ accepted: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// signature
+// ---------------------------------------------------------------------------
+
+describe('validateSignatureInternal', () => {
+  it('valid signature -> accepted', async () => {
+    const { privateKey, publicKey } = await generateKeypairFromSeed(FIXED_SEED);
+    const result = await issue({
+      iss: 'https://issuer.example',
+      kind: 'evidence',
+      type: 'org.example/sig-test',
+      privateKey,
+      kid: 'sig-test-key',
+      jti: '019b0000-0000-7000-8000-000000000sig',
+      pillars: ['safety'],
+    });
+    const sig = await validateSignatureInternal(result.jws, publicKey);
+    expect(sig.accepted).toBe(true);
+    expect(sig.errorCode).toBeUndefined();
+  });
+
+  it('tampered signature -> rejected with a CRYPTO_* error code', async () => {
+    const { privateKey, publicKey } = await generateKeypairFromSeed(FIXED_SEED);
+    const result = await issue({
+      iss: 'https://issuer.example',
+      kind: 'evidence',
+      type: 'org.example/sig-test',
+      privateKey,
+      kid: 'sig-test-key',
+      jti: '019b0000-0000-7000-8000-000000000bad',
+      pillars: ['safety'],
+    });
+    // Flip the first char of the signature segment to force a
+    // mismatch. First-position flip avoids edge cases at the trailing
+    // boundary; replacement char is picked from the base64url
+    // alphabet to produce a structurally valid but byte-different
+    // signature.
+    const segments = result.jws.split('.');
+    const sigSegment = segments[2];
+    const original = sigSegment.charAt(0);
+    const replacement = original === 'A' ? 'B' : 'A';
+    const tampered = `${segments[0]}.${segments[1]}.${replacement}${sigSegment.slice(1)}`;
+    const sig = await validateSignatureInternal(tampered, publicKey);
+    expect(sig.accepted).toBe(false);
+    expect(typeof sig.errorCode).toBe('string');
+    expect((sig.errorCode ?? '').startsWith('CRYPTO_')).toBe(true);
+  });
+
+  it('malformed JWS shape -> rejected with a CRYPTO_* error code', async () => {
+    const { publicKey } = await generateKeypairFromSeed(FIXED_SEED);
+    const sig = await validateSignatureInternal('not-a-jws', publicKey);
+    expect(sig.accepted).toBe(false);
+    expect((sig.errorCode ?? '').startsWith('CRYPTO_')).toBe(true);
+  });
+});

--- a/packages/protocol/__tests__/_internal/parity-canonical-vs-candidate.test.ts
+++ b/packages/protocol/__tests__/_internal/parity-canonical-vs-candidate.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Canonical-vs-candidate differential.
+ *
+ * Runs the canonical validator path (`canonical-runner`) and the
+ * canonical-composed candidate path (`candidate-runner`) on every
+ * eligible fixture from the existing manifest and asserts the
+ * normalized `ParityVerdict` byte-for-byte equals across both sides.
+ *
+ * The candidate is canonical-composed by construction: every layer
+ * either delegates to the same canonical helper the canonical runner
+ * uses or mirrors a canonical inline check verbatim. Byte equality
+ * is therefore expected on every fixture; any divergence indicates a
+ * defect in the candidate-runner's projection logic.
+ *
+ * This test asserts the candidate projection remains byte-equal to
+ * the canonical verdict shape across the fixture manifest, not merely
+ * that two implementations happened to agree by accident.
+ *
+ * Coverage inherited from the fixture manifest:
+ *   - 31 schema-validated parity-corpus vectors (4 families).
+ *   - All eligible wire-02-conformance fixtures (full-pipeline,
+ *     jws-security with header_overrides, warning).
+ *
+ * Excluded fixtures are tracked in the manifest with explicit reasons
+ * and do not run on either side.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { runCanonicalForKind } from '../../src/_internal/test-helpers/canonical-runner';
+import { runCandidateForKind } from '../../src/_internal/test-helpers/candidate-runner';
+import { verdictKey } from '../../src/_internal/test-helpers/parity-verdict';
+import { loadFixtureManifest } from '../../src/_internal/test-helpers/fixture-manifest';
+
+const manifest = loadFixtureManifest();
+
+describe('parity differential (canonical vs candidate)', () => {
+  it('manifest has fixtures eligible for the canonical-vs-candidate differential', () => {
+    expect(manifest.totals.included).toBeGreaterThan(0);
+  });
+
+  describe('zero divergence: candidate verdict byte-equals canonical verdict on every included fixture', () => {
+    for (const entry of manifest.included) {
+      it(`${entry.source}/${entry.family}/${entry.id}: CANDIDATE === CANONICAL`, async () => {
+        const canonical = await runCanonicalForKind(entry.runnerKind, entry.input);
+        const candidate = await runCandidateForKind(entry.runnerKind, entry.input);
+        expect(verdictKey(candidate)).toBe(verdictKey(canonical));
+      });
+    }
+  });
+});

--- a/packages/protocol/__tests__/_internal/shadow-byte-equivalence.test.ts
+++ b/packages/protocol/__tests__/_internal/shadow-byte-equivalence.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Shadow byte-equivalence.
+ *
+ * Asserts that `issue()` produces byte-identical compact JWS output
+ * across `PEAC_INTERNAL_SHADOW_CORE=0` and `PEAC_INTERNAL_SHADOW_CORE=1`
+ * when every input is deterministic. Determinism requires:
+ *
+ *   - fixed Ed25519 keypair (seeded)
+ *   - fixed `kid`
+ *   - explicit `jti` (not generated)
+ *   - explicit `occurred_at`
+ *   - locked `Date.now()` via `vi.useFakeTimers` so the `iat` claim is
+ *     identical across both invocations
+ *
+ * With those held, `issue()` produces the exact same JWS bytes both
+ * times. The shadow scheduler runs the bounded validator on a
+ * macrotask boundary AFTER the public call returns its real-path
+ * value, so the caller's observable JWS bytes do not depend on
+ * shadow flag state.
+ *
+ * `verifyLocal()` is also asserted byte-equivalent on a fixed JWS
+ * across both shadow flag values.
+ *
+ * Drains the shadow queue between flag toggles via
+ * `_drainShadowQueueForTests` so no orphan tasks bleed across runs.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { generateKeypairFromSeed } from '@peac/crypto/testkit';
+import { issue, verifyLocal } from '../../src/index.js';
+import { _drainShadowQueueForTests } from '../../src/_internal/shadow.js';
+
+const FIXED_SEED = new Uint8Array([
+  0xa1, 0xc4, 0x3f, 0x09, 0x77, 0x2e, 0xb6, 0x80, 0x55, 0x12, 0xee, 0x47, 0x3d, 0x9b, 0x60, 0x18,
+  0x73, 0x21, 0xf5, 0x4c, 0xab, 0xc2, 0x9e, 0x06, 0x44, 0x37, 0x55, 0x8a, 0x6f, 0xd0, 0x12, 0xe7,
+]);
+const FIXED_KID = 'shadow-byte-eq-test-key-1';
+const FIXED_JTI = '019b0000-0000-7000-8000-00000000ab12';
+const FIXED_OCCURRED_AT = '2026-05-02T00:00:00Z';
+const FIXED_ISS = 'https://issuer.example';
+const FIXED_TYPE = 'org.example/shadow-byte-eq-test';
+/** Locked wall-clock value: 2026-05-02T00:00:00Z. */
+const FIXED_NOW_MS = Date.UTC(2026, 4, 2, 0, 0, 0);
+
+const STABLE_OPTIONS = {
+  iss: FIXED_ISS,
+  kind: 'evidence' as const,
+  type: FIXED_TYPE,
+  kid: FIXED_KID,
+  jti: FIXED_JTI,
+  occurred_at: FIXED_OCCURRED_AT,
+  pillars: ['safety'] as const,
+};
+
+async function withShadowEnvAsync<T>(value: string | undefined, fn: () => Promise<T>): Promise<T> {
+  const prior = process.env.PEAC_INTERNAL_SHADOW_CORE;
+  if (value === undefined) delete process.env.PEAC_INTERNAL_SHADOW_CORE;
+  else process.env.PEAC_INTERNAL_SHADOW_CORE = value;
+  try {
+    return await fn();
+  } finally {
+    if (prior === undefined) delete process.env.PEAC_INTERNAL_SHADOW_CORE;
+    else process.env.PEAC_INTERNAL_SHADOW_CORE = prior;
+  }
+}
+
+describe('shadow byte-equivalence: issue() and verifyLocal() are stable across shadow flag values', () => {
+  beforeEach(() => {
+    // Lock Date.now() so the `iat` claim inside issue() is identical
+    // across both invocations. A targeted `Date.now` spy is preferred
+    // to `vi.useFakeTimers()` because the shadow scheduler uses
+    // `setTimeout` to defer the bounded validator to a macrotask
+    // boundary; faking the timer queue blocks `_drainShadowQueueForTests`.
+    vi.spyOn(Date, 'now').mockReturnValue(FIXED_NOW_MS);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await _drainShadowQueueForTests();
+  });
+
+  it('issue(): JWS bytes are identical with PEAC_INTERNAL_SHADOW_CORE=0 vs =1', async () => {
+    const { privateKey } = await generateKeypairFromSeed(FIXED_SEED);
+
+    const issuedShadowOff = await withShadowEnvAsync('0', async () =>
+      issue({ ...STABLE_OPTIONS, pillars: [...STABLE_OPTIONS.pillars], privateKey })
+    );
+    await _drainShadowQueueForTests();
+
+    const issuedShadowOn = await withShadowEnvAsync('1', async () =>
+      issue({ ...STABLE_OPTIONS, pillars: [...STABLE_OPTIONS.pillars], privateKey })
+    );
+    await _drainShadowQueueForTests();
+
+    expect(issuedShadowOn.jws).toBe(issuedShadowOff.jws);
+  });
+
+  it('verifyLocal(): result-shape byte-equal across shadow flag values for a fixed JWS', async () => {
+    const { privateKey, publicKey } = await generateKeypairFromSeed(FIXED_SEED);
+    const issued = await issue({
+      ...STABLE_OPTIONS,
+      pillars: [...STABLE_OPTIONS.pillars],
+      privateKey,
+    });
+    await _drainShadowQueueForTests();
+    const fixedJws = issued.jws;
+
+    const verifiedShadowOff = await withShadowEnvAsync('0', async () =>
+      verifyLocal(fixedJws, publicKey)
+    );
+    await _drainShadowQueueForTests();
+    const verifiedShadowOn = await withShadowEnvAsync('1', async () =>
+      verifyLocal(fixedJws, publicKey)
+    );
+    await _drainShadowQueueForTests();
+
+    expect(JSON.stringify(verifiedShadowOff)).toBe(JSON.stringify(verifiedShadowOn));
+  });
+});

--- a/packages/protocol/src/_internal/record-core/bounded-validator.ts
+++ b/packages/protocol/src/_internal/record-core/bounded-validator.ts
@@ -1,49 +1,61 @@
 /**
- * Bounded observation subset: composition aggregator.
+ * Canonical-composed shadow validation: composition aggregator.
  *
- * INTERNAL ONLY. Composes the six proven layer validators introduced
- * across this PR (kernel constraints; type-extension mapping; JOSE
- * header hardening; issuer form; occurred_at temporal skew;
- * extension byte budget) into a single aggregated result. The
- * canonical-truth sanity test, layer-isolated parity tests, and
- * differential same-path proof have already established that each
- * underlying validator is byte-equal with the existing canonical
- * surface for the layer it covers.
+ * INTERNAL ONLY. Composes layer validators into a single aggregated
+ * result. Each layer either delegates to a canonical helper from
+ * `@peac/schema` / `@peac/crypto` / `@peac/protocol` (canonical-
+ * composed wrapper pattern) or mirrors a canonical inline check
+ * verbatim. The canonical-vs-candidate differential test asserts
+ * byte-equality of the candidate verdict with the canonical verdict
+ * on every eligible fixture; any divergence indicates a defect in
+ * the projection logic.
  *
- * NOT WIRED. This module is NOT called from issue.ts, verify-local.ts,
- * or any runtime path in v0.13.1. It exists as a composition example
- * so PR D can wire the inert shadow-call hook to a real bounded
- * pipeline behind an internal feature flag without re-deriving the
- * composition shape.
+ * Always-on layers (run on every input):
+ *   - kernel-constraints (depth / array / keys / string / nodes)
+ *   - issuer-form (canonical iss)
+ *   - type-extension-mapping (warnings only)
+ *   - extension-byte-budget
+ *   - unknown-extension-grammar (warnings only)
  *
- * NOT FULL VALIDATION. The bounded subset deliberately EXCLUDES:
- *   - full Wire 0.2 schema parsing (parseReceiptClaims; the canonical
- *     parse continues to drive the runtime path)
- *   - signature verification and full JWS decode (decodeWire02;
- *     @peac/crypto remains canonical)
- *   - iat-not-yet-valid temporal check (lives inline at
- *     verify-local.ts:454 with no helper to import)
- *   - typ_missing strictness handling
- *   - policy binding verification
- *   - unknown_extension key grammar / plain-JSON guard / typed
- *     extension schema parse (only the byte-budget portion of
- *     validateKnownExtensions is in scope)
+ * Optional-input layers (skip when their inputs are absent):
+ *   - jose-header-hardening (header)
+ *   - temporal occurred_at skew (evidence kind)
+ *   - schema-parse (fullClaims)
+ *   - jose-typ-strictness (header + strictness)
+ *   - iat-not-yet-valid (maxClockSkew)
+ *   - policy-binding (receiptPolicyDigest + localPolicyDigest)
+ *   - type-extension-enforcement (strictness)
+ *
+ * Out of scope:
+ *   - signature verification (the standalone `validateSignatureInternal`
+ *     export is async and is not composed here; callers that need it
+ *     invoke it directly with serialized + publicKey)
  *   - any control-plane behavior (issuer resolver, JWKS fetch, etc.)
  *
- * Public-facing wording for this module: "bounded observation subset",
- * never "complete validator" or "primary validator".
+ * Public-facing wording for this module: "canonical-composed shadow
+ * validation" or "observational equivalence harness". Never
+ * "complete validator", "primary validator", or "divergent validator".
  */
 
 import {
   validateExtensionBudgetInternal,
+  validateIatNotYetValidInternal,
   validateIssuerFormInternal,
   validateJoseHardeningInternal,
+  validateJoseTypStrictnessInternal,
   validateKernelConstraintsInternal,
+  validatePolicyBindingInternal,
+  validateSchemaParseInternal,
   validateTemporalInternal,
+  validateTypeExtensionEnforcementInternal,
   validateTypeExtensionMappingInternal,
+  validateUnknownExtensionGrammarInternal,
   type ExtensionBudgetViolation,
+  type Strictness,
   type TemporalWarning,
+  type TypeExtensionEnforcementWarning,
   type TypeExtensionMappingWarning,
+  type UnknownExtensionWarning,
 } from './validators/index.js';
 
 /** Minimal claims shape required by the bounded subset. */
@@ -65,6 +77,38 @@ export interface BoundedValidationInput {
   readonly header?: BoundedHeaderInput;
   /** Fixed Unix-second clock for temporal evaluation; required. */
   readonly now: number;
+  /**
+   * Strictness profile for layers that promote warnings to errors
+   * under `'strict'` mode. When omitted, layers that consume
+   * strictness skip (they do not run). Mirrors the canonical
+   * `verifyLocal({ strictness })` option.
+   */
+  readonly strictness?: Strictness;
+  /**
+   * Maximum permitted clock skew in seconds for the iat-not-yet-valid
+   * check. When omitted, the iat layer skips. Mirrors
+   * `verifyLocal({ maxClockSkew })`; canonical default is 300.
+   */
+  readonly maxClockSkew?: number;
+  /**
+   * Receipt-side policy digest (`claims.policy.digest`). Used together
+   * with `localPolicyDigest` by the policy-binding layer. Either
+   * absent skips the layer.
+   */
+  readonly receiptPolicyDigest?: string;
+  /**
+   * Caller-supplied policy digest. Used together with
+   * `receiptPolicyDigest`. Either absent skips the layer.
+   */
+  readonly localPolicyDigest?: string;
+  /**
+   * Full receipt-claims object for the schema-parse layer. When
+   * omitted, the schema-parse layer falls back to running on the
+   * minimal `BoundedClaimsInput` projection (which may not surface
+   * field-level parse errors that depend on optional fields outside
+   * the bounded subset).
+   */
+  readonly fullClaims?: Record<string, unknown>;
 }
 
 /**
@@ -78,7 +122,13 @@ export type BoundedLayer =
   | 'jose-header-hardening'
   | 'issuer-form'
   | 'temporal'
-  | 'extension-budget';
+  | 'extension-budget'
+  | 'schema-parse'
+  | 'jose-typ-strictness'
+  | 'iat-not-yet-valid'
+  | 'policy-binding'
+  | 'unknown-extension-grammar'
+  | 'type-extension-enforcement';
 
 export interface BoundedViolation {
   readonly layer: BoundedLayer;
@@ -175,6 +225,94 @@ export function runBoundedValidatorShadow(input: BoundedValidationInput): Bounde
     const list: readonly ExtensionBudgetViolation[] = budgetRes.violations;
     for (const v of list) {
       violations.push({ layer: 'extension-budget', code: v.code, path: v.path });
+    }
+  }
+
+  // 7. Schema-parse projection (canonical-composed; delegates to
+  // parseReceiptClaims). Skips when `fullClaims` is not supplied;
+  // `BoundedClaimsInput` is a 6-field subset and would never satisfy
+  // the canonical Wire 0.2 schema. Callers that want the schema-parse
+  // layer to fire MUST pass the full claims object via `fullClaims`.
+  if (input.fullClaims !== undefined) {
+    const schemaRes = validateSchemaParseInternal(input.fullClaims);
+    if (!schemaRes.accepted && schemaRes.errorCode !== undefined) {
+      violations.push({ layer: 'schema-parse', code: schemaRes.errorCode });
+    }
+  }
+
+  // 8. JOSE typ-strictness (canonical-composed; mirrors verify-local
+  // strictness routing). Skip when no header or no strictness
+  // supplied; canonical surface only routes typ-missing under a
+  // declared strictness.
+  if (input.header !== undefined && input.strictness !== undefined) {
+    const typRes = validateJoseTypStrictnessInternal(input.header.typ, input.strictness);
+    if (!typRes.accepted) {
+      violations.push({ layer: 'jose-typ-strictness', code: typRes.errorCode });
+    } else if (typRes.warnings) {
+      for (const w of typRes.warnings) {
+        warnings.push({ layer: 'jose-typ-strictness', code: w.code });
+      }
+    }
+  }
+
+  // 9. iat-not-yet-valid (mirrors the inline verify-local check).
+  // Skip when no maxClockSkew supplied; canonical surface only runs
+  // this check inside verifyLocal where maxClockSkew is bound.
+  if (input.maxClockSkew !== undefined) {
+    const iatRes = validateIatNotYetValidInternal(input.claims.iat, input.now, input.maxClockSkew);
+    if (!iatRes.accepted && iatRes.errorCode !== undefined) {
+      violations.push({ layer: 'iat-not-yet-valid', code: iatRes.errorCode });
+    }
+  }
+
+  // 10. Policy-binding (canonical-composed; delegates to
+  // verifyPolicyBinding). The `unavailable` projection (either
+  // digest absent) is accepted with no surfacing; only `failed`
+  // produces a violation.
+  if (input.receiptPolicyDigest !== undefined && input.localPolicyDigest !== undefined) {
+    const policyRes = validatePolicyBindingInternal(
+      input.receiptPolicyDigest,
+      input.localPolicyDigest
+    );
+    if (!policyRes.accepted && policyRes.errorCode !== undefined) {
+      violations.push({ layer: 'policy-binding', code: policyRes.errorCode });
+    }
+  }
+
+  // 11. Unknown-extension grammar (canonical-composed; warnings only).
+  const unknownExtRes = validateUnknownExtensionGrammarInternal(input.claims.extensions);
+  for (const w of unknownExtRes.warnings as readonly UnknownExtensionWarning[]) {
+    warnings.push({
+      layer: 'unknown-extension-grammar',
+      code: w.code,
+      path: w.pointer,
+    });
+  }
+
+  // 12. Type-extension enforcement (canonical-composed; promotes
+  // missing/mismatch to errors under strict mode, surfaces them as
+  // warnings under interop). Skip when no strictness supplied.
+  if (input.strictness !== undefined) {
+    const enforceRes = validateTypeExtensionEnforcementInternal(
+      input.claims.kind,
+      input.claims.type,
+      input.claims.extensions,
+      input.strictness
+    );
+    if (!enforceRes.accepted) {
+      violations.push({
+        layer: 'type-extension-enforcement',
+        code: enforceRes.errorCode,
+        path: enforceRes.pointer,
+      });
+    } else if (enforceRes.warnings) {
+      for (const w of enforceRes.warnings as readonly TypeExtensionEnforcementWarning[]) {
+        warnings.push({
+          layer: 'type-extension-enforcement',
+          code: w.code,
+          path: w.pointer,
+        });
+      }
     }
   }
 

--- a/packages/protocol/src/_internal/record-core/validators/iat-not-yet-valid.ts
+++ b/packages/protocol/src/_internal/record-core/validators/iat-not-yet-valid.ts
@@ -1,0 +1,43 @@
+/**
+ * Bounded internal iat-not-yet-valid validator.
+ *
+ * INTERNAL ONLY. Parity-observed counterpart of the inline iat-not-yet-valid
+ * check in `verify-local.ts` (`if (claims.iat > now + maxClockSkew) ...`).
+ * Both implementations consume the same `iat`, `now`, and `maxClockSkew`
+ * inputs and apply the same comparison; behavioral parity is proven
+ * byte-equal by the parity tests.
+ *
+ * Existing canonical iat handling in `verify-local.ts` remains canonical.
+ * This module is observational only; it is not re-exported from
+ * `packages/protocol/src/index.ts` and is not wired into the public
+ * runtime path.
+ *
+ * SCOPE:
+ *   - Reject when `iat > now + maxClockSkew` (claim issued too far in the future).
+ *   - Accept when `iat <= now + maxClockSkew`.
+ *   - Never reads `Date.now()`; the caller injects `now` for determinism.
+ *
+ * Out of scope:
+ *   - `exp` / `nbf` checks (Wire 0.2 records do not expire and have no nbf).
+ *   - `occurred_at` skew (handled by `temporal.ts`).
+ */
+
+export interface IatNotYetValidResult {
+  readonly accepted: boolean;
+  readonly errorCode?: string;
+}
+
+const ACCEPTED: IatNotYetValidResult = { accepted: true } as const;
+const REJECTED: IatNotYetValidResult = {
+  accepted: false,
+  errorCode: 'E_NOT_YET_VALID',
+} as const;
+
+export function validateIatNotYetValidInternal(
+  iat: number,
+  now: number,
+  maxClockSkew: number
+): IatNotYetValidResult {
+  if (iat > now + maxClockSkew) return REJECTED;
+  return ACCEPTED;
+}

--- a/packages/protocol/src/_internal/record-core/validators/index.ts
+++ b/packages/protocol/src/_internal/record-core/validators/index.ts
@@ -22,3 +22,23 @@ export {
   type ExtensionBudgetResult,
   type ExtensionBudgetViolation,
 } from './extension-budget.js';
+export { validateSchemaParseInternal, type SchemaParseResult } from './schema-parse.js';
+export {
+  validateJoseTypStrictnessInternal,
+  type JoseTypStrictnessResult,
+  type JoseTypStrictnessWarning,
+  type Strictness,
+} from './jose-typ-strictness.js';
+export { validateIatNotYetValidInternal, type IatNotYetValidResult } from './iat-not-yet-valid.js';
+export { validatePolicyBindingInternal, type PolicyBindingResult } from './policy-binding.js';
+export {
+  validateUnknownExtensionGrammarInternal,
+  type UnknownExtensionGrammarResult,
+  type UnknownExtensionWarning,
+} from './unknown-extension-grammar.js';
+export {
+  validateTypeExtensionEnforcementInternal,
+  type TypeExtensionEnforcementResult,
+  type TypeExtensionEnforcementWarning,
+} from './type-extension-enforcement.js';
+export { validateSignatureInternal, type SignatureResult } from './signature.js';

--- a/packages/protocol/src/_internal/record-core/validators/jose-typ-strictness.ts
+++ b/packages/protocol/src/_internal/record-core/validators/jose-typ-strictness.ts
@@ -1,0 +1,56 @@
+/**
+ * Bounded internal JOSE typ-strictness validator.
+ *
+ * INTERNAL ONLY. Parity-observed counterpart of the typ-strictness
+ * routing in `verify-local.ts` (the block that rejects a missing typ
+ * under `'strict'` mode and surfaces a `typ_missing` warning under
+ * `'interop'` mode). Both implementations consume the same protected-
+ * header `typ` value plus a `strictness` parameter and apply the same
+ * accept/reject/warning rules.
+ *
+ * Existing canonical strictness routing in `verify-local.ts` remains
+ * canonical. This module is observational only; not re-exported and
+ * not wired into the public runtime path.
+ *
+ * SCOPE:
+ *   - typ present (any string) -> accepted, no warning.
+ *   - typ absent (undefined or non-string) and strictness === 'strict'
+ *     -> rejected with E_INVALID_FORMAT.
+ *   - typ absent and strictness === 'interop' -> accepted with
+ *     typ_missing warning.
+ *
+ * Out of scope:
+ *   - typ value validation (`'interaction-record+jwt'` enforcement lives
+ *     in `@peac/crypto.validateWire02Header` / the JOSE-hardening layer).
+ *   - alg / kid / crit / b64 / zip checks (handled by `jose-hardening.ts`).
+ */
+
+export type Strictness = 'strict' | 'interop';
+
+export interface JoseTypStrictnessWarning {
+  readonly code: string;
+}
+
+export type JoseTypStrictnessResult =
+  | { readonly accepted: true; readonly warnings?: readonly JoseTypStrictnessWarning[] }
+  | { readonly accepted: false; readonly errorCode: string };
+
+const ACCEPTED_NO_WARN: JoseTypStrictnessResult = { accepted: true } as const;
+const ACCEPTED_TYP_MISSING: JoseTypStrictnessResult = {
+  accepted: true,
+  warnings: [{ code: 'typ_missing' }],
+} as const;
+const REJECTED_INVALID_FORMAT: JoseTypStrictnessResult = {
+  accepted: false,
+  errorCode: 'E_INVALID_FORMAT',
+} as const;
+
+export function validateJoseTypStrictnessInternal(
+  typ: unknown,
+  strictness: Strictness
+): JoseTypStrictnessResult {
+  const present = typeof typ === 'string' && typ.length > 0;
+  if (present) return ACCEPTED_NO_WARN;
+  if (strictness === 'strict') return REJECTED_INVALID_FORMAT;
+  return ACCEPTED_TYP_MISSING;
+}

--- a/packages/protocol/src/_internal/record-core/validators/policy-binding.ts
+++ b/packages/protocol/src/_internal/record-core/validators/policy-binding.ts
@@ -1,0 +1,48 @@
+/**
+ * Bounded internal policy-binding validator (canonical-composed).
+ *
+ * INTERNAL ONLY. Thin wrapper around `verifyPolicyBinding` from
+ * `@peac/schema`. Surfaces the canonical three-state result
+ * (`verified` / `failed` / `unavailable`) projected into the bounded
+ * validator's accept/reject contract, where `failed` is the only
+ * rejection.
+ *
+ * This is observational equivalence by construction, not a divergent
+ * binding check. Module is observational only; not re-exported from
+ * `packages/protocol/src/index.ts` and not wired into the public
+ * runtime path.
+ *
+ * SCOPE:
+ *   - Both digests present and equal -> accepted (`verified`).
+ *   - Either digest absent -> accepted (`unavailable`); no policy
+ *     check is performed when the receipt or caller omits the digest.
+ *   - Both present but unequal -> rejected with E_POLICY_BINDING_FAILED.
+ *
+ * Out of scope:
+ *   - Policy-document fetch and digest computation (lives in
+ *     `verifyLocal()` / caller responsibility).
+ *   - Policy URI handling (`policy.uri` is informational only).
+ */
+
+import { verifyPolicyBinding } from '@peac/schema';
+
+export interface PolicyBindingResult {
+  readonly accepted: boolean;
+  readonly errorCode?: string;
+  /** 'verified' | 'failed' | 'unavailable'. Surfaced unchanged from canonical. */
+  readonly status: 'verified' | 'failed' | 'unavailable';
+}
+
+export function validatePolicyBindingInternal(
+  receiptPolicyDigest: string | undefined,
+  localPolicyDigest: string | undefined
+): PolicyBindingResult {
+  if (receiptPolicyDigest === undefined || localPolicyDigest === undefined) {
+    return { accepted: true, status: 'unavailable' };
+  }
+  const status = verifyPolicyBinding(receiptPolicyDigest, localPolicyDigest);
+  if (status === 'failed') {
+    return { accepted: false, errorCode: 'E_POLICY_BINDING_FAILED', status };
+  }
+  return { accepted: true, status };
+}

--- a/packages/protocol/src/_internal/record-core/validators/schema-parse.ts
+++ b/packages/protocol/src/_internal/record-core/validators/schema-parse.ts
@@ -1,0 +1,54 @@
+/**
+ * Bounded internal schema-parse validator (canonical-composed).
+ *
+ * INTERNAL ONLY. Thin wrapper around the canonical
+ * `parseReceiptClaims` from `@peac/schema`, projecting the canonical
+ * result into the bounded validator's normalized shape. The wrapper
+ * has no decision logic of its own: it delegates the parse, then
+ * surfaces the canonical accept/reject and the canonical error code.
+ *
+ * This is observational equivalence by construction, not a divergent
+ * parser. The layer boundary allows an alternate implementation
+ * without changing callers; the input/output shape is stable enough
+ * for a drop-in replacement should rigorous cross-implementation
+ * parity beyond observational evidence be required.
+ *
+ * Module is observational only; not re-exported from
+ * `packages/protocol/src/index.ts` and not wired into the public
+ * runtime path.
+ *
+ * SCOPE:
+ *   - Run `parseReceiptClaims(payload)` and surface its accept/reject.
+ *   - On rejection, surface `pr.error.code` (canonical parse-error code)
+ *     so the candidate's error taxonomy matches the canonical's.
+ *   - On acceptance, no warnings are surfaced from this layer; parser
+ *     warnings (e.g., `type_unregistered`, `unknown_extension_preserved`)
+ *     are emitted by the canonical parser and consumed at higher layers
+ *     (verifyLocal warning aggregation).
+ */
+
+import { parseReceiptClaims } from '@peac/schema';
+import type { Wire02Claims } from '@peac/schema';
+
+export interface SchemaParseResult {
+  readonly accepted: boolean;
+  readonly errorCode?: string;
+  /**
+   * Parsed Wire 0.2 claims when accepted. Internal-only; does not
+   * appear on any emitted record or public surface. Callers that need
+   * a typed view of the parsed claims read this field; callers that
+   * only need the accept/reject signal ignore it.
+   */
+  readonly claims?: Wire02Claims;
+}
+
+export function validateSchemaParseInternal(payload: unknown): SchemaParseResult {
+  const pr = parseReceiptClaims(payload);
+  if (!pr.ok) {
+    return { accepted: false, errorCode: pr.error.code };
+  }
+  if (pr.wireVersion !== '0.2') {
+    return { accepted: false, errorCode: 'E_UNSUPPORTED_WIRE_VERSION' };
+  }
+  return { accepted: true, claims: pr.claims as Wire02Claims };
+}

--- a/packages/protocol/src/_internal/record-core/validators/signature.ts
+++ b/packages/protocol/src/_internal/record-core/validators/signature.ts
@@ -1,0 +1,52 @@
+/**
+ * Bounded internal signature validator (canonical-composed).
+ *
+ * INTERNAL ONLY. Thin wrapper around `verify` from `@peac/crypto`.
+ * Surfaces the canonical Ed25519 signature-verification result
+ * projected into the bounded validator's accept/reject contract.
+ * The wrapper has no decision logic of its own and never re-implements
+ * Ed25519; it always delegates to the canonical signer/verifier.
+ *
+ * Module is observational only; not re-exported from
+ * `packages/protocol/src/index.ts` and not wired into the public
+ * runtime path.
+ *
+ * SCOPE:
+ *   - Run `verify(serialized, publicKey)` against the supplied compact JWS.
+ *   - On structural-format failure (CryptoError with a CRYPTO_* code),
+ *     surface the code unchanged.
+ *   - On signature mismatch, surface CRYPTO_INVALID_SIGNATURE.
+ *   - On success, accepted=true with no further claims projection.
+ *
+ * Out of scope:
+ *   - JOSE header hardening (handled by `jose-hardening.ts`).
+ *   - typ strictness routing (handled by `jose-typ-strictness.ts`).
+ *   - Schema parse on the verified payload (handled by `schema-parse.ts`).
+ */
+
+import { verify as cryptoVerify } from '@peac/crypto';
+
+export interface SignatureResult {
+  readonly accepted: boolean;
+  readonly errorCode?: string;
+}
+
+export async function validateSignatureInternal(
+  serialized: string,
+  publicKey: Uint8Array
+): Promise<SignatureResult> {
+  try {
+    const result = await cryptoVerify(serialized, publicKey);
+    if (result.valid) return { accepted: true };
+    return { accepted: false, errorCode: 'CRYPTO_INVALID_SIGNATURE' };
+  } catch (err) {
+    const code =
+      err &&
+      typeof err === 'object' &&
+      'code' in err &&
+      typeof (err as { code: unknown }).code === 'string'
+        ? (err as { code: string }).code
+        : 'CRYPTO_UNKNOWN';
+    return { accepted: false, errorCode: code };
+  }
+}

--- a/packages/protocol/src/_internal/record-core/validators/type-extension-enforcement.ts
+++ b/packages/protocol/src/_internal/record-core/validators/type-extension-enforcement.ts
@@ -1,0 +1,76 @@
+/**
+ * Bounded internal type-extension-enforcement validator (canonical-composed).
+ *
+ * INTERNAL ONLY. Thin wrapper around `checkTypeExtensionMapping` from
+ * `@peac/protocol/src/type-extension-check` plus the strictness-mode
+ * routing performed by `verifyLocal`. Surfaces the canonical mapping
+ * result projected into the bounded validator's accept/reject and
+ * warning contract.
+ *
+ * Distinct from `type-extension-mapping.ts` (warnings-only) in this
+ * module's directory: this layer covers the strictness-mode path that
+ * promotes `missing` and `mismatch` to hard errors when
+ * `strictness === 'strict'`. Both layers consume the same canonical
+ * mapping result; they differ only in how they project it.
+ *
+ * Module is observational only; not re-exported from
+ * `packages/protocol/src/index.ts` and not wired into the public
+ * runtime path.
+ *
+ * SCOPE:
+ *   - `skip` -> accepted, no warning, no error.
+ *   - `ok` -> accepted, no warning, no error.
+ *   - `missing` + strict -> rejected with E_EXTENSION_GROUP_REQUIRED.
+ *   - `mismatch` + strict -> rejected with E_EXTENSION_GROUP_MISMATCH.
+ *   - `missing` + interop -> accepted with extension_group_missing warning at /type.
+ *   - `mismatch` + interop -> accepted with extension_group_mismatch warning at /type.
+ */
+
+import { TYPE_TO_EXTENSION_MAP } from '@peac/kernel';
+import { REGISTERED_EXTENSION_GROUP_KEYS } from '@peac/schema';
+import { checkTypeExtensionMapping } from '../../../type-extension-check.js';
+import type { Strictness } from './jose-typ-strictness.js';
+
+export interface TypeExtensionEnforcementWarning {
+  readonly code: string;
+  readonly pointer: string;
+}
+
+export type TypeExtensionEnforcementResult =
+  | { readonly accepted: true; readonly warnings?: readonly TypeExtensionEnforcementWarning[] }
+  | { readonly accepted: false; readonly errorCode: string; readonly pointer?: string };
+
+const ACCEPTED_NO_WARN: TypeExtensionEnforcementResult = { accepted: true } as const;
+
+export function validateTypeExtensionEnforcementInternal(
+  kind: string,
+  type: string,
+  extensions: Record<string, unknown> | undefined,
+  strictness: Strictness
+): TypeExtensionEnforcementResult {
+  const result = checkTypeExtensionMapping(
+    kind,
+    type,
+    extensions,
+    TYPE_TO_EXTENSION_MAP,
+    REGISTERED_EXTENSION_GROUP_KEYS
+  );
+
+  if (result.status === 'ok' || result.status === 'skip') {
+    return ACCEPTED_NO_WARN;
+  }
+
+  if (strictness === 'strict') {
+    const errorCode =
+      result.status === 'missing' ? 'E_EXTENSION_GROUP_REQUIRED' : 'E_EXTENSION_GROUP_MISMATCH';
+    return { accepted: false, errorCode, pointer: '/type' };
+  }
+
+  // interop mode: surface as warning, accept the record.
+  const warningCode =
+    result.status === 'missing' ? 'extension_group_missing' : 'extension_group_mismatch';
+  return {
+    accepted: true,
+    warnings: [{ code: warningCode, pointer: '/type' }],
+  };
+}

--- a/packages/protocol/src/_internal/record-core/validators/unknown-extension-grammar.ts
+++ b/packages/protocol/src/_internal/record-core/validators/unknown-extension-grammar.ts
@@ -1,0 +1,73 @@
+/**
+ * Bounded internal unknown-extension-grammar validator (canonical-composed).
+ *
+ * INTERNAL ONLY. Thin wrapper around `isValidExtensionKey` and
+ * `REGISTERED_EXTENSION_GROUP_KEYS` from `@peac/schema`. Identifies
+ * unknown-but-well-formed extension keys and surfaces them as
+ * non-blocking warnings, mirroring the canonical
+ * `unknown_extension_preserved` warning emitted by `verifyLocal`.
+ *
+ * Malformed extension keys (failing `isValidExtensionKey`) are NOT
+ * surfaced here as warnings; they are hard errors at the canonical
+ * schema-parse layer (`E_INVALID_EXTENSION_KEY`) and therefore never
+ * reach this layer on an accepted record.
+ *
+ * Module is observational only; not re-exported from
+ * `packages/protocol/src/index.ts` and not wired into the public
+ * runtime path.
+ *
+ * SCOPE:
+ *   - Walk `claims.extensions` keys.
+ *   - For every key that is well-formed but not registered, emit a
+ *     warning with code `unknown_extension_preserved` and an
+ *     RFC 6901 JSON-pointer-encoded path.
+ *   - Always accepted; this layer never rejects.
+ *
+ * Out of scope:
+ *   - Malformed-key rejection (canonical schema-parse owns this).
+ *   - Per-extension content validation (extension-specific schemas).
+ */
+
+import { REGISTERED_EXTENSION_GROUP_KEYS, isValidExtensionKey } from '@peac/schema';
+
+export interface UnknownExtensionWarning {
+  readonly code: string;
+  readonly pointer: string;
+}
+
+export interface UnknownExtensionGrammarResult {
+  readonly accepted: true;
+  readonly warnings: readonly UnknownExtensionWarning[];
+}
+
+const ACCEPTED_EMPTY: UnknownExtensionGrammarResult = {
+  accepted: true,
+  warnings: [],
+} as const;
+
+/**
+ * Encode a JSON-pointer reference token per RFC 6901: `~` -> `~0`,
+ * `/` -> `~1`. Order matters: `~` must be replaced before `/`.
+ */
+function escapeJsonPointer(token: string): string {
+  return token.replace(/~/g, '~0').replace(/\//g, '~1');
+}
+
+export function validateUnknownExtensionGrammarInternal(
+  extensions: Record<string, unknown> | undefined
+): UnknownExtensionGrammarResult {
+  if (extensions === undefined) return ACCEPTED_EMPTY;
+  const keys = Object.keys(extensions);
+  if (keys.length === 0) return ACCEPTED_EMPTY;
+
+  const warnings: UnknownExtensionWarning[] = [];
+  for (const key of keys) {
+    if (!REGISTERED_EXTENSION_GROUP_KEYS.has(key) && isValidExtensionKey(key)) {
+      warnings.push({
+        code: 'unknown_extension_preserved',
+        pointer: `/extensions/${escapeJsonPointer(key)}`,
+      });
+    }
+  }
+  return { accepted: true, warnings };
+}

--- a/packages/protocol/src/_internal/test-helpers/candidate-runner.ts
+++ b/packages/protocol/src/_internal/test-helpers/candidate-runner.ts
@@ -1,0 +1,131 @@
+/**
+ * Canonical-composed candidate-runner for parity tests.
+ *
+ * INTERNAL TEST HELPER. Wraps `runBoundedValidatorShadow` (the
+ * canonical-composed candidate validator) and projects its
+ * `BoundedValidationResult` into the same `ParityVerdict` shape that
+ * `canonical-runner` emits. The candidate-runner is the LEFT input to
+ * the canonical-vs-candidate differential test; the canonical-runner
+ * is the RIGHT input. Both produce verdicts; the differential test
+ * asserts byte-equality (or, where applicable, error-class
+ * equivalence).
+ *
+ * The candidate is canonical-composed by construction: every layer
+ * either delegates to a canonical helper from `@peac/schema` /
+ * `@peac/crypto` / `@peac/protocol`, or mirrors a canonical inline
+ * check verbatim. Divergence between canonical and candidate
+ * therefore indicates a defect in the bounded validator's projection
+ * logic, not a "different implementation disagreed."
+ *
+ * Pure: same input always yields the same verdict bytes.
+ */
+
+import { canonicalize, sha256Hex } from '@peac/crypto';
+import { runBoundedValidatorShadow } from '../record-core/bounded-validator.js';
+import { validateSchemaParseInternal } from '../record-core/validators/index.js';
+import { makeVerdict, type ParityError, type ParityVerdict } from './parity-verdict.js';
+import type { CanonicalRunnerKind } from './canonical-runner.js';
+
+/**
+ * Compute the same canonical claims digest the canonical-runner emits
+ * for accepted records. Local helper duplicating the canonical-runner's
+ * private digest computation; both must use the same JCS + SHA-256 +
+ * "sha256:" formula or the differential will surface a digest-only
+ * divergence on every accepted fixture.
+ */
+async function computeCanonicalClaimsDigest(claims: unknown): Promise<string> {
+  const canonical = canonicalize(claims);
+  const hex = await sha256Hex(canonical);
+  return `sha256:${hex}`;
+}
+
+/**
+ * Run the canonical-composed candidate path on a Wire 0.2 envelope
+ * payload. Mirrors `runEnvelopeCanonical` shape-for-shape:
+ *
+ *   1. Kernel-constraints check via `runBoundedValidatorShadow`
+ *      (composes the parallel `validateKernelConstraintsInternal`).
+ *   2. Schema-parse projection (delegates to canonical
+ *      `parseReceiptClaims`).
+ *   3. Canonical claims digest on accepted records.
+ *
+ * Errors from bounded-validator are projected onto `ParityError`
+ * entries so the verdict shape is comparable byte-for-byte against
+ * `runEnvelopeCanonical`.
+ */
+export async function runEnvelopeCandidate(
+  payload: Record<string, unknown>
+): Promise<ParityVerdict> {
+  const errors: ParityError[] = [];
+
+  // Kernel-constraints first (matches canonical-runner ordering).
+  const bounded = runBoundedValidatorShadow({
+    claims: {
+      kind: typeof payload.kind === 'string' ? payload.kind : '',
+      type: typeof payload.type === 'string' ? payload.type : '',
+      iss: payload.iss,
+      iat: typeof payload.iat === 'number' ? payload.iat : 0,
+      occurred_at: typeof payload.occurred_at === 'string' ? payload.occurred_at : undefined,
+      extensions:
+        typeof payload.extensions === 'object' && payload.extensions !== null
+          ? (payload.extensions as Record<string, unknown>)
+          : undefined,
+    },
+    now: typeof payload.iat === 'number' ? payload.iat : 0,
+  });
+
+  for (const v of bounded.violations) {
+    if (v.layer === 'kernel-constraints') {
+      errors.push({ code: v.code, path: v.path });
+    }
+  }
+  if (errors.length > 0) {
+    return makeVerdict(false, errors);
+  }
+
+  // Schema-parse on the full payload (matches canonical-runner's
+  // `parseReceiptClaims` step).
+  const parseRes = validateSchemaParseInternal(payload);
+  if (!parseRes.accepted) {
+    errors.push({ code: parseRes.errorCode ?? 'E_INVALID_FORMAT' });
+    return makeVerdict(false, errors);
+  }
+
+  const digest = await computeCanonicalClaimsDigest(parseRes.claims);
+  return makeVerdict(true, [], [], digest);
+}
+
+/**
+ * Run the canonical-composed candidate JOSE-hardening path on a
+ * protected header. The bounded `validateJoseHardeningInternal`
+ * mirrors `validateWire02Header` from `@peac/crypto`; the candidate
+ * runner surfaces the same first-violation error code projected into
+ * the parity verdict shape.
+ */
+export function runJoseCandidate(header: Record<string, unknown> | undefined): ParityVerdict {
+  if (!header) {
+    return makeVerdict(false, [{ code: 'CORPUS_MISSING_HEADER' }]);
+  }
+  const bounded = runBoundedValidatorShadow({
+    claims: { kind: '', type: '', iss: '', iat: 0 },
+    header,
+    now: 0,
+  });
+  const joseViolation = bounded.violations.find((v) => v.layer === 'jose-header-hardening');
+  if (joseViolation) {
+    return makeVerdict(false, [{ code: joseViolation.code }]);
+  }
+  return makeVerdict(true);
+}
+
+/**
+ * Dispatch to the appropriate candidate runner by kind. Mirrors
+ * `runCanonicalForKind`. Always async so callers can uniformly await.
+ */
+export async function runCandidateForKind(
+  kind: CanonicalRunnerKind,
+  input: Record<string, unknown>
+): Promise<ParityVerdict> {
+  if (kind === 'jose') return runJoseCandidate(input);
+  return runEnvelopeCandidate(input);
+}


### PR DESCRIPTION
## Summary

Expands internal validation parity coverage in shadow mode. The
candidate is canonical-composed: every layer either delegates to a
canonical helper from `@peac/schema` / `@peac/crypto` / `@peac/protocol`
or mirrors a canonical inline check verbatim. This is observational
equivalence, not a divergent validator.

No public behavior change. No public API change. No wire-format change. No package-surface change. No extension-key change.

## Scope

- Adds seven canonical-composed validators under
  `packages/protocol/src/_internal/record-core/validators/`:
  - `schema-parse` (delegates to `parseReceiptClaims`)
  - `jose-typ-strictness` (mirrors verify-local strictness routing)
  - `iat-not-yet-valid` (mirrors `iat > now + maxClockSkew`)
  - `policy-binding` (delegates to `verifyPolicyBinding`)
  - `unknown-extension-grammar` (delegates to `isValidExtensionKey` +
    `REGISTERED_EXTENSION_GROUP_KEYS`)
  - `type-extension-enforcement` (delegates to
    `checkTypeExtensionMapping` + strictness routing)
  - `signature` (delegates to `@peac/crypto.verify`; standalone async
    export, NOT composed into `runBoundedValidatorShadow`)
- Wires the six sync layers into `runBoundedValidatorShadow` as
  optional-input layers that skip when their inputs are absent. The
  existing six-layer composition is preserved unchanged. The async
  signature wrapper is exercised independently.
- Adds `candidate-runner.ts` test helper that projects
  bounded-validator output into the `ParityVerdict` shape used by the
  canonical-runner.
- Adds `parity-canonical-vs-candidate.test.ts`: 230 fixtures from the
  existing manifest assert canonical-vs-candidate verdict byte-equality.
- Adds `bounded-validator-expanded-layers.test.ts`: per-layer
  activation proof for each of the six new sync layers (and skip
  proof when inputs are absent).
- Adds `canonical-composed-validators.test.ts`: per-validator unit
  tests for the seven new modules including the standalone signature
  wrapper.
- Adds `shadow-byte-equivalence.test.ts`: with `Date.now` locked,
  `issue()` produces byte-identical compact JWS output across
  `PEAC_INTERNAL_SHADOW_CORE` flag values; `verifyLocal()` returns
  byte-equal result shape on a fixed JWS across both values.

## Validation

- `pnpm --filter @peac/protocol test` (56 files / 1669 tests) green
  under `PEAC_INTERNAL_LEGACY_PATH=0`, `=1`, and
  `PEAC_INTERNAL_SHADOW_CORE=1`.
- `pnpm exec vitest run packages/protocol/__tests__/_internal/`
  (27 files / 1109 tests).
- `pnpm format:check`
- `node scripts/verify-trust-artifacts.mjs`
- `node scripts/verify-no-semantic-widening.mjs`
- `node scripts/verify-dist-private-leaks.mjs` (36 packages scanned;
  no Tier 1, Tier 2, or Tier 2b leaks)
- `bash scripts/guard.sh`
- `bash scripts/ci/forbid-strings.sh`
- `node scripts/check-public-artifacts.mjs`
- Trojan Source scan on changed files: clean.
