### PR TITLE
chore(release): stamp v0.14.0 publish date

### DIFF
--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable surface classification for PEAC Protocol workspace. CI fails if any workspace member is missing. See docs/PACKAGE_STATUS.md for human-readable view.",
   "version": "0.13.0",
-  "updated": "2026-05-02",
+  "updated": "2026-05-03",
   "states": {
     "default": "Current recommended path. Actively maintained, Wire 0.2 native.",
     "supported": "Actively maintained, published, production-ready. May not be on default quickstart path.",

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -2,7 +2,7 @@
 
 Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scripts/generate-surface-status.mjs`.
 
-**Version:** 0.13.0 | **Updated:** 2026-05-02
+**Version:** 0.13.0 | **Updated:** 2026-05-03
 
 ## Layer 1
 

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -4,7 +4,7 @@
   "version": "0.14.0",
   "wire_format_version": "0.2",
   "dist_tag": "next",
-  "release_date": "2026-05-02",
+  "release_date": "2026-05-03",
   "metrics": {
     "tests": 8930,
     "test_files": 390,


### PR DESCRIPTION
## Summary

Stamps release-state metadata to reflect the actual v0.14.0 publish
day (2026-05-03 UTC). The pre-tag stamp in [#745](https://github.com/peacprotocol/peac/pull/745)
set 2026-05-02; the tag was pushed and `publish.yml` ran on
2026-05-03, one UTC day later.

Stamp-only PR. No source change. No package version change. No
extension key, wire format, or public API touch.

## Scope

- `docs/releases/facts.json` `release_date`: 2026-05-02 → 2026-05-03.
- `REPO_SURFACE_STATUS.json` `updated`: 2026-05-02 → 2026-05-03.
- `docs/SURFACE_STATUS.md` regenerated.

## Validation

- `pnpm verify:release`: 25 / 25 (1 expected skip).
- `pnpm verify:release-closeout --version 0.14.0 --stage publish`:
  5 GREEN / 1 YELLOW / 1 RED. The YELLOW (`npm-latest not audited at
  stage=publish`) is correct for Mode 2 next-only. The RED
  (`github-release` at tag `v0.14.0`) flips GREEN once the
  maintainer authors the GitHub Release post-publish.
- Pre-push Tier 1 + Tier 2 gates: all passed.
