### PR TITLE
release: align changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.14.0] - 2026-05-02
 
-Internal Default Switch.
+Bounded Validation Gate.
 
-The bounded validation path is now the primary internal runtime path
-for PEAC interaction-record issuance and local verification. The
-previous direct-canonical path remains available as an internal
-rollback path.
+Wire 0.2 issuance and local verification now route through the
+bounded validation gate. The previous direct-canonical admission
+path remains available as an internal rollback path.
 
 Public API: unchanged.
 Wire format: unchanged.

--- a/docs/release-notes/v0.14.0.md
+++ b/docs/release-notes/v0.14.0.md
@@ -1,11 +1,10 @@
-# v0.14.0 — Internal Default Switch
+# v0.14.0 — Bounded Validation Gate
 
 **Status:** Pre-release. Final release metadata is recorded in `docs/releases/facts.json`.
 
-The bounded validation path is now the primary internal runtime path
-for PEAC interaction-record issuance and local verification. The
-previous direct-canonical path remains available as an internal
-rollback path.
+Wire 0.2 issuance and local verification now route through the
+bounded validation gate. The previous direct-canonical admission
+path remains available as an internal rollback path.
 
 Public API: unchanged.
 Wire format: unchanged.


### PR DESCRIPTION

Documentation only. No source change. No package version change. No
generated surfaces touched.

`CHANGELOG.md` v0.14.0 section: title `Internal Default Switch` →
  `Bounded Validation Gate`; 

Subsequent sections (Changed / Added / Notes in CHANGELOG; Highlights
/ Operator references / Verification / Distribution / What did NOT
change in release-notes) are unchanged.

## Validation

- `pnpm format:check`: clean.
- `node scripts/extract-changelog-entry.mjs --version 0.14.0`:
  release-notes file extracts cleanly with the new title.
- `node scripts/verify-no-semantic-widening.mjs`: 18 / 18.
- `node scripts/verify-trust-artifacts.mjs`: clean.
- `bash scripts/guard.sh`: clean.
- `bash scripts/ci/forbid-strings.sh`: clean.
- `find-invisible-unicode.mjs --stdin` over the diff: clean.
- Strict bidi / zero-width audit on the two changed files: clean.
- `docs/release-notes/v0.14.0.md` on the pushed branch: 75 LF
  lines, 0 CR, byte-identical via `raw.githubusercontent.com` and
  `git show origin/<branch>:<file>`. Heading on line 1, blank line,
  status on its own line, paragraphs and section headings separated
  by blank lines.
