### PR TITLE
feat(protocol): route Wire 0.2 admission through bounded validation gate

### DIFF
--- a/packages/protocol/__tests__/_internal/bounded-default-runtime.test.ts
+++ b/packages/protocol/__tests__/_internal/bounded-default-runtime.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Runtime activation: the bounded validation gate is exercised by the
+ * default branch and bypassed by the rollback branch.
+ *
+ * Asserts:
+ *   A1   `runBoundedValidationGate` IS called from `issue()` and
+ *        `verifyLocal()` when the rollback flag is unset (default
+ *        branch).
+ *   A2   `runBoundedValidationGate` is NOT called from `issue()` and
+ *        `verifyLocal()` when the rollback flag is set (rollback
+ *        branch).
+ *
+ * Out of scope: a global "`parseReceiptClaims` is never called on the
+ * default branch" assertion. The bounded `schema-parse` layer
+ * correctly delegates to canonical `parseReceiptClaims` from inside
+ * the gate, so a global non-call assertion would fail by design.
+ *
+ * The byte-equivalence assertions in `legacy-path-flag.test.ts` (T8 /
+ * T9 / T10 / T11) provide end-to-end public-surface coverage; this
+ * file is the call-site activation evidence.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { generateKeypairFromSeed } from '@peac/crypto/testkit';
+
+vi.mock('../../src/_internal/record-core/validation-gate.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../src/_internal/record-core/validation-gate.js')>();
+  return {
+    ...actual,
+    runBoundedValidationGate: vi.fn(actual.runBoundedValidationGate),
+  };
+});
+
+import { runBoundedValidationGate } from '../../src/_internal/record-core/validation-gate.js';
+import { issue, verifyLocal } from '../../src/index.js';
+
+const FIXED_SEED = new Uint8Array([
+  0x55, 0x4c, 0xa3, 0x18, 0xb6, 0x1d, 0x09, 0x42, 0x8e, 0x7b, 0x21, 0x4f, 0x6c, 0xa2, 0x35, 0x77,
+  0x91, 0x40, 0xe3, 0x5b, 0xc8, 0x06, 0x12, 0x99, 0x4d, 0x37, 0x88, 0xa1, 0x6f, 0x2b, 0xc4, 0x0e,
+]);
+const FIXED_KID = 'bounded-default-runtime-test-key-1';
+const FIXED_JTI = '019b0000-0000-7000-8000-000000000008';
+const FIXED_OCCURRED_AT = '2026-05-01T00:00:00Z';
+const FIXED_ISS = 'https://issuer.example';
+const FIXED_TYPE = 'org.example/bounded-default-runtime';
+
+const STABLE_OPTIONS = {
+  iss: FIXED_ISS,
+  kind: 'evidence' as const,
+  type: FIXED_TYPE,
+  kid: FIXED_KID,
+  jti: FIXED_JTI,
+  occurred_at: FIXED_OCCURRED_AT,
+  pillars: ['safety'] as const,
+};
+
+const gateMock = vi.mocked(runBoundedValidationGate);
+
+afterEach(() => {
+  gateMock.mockClear();
+});
+
+describe('A1: runBoundedValidationGate IS called on the default branch', () => {
+  it('issue(): default branch invokes the gate with surface "issueWire02"', async () => {
+    const { privateKey } = await generateKeypairFromSeed(FIXED_SEED);
+    delete process.env.PEAC_INTERNAL_LEGACY_PATH;
+    await issue({
+      ...STABLE_OPTIONS,
+      pillars: [...STABLE_OPTIONS.pillars],
+      privateKey,
+    });
+    expect(gateMock).toHaveBeenCalled();
+    const surfaces = gateMock.mock.calls.map((call) => call[0].surface);
+    expect(surfaces).toContain('issueWire02');
+  });
+
+  it('verifyLocal(): default branch invokes the gate with surface "verifyLocal"', async () => {
+    const { privateKey, publicKey } = await generateKeypairFromSeed(FIXED_SEED);
+    delete process.env.PEAC_INTERNAL_LEGACY_PATH;
+    const issued = await issue({
+      ...STABLE_OPTIONS,
+      pillars: [...STABLE_OPTIONS.pillars],
+      privateKey,
+    });
+    gateMock.mockClear();
+    await verifyLocal(issued.jws, publicKey);
+    expect(gateMock).toHaveBeenCalled();
+    const surfaces = gateMock.mock.calls.map((call) => call[0].surface);
+    expect(surfaces).toContain('verifyLocal');
+  });
+});
+
+describe('A2: runBoundedValidationGate is NOT called on the rollback branch', () => {
+  it('issue(): rollback branch (env=1) does not invoke the gate', async () => {
+    const { privateKey } = await generateKeypairFromSeed(FIXED_SEED);
+    process.env.PEAC_INTERNAL_LEGACY_PATH = '1';
+    try {
+      await issue({
+        ...STABLE_OPTIONS,
+        pillars: [...STABLE_OPTIONS.pillars],
+        privateKey,
+      });
+    } finally {
+      delete process.env.PEAC_INTERNAL_LEGACY_PATH;
+    }
+    expect(gateMock).not.toHaveBeenCalled();
+  });
+
+  it('verifyLocal(): rollback branch (env=1) does not invoke the gate', async () => {
+    const { privateKey, publicKey } = await generateKeypairFromSeed(FIXED_SEED);
+    // Issue with default flag state, then verify under rollback.
+    delete process.env.PEAC_INTERNAL_LEGACY_PATH;
+    const issued = await issue({
+      ...STABLE_OPTIONS,
+      pillars: [...STABLE_OPTIONS.pillars],
+      privateKey,
+    });
+    gateMock.mockClear();
+    process.env.PEAC_INTERNAL_LEGACY_PATH = '1';
+    try {
+      await verifyLocal(issued.jws, publicKey);
+    } finally {
+      delete process.env.PEAC_INTERNAL_LEGACY_PATH;
+    }
+    expect(gateMock).not.toHaveBeenCalled();
+  });
+
+  it('issue(): rollback branch (programmatic option) does not invoke the gate', async () => {
+    const { privateKey } = await generateKeypairFromSeed(FIXED_SEED);
+    delete process.env.PEAC_INTERNAL_LEGACY_PATH;
+    await issue({
+      ...STABLE_OPTIONS,
+      pillars: [...STABLE_OPTIONS.pillars],
+      privateKey,
+      ...({ _internal: { legacyPath: true } } as object),
+    } as Parameters<typeof issue>[0]);
+    expect(gateMock).not.toHaveBeenCalled();
+  });
+
+  it('verifyLocal(): rollback branch (programmatic option) does not invoke the gate', async () => {
+    const { privateKey, publicKey } = await generateKeypairFromSeed(FIXED_SEED);
+    delete process.env.PEAC_INTERNAL_LEGACY_PATH;
+    const issued = await issue({
+      ...STABLE_OPTIONS,
+      pillars: [...STABLE_OPTIONS.pillars],
+      privateKey,
+    });
+    gateMock.mockClear();
+    await verifyLocal(issued.jws, publicKey, {
+      ...({ _internal: { legacyPath: true } } as object),
+    } as Parameters<typeof verifyLocal>[2]);
+    expect(gateMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/protocol/__tests__/_internal/legacy-path-flag.test.ts
+++ b/packages/protocol/__tests__/_internal/legacy-path-flag.test.ts
@@ -286,3 +286,81 @@ describe('LegacyPathOptions structural shape (smoke; not a type-surface test)', 
     expect(readLegacyPathFlag(opts)).toBe(true);
   });
 });
+
+// Rejection-shape parity: a malformed input rejected at admission must
+// produce the identical public failure shape on both branches. This is
+// the §1.5 byte-equivalence contract on the failure path; byte-equality
+// on acceptance is asserted by T8/T9 above.
+
+describe('issue(): rejection-shape parity across both flag values', () => {
+  it('T10: invalid `iss` produces identical IssueError under both flag values', async () => {
+    const { privateKey } = await generateKeypairFromSeed(FIXED_SEED);
+    const malformed = {
+      ...STABLE_OPTIONS,
+      pillars: [...STABLE_OPTIONS.pillars],
+      privateKey,
+      iss: 'http://not-canonical.example', // missing https:// canonical iss
+    };
+
+    let errorOff: unknown;
+    let errorOn: unknown;
+    try {
+      await withEnvFlagAsync('0', async () => issue(malformed));
+    } catch (err) {
+      errorOff = err;
+    }
+    try {
+      await withEnvFlagAsync('1', async () => issue(malformed));
+    } catch (err) {
+      errorOn = err;
+    }
+
+    expect(errorOff).toBeDefined();
+    expect(errorOn).toBeDefined();
+    // `isCanonicalIss` rejection happens inline above the gate dispatch
+    // on both branches; the IssueError shape must be byte-equal.
+    expect((errorOff as { name?: string }).name).toBe('IssueError');
+    expect((errorOn as { name?: string }).name).toBe('IssueError');
+    expect((errorOff as { peacError?: { code?: string } }).peacError?.code).toBe(
+      (errorOn as { peacError?: { code?: string } }).peacError?.code
+    );
+    expect((errorOff as Error).message).toBe((errorOn as Error).message);
+  });
+});
+
+describe('verifyLocal(): rejection-shape parity across both flag values', () => {
+  // Build a JWS whose payload fails `parseReceiptClaims` (e.g. missing
+  // required Wire 0.2 fields), then verify under both flag values and
+  // assert identical failure shape.
+  it('T11: malformed Wire 0.2 payload produces identical VerifyLocalFailure shape under both flag values', async () => {
+    const { privateKey, publicKey } = await generateKeypairFromSeed(FIXED_SEED);
+    // Sign a payload with a missing required field. The codec's
+    // `defaultCodec.encode` requires a Wire02Claims-shaped object;
+    // build it via `issue()` then tamper with the JWS payload section.
+    const baseline = await issue({
+      ...STABLE_OPTIONS,
+      pillars: [...STABLE_OPTIONS.pillars],
+      privateKey,
+    });
+    // The signature will fail when we tamper, which produces
+    // `E_INVALID_SIGNATURE` on both branches before admission. To
+    // exercise admission rejection specifically, we rely on the fact
+    // that the codec accepts encoding any object satisfying
+    // `Wire02Claims`. The tampered JWS path is therefore covered by
+    // the existing E_INVALID_SIGNATURE tests; admission-rejection
+    // parity is demonstrated by the dual-mode CI matrix executing the
+    // full 1669-test suite under both flag values, which exercises
+    // every malformed-payload and reject-shape vector. The single
+    // assertion here is the success-path byte-equivalence already
+    // covered at T9, surfaced again under a bad-signature input to
+    // confirm the failure-shape envelope is identical.
+    const tampered = baseline.jws.slice(0, baseline.jws.lastIndexOf('.') + 1) + 'A'.repeat(86); // fabricate a 64-byte signature that will not verify
+
+    const failOff = await withEnvFlagAsync('0', async () => verifyLocal(tampered, publicKey));
+    const failOn = await withEnvFlagAsync('1', async () => verifyLocal(tampered, publicKey));
+
+    expect(failOff.valid).toBe(false);
+    expect(failOn.valid).toBe(false);
+    expect(JSON.stringify(failOff)).toBe(JSON.stringify(failOn));
+  });
+});

--- a/packages/protocol/__tests__/_internal/legacy-path-flag.test.ts
+++ b/packages/protocol/__tests__/_internal/legacy-path-flag.test.ts
@@ -36,6 +36,7 @@
 import { describe, it, expect } from 'vitest';
 import { generateKeypairFromSeed } from '@peac/crypto/testkit';
 import { readLegacyPathFlag, type LegacyPathOptions } from '../../src/_internal/legacy-path.js';
+import { defaultCodec } from '../../src/_internal/record-core/codec/jws-jwt.js';
 import { issue, verifyLocal } from '../../src/index.js';
 
 // 32-byte deterministic seed; isolated to this test file. Different from
@@ -329,31 +330,17 @@ describe('issue(): rejection-shape parity across both flag values', () => {
 });
 
 describe('verifyLocal(): rejection-shape parity across both flag values', () => {
-  // Build a JWS whose payload fails `parseReceiptClaims` (e.g. missing
-  // required Wire 0.2 fields), then verify under both flag values and
-  // assert identical failure shape.
-  it('T11: malformed Wire 0.2 payload produces identical VerifyLocalFailure shape under both flag values', async () => {
+  // T11 covers a tampered-signature path that fails before the
+  // admission gate / inline canonical sequence is reached. T13 below
+  // covers the gate-failure parity with a validly signed but admission-
+  // rejected payload.
+  it('T11: tampered-signature payload produces identical VerifyLocalFailure shape under both flag values', async () => {
     const { privateKey, publicKey } = await generateKeypairFromSeed(FIXED_SEED);
-    // Sign a payload with a missing required field. The codec's
-    // `defaultCodec.encode` requires a Wire02Claims-shaped object;
-    // build it via `issue()` then tamper with the JWS payload section.
     const baseline = await issue({
       ...STABLE_OPTIONS,
       pillars: [...STABLE_OPTIONS.pillars],
       privateKey,
     });
-    // The signature will fail when we tamper, which produces
-    // `E_INVALID_SIGNATURE` on both branches before admission. To
-    // exercise admission rejection specifically, we rely on the fact
-    // that the codec accepts encoding any object satisfying
-    // `Wire02Claims`. The tampered JWS path is therefore covered by
-    // the existing E_INVALID_SIGNATURE tests; admission-rejection
-    // parity is demonstrated by the dual-mode CI matrix executing the
-    // full 1669-test suite under both flag values, which exercises
-    // every malformed-payload and reject-shape vector. The single
-    // assertion here is the success-path byte-equivalence already
-    // covered at T9, surfaced again under a bad-signature input to
-    // confirm the failure-shape envelope is identical.
     const tampered = baseline.jws.slice(0, baseline.jws.lastIndexOf('.') + 1) + 'A'.repeat(86); // fabricate a 64-byte signature that will not verify
 
     const failOff = await withEnvFlagAsync('0', async () => verifyLocal(tampered, publicKey));
@@ -361,6 +348,131 @@ describe('verifyLocal(): rejection-shape parity across both flag values', () => 
 
     expect(failOff.valid).toBe(false);
     expect(failOn.valid).toBe(false);
+    expect(JSON.stringify(failOff)).toBe(JSON.stringify(failOn));
+  });
+});
+
+// Real gate-failure parity: the failures below originate inside the
+// admission step itself. Default branch fails inside
+// `runBoundedValidationGate`; rollback branch fails inside the inline
+// canonical sequence (`Wire02ClaimsSchema.safeParse` for issueWire02;
+// `validateKernelConstraints` + `parseReceiptClaims` for verifyLocal).
+// Public-facing IssueError / VerifyLocalFailure shape must be byte-
+// equal across both branches.
+
+describe('issue(): real gate-failure parity (canonical iss + schema-rejected claims)', () => {
+  it('T12: malformed `type` after canonical iss produces identical IssueError under both flag values', async () => {
+    const { privateKey } = await generateKeypairFromSeed(FIXED_SEED);
+    // `iss` is canonical so `isCanonicalIss` accepts inline above the
+    // gate. The malformed `type` value violates the Wire 0.2 schema,
+    // forcing the failure to land inside admission: the gate on the
+    // default branch, the inline `Wire02ClaimsSchema.safeParse` on the
+    // rollback branch.
+    const malformed = {
+      ...STABLE_OPTIONS,
+      pillars: [...STABLE_OPTIONS.pillars],
+      privateKey,
+      type: 'invalid type with spaces',
+    };
+
+    let errorOff: unknown;
+    let errorOn: unknown;
+    try {
+      await withEnvFlagAsync('0', async () => issue(malformed));
+    } catch (err) {
+      errorOff = err;
+    }
+    try {
+      await withEnvFlagAsync('1', async () => issue(malformed));
+    } catch (err) {
+      errorOn = err;
+    }
+
+    expect(errorOff).toBeDefined();
+    expect(errorOn).toBeDefined();
+    expect((errorOff as { name?: string }).name).toBe('IssueError');
+    expect((errorOn as { name?: string }).name).toBe('IssueError');
+    expect((errorOff as { peacError?: { code?: string } }).peacError?.code).toBe(
+      'E_INVALID_FORMAT'
+    );
+    expect((errorOn as { peacError?: { code?: string } }).peacError?.code).toBe('E_INVALID_FORMAT');
+    // Byte-equal Error.message (gate's projection vs canonical
+    // Wire02ClaimsSchema.safeParse first-issue message).
+    expect((errorOff as Error).message).toBe((errorOn as Error).message);
+    // Byte-equal peacError.details.message (the canonical issuance
+    // surface places the message under details.message).
+    const detailsOff = (errorOff as { peacError?: { details?: { message?: string } } }).peacError
+      ?.details;
+    const detailsOn = (errorOn as { peacError?: { details?: { message?: string } } }).peacError
+      ?.details;
+    expect(detailsOff?.message).toBe(detailsOn?.message);
+  });
+});
+
+describe('verifyLocal(): real gate-failure parity (validly signed but admission-rejected payload)', () => {
+  it('T13: validly signed Wire 0.2 payload with malformed `type` produces identical VerifyLocalFailure under both flag values', async () => {
+    const { privateKey, publicKey } = await generateKeypairFromSeed(FIXED_SEED);
+    // Construct a Wire 0.2 payload that signature-verifies but fails
+    // canonical Wire 0.2 admission: the `type` value violates the
+    // schema's reverse-DNS / URI validator. The codec encodes any
+    // object whose shape is compatible with `Wire02Claims`; we cast
+    // through `unknown` to bypass the TypeScript guard so the failure
+    // lands inside admission rather than at the codec boundary.
+    const malformedClaims = {
+      peac_version: '0.2',
+      kind: 'evidence',
+      type: 'invalid type with spaces',
+      iss: FIXED_ISS,
+      iat: 1700000000,
+      jti: FIXED_JTI,
+    } as unknown as Parameters<typeof defaultCodec.encode>[0];
+
+    const jws = await defaultCodec.encode(malformedClaims, privateKey, FIXED_KID);
+
+    const failOff = await withEnvFlagAsync('0', async () => verifyLocal(jws, publicKey));
+    const failOn = await withEnvFlagAsync('1', async () => verifyLocal(jws, publicKey));
+
+    expect(failOff.valid).toBe(false);
+    expect(failOn.valid).toBe(false);
+    if (failOff.valid || failOn.valid) return; // narrowing for the type system
+
+    expect(failOff.code).toBe('E_INVALID_FORMAT');
+    expect(failOn.code).toBe('E_INVALID_FORMAT');
+    expect(JSON.stringify(failOff)).toBe(JSON.stringify(failOn));
+  });
+
+  it('T13b: validly signed Wire 0.2 payload that violates kernel constraints produces identical VerifyLocalFailure under both flag values', async () => {
+    const { privateKey, publicKey } = await generateKeypairFromSeed(FIXED_SEED);
+    // Construct deeply nested extensions to violate the kernel
+    // depth constraint. Both branches run kernel-constraints first
+    // (gate inside `runBoundedValidationGate`; canonical inline at
+    // `validateKernelConstraints` on the rollback branch); both must
+    // surface byte-equal `E_CONSTRAINT_VIOLATION`.
+    let deep: Record<string, unknown> = { v: 1 };
+    for (let i = 0; i < 32; i += 1) {
+      deep = { nested: deep };
+    }
+    const malformedClaims = {
+      peac_version: '0.2',
+      kind: 'evidence',
+      type: FIXED_TYPE,
+      iss: FIXED_ISS,
+      iat: 1700000000,
+      jti: FIXED_JTI,
+      extensions: { 'org.example/deep': deep },
+    } as unknown as Parameters<typeof defaultCodec.encode>[0];
+
+    const jws = await defaultCodec.encode(malformedClaims, privateKey, FIXED_KID);
+
+    const failOff = await withEnvFlagAsync('0', async () => verifyLocal(jws, publicKey));
+    const failOn = await withEnvFlagAsync('1', async () => verifyLocal(jws, publicKey));
+
+    expect(failOff.valid).toBe(false);
+    expect(failOn.valid).toBe(false);
+    if (failOff.valid || failOn.valid) return;
+
+    expect(failOff.code).toBe('E_CONSTRAINT_VIOLATION');
+    expect(failOn.code).toBe('E_CONSTRAINT_VIOLATION');
     expect(JSON.stringify(failOff)).toBe(JSON.stringify(failOn));
   });
 });

--- a/packages/protocol/src/_internal/record-core/validation-gate.ts
+++ b/packages/protocol/src/_internal/record-core/validation-gate.ts
@@ -3,20 +3,20 @@
  *
  * INTERNAL ONLY. Not re-exported from `packages/protocol/src/index.ts`.
  *
- * The gate is the single production entry point for the bounded
- * validation path. The pre-existing `runBoundedValidatorShadow` from
- * `bounded-validator.ts` is reserved for shadow / corpus / parity-
- * harness consumers and MUST NOT be invoked from the protocol entry
- * points. The boundary is enforced by
- * `tests/tooling/no-production-shadow-import.test.ts`.
+ * The gate is the only production wrapper for the bounded validation
+ * path. The pre-existing `runBoundedValidatorShadow` from
+ * `bounded-validator.ts` remains the entry point for shadow / corpus
+ * / parity-harness consumers and is not the primary admission path
+ * for the protocol entry points; the production-wrapper boundary is
+ * enforced by `tests/tooling/production-gate-boundary.test.ts`.
  *
  * The gate is entrypoint-aware: callers identify themselves with a
  * `surface` discriminator, and the gate applies a per-surface
  * production projection allowlist. Layers in the bounded validator's
  * broader composition that fall outside the allowlist for a given
- * surface are observed (still available to shadow / parity tests
- * through `runBoundedValidatorShadow`) but NEVER surfaced as
- * production failure or production warning here.
+ * surface stay available to shadow / parity tests through
+ * `runBoundedValidatorShadow` but are not surfaced as production
+ * failure or production warning here.
  *
  * Allowlist for surface 'issueWire02':
  *   - schema-parse only.
@@ -128,9 +128,9 @@ function sanitizeIssues(issues: unknown): readonly SanitizedParseIssue[] | undef
  * Behavior is byte-equivalent to the inline canonical sequences at
  * `issue.ts` and `verify-local.ts` for every input on the covered
  * runtime matrix. Any cross-branch divergence on JWS bytes, result
- * shape, error code, warning order, thrown error class, success/
- * failure classification, or observable default behavior is a stop-
- * the-line event for the maintainer.
+ * shape, error code, warning order, thrown error class, success /
+ * failure classification, or observable default behavior is a
+ * validation-equivalence regression.
  */
 export function runBoundedValidationGate(input: ValidationGateInput): ValidationGateResult {
   if (input.surface === 'issueWire02') {

--- a/packages/protocol/src/_internal/record-core/validation-gate.ts
+++ b/packages/protocol/src/_internal/record-core/validation-gate.ts
@@ -1,0 +1,222 @@
+/**
+ * Production-facing bounded validation gate.
+ *
+ * INTERNAL ONLY. Not re-exported from `packages/protocol/src/index.ts`.
+ *
+ * The gate is the single production entry point for the bounded
+ * validation path. The pre-existing `runBoundedValidatorShadow` from
+ * `bounded-validator.ts` is reserved for shadow / corpus / parity-
+ * harness consumers and MUST NOT be invoked from the protocol entry
+ * points. The boundary is enforced by
+ * `tests/tooling/no-production-shadow-import.test.ts`.
+ *
+ * The gate is entrypoint-aware: callers identify themselves with a
+ * `surface` discriminator, and the gate applies a per-surface
+ * production projection allowlist. Layers in the bounded validator's
+ * broader composition that fall outside the allowlist for a given
+ * surface are observed (still available to shadow / parity tests
+ * through `runBoundedValidatorShadow`) but NEVER surfaced as
+ * production failure or production warning here.
+ *
+ * Allowlist for surface 'issueWire02':
+ *   - schema-parse only.
+ *
+ * Allowlist for surface 'verifyLocal':
+ *   - kernel-constraints (via canonical `validateKernelConstraints`).
+ *   - schema-parse (via the extended `validateSchemaParseInternal`).
+ *
+ * Out of scope here (kept inline-canonical on both branches by the
+ * caller): caller-option-bearing checks (issuer mismatch, subjectUri
+ * mismatch, policyDigest format), strictness routing for missing typ,
+ * iat-not-yet-valid, occurred_at temporal, type-extension warnings,
+ * type-extension enforcement, policy-binding compute, bindings
+ * construction, sortWarnings.
+ *
+ * The canonical materializer (claim encoding, JWS signing, JWS
+ * decoding, result-shape construction) is shared between the
+ * bounded-default and rollback branches and is not touched by the
+ * gate.
+ */
+
+import { validateKernelConstraints } from '@peac/schema';
+import type { VerificationWarning } from '@peac/kernel';
+import type { Wire02Claims } from '@peac/schema';
+import { validateSchemaParseInternal } from './validators/schema-parse.js';
+
+/**
+ * Discriminator identifying which protocol entry point invoked the
+ * gate. Drives the production projection allowlist. Adding a third
+ * surface requires a deliberate plan amendment, not an unannounced
+ * source change.
+ */
+export type GateSurface = 'issueWire02' | 'verifyLocal';
+
+/** Sanitized parse-issue projection surfaced on rejection. */
+export interface SanitizedParseIssue {
+  readonly path: string;
+  readonly message: string;
+}
+
+/** Parsed-claims projection surfaced on `verifyLocal` acceptance. */
+export interface ValidationGateParsed {
+  readonly wireVersion: '0.2';
+  readonly claims: Wire02Claims;
+  readonly parserWarnings: readonly VerificationWarning[];
+}
+
+/** Failure-detail projection. Smaller than the bounded layer set. */
+export interface ValidationGateFailureDetails {
+  readonly parse_code?: string;
+  readonly issues?: readonly SanitizedParseIssue[];
+}
+
+/** Successful gate result. */
+export interface ValidationGateSuccess {
+  readonly ok: true;
+  readonly parsed?: ValidationGateParsed;
+}
+
+/** Failed gate result. */
+export interface ValidationGateFailure {
+  readonly ok: false;
+  readonly code: string;
+  readonly message: string;
+  readonly details?: ValidationGateFailureDetails;
+}
+
+export type ValidationGateResult = ValidationGateSuccess | ValidationGateFailure;
+
+/** Inputs to the gate. Only `surface` and `payload` are required. */
+export interface ValidationGateInput {
+  readonly surface: GateSurface;
+  /**
+   * Full claims object. For surface 'issueWire02' this is the just-
+   * constructed `Wire02Claims` cast to a plain record (the same
+   * object that today flows through `Wire02ClaimsSchema.safeParse`).
+   * For surface 'verifyLocal' this is the decoded JWS payload (the
+   * same object that today flows through `validateKernelConstraints`
+   * and `parseReceiptClaims`).
+   */
+  readonly payload: unknown;
+}
+
+/** Maximum sanitized-issue list length surfaced to a verifier report. */
+const MAX_SANITIZED_ISSUES = 25;
+
+function sanitizeIssues(issues: unknown): readonly SanitizedParseIssue[] | undefined {
+  if (!Array.isArray(issues)) return undefined;
+  return issues.slice(0, MAX_SANITIZED_ISSUES).map((issue) => {
+    const candidate = issue as { path?: unknown; message?: unknown };
+    const path = Array.isArray(candidate.path)
+      ? candidate.path
+          .map((segment) =>
+            typeof segment === 'string' || typeof segment === 'number' ? String(segment) : ''
+          )
+          .join('.')
+      : '';
+    const message =
+      typeof candidate.message === 'string'
+        ? candidate.message
+        : String(candidate.message ?? issue);
+    return { path, message };
+  });
+}
+
+/**
+ * Run the production projection of the bounded validation path.
+ *
+ * Behavior is byte-equivalent to the inline canonical sequences at
+ * `issue.ts` and `verify-local.ts` for every input on the covered
+ * runtime matrix. Any cross-branch divergence on JWS bytes, result
+ * shape, error code, warning order, thrown error class, success/
+ * failure classification, or observable default behavior is a stop-
+ * the-line event for the maintainer.
+ */
+export function runBoundedValidationGate(input: ValidationGateInput): ValidationGateResult {
+  if (input.surface === 'issueWire02') {
+    return runIssueWire02(input.payload);
+  }
+  return runVerifyLocal(input.payload);
+}
+
+function runIssueWire02(payload: unknown): ValidationGateResult {
+  // Issuance projection mirrors `issue.ts` Wire02ClaimsSchema.safeParse.
+  // Today's canonical issuance reports the first Zod issue message in
+  // the IssueError details. The gate reproduces that surface here.
+  const schemaRes = validateSchemaParseInternal(payload);
+  if (!schemaRes.accepted) {
+    const firstIssueMessage = schemaRes.errorIssues?.[0]?.message;
+    return {
+      ok: false,
+      code: 'E_INVALID_FORMAT',
+      message: `Wire 0.2 claims schema validation failed: ${firstIssueMessage ?? 'unknown'}`,
+    };
+  }
+  return { ok: true };
+}
+
+function runVerifyLocal(payload: unknown): ValidationGateResult {
+  // Kernel constraints first (canonical-helper delegation preserves
+  // the existing `Kernel constraint violated: <constraint>
+  // (actual: <actual>, limit: <limit>)` message byte-equally).
+  const kernelRes = validateKernelConstraints(payload);
+  if (!kernelRes.valid) {
+    const v = kernelRes.violations[0];
+    return {
+      ok: false,
+      code: 'E_CONSTRAINT_VIOLATION',
+      message: `Kernel constraint violated: ${v.constraint} (actual: ${v.actual}, limit: ${v.limit})`,
+    };
+  }
+
+  // Schema parse next. Surface the canonical
+  // `Receipt schema validation failed: <message>` shape with
+  // `details: { parse_code, issues }` byte-equally.
+  //
+  // Wire 0.1 payloads parse successfully under the canonical parser
+  // but are rejected at the bounded layer with errorCode
+  // 'E_UNSUPPORTED_WIRE_VERSION'. The verify-local canonical surface
+  // routes Wire 0.1 to a distinct error code (not E_INVALID_FORMAT)
+  // and a distinct message; preserve that branch here.
+  const schemaRes = validateSchemaParseInternal(payload);
+  if (!schemaRes.accepted) {
+    if (schemaRes.errorCode === 'E_UNSUPPORTED_WIRE_VERSION') {
+      return {
+        ok: false,
+        code: 'E_UNSUPPORTED_WIRE_VERSION',
+        message: 'Wire 0.1 receipts are not supported. Re-issue as Wire 0.2 using issue().',
+      };
+    }
+    const sanitized = sanitizeIssues(schemaRes.errorIssues);
+    const details: ValidationGateFailureDetails = {};
+    if (schemaRes.errorCode !== undefined) {
+      Object.assign(details, { parse_code: schemaRes.errorCode });
+    }
+    if (sanitized !== undefined) {
+      Object.assign(details, { issues: sanitized });
+    }
+    return {
+      ok: false,
+      code: 'E_INVALID_FORMAT',
+      message: `Receipt schema validation failed: ${schemaRes.errorMessage ?? 'unknown'}`,
+      ...(Object.keys(details).length > 0 && { details }),
+    };
+  }
+
+  if (schemaRes.wireVersion !== '0.2' || schemaRes.claims === undefined) {
+    return {
+      ok: false,
+      code: 'E_UNSUPPORTED_WIRE_VERSION',
+      message: 'Wire 0.1 receipts are not supported. Re-issue as Wire 0.2 using issue().',
+    };
+  }
+
+  return {
+    ok: true,
+    parsed: {
+      wireVersion: '0.2',
+      claims: schemaRes.claims,
+      parserWarnings: schemaRes.warnings ?? [],
+    },
+  };
+}

--- a/packages/protocol/src/_internal/record-core/validators/schema-parse.ts
+++ b/packages/protocol/src/_internal/record-core/validators/schema-parse.ts
@@ -1,54 +1,98 @@
 /**
- * Bounded internal schema-parse validator (canonical-composed).
+ * Bounded internal schema-parse validator.
  *
  * INTERNAL ONLY. Thin wrapper around the canonical
- * `parseReceiptClaims` from `@peac/schema`, projecting the canonical
- * result into the bounded validator's normalized shape. The wrapper
- * has no decision logic of its own: it delegates the parse, then
- * surfaces the canonical accept/reject and the canonical error code.
+ * `parseReceiptClaims` from `@peac/schema`. Projects the canonical
+ * accept/reject signal plus the full canonical projection (parsed
+ * claims, parser warnings, canonical error triple) so production
+ * callers can reproduce the canonical surface byte-equally without
+ * re-invoking `parseReceiptClaims`.
  *
- * This is observational equivalence by construction, not a divergent
- * parser. The layer boundary allows an alternate implementation
- * without changing callers; the input/output shape is stable enough
- * for a drop-in replacement should rigorous cross-implementation
- * parity beyond observational evidence be required.
- *
- * Module is observational only; not re-exported from
- * `packages/protocol/src/index.ts` and not wired into the public
- * runtime path.
+ * Module is internal-only; not re-exported from
+ * `packages/protocol/src/index.ts`.
  *
  * SCOPE:
  *   - Run `parseReceiptClaims(payload)` and surface its accept/reject.
- *   - On rejection, surface `pr.error.code` (canonical parse-error code)
- *     so the candidate's error taxonomy matches the canonical's.
- *   - On acceptance, no warnings are surfaced from this layer; parser
- *     warnings (e.g., `type_unregistered`, `unknown_extension_preserved`)
- *     are emitted by the canonical parser and consumed at higher layers
- *     (verifyLocal warning aggregation).
+ *   - On acceptance: surface `wireVersion`, parsed `claims`, and
+ *     parser `warnings` (e.g., `type_unregistered`,
+ *     `unknown_extension_preserved`). Higher-layer aggregation merges
+ *     these into the caller's warning array.
+ *   - On rejection: surface the canonical error triple
+ *     (`errorCode`, `errorMessage`, `errorIssues`) so callers can
+ *     project the canonical `details: { parse_code, issues }` and
+ *     `message: 'Receipt schema validation failed: <message>'`
+ *     surface byte-equally.
  */
 
+import type { ZodError } from 'zod';
+import type { VerificationWarning } from '@peac/kernel';
 import { parseReceiptClaims } from '@peac/schema';
 import type { Wire02Claims } from '@peac/schema';
 
 export interface SchemaParseResult {
   readonly accepted: boolean;
+  /**
+   * Canonical parse-error code from `parseReceiptClaims` when the
+   * parse rejects. Mirrors `pr.error.code`.
+   */
   readonly errorCode?: string;
   /**
+   * Canonical parse-error message from `parseReceiptClaims` when the
+   * parse rejects. Mirrors `pr.error.message`. Required for callers
+   * that reproduce the canonical surface message
+   * `Receipt schema validation failed: <message>` byte-equally.
+   */
+  readonly errorMessage?: string;
+  /**
+   * Canonical parse-error issues from `parseReceiptClaims` when the
+   * parse rejects. Mirrors `pr.error.issues`. Callers downstream
+   * apply their own bounded sanitization (path-join, length cap)
+   * before surfacing on a public verifier-result `details` payload.
+   */
+  readonly errorIssues?: ZodError['issues'];
+  /**
    * Parsed Wire 0.2 claims when accepted. Internal-only; does not
-   * appear on any emitted record or public surface. Callers that need
-   * a typed view of the parsed claims read this field; callers that
-   * only need the accept/reject signal ignore it.
+   * appear on any emitted record or public surface.
    */
   readonly claims?: Wire02Claims;
+  /**
+   * Wire version surfaced from `parseReceiptClaims` on acceptance.
+   * The bounded surface only admits `'0.2'`; Wire 0.1 acceptance from
+   * the canonical parser is rejected at this layer with
+   * `E_UNSUPPORTED_WIRE_VERSION` because the bounded composition is
+   * keyed on Wire 0.2 claim shapes.
+   */
+  readonly wireVersion?: '0.2';
+  /**
+   * Parser warnings surfaced on acceptance. Mirrors `pr.warnings` for
+   * Wire 0.2 acceptance. Callers that aggregate into a single
+   * canonical warning array merge this list at the canonical-equivalent
+   * flow position before the canonical sort.
+   */
+  readonly warnings?: readonly VerificationWarning[];
 }
 
 export function validateSchemaParseInternal(payload: unknown): SchemaParseResult {
   const pr = parseReceiptClaims(payload);
   if (!pr.ok) {
-    return { accepted: false, errorCode: pr.error.code };
+    return {
+      accepted: false,
+      errorCode: pr.error.code,
+      errorMessage: pr.error.message,
+      ...(pr.error.issues !== undefined && { errorIssues: pr.error.issues }),
+    };
   }
   if (pr.wireVersion !== '0.2') {
-    return { accepted: false, errorCode: 'E_UNSUPPORTED_WIRE_VERSION' };
+    return {
+      accepted: false,
+      errorCode: 'E_UNSUPPORTED_WIRE_VERSION',
+      errorMessage: `Unsupported wire version: ${pr.wireVersion}`,
+    };
   }
-  return { accepted: true, claims: pr.claims as Wire02Claims };
+  return {
+    accepted: true,
+    claims: pr.claims as Wire02Claims,
+    wireVersion: '0.2',
+    warnings: pr.warnings,
+  };
 }

--- a/packages/protocol/src/issue.ts
+++ b/packages/protocol/src/issue.ts
@@ -7,6 +7,7 @@ import { uuidv7 } from 'uuidv7';
 import { sign } from '@peac/crypto';
 import { defaultCodec } from './_internal/record-core/codec/jws-jwt.js';
 import { runBoundedValidatorShadow } from './_internal/record-core/bounded-validator.js';
+import { runBoundedValidationGate } from './_internal/record-core/validation-gate.js';
 import { isShadowEnabled, scheduleShadow, type ShadowEnableOptions } from './_internal/shadow.js';
 import { readLegacyPathFlag, type LegacyPathOptions } from './_internal/legacy-path.js';
 import {
@@ -477,10 +478,11 @@ export type IssueOptions = IssueWire02Options;
  * @throws IssueError if iss is not canonical or schema validation fails
  */
 export async function issueWire02(options: IssueWire02Options): Promise<IssueResult> {
-  // Internal rollback-path flag. The returned boolean is intentionally
-  // discarded; both flag values currently use the same protocol path.
-  // See `_internal/legacy-path.ts` for the full contract.
-  void readLegacyPathFlag(options as unknown as LegacyPathOptions);
+  // Internal rollback-path flag. Selects the bounded-validation
+  // admission gate (default) or the inline canonical schema check
+  // (rollback). Both branches share the canonical materializer that
+  // builds the IssueResult and the JWS bytes.
+  const legacyPath = readLegacyPathFlag(options as unknown as LegacyPathOptions);
 
   // Validate canonical iss before signing
   if (!isCanonicalIss(options.iss)) {
@@ -518,20 +520,40 @@ export async function issueWire02(options: IssueWire02Options): Promise<IssueRes
     ...(options.extensions !== undefined && { extensions: options.extensions }),
   };
 
-  // Validate schema before signing (fail-closed)
-  const parseResult = Wire02ClaimsSchema.safeParse(claims);
-  if (!parseResult.success) {
-    const firstIssue = parseResult.error.issues[0];
-    throw new IssueError({
-      code: 'E_INVALID_FORMAT',
-      category: 'validation',
-      severity: 'error',
-      retryable: false,
-      http_status: 400,
-      details: {
-        message: `Wire 0.2 claims schema validation failed: ${firstIssue?.message ?? 'unknown'}`,
-      },
-    } as PEACError);
+  // Validate schema before signing (fail-closed). The default branch
+  // routes through the bounded validation gate; the rollback branch
+  // retains the inline canonical schema check. Both branches produce
+  // byte-identical JWS bytes for every input both branches accept.
+  if (legacyPath) {
+    const parseResult = Wire02ClaimsSchema.safeParse(claims);
+    if (!parseResult.success) {
+      const firstIssue = parseResult.error.issues[0];
+      throw new IssueError({
+        code: 'E_INVALID_FORMAT',
+        category: 'validation',
+        severity: 'error',
+        retryable: false,
+        http_status: 400,
+        details: {
+          message: `Wire 0.2 claims schema validation failed: ${firstIssue?.message ?? 'unknown'}`,
+        },
+      } as PEACError);
+    }
+  } else {
+    const gateResult = runBoundedValidationGate({
+      surface: 'issueWire02',
+      payload: claims as unknown,
+    });
+    if (!gateResult.ok) {
+      throw new IssueError({
+        code: gateResult.code,
+        category: 'validation',
+        severity: 'error',
+        retryable: false,
+        http_status: 400,
+        details: { message: gateResult.message },
+      } as PEACError);
+    }
   }
 
   // Sign with Wire 0.2 via the internal codec boundary (always sets
@@ -540,7 +562,12 @@ export async function issueWire02(options: IssueWire02Options): Promise<IssueRes
   // the prior release.
   const jws = await defaultCodec.encode(claims, options.privateKey, options.kid);
 
-  if (isShadowEnabled(options as unknown as ShadowEnableOptions)) {
+  // Shadow scheduling fires only on the rollback branch where the
+  // bounded validator is genuinely a comparison path; under the
+  // default branch the bounded validator runs as the production
+  // admission gate, so a duplicate shadow run would compare the same
+  // code path against itself.
+  if (legacyPath && isShadowEnabled(options as unknown as ShadowEnableOptions)) {
     scheduleShadow<ShadowObservation>({
       call: 'issue',
       realResult: realObservationForIssue(),

--- a/packages/protocol/src/verify-local.ts
+++ b/packages/protocol/src/verify-local.ts
@@ -27,6 +27,7 @@ import { TYPE_TO_EXTENSION_MAP } from '@peac/kernel';
 import { checkTypeExtensionMapping } from './type-extension-check';
 import { maybeRunShadowValidation } from './_internal/record-core/shadow-hook';
 import { runBoundedValidatorShadow } from './_internal/record-core/bounded-validator.js';
+import { runBoundedValidationGate } from './_internal/record-core/validation-gate.js';
 import { isShadowEnabled, scheduleShadow, type ShadowEnableOptions } from './_internal/shadow.js';
 import { readLegacyPathFlag, type LegacyPathOptions } from './_internal/legacy-path.js';
 import {
@@ -365,9 +366,12 @@ export async function verifyLocal(
   publicKey: Uint8Array,
   options: VerifyLocalOptions = {}
 ): Promise<VerifyLocalResult> {
-  // Internal rollback-path flag. See `_internal/legacy-path.ts` for
-  // the full contract.
-  void readLegacyPathFlag(options as unknown as LegacyPathOptions);
+  // Internal rollback-path flag. Selects the bounded validation
+  // admission gate (default) or the inline canonical sequence
+  // (rollback). Both branches share the post-admission flow: caller-
+  // option binding, temporal checks, type-extension enforcement,
+  // policy-binding compute, bindings construction, sortWarnings.
+  const legacyPath = readLegacyPathFlag(options as unknown as LegacyPathOptions);
 
   const {
     issuer,
@@ -413,30 +417,76 @@ export async function verifyLocal(
       });
     }
 
-    // 3. Validate structural kernel constraints (fail-closed)
-    const constraintResult = validateKernelConstraints(result.payload);
-    if (!constraintResult.valid) {
-      const v = constraintResult.violations[0];
-      return {
-        valid: false,
-        code: 'E_CONSTRAINT_VIOLATION',
-        message: `Kernel constraint violated: ${v.constraint} (actual: ${v.actual}, limit: ${v.limit})`,
+    // 3-5. Admission: kernel constraints, schema parse, parser warnings.
+    //
+    // The default branch routes through the bounded validation gate,
+    // which surfaces canonical-equivalent E_CONSTRAINT_VIOLATION /
+    // E_INVALID_FORMAT / E_UNSUPPORTED_WIRE_VERSION verdicts on
+    // rejection and the parsed Wire 0.2 claims plus parser warnings
+    // on acceptance. The rollback branch retains the inline canonical
+    // sequence (validateKernelConstraints + parseReceiptClaims). Both
+    // branches feed the same post-admission flow.
+    type AdmittedClaims = {
+      readonly ok: true;
+      readonly wireVersion: '0.1' | '0.2';
+      readonly warnings: readonly VerificationWarning[];
+      readonly claims: unknown;
+    };
+    let pr: AdmittedClaims;
+
+    if (legacyPath) {
+      const constraintResult = validateKernelConstraints(result.payload);
+      if (!constraintResult.valid) {
+        const v = constraintResult.violations[0];
+        return {
+          valid: false,
+          code: 'E_CONSTRAINT_VIOLATION',
+          message: `Kernel constraint violated: ${v.constraint} (actual: ${v.actual}, limit: ${v.limit})`,
+        };
+      }
+      const parsed = parseReceiptClaims(result.payload);
+      if (!parsed.ok) {
+        return {
+          valid: false,
+          code: 'E_INVALID_FORMAT',
+          message: `Receipt schema validation failed: ${parsed.error.message}`,
+          details: {
+            parse_code: parsed.error.code,
+            issues: sanitizeParseIssues(parsed.error.issues),
+          },
+        };
+      }
+      pr = parsed;
+    } else {
+      const gateResult = runBoundedValidationGate({
+        surface: 'verifyLocal',
+        payload: result.payload,
+      });
+      if (!gateResult.ok) {
+        return {
+          valid: false,
+          code: gateResult.code as VerifyLocalErrorCode,
+          message: gateResult.message,
+          ...(gateResult.details !== undefined && { details: gateResult.details }),
+        };
+      }
+      const parsedFromGate = gateResult.parsed;
+      if (parsedFromGate === undefined) {
+        return {
+          valid: false,
+          code: 'E_INTERNAL',
+          message: 'Bounded validation gate accepted without surfacing parsed claims',
+        };
+      }
+      pr = {
+        ok: true,
+        wireVersion: parsedFromGate.wireVersion,
+        warnings: parsedFromGate.parserWarnings,
+        claims: parsedFromGate.claims,
       };
     }
 
-    // 4. Validate schema (unified parser supports Wire 0.1 and Wire 0.2)
-    const pr = parseReceiptClaims(result.payload);
-
-    if (!pr.ok) {
-      return {
-        valid: false,
-        code: 'E_INVALID_FORMAT',
-        message: `Receipt schema validation failed: ${pr.error.message}`,
-        details: { parse_code: pr.error.code, issues: sanitizeParseIssues(pr.error.issues) },
-      };
-    }
-
-    // 5. Collect parser warnings (Wire 0.2 parser may emit type/extension warnings)
+    // Collect parser warnings (Wire 0.2 parser may emit type/extension warnings).
     if (pr.wireVersion === '0.2') {
       accumulatedWarnings.push(...pr.warnings);
     }
@@ -603,7 +653,12 @@ export async function verifyLocal(
 
       const sortedWarnings = sortWarnings(accumulatedWarnings);
 
-      if (isShadowEnabled(options as unknown as ShadowEnableOptions)) {
+      // Shadow scheduling fires only on the rollback branch where the
+      // bounded validator is genuinely a comparison path. Under the
+      // default branch the gate runs as the production admission
+      // path, so a duplicate shadow run would compare the same code
+      // path against itself.
+      if (legacyPath && isShadowEnabled(options as unknown as ShadowEnableOptions)) {
         const headerSnapshot = { ...result.header } as Record<string, unknown>;
         scheduleShadow<ShadowObservation>({
           call: 'verifyLocal',

--- a/tests/tooling/no-production-shadow-import.test.ts
+++ b/tests/tooling/no-production-shadow-import.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Source-level guard: production protocol entry points MUST NOT
+ * import or reference `runBoundedValidatorShadow`. The shadow function
+ * is reserved for shadow / corpus / parity-harness consumers
+ * (`runBoundedValidationGate` is the production wrapper).
+ *
+ * Scope:
+ *   - packages/protocol/src/issue.ts
+ *   - packages/protocol/src/verify-local.ts
+ *   - packages/protocol/src/verify.ts
+ *
+ * The shadow function MAY appear inside an existing `scheduleShadow`
+ * call body (issue.ts and verify-local.ts both schedule the bounded
+ * validator under the rollback branch as a parity comparator). The
+ * test enforces that no production entry point depends on the shadow
+ * helper as the primary admission path; runtime gating is layered on
+ * top by activation tests in
+ * `packages/protocol/__tests__/_internal/bounded-default-runtime.test.ts`.
+ *
+ * Therefore the rule encoded here is the single static invariant:
+ * the canonical production wrapper `runBoundedValidationGate` MUST
+ * appear in the imports of every Wire 0.2 admission entry point and
+ * MUST NOT appear in `verify.ts` (Wire 0.1 verifier; bounded
+ * validation is out of scope per the v0.14.0 plan).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..', '..');
+
+const ISSUE_FILE = join(ROOT, 'packages', 'protocol', 'src', 'issue.ts');
+const VERIFY_LOCAL_FILE = join(ROOT, 'packages', 'protocol', 'src', 'verify-local.ts');
+const VERIFY_FILE = join(ROOT, 'packages', 'protocol', 'src', 'verify.ts');
+
+const PRODUCTION_GATE_IMPORT = /from\s+['"][^'"]*validation-gate(\.js)?['"]/;
+const PRODUCTION_GATE_SYMBOL = /\brunBoundedValidationGate\b/;
+const SHADOW_FN_SYMBOL = /\brunBoundedValidatorShadow\b/;
+
+describe('production wrapper boundary: Wire 0.2 entry points use runBoundedValidationGate', () => {
+  it('issue.ts imports the production gate wrapper', () => {
+    const content = readFileSync(ISSUE_FILE, 'utf8');
+    expect(PRODUCTION_GATE_IMPORT.test(content)).toBe(true);
+    expect(PRODUCTION_GATE_SYMBOL.test(content)).toBe(true);
+  });
+
+  it('verify-local.ts imports the production gate wrapper', () => {
+    const content = readFileSync(VERIFY_LOCAL_FILE, 'utf8');
+    expect(PRODUCTION_GATE_IMPORT.test(content)).toBe(true);
+    expect(PRODUCTION_GATE_SYMBOL.test(content)).toBe(true);
+  });
+});
+
+describe('production wrapper boundary: verify.ts (Wire 0.1) does not reference the gate', () => {
+  it('verify.ts does NOT import or reference runBoundedValidationGate', () => {
+    const content = readFileSync(VERIFY_FILE, 'utf8');
+    expect(PRODUCTION_GATE_IMPORT.test(content)).toBe(false);
+    expect(PRODUCTION_GATE_SYMBOL.test(content)).toBe(false);
+  });
+
+  it('verify.ts does NOT reference runBoundedValidatorShadow', () => {
+    const content = readFileSync(VERIFY_FILE, 'utf8');
+    expect(SHADOW_FN_SYMBOL.test(content)).toBe(false);
+  });
+});

--- a/tests/tooling/no-rollback-flag-discard-pattern.test.ts
+++ b/tests/tooling/no-rollback-flag-discard-pattern.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Source-level guard: the rollback-path flag MUST NOT appear as a
+ * `void readLegacyPathFlag(...)` discard in the Wire 0.2 protocol
+ * entry points. Both flag values must select genuinely different
+ * admission paths in `issueWire02()` and `verifyLocal()`.
+ *
+ * Scope is intentional:
+ *   - packages/protocol/src/issue.ts        (Wire 0.2 issuance)
+ *   - packages/protocol/src/verify-local.ts (Wire 0.2 local verification)
+ *
+ * Out of scope:
+ *   - packages/protocol/src/verify.ts is the Wire 0.1 verifier; the
+ *     bounded validation gate is keyed on Wire 0.2 claim shapes and
+ *     does not apply there. The flag-read symmetry invariant is
+ *     deliberately not enforced for Wire 0.1.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..', '..');
+
+const SCOPED_FILES = [
+  join(ROOT, 'packages', 'protocol', 'src', 'issue.ts'),
+  join(ROOT, 'packages', 'protocol', 'src', 'verify-local.ts'),
+];
+
+const FORBIDDEN_PATTERN = /void\s+readLegacyPathFlag\s*\(/;
+
+describe('rollback-flag discard-pattern guard (Wire 0.2 admission paths only)', () => {
+  for (const file of SCOPED_FILES) {
+    it(`${file.replace(ROOT, '<repo>')}: must not contain "void readLegacyPathFlag(..."`, () => {
+      const content = readFileSync(file, 'utf8');
+      expect(FORBIDDEN_PATTERN.test(content)).toBe(false);
+    });
+  }
+});

--- a/tests/tooling/production-gate-boundary.test.ts
+++ b/tests/tooling/production-gate-boundary.test.ts
@@ -1,27 +1,27 @@
 /**
- * Source-level guard: production protocol entry points MUST NOT
- * import or reference `runBoundedValidatorShadow`. The shadow function
- * is reserved for shadow / corpus / parity-harness consumers
- * (`runBoundedValidationGate` is the production wrapper).
+ * Source-level guard: production gate boundary.
  *
- * Scope:
- *   - packages/protocol/src/issue.ts
- *   - packages/protocol/src/verify-local.ts
- *   - packages/protocol/src/verify.ts
+ * The Wire 0.2 admission paths (`issue.ts` and `verify-local.ts`)
+ * import `runBoundedValidationGate` and route their primary admission
+ * step through it. The shadow function `runBoundedValidatorShadow`
+ * remains available inside the existing `scheduleShadow` call bodies
+ * as an observational parity comparator on the rollback branch; it
+ * is not the primary admission path.
  *
- * The shadow function MAY appear inside an existing `scheduleShadow`
- * call body (issue.ts and verify-local.ts both schedule the bounded
- * validator under the rollback branch as a parity comparator). The
- * test enforces that no production entry point depends on the shadow
- * helper as the primary admission path; runtime gating is layered on
- * top by activation tests in
+ * The Wire 0.1 verifier (`verify.ts`) is intentionally out of scope:
+ * the bounded validation gate is keyed on Wire 0.2 claim shapes and
+ * does not apply to Wire 0.1.
+ *
+ * The static invariants enforced here:
+ *
+ *   1. `issue.ts` and `verify-local.ts` import the production gate
+ *      wrapper and reference its symbol.
+ *   2. `verify.ts` does not import the gate, does not reference its
+ *      symbol, and does not reference the shadow function symbol.
+ *
+ * Runtime activation (the gate IS called on the default branch and is
+ * NOT called on the rollback branch) is asserted separately in
  * `packages/protocol/__tests__/_internal/bounded-default-runtime.test.ts`.
- *
- * Therefore the rule encoded here is the single static invariant:
- * the canonical production wrapper `runBoundedValidationGate` MUST
- * appear in the imports of every Wire 0.2 admission entry point and
- * MUST NOT appear in `verify.ts` (Wire 0.1 verifier; bounded
- * validation is out of scope per the v0.14.0 plan).
  */
 
 import { describe, it, expect } from 'vitest';
@@ -55,13 +55,13 @@ describe('production wrapper boundary: Wire 0.2 entry points use runBoundedValid
 });
 
 describe('production wrapper boundary: verify.ts (Wire 0.1) does not reference the gate', () => {
-  it('verify.ts does NOT import or reference runBoundedValidationGate', () => {
+  it('verify.ts does not import or reference runBoundedValidationGate', () => {
     const content = readFileSync(VERIFY_FILE, 'utf8');
     expect(PRODUCTION_GATE_IMPORT.test(content)).toBe(false);
     expect(PRODUCTION_GATE_SYMBOL.test(content)).toBe(false);
   });
 
-  it('verify.ts does NOT reference runBoundedValidatorShadow', () => {
+  it('verify.ts does not reference runBoundedValidatorShadow', () => {
     const content = readFileSync(VERIFY_FILE, 'utf8');
     expect(SHADOW_FN_SYMBOL.test(content)).toBe(false);
   });


### PR DESCRIPTION
## Summary

Wires the bounded validation path into the primary internal runtime
path of `issueWire02()` and `verifyLocal()`. The previous direct-
canonical admission sequence remains available as the internal
rollback path. The internal rollback flag now selects between the
bounded validation gate and the direct-canonical admission path for
Wire 0.2 issuance and local verification.

Public API, wire format, package surface, extension keys, and default
observable behavior are unchanged.

## Scope

Internal runtime change in `@peac/protocol` only.

- Adds `runBoundedValidationGate` at
  `packages/protocol/src/_internal/record-core/validation-gate.ts` as
  the production wrapper for the bounded validation path. The gate is
  entrypoint-aware (`surface: 'issueWire02' | 'verifyLocal'`) and
  applies a per-surface production projection allowlist:
  `issueWire02` surfaces schema-parse only; `verifyLocal` surfaces
  kernel-constraints (via canonical `validateKernelConstraints`) and
  schema-parse. Other bounded layers stay observation / parity-only
  on the production projection.
- Extends `validateSchemaParseInternal` to expose the full canonical
  parse projection (`wireVersion`, parsed `claims`, parser
  `warnings`, and the canonical error triple) so production callers
  reproduce the canonical surface byte-equally.
- Wires `issueWire02()` and `verifyLocal()` to read the rollback flag
  at function top and dispatch to the gate (default) or the inline
  canonical sequence (rollback). The canonical materializer (claim
  construction, JWS sign / decode via the codec, caller-option
  binding, temporal checks, type-extension enforcement, policy-
  binding compute, bindings construction, sortWarnings) is shared
  between branches and is not modified.
- `runBoundedValidatorShadow` is not used as the primary admission
  path. It remains available only inside shadow / parity comparison
  paths: the existing `scheduleShadow` call sites in `issue.ts` and
  `verify-local.ts` are gated on the rollback branch so the bounded
  validator does not run twice on the default branch. The shadow
  harness module is preserved.

`packages/protocol/src/verify.ts` (Wire 0.1 verifier) is intentionally
not modified: the bounded validator is keyed on Wire 0.2 claim shapes
and does not apply to Wire 0.1.

## Validation

- `pnpm --filter '@peac/protocol...' build`: clean.
- `pnpm --filter '@peac/protocol' test`: 1680 tests across 57 files.
- `PEAC_INTERNAL_LEGACY_PATH=0 pnpm --filter @peac/protocol test`:
  1680 / 1680.
- `PEAC_INTERNAL_LEGACY_PATH=1 pnpm --filter @peac/protocol test`:
  1680 / 1680.
- Targeted parity / activation / boundary tests
  (`legacy-path-flag.test.ts`, `bounded-default-runtime.test.ts`,
  `no-rollback-flag-discard-pattern.test.ts`,
  `production-gate-boundary.test.ts`): 32 / 32. Includes
  byte-equivalent acceptance parity (T8 / T9), pre-admission
  rejection parity (T10 / T11), and real gate-failure parity
  (T12 issueWire02 schema rejection, T13 verifyLocal schema
  rejection, T13b verifyLocal kernel-constraint rejection).
- `node scripts/verify-no-semantic-widening.mjs`: 18 / 18.
- `node scripts/verify-dist-private-leaks.mjs`: scanned 36 packages,
  no leaks.
- `node scripts/verify-trust-artifacts.mjs`: clean.
- `pnpm verify:codegen-drift`: up to date.
- `pnpm verify:release`: 25 / 25 passed (1 expected skip for
  release-tagging-time gate report).
- `bash scripts/guard.sh`: clean.
- `bash scripts/ci/forbid-strings.sh`: clean.
- `find-invisible-unicode.mjs --stdin` over the diff: clean.
- `gofmt -l . && go vet ./...` in `sdks/go`: clean.

## Notes

The rollback flag is documented as an internal-only flag in
`docs/STABILITY-CONTRACT.md`. The operator runbook for the rollback
path lands in a follow-up PR.
