### PR TITLE
docs: add abstraction boundary guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,10 +34,13 @@
 
 ## Neutrality and abstraction check
 
-For changes involving an external standard, ecosystem, vendor, or framework
-(see [`docs/architecture/ABSTRACTION-BOUNDARIES.md`](../docs/architecture/ABSTRACTION-BOUNDARIES.md)):
+Required only for changes involving an external standard, ecosystem, vendor,
+framework, or integration surface
+(see [`docs/architecture/ABSTRACTION-BOUNDARIES.md`](../docs/architecture/ABSTRACTION-BOUNDARIES.md)).
+For PRs that do not touch any external integration surface, mark each item
+"not applicable" and proceed.
 
-- [ ] Generic PEAC primitive identified.
+- [ ] Generic PEAC primitive identified, or not applicable.
 - [ ] Ecosystem-specific semantics kept in profile, mapping, adapter, fixture, or example (not in core).
 - [ ] No external SDK dependency added to PEAC core (`@peac/kernel`, `@peac/schema`, `@peac/crypto`, `@peac/protocol`).
 - [ ] Generic abstraction does not weaken profile-specific validation.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,6 +32,17 @@
 - [ ] PR title is technical and under 70 chars
 - [ ] PR body contains only technical content (no internal planning, sequencing, or process language)
 
+## Neutrality and abstraction check
+
+For changes involving an external standard, ecosystem, vendor, or framework
+(see [`docs/architecture/ABSTRACTION-BOUNDARIES.md`](../docs/architecture/ABSTRACTION-BOUNDARIES.md)):
+
+- [ ] Generic PEAC primitive identified.
+- [ ] Ecosystem-specific semantics kept in profile, mapping, adapter, fixture, or example (not in core).
+- [ ] No external SDK dependency added to PEAC core (`@peac/kernel`, `@peac/schema`, `@peac/crypto`, `@peac/protocol`).
+- [ ] Generic abstraction does not weaken profile-specific validation.
+- [ ] Normative vs informative boundaries are clear.
+
 ## Follow-ups
 
 <!-- Technical follow-ups only. Leave empty if none. -->

--- a/docs/architecture/ABSTRACTION-BOUNDARIES.md
+++ b/docs/architecture/ABSTRACTION-BOUNDARIES.md
@@ -2,8 +2,8 @@
 
 PEAC core defines reusable protocol primitives. External standards and
 ecosystem-specific semantics belong in thin profiles, mappings, adapters,
-fixtures, and examples. This document records the abstraction-boundary
-discipline that keeps PEAC vendor-neutral and reusable across ecosystems.
+fixtures, and examples. This document defines the abstraction boundaries
+that keep PEAC vendor-neutral and reusable across ecosystems.
 
 ## Core hierarchy
 

--- a/docs/architecture/ABSTRACTION-BOUNDARIES.md
+++ b/docs/architecture/ABSTRACTION-BOUNDARIES.md
@@ -1,0 +1,124 @@
+# Abstraction Boundaries
+
+PEAC core defines reusable protocol primitives. External standards and
+ecosystem-specific semantics belong in thin profiles, mappings, adapters,
+fixtures, and examples. This document records the abstraction-boundary
+discipline that keeps PEAC vendor-neutral and reusable across ecosystems.
+
+## Core hierarchy
+
+```text
+Core    = generic PEAC semantics
+Profile = external standard mapping
+Adapter = implementation convenience
+Example = ecosystem-specific demonstration
+```
+
+| Layer   | Where it lives                                                                     | What it owns                                                                                                                                                                        |
+| ------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Core    | `@peac/kernel`, `@peac/schema`, `@peac/crypto`, `@peac/protocol`                   | Generic types, schemas, validators, signing, the canonical wire envelope, shared reference grammars (`OpaqueRefSchema`, `Sha256DigestSchema`), the canonical type-to-extension map. |
+| Profile | `packages/mappings/<system>/`, `docs/specs/<SYSTEM>-*-PROFILE.md`                  | Ecosystem-specific field shapes, vocabulary, and validation rules (e.g. `org.peacprotocol/a2a-handoff` for A2A v1.0 handoff records).                                               |
+| Adapter | `packages/adapters/<system>/`, `packages/rails-<system>/`, `packages/middleware-*` | Implementation convenience that bridges PEAC primitives to a specific runtime, framework, or rail.                                                                                  |
+| Example | `examples/<system>-*/`, `integrator-kits/<system>/`                                | Vendor- or project-specific demonstrations of profiles in action.                                                                                                                   |
+
+## Standing principle
+
+PEAC should be generic where semantics are shared, profile-specific where
+correctness requires it, adapter-specific only at the implementation edge,
+and vendor-specific only in examples or compatibility notes.
+
+## Rules
+
+1. **Core is ecosystem-neutral.** Names, types, and runtime imports in the
+   core layer (`@peac/kernel`, `@peac/schema`, `@peac/crypto`, `@peac/protocol`)
+   must not encode any single ecosystem's vocabulary. Shared names like
+   `OpaqueRefSchema`, `Sha256DigestSchema`, `HandoffObservation`-shaped types,
+   and `TYPE_TO_EXTENSION_MAP` are correct. Names like `A2ATaskRef`,
+   `McpToolReceipt`, `OpenAITraceRecord`, or `StripePaymentRecord` are not
+   acceptable in core; they belong in the profile or adapter layer.
+
+2. **Profile validators stay strict.** Generic abstraction must not weaken
+   profile-specific validation. The generic layer provides reusable shape;
+   the profile layer enforces ecosystem-specific correctness. For example,
+   `A2AHandoffSchema` uses a discriminated union over per-event
+   `z.literal(...)` schemas so a payload's `type` and `event` fields cannot
+   drift apart, even though the surrounding extension namespace is generic.
+
+3. **Compose with external systems; do not absorb them.** PEAC composes with
+   A2A, MCP, x402, AP2, OpenTelemetry, gateways, agent frameworks, CI
+   systems, CLIs, and orchestration systems. PEAC does not become an
+   orchestrator, observability backend, payment rail, auth system,
+   governance engine, agent runtime, policy-decision engine, workflow
+   manager, task scheduler, or monitoring platform.
+
+4. **External SDKs do not enter core.** Mapping to another ecosystem's
+   vocabulary does not require depending on its SDK. A profile understands
+   the external wire or document shape; a helper accepts caller-supplied
+   JSON and normalizes it internally; PEAC core does not import the
+   external runtime SDK. Adding an external SDK dependency to the core
+   layer requires explicit architecture review.
+
+5. **Extension points are explicit, not loose.** Every profile or
+   integration surface uses named extension points: extension namespace
+   (`org.peacprotocol/<group>`), type URIs, carrier profile, reference
+   grammar, digest grammar, error-code family (when emitted), conformance
+   section, fixture verifier, and profile version. Avoid `metadata: any`,
+   `extra: object`, `custom: object`, vague vendor-shaped payloads in core,
+   or silent pass-through semantics without validation.
+
+6. **Custom attributes are scoped.** When PEAC publishes an attribute name
+   intended to compose with an external standard's namespace
+   (for example, OpenTelemetry span attributes), the attribute is a PEAC
+   custom attribute unless that standard has accepted it. PEAC does not
+   ship exporters, SDK dependencies, collectors, or
+   semantic-convention claims for external standards unless a release
+   explicitly adds one.
+
+## Promoting a primitive to core
+
+A concept is admitted to the core layer only if it satisfies all of:
+
+1. It applies to at least two plausible integrations.
+2. Its semantics are stable independent of any one vendor or project.
+3. It can be validated without importing the originating ecosystem's SDK.
+4. It does not weaken correctness for the first concrete profile.
+5. Its name still makes sense if the first integration disappeared.
+
+If any criterion fails, the concept stays in its profile or adapter
+package.
+
+## Worked example
+
+The v0.14.1 A2A handoff records release illustrates the hierarchy in
+practice:
+
+- **Core** (`@peac/schema`): `OpaqueRefSchema` (multi-prefix grammar with
+  UTF-8 byte bounds), `Sha256DigestSchema` (canonical digest grammar),
+  `validateA2AHandoff` structured-error contract, the
+  `org.peacprotocol/a2a-handoff` extension group entry, and the 10
+  type URIs in the canonical type-to-extension map.
+- **Profile** (`@peac/mappings-a2a` and
+  [`docs/specs/A2A-HANDOFF-RECORDS.md`](../specs/A2A-HANDOFF-RECORDS.md)):
+  A2A v1.0 vocabulary mapping, the
+  `signature_observation.caller_reported_verification` field shape,
+  digest-only `card_ref`, and the per-event discriminated-union schemas
+  that prevent `type` and `event` from drifting.
+- **Examples**:
+  [`examples/a2a-gateway-pattern/`](../../examples/a2a-gateway-pattern/) and
+  [`integrator-kits/a2a/fixtures/`](../../integrator-kits/a2a/fixtures/)
+  demonstrate the profile in action without leaking
+  ecosystem-specific names back into core.
+
+The same pattern applies to subsequent profiles (CLI execution records,
+lifecycle observation records, MCP tool-call records, AP2 mandate
+references): hoist truly shared pieces into core only after the
+admission test above passes; everything ecosystem-specific stays at the
+profile or adapter layer.
+
+## See also
+
+- [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md) (canonical layered package
+  model and wire format)
+- [`docs/specs/A2A-HANDOFF-RECORDS.md`](../specs/A2A-HANDOFF-RECORDS.md)
+  (worked profile example)
+- [`docs/architecture/ADR-001-telemetry-package-taxonomy.md`](ADR-001-telemetry-package-taxonomy.md)

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -4,6 +4,12 @@ The authoritative architecture document is [`docs/ARCHITECTURE.md`](../ARCHITECT
 It covers the layered package model, wire format, protocol boundaries, and the
 10-pillar framework.
 
+Cross-cutting architecture guidance:
+
+- [Abstraction Boundaries](ABSTRACTION-BOUNDARIES.md): the
+  Core / Profile / Adapter / Example hierarchy and the rules that keep
+  PEAC vendor-neutral and reusable across ecosystems.
+
 Architecture Decision Records live in this directory:
 
 - [ADR-001: Telemetry Package Taxonomy](ADR-001-telemetry-package-taxonomy.md)


### PR DESCRIPTION
## Summary

Add public architecture guidance for PEAC abstraction boundaries and add a conditional PR checklist for changes involving external standards, ecosystems, vendors, frameworks, or integration surfaces.

## Scope

- Adds `docs/architecture/ABSTRACTION-BOUNDARIES.md`.
- Updates `docs/architecture/README.md` to link the new guidance.
- Updates `.github/pull_request_template.md` with a conditional neutrality and abstraction check.
- Does not modify local-only reference files.

## Changes

- Defines the Core / Profile / Adapter / Example hierarchy.
- Documents that PEAC core stays ecosystem-neutral.
- Clarifies that ecosystem-specific semantics belong in profiles, mappings, adapters, fixtures, or examples.
- States that generic abstractions must not weaken profile-specific validation.
- Documents the boundary that PEAC composes with external systems without replacing or absorbing them.
- Adds a checklist for PRs that touch external integration surfaces.

## Notes

The worked example references `docs/specs/A2A-HANDOFF-RECORDS.md`, which is present on `main` after #749.