### PR TITLE
docs(protocol): Wire version compatibility

### DIFF
--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -113,6 +113,8 @@ Records travel in several carriers depending on the surface:
 
 A record's `kind` is one of two fixed structural values — `evidence` (records what happened) or `challenge` (requests proof from a peer). A record's `type` is an open reverse-DNS or URI identifier for **what** the record represents (for example `org.peacprotocol/payment`, `org.peacprotocol/mcp-tool-call`, `org.peacprotocol/api-receipt`). Extensions are typed data groups organized by pillar (access, attribution, commerce, consent, compliance, privacy, provenance, safety, identity, purpose).
 
+`org.peacprotocol/mcp-tool-call` is an example custom type URI used by the MCP recipe. It is not a registered PEAC extension group or registered receipt type. The reference public verifier (`@peac/protocol.verifyLocal()`) emits a `type_unregistered` warning for unregistered type values, which downstream policy logic may treat as informational. Operators who want a registered MCP-specific receipt type should propose a dedicated PEAC profile and registry entry before relying on it as a registered type.
+
 Normative detail: [`docs/specs/WIRE-0.2.md`](specs/WIRE-0.2.md) and [`docs/specs/PROTOCOL-BEHAVIOR.md`](specs/PROTOCOL-BEHAVIOR.md).
 
 ## What PEAC does not do in this loop

--- a/docs/SOLUTIONS/mcp-tool-call-receipts.md
+++ b/docs/SOLUTIONS/mcp-tool-call-receipts.md
@@ -23,6 +23,10 @@ PEAC packages:
 
 Prerequisites: Node 22+, pnpm 8+. An MCP client to call the server (the shipped examples use the MCP SDK stdio transport).
 
+## Type URI used in this recipe
+
+`org.peacprotocol/mcp-tool-call` is an example custom type URI used by the MCP recipe. It is not a registered PEAC extension group or registered receipt type. The reference public verifier (`@peac/protocol.verifyLocal()`) emits a `type_unregistered` warning for unregistered type values, which downstream policy logic may treat as informational. Operators who want a registered MCP-specific receipt type should propose a dedicated PEAC profile and registry entry before relying on it as a registered type.
+
 ## Step-by-step
 
 1. Install dependencies:

--- a/docs/STABILITY-CONTRACT.md
+++ b/docs/STABILITY-CONTRACT.md
@@ -29,6 +29,8 @@ maintenance (security and correctness fixes apply to every active line per
 | Canonical JSON             | JCS (RFC 8785)                                            | `stable`       | Cross-language parity fixtures in `specs/conformance/`                                                                                              |
 | Verifier response bodies   | `application/json` (RFC 8259)                             | `stable`       | Error bodies: `application/problem+json` (RFC 9457)                                                                                                 |
 
+**Wire 0.1 compatibility.** `issueWire01()` and `IssueWire01Options` in `@peac/protocol`, plus `Wire01JWSHeader` / `Wire01JWSHeaderSchema` in `@peac/crypto` and `@peac/schema`, remain stable for backward compatibility with existing downstream issuers. Wire 0.1 issuance is deprecated and discouraged for new integrations; new applications should use `issue()`. The public default verifier `verifyLocal()` is current-Wire only and returns `E_UNSUPPORTED_WIRE_VERSION` for Wire 0.1 input. The reference implementation retains `verifyLocalWire01()` as an internal legacy verification path for archival and replay use cases. No new protocol features are added to Wire 0.1.
+
 ## Public TypeScript APIs
 
 | Surface (package)                                                                           | Classification  | Notes                                                                                                                      |

--- a/docs/contributing/TEST-LAYOUT.md
+++ b/docs/contributing/TEST-LAYOUT.md
@@ -1,0 +1,22 @@
+# Test layout convention
+
+PEAC's test layout reflects which boundary the test exercises. Authors and reviewers should place new tests according to the boundary they cover.
+
+## Conventions
+
+| Location                    | Scope                                                                                                                                                            | Examples                                                                                                                            |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/<pkg>/__tests__/` | Package-local unit and integration tests for a single workspace package. Default for new package-local tests unless the package already uses another convention. | `packages/schema/__tests__/`, `packages/kernel/__tests__/`, `packages/protocol/__tests__/`                                          |
+| `packages/<pkg>/tests/`     | Package-local tests that use a package-specific suite layout or established package precedent.                                                                   | `packages/cli/tests/`, `packages/protocol/tests/`                                                                                   |
+| `tests/tooling/`            | Cross-package boundary tests, repo-wide invariants, build/typecheck/lint guards, and dependency-graph assertions.                                                | `tests/tooling/no-otel-dep.test.ts`, `tests/tooling/private-package-deps.test.ts`, `tests/tooling/production-gate-boundary.test.ts` |
+| `tests/conformance/`        | Conformance fixtures and spec tests asserting registry composition, requirement-ID coverage, and type-URI mapping invariants.                                    | `tests/conformance/registry-composition.spec.ts`                                                                                    |
+
+## File naming
+
+- Prefer `kebab-case.test.ts` for new test files unless a directory has a strong existing convention.
+- Use `.spec.ts` where the existing directory convention uses that suffix for normative or conformance-style assertions.
+- Avoid mixing unrelated concerns in one file; split by boundary or behavior.
+
+## When in doubt
+
+Find the closest existing test by package and boundary, then follow that precedent. This note documents current convention only; it does not rename existing tests.

--- a/docs/specs/WIRE-0.2.md
+++ b/docs/specs/WIRE-0.2.md
@@ -1056,6 +1056,8 @@ A mismatch produces `E_WIRE_VERSION_MISMATCH`.
 
 Wire 0.1 (`peac-receipt/0.1`) is FROZEN. All Wire 0.1 schemas, test fixtures, and verification behavior remain unchanged. Wire 0.1 receipts do not gain Wire 0.2 fields or constraints. No new fields, constraints, or semantics will be added to Wire 0.1.
 
+For the Wire 0.1 compatibility and issuance-deprecation policy, see [`docs/STABILITY-CONTRACT.md`](../STABILITY-CONTRACT.md).
+
 ### 15.5 Receipt Reference
 
 The receipt reference (`receipt_ref`) computation is unchanged across wire versions:

--- a/packages/protocol/src/issue.ts
+++ b/packages/protocol/src/issue.ts
@@ -174,10 +174,11 @@ export class IssueError extends Error {
 }
 
 /**
- * Issue a Wire 0.1 PEAC record.
+ * Issues a legacy Wire 0.1 receipt.
  *
- * @deprecated Wire 0.1 issuance is frozen legacy. Use {@link issue} (current stable format)
- * or {@link issueWire02} (explicit wire-pinned API) for Wire 0.2 records.
+ * @deprecated Use {@link issue} for current stable issuance. Wire 0.1
+ * issuance is retained for backward compatibility but discouraged for new
+ * applications.
  *
  * @param options - Wire 0.1 record options
  * @returns Issue result with JWS and optional subject_snapshot


### PR DESCRIPTION
## Summary

Clarify Wire 0.1 compatibility and current issuance guidance.

This keeps Wire 0.1 compatibility behavior unchanged while documenting that new integrations should use current issuance through `issue()`.

## Scope

- Documents Wire 0.1 compatibility in `docs/STABILITY-CONTRACT.md`.
- Adds a cross-reference from `docs/specs/WIRE-0.2.md`.
- Tightens function-level `@deprecated` JSDoc on `issueWire01()` to recommend `issue()` for new applications.
- Clarifies that `org.peacprotocol/mcp-tool-call` is an example custom type URI, not a registered PEAC receipt type.
- Adds a test layout convention note for contributors.

## Behavior

No runtime behavior change.

`issueWire01()` remains exported for backward compatibility.

`verifyLocal()` remains current-Wire only and returns `E_UNSUPPORTED_WIRE_VERSION` for Wire 0.1 input.

`verifyLocalWire01()` remains an internal legacy verification path for archival and replay use cases.

## Validation

- Formatting passes.
- Typecheck passes.
- Package tests pass.
- Conformance and registry checks pass.
- API contract and release-surface checks pass.
- Public hygiene checks pass.

## Compatibility

No Wire format change.

No signing-envelope change.

No public export removal.

No registry or conformance change.

No example or sandbox behavior change.
