### PR TITLE
chore(examples): migrate current-compatible demos

### DIFF
--- a/examples/erc8004-feedback/src/demo.ts
+++ b/examples/erc8004-feedback/src/demo.ts
@@ -1,6 +1,11 @@
 /**
  * ERC-8004 Feedback Demo
  *
+ * Legacy Wire 0.1 exact-byte mapping example.
+ * This example keeps a Wire 0.1 receipt fixture because its canonical bytes are
+ * bound to the ERC-8004 mapping hashes and conformance wrapper. Migrating it to
+ * current Wire requires updating the ERC-8004 mapping fixture in a dedicated PR.
+ *
  * Demonstrates how to use PEAC records as evidence behind
  * ERC-8004 reputation signals.
  *

--- a/examples/erc8004-feedback/src/verify-hash.ts
+++ b/examples/erc8004-feedback/src/verify-hash.ts
@@ -1,6 +1,11 @@
 /**
  * Hash Verification Smoke Test (CI-Safe)
  *
+ * Legacy Wire 0.1 exact-byte mapping example.
+ * This example keeps a Wire 0.1 receipt fixture because its canonical bytes are
+ * bound to the ERC-8004 mapping hashes and conformance wrapper. Migrating it to
+ * current Wire requires updating the ERC-8004 mapping fixture in a dedicated PR.
+ *
  * Verifies both Mode A (direct receipt) and Mode B (wrapper) conformance vectors.
  * This test is deterministic and does not depend on generated files.
  *

--- a/examples/mcp-tool-call/demo.ts
+++ b/examples/mcp-tool-call/demo.ts
@@ -1,17 +1,23 @@
 /**
  * MCP Tool Call Example
  *
- * Demonstrates MCP tool integration with PEAC receipts:
+ * Demonstrates MCP tool integration with PEAC records:
  * 1. MCP server exposes a paid tool
- * 2. Receipt is attached to tool response
- * 3. Client extracts and verifies receipt
+ * 2. A signed record is attached to the tool response via the _meta carrier
+ * 3. Client extracts and verifies the record
+ *
+ * The record uses `type: 'org.peacprotocol/mcp-tool-call'`. This is an example
+ * custom type URI used by the MCP recipe. It is not a registered PEAC extension
+ * group or registered receipt type. The reference public verifier
+ * (`@peac/protocol.verifyLocal()`) emits a `type_unregistered` warning for
+ * unregistered type values, which downstream policy logic may treat as
+ * informational.
  *
  * This example uses local stubs - no external services required.
  */
 
-import { issueWire01 } from '@peac/protocol';
-import { generateKeypair, verify } from '@peac/crypto';
-import { type PEACReceiptClaims } from '@peac/schema';
+import { issue, verifyLocal } from '@peac/protocol';
+import { generateKeypair } from '@peac/crypto';
 import {
   extractReceipt,
   hasReceipt,
@@ -47,19 +53,23 @@ async function mcpToolHandler(params: {
   const query = params.args.query as string;
   const toolResult = await webSearchTool(query);
 
-  // Issue receipt
-  const receiptResult = await issueWire01({
+  // Issue a signed record. The `type` value is an example custom URI used by
+  // this MCP recipe; it is not a registered PEAC receipt type, so verification
+  // will surface a `type_unregistered` warning.
+  const receiptResult = await issue({
     iss: ISSUER_URL,
-    aud: `mcp:${params.tool}`,
-    amt: COST_PER_CALL_CENTS,
-    cur: CURRENCY,
-    rail: 'mcp',
-    reference: `mcp_${Date.now()}`,
-    asset: CURRENCY,
-    env: 'test',
-    evidence: {
-      tool: params.tool,
-      query,
+    kind: 'evidence',
+    type: 'org.peacprotocol/mcp-tool-call',
+    pillars: ['attribution', 'commerce'],
+    extensions: {
+      'org.peacprotocol/commerce': {
+        payment_rail: 'mcp',
+        amount_minor: String(COST_PER_CALL_CENTS),
+        currency: CURRENCY,
+        reference: `mcp_${Date.now()}`,
+        asset: CURRENCY,
+        env: 'test',
+      },
     },
     privateKey: params.privateKey,
     kid: 'mcp-key-2025',
@@ -92,15 +102,27 @@ async function mcpClient(params: { privateKey: Uint8Array; publicKey: Uint8Array
       privateKey: params.privateKey,
     });
 
-    // Check for receipt
+    // Check for record
     if (hasReceipt(response)) {
       const receipt = extractReceipt(response);
-      console.log(`  Receipt attached: ${receipt!.length} chars`);
+      console.log(`  Record attached: ${receipt!.length} chars`);
 
-      // Verify receipt
-      const { valid, payload } = await verify<PEACReceiptClaims>(receipt!, params.publicKey);
-      console.log(`  Receipt valid: ${valid}`);
-      console.log(`  Amount: ${payload.amt} ${payload.cur}`);
+      // Verify record. Expect a `type_unregistered` warning because
+      // org.peacprotocol/mcp-tool-call is intentionally unregistered.
+      const result = await verifyLocal(receipt!, params.publicKey, { issuer: ISSUER_URL });
+      if (result.valid) {
+        const commerce = (
+          result.claims.extensions as
+            | { 'org.peacprotocol/commerce'?: { amount_minor?: string; currency?: string } }
+            | undefined
+        )?.['org.peacprotocol/commerce'];
+        const typeUnregistered = result.warnings.some((w) => w.code === 'type_unregistered');
+        console.log(`  Record valid: true`);
+        console.log(`  Amount: ${commerce?.amount_minor ?? '?'} ${commerce?.currency ?? '?'}`);
+        console.log(`  Warning type_unregistered (expected): ${typeUnregistered}`);
+      } else {
+        console.error(`  Record invalid: ${result.code} ${result.message}`);
+      }
     }
 
     // Show results

--- a/examples/pay-per-crawl/demo.ts
+++ b/examples/pay-per-crawl/demo.ts
@@ -19,9 +19,8 @@ import {
   type PolicyDocument,
   type EvaluationContext,
 } from '@peac/policy-kit';
-import { issueWire01 } from '@peac/protocol';
-import { generateKeypair, verify } from '@peac/crypto';
-import { toCoreClaims, PEACReceiptClaims } from '@peac/schema';
+import { issue, verifyLocal } from '@peac/protocol';
+import { generateKeypair } from '@peac/crypto';
 
 console.log('\n=== PEAC Pay-Per-Crawl Demo ===\n');
 
@@ -176,39 +175,58 @@ console.log('\n5. Crawler obtains and presents receipt\n');
 async function demonstrateReceiptFlow() {
   const { privateKey, publicKey } = await generateKeypair();
 
-  // Crawler issues receipt (in real scenario, this comes from payment provider)
-  const receiptResult = await issueWire01({
+  // Crawler issues record (in real scenario, this comes from payment provider)
+  const receiptResult = await issue({
     iss: 'https://payment.example.com',
-    aud: 'https://publisher.example.com/content/article-123',
-    amt: 100, // $1.00
-    cur: 'USD',
-    rail: 'stripe',
-    reference: 'cs_crawl_demo_123',
-    asset: 'USD',
-    env: 'test',
-    evidence: { purpose: 'crawl' },
+    kind: 'evidence',
+    type: 'org.peacprotocol/payment',
+    pillars: ['commerce'],
+    sub: 'https://publisher.example.com/content/article-123',
+    extensions: {
+      'org.peacprotocol/commerce': {
+        payment_rail: 'stripe',
+        amount_minor: '100', // $1.00
+        currency: 'USD',
+        reference: 'cs_crawl_demo_123',
+        asset: 'USD',
+        env: 'test',
+      },
+    },
     privateKey,
     kid: 'demo-key-2025',
   });
 
-  console.log(`   Receipt issued (${receiptResult.jws.length} chars)`);
+  console.log(`   Record issued (${receiptResult.jws.length} chars)`);
 
-  // Publisher verifies receipt
-  const { valid, payload } = await verify<PEACReceiptClaims>(receiptResult.jws, publicKey);
-  if (!valid) {
-    throw new Error('Receipt verification failed');
+  // Publisher verifies record
+  const result = await verifyLocal(receiptResult.jws, publicKey, {
+    issuer: 'https://payment.example.com',
+  });
+  if (!result.valid) {
+    throw new Error(`Record verification failed: ${result.code}`);
   }
-  console.log('   Receipt verified successfully');
+  console.log('   Record verified successfully');
 
-  // Extract core claims for logging/audit
-  const core = toCoreClaims(payload);
-  console.log('   Core claims:');
-  console.log(`     iss: ${core.iss}`);
-  console.log(`     aud: ${core.aud}`);
-  console.log(`     amt: ${core.amt} ${core.cur}`);
+  // Extract claim fields for logging/audit
+  const commerce = (
+    result.claims.extensions as
+      | {
+          'org.peacprotocol/commerce'?: {
+            amount_minor?: string;
+            currency?: string;
+            payment_rail?: string;
+          };
+        }
+      | undefined
+  )?.['org.peacprotocol/commerce'];
+  console.log('   Verified claims:');
+  console.log(`     iss: ${result.claims.iss}`);
+  console.log(`     sub: ${result.claims.sub ?? '(none)'}`);
+  console.log(`     amount_minor: ${commerce?.amount_minor ?? '?'} ${commerce?.currency ?? '?'}`);
+  console.log(`     payment_rail: ${commerce?.payment_rail ?? '?'}`);
 
   // Decision: allow access
-  console.log('\n   -> Access granted with valid receipt');
+  console.log('\n   -> Access granted with valid record');
 }
 
 await demonstrateReceiptFlow();

--- a/examples/pay-per-inference/demo.ts
+++ b/examples/pay-per-inference/demo.ts
@@ -1,19 +1,21 @@
 /**
  * Pay-Per-Inference Example
  *
- * Demonstrates the core PEAC receipt flow:
+ * Demonstrates the core PEAC record flow:
  * 1. Agent makes request to resource
  * 2. Resource returns 402 Payment Required
- * 3. Agent obtains receipt (simulated payment)
- * 4. Agent retries with receipt
- * 5. Resource verifies receipt and grants access
+ * 3. Agent obtains a signed record (simulated payment)
+ * 4. Agent retries with the record
+ * 5. Resource verifies the record and grants access
  *
  * This example uses local stubs - no external services required.
+ *
+ * Note: PEAC records normalized payment fields. Provider/chain context lives
+ * upstream in the payment system.
  */
 
-import { issueWire01 } from '@peac/protocol';
-import { generateKeypair, verify, canonicalize } from '@peac/crypto';
-import { toCoreClaims, PEACReceiptClaims } from '@peac/schema';
+import { issue, verifyLocal } from '@peac/protocol';
+import { generateKeypair, canonicalize } from '@peac/crypto';
 
 // Simulated resource server state
 const RESOURCE_URL = 'https://api.example.com/inference/gpt-4';
@@ -92,16 +94,22 @@ async function paymentService(params: {
   privateKey: Uint8Array;
   publicKey: Uint8Array;
 }): Promise<string> {
-  const result = await issueWire01({
+  const result = await issue({
     iss: ISSUER_URL,
-    aud: params.resource,
-    amt: params.amount,
-    cur: params.currency,
-    rail: 'demo',
-    reference: `demo_${Date.now()}`,
-    asset: params.currency,
-    env: 'test',
-    evidence: { demo: true },
+    kind: 'evidence',
+    type: 'org.peacprotocol/payment',
+    pillars: ['commerce'],
+    sub: params.resource,
+    extensions: {
+      'org.peacprotocol/commerce': {
+        payment_rail: 'demo',
+        amount_minor: String(params.amount),
+        currency: params.currency,
+        reference: `demo_${Date.now()}`,
+        asset: params.currency,
+        env: 'test',
+      },
+    },
     privateKey: params.privateKey,
     kid: 'demo-key-2025',
   });
@@ -156,17 +164,33 @@ async function agent(params: {
       console.log(`   -> Unexpected status: ${response2.status}`);
     }
 
-    // Step 4: Demonstrate toCoreClaims normalization
-    console.log('\n4. Demonstrating toCoreClaims() normalization...');
-    const { payload } = await verify<PEACReceiptClaims>(receipt, params.publicKey);
-    const core = toCoreClaims(payload);
-    const canonical = canonicalize(core);
-    console.log('   -> Core claims (normalized):');
-    console.log(`      iss: ${core.iss}`);
-    console.log(`      aud: ${core.aud}`);
-    console.log(`      amt: ${core.amt} ${core.cur}`);
-    console.log(`      payment.rail: ${core.payment?.rail}`);
-    console.log(`   -> Canonical JCS (${canonical.length} bytes)`);
+    // Step 4: Decode + canonicalize the verified claims
+    console.log('\n4. Inspecting verified record claims...');
+    const result = await verifyLocal(receipt, params.publicKey, { issuer: ISSUER_URL });
+    if (result.valid) {
+      const commerce = (
+        result.claims.extensions as
+          | {
+              'org.peacprotocol/commerce'?: {
+                payment_rail?: string;
+                amount_minor?: string;
+                currency?: string;
+              };
+            }
+          | undefined
+      )?.['org.peacprotocol/commerce'];
+      const canonical = canonicalize(result.claims as unknown as Record<string, unknown>);
+      console.log('   -> Verified claims:');
+      console.log(`      iss: ${result.claims.iss}`);
+      console.log(`      sub: ${result.claims.sub ?? '(none)'}`);
+      console.log(
+        `      amount_minor: ${commerce?.amount_minor ?? '?'} ${commerce?.currency ?? '?'}`
+      );
+      console.log(`      payment_rail: ${commerce?.payment_rail ?? '?'}`);
+      console.log(`   -> Canonical JCS (${canonical.length} bytes)`);
+    } else {
+      console.error(`   -> Verification failed: ${result.code}`);
+    }
   }
 
   console.log('\n=== Demo Complete ===\n');
@@ -180,7 +204,7 @@ async function main() {
   // Create verifier function
   const verifyReceipt = async (jws: string): Promise<boolean> => {
     try {
-      const result = await verify(jws, publicKey);
+      const result = await verifyLocal(jws, publicKey, { issuer: ISSUER_URL });
       return result.valid;
     } catch {
       return false;

--- a/examples/rsl-collective/demo.ts
+++ b/examples/rsl-collective/demo.ts
@@ -1,6 +1,12 @@
 /**
  * RSL Collective Integration Example
  *
+ * Legacy Wire 0.1 compatibility example.
+ * This demo uses the Wire 0.1 ControlBlock shape. Current Wire does not define
+ * a canonical control or RSL extension profile, so this example remains a
+ * Wire 0.1 compatibility demonstration. The Wire 0.1 envelope and signing
+ * semantics it relies on are retained for backward compatibility.
+ *
  * Demonstrates:
  * 1. RSL signal/license mapping to PEAC ControlPurpose
  * 2. Receipt issuance with RSL-derived control blocks

--- a/examples/stripe-x402-crypto/demo.ts
+++ b/examples/stripe-x402-crypto/demo.ts
@@ -1,26 +1,21 @@
 /**
- * Stripe x402 Crypto Payment -> PEAC Receipt -> Offline Verify
+ * Stripe x402 Crypto Payment -> PEAC Record -> Offline Verify
  *
  * Run: pnpm --filter @peac/example-stripe-x402-crypto demo
  *
  * This demo shows the full flow:
  * 1. Normalize a Stripe crypto payment intent to PEAC PaymentEvidence
- * 2. Issue a signed PEAC receipt embedding the payment evidence
- * 3. Verify the receipt offline (no network, no Stripe API)
+ * 2. Issue a signed PEAC record carrying normalized commerce fields
+ * 3. Verify the record offline (no network, no Stripe API)
+ *
+ * Note: PEAC records normalized commerce fields. The Stripe crypto chain context
+ * (tx hash, network, recipient) lives upstream in Stripe and the underlying
+ * blockchain; the signed PEAC record carries only normalized payment fields.
  */
 
 import { fromCryptoPaymentIntent } from '@peac/rails-stripe';
-import { issueWire01, verify } from '@peac/protocol';
+import { issue, verifyLocal } from '@peac/protocol';
 import { generateKeypair, derivePublicKey } from '@peac/crypto';
-
-interface ReceiptPayload {
-  iss: string;
-  aud: string;
-  amt: number;
-  cur: string;
-  rid: string;
-  iat: number;
-}
 
 async function main(): Promise<void> {
   console.log('='.repeat(60));
@@ -63,19 +58,27 @@ async function main(): Promise<void> {
   console.log('    Reference:', payment.reference);
   console.log();
 
-  // --- Step 2: Issue a signed PEAC receipt ---
-  console.log('[2] Issuing signed PEAC receipt...');
+  // --- Step 2: Issue a signed PEAC record ---
+  console.log('[2] Issuing signed PEAC record...');
 
   const { privateKey } = await generateKeypair();
   const publicKey = await derivePublicKey(privateKey);
+  const issuerUrl = 'https://api.weather.example.com';
 
-  const result = await issueWire01({
-    iss: 'https://api.weather.example.com',
-    aud: 'https://agent.example.com',
-    amt: payment.amount,
-    cur: payment.currency,
-    rail: payment.rail,
-    reference: payment.reference,
+  const result = await issue({
+    iss: issuerUrl,
+    kind: 'evidence',
+    type: 'org.peacprotocol/payment',
+    pillars: ['commerce'],
+    sub: 'https://agent.example.com',
+    extensions: {
+      'org.peacprotocol/commerce': {
+        payment_rail: payment.rail,
+        amount_minor: String(payment.amount),
+        currency: payment.currency,
+        reference: payment.reference,
+      },
+    },
     privateKey,
     kid: '2026-02-13',
   });
@@ -85,33 +88,48 @@ async function main(): Promise<void> {
   console.log();
 
   // --- Step 3: Verify offline ---
-  console.log('[3] Verifying receipt offline (no network)...');
+  console.log('[3] Verifying record offline (no network)...');
 
-  const verification = await verify<ReceiptPayload>(result.jws, publicKey);
+  const verification = await verifyLocal(result.jws, publicKey, { issuer: issuerUrl });
 
   console.log('    Valid:    ', verification.valid);
-  console.log('    Issuer:   ', verification.payload.iss);
-  console.log('    Audience: ', verification.payload.aud);
-  console.log('    Amount:   ', verification.payload.amt, verification.payload.cur);
+  if (verification.valid) {
+    const commerce = (
+      verification.claims.extensions as
+        | {
+            'org.peacprotocol/commerce'?: {
+              payment_rail?: string;
+              amount_minor?: string;
+              currency?: string;
+            };
+          }
+        | undefined
+    )?.['org.peacprotocol/commerce'];
+    console.log('    Issuer:   ', verification.claims.iss);
+    console.log('    Subject:  ', verification.claims.sub ?? '(none)');
+    console.log('    Amount:   ', commerce?.amount_minor ?? '?', commerce?.currency ?? '?');
+    console.log('    Rail:     ', commerce?.payment_rail ?? '?');
+  }
   console.log();
 
   // --- Summary ---
   console.log('='.repeat(60));
   if (verification.valid) {
-    console.log('SUCCESS: Receipt issued and verified offline.');
+    console.log('SUCCESS: Record issued and verified offline.');
     console.log();
     console.log('What just happened:');
-    console.log('  1. Stripe crypto payment (USDC on Base) -> PaymentEvidence');
-    console.log('  2. PaymentEvidence -> signed JWS receipt (Ed25519)');
-    console.log('  3. JWS receipt -> verified with public key (no network)');
+    console.log('  1. Stripe crypto payment (USDC on Base) -> normalized payment fields');
+    console.log('  2. Normalized fields -> signed JWS record (Ed25519)');
+    console.log('  3. JWS record -> verified with public key (no network)');
     console.log();
     console.log('Verification meaning:');
-    console.log('  - The receipt is a signed issuer attestation of payment.');
+    console.log('  - The record is a signed issuer attestation of payment.');
     console.log('  - Offline verify confirms integrity + origin (Ed25519).');
     console.log('  - It does NOT confirm on-chain settlement.');
-    console.log('  - Use tx_hash + network with an RPC endpoint for that.');
+    console.log('  - Provider/chain context (tx hash, network, recipient) lives upstream');
+    console.log('    in Stripe and the underlying blockchain.');
   } else {
-    console.log('FAILURE: Receipt verification failed.');
+    console.log('FAILURE: Record verification failed.');
     process.exit(1);
   }
   console.log('='.repeat(60));

--- a/examples/telemetry-otel/src/server.ts
+++ b/examples/telemetry-otel/src/server.ts
@@ -13,7 +13,7 @@ import {
   SimpleSpanProcessor,
   ConsoleSpanExporter,
 } from '@opentelemetry/sdk-trace-base';
-import { issueWire01 } from '@peac/protocol';
+import { issue } from '@peac/protocol';
 import { generateKeypair } from '@peac/crypto';
 import { setTelemetryProvider } from '@peac/telemetry';
 import { createOtelProvider } from '@peac/telemetry-otel';
@@ -61,13 +61,19 @@ async function issueReceiptWithTracing(): Promise<void> {
     try {
       console.log('[Demo] Issuing receipt...');
 
-      const result = await issueWire01({
+      const result = await issue({
         iss: 'https://api.example.com',
-        aud: 'https://shop.example.com',
-        amt: 1999, // $19.99 in cents
-        cur: 'USD',
-        rail: 'stripe',
-        reference: 'pi_demo_12345',
+        kind: 'evidence',
+        type: 'org.peacprotocol/payment',
+        pillars: ['commerce'],
+        extensions: {
+          'org.peacprotocol/commerce': {
+            payment_rail: 'stripe',
+            amount_minor: '1999', // $19.99 in cents
+            currency: 'USD',
+            reference: 'pi_demo_12345',
+          },
+        },
         privateKey,
         kid: '2025-01-01',
       });

--- a/examples/workflow-correlation/demo.ts
+++ b/examples/workflow-correlation/demo.ts
@@ -1,34 +1,47 @@
 /**
  * PEAC Workflow Correlation Demo
  *
- * Demonstrates linking receipts into a multi-step workflow DAG.
- * Pattern: root -> fork (2 branches) -> join
+ * Demonstrates linking receipts via canonical correlation metadata.
+ * Pattern: root -> fork (2 branches) -> join, using `parent_jti` and `depends_on`.
  *
  * Run with: pnpm demo
+ *
+ * Note: PEAC records correlation metadata. Step indexing, tool naming, framework
+ * tagging, and orchestrator identity are properties of the upstream orchestrator,
+ * not of the PEAC record. This demo links receipts by their JTIs to show causal
+ * structure; richer orchestrator state lives in the orchestration system itself.
  */
 
-import { issueWire01, verifyLocal, generateKeypair } from '@peac/protocol';
-import {
-  type WorkflowContext,
-  type WorkflowId,
-  type StepId,
-  WORKFLOW_EXTENSION_KEY,
-  type PEACReceiptClaims,
-  createWorkflowId,
-  createStepId,
-} from '@peac/schema';
+import { issue, verifyLocal, generateKeypair } from '@peac/protocol';
 import { decode } from '@peac/crypto';
 
+interface DecodedClaims {
+  jti: string;
+  iss: string;
+  iat: number;
+  kind: string;
+  type: string;
+  extensions?: {
+    'org.peacprotocol/commerce'?: {
+      payment_rail?: string;
+      amount_minor?: string;
+      currency?: string;
+    };
+    'org.peacprotocol/correlation'?: {
+      workflow_id?: string;
+      parent_jti?: string;
+      depends_on?: string[];
+    };
+  };
+}
+
 /**
- * Generate a ULID-like identifier for demo purposes.
+ * Generate a ULID-like identifier for the workflow id.
  *
  * In production, use a proper ULID library (e.g., 'ulid' or 'ulidx' npm package)
  * for cryptographic randomness and correct Crockford Base32 encoding.
- *
- * IDs must be 20-48 chars to pass schema validation.
  */
-function generateUlidLike(): string {
-  // 10 chars timestamp (Crockford Base32-ish) + 16 chars random
+function generateWorkflowId(): string {
   const timestamp = Date.now().toString(36).toUpperCase().padStart(10, '0');
   const random = Array.from({ length: 16 }, () =>
     '0123456789ABCDEFGHJKMNPQRSTVWXYZ'.charAt(Math.floor(Math.random() * 32))
@@ -39,139 +52,135 @@ function generateUlidLike(): string {
 async function main() {
   console.log('PEAC Workflow Correlation Demo\n');
   console.log('Pattern: root -> fork (2 parallel branches) -> join\n');
+  console.log(
+    'PEAC records correlation metadata; orchestrator step index, tool name,\n' +
+      'framework, and orchestrator identity remain in the upstream orchestrator.\n'
+  );
 
-  // Generate a signing keypair
   const { privateKey, publicKey } = await generateKeypair();
-
-  // Create workflow and step IDs using schema constructors
-  // In production, use a proper ULID library instead of generateUlidLike()
-  const workflowId = createWorkflowId(generateUlidLike());
-  const rootStepId = createStepId(generateUlidLike());
-  const branchAStepId = createStepId(generateUlidLike());
-  const branchBStepId = createStepId(generateUlidLike());
-  const joinStepId = createStepId(generateUlidLike());
+  const workflowId = generateWorkflowId();
 
   console.log('Workflow ID:', workflowId);
   console.log('');
 
-  // Step 1: Root step (no parents)
-  console.log('Step 1: Root step (orchestrator initialization)');
-  const rootContext: WorkflowContext = {
-    workflow_id: workflowId,
-    step_id: rootStepId,
-    parent_step_ids: [],
-    step_index: 0,
-    step_total: 4,
-    framework: 'custom',
-    orchestrator_id: 'agent:demo-orchestrator',
-  };
-
-  const rootReceipt = await issueWire01({
+  // Step 1: Root step (no parent)
+  console.log('Step 1: Root step (workflow initialization)');
+  const rootReceipt = await issue({
     iss: 'https://orchestrator.example.com',
-    aud: 'https://workflow.example.com',
-    amt: 100,
-    cur: 'USD',
-    rail: 'internal',
-    reference: 'init-001',
-    subject: 'https://workflow.example.com/tasks/init',
+    kind: 'evidence',
+    type: 'org.peacprotocol/payment',
+    pillars: ['commerce'],
+    sub: 'https://workflow.example.com/tasks/init',
+    extensions: {
+      'org.peacprotocol/commerce': {
+        payment_rail: 'internal',
+        amount_minor: '100',
+        currency: 'USD',
+        reference: 'init-001',
+      },
+      'org.peacprotocol/correlation': {
+        workflow_id: workflowId,
+      },
+    },
     privateKey,
     kid: 'key-2026-01',
-    workflow_context: rootContext,
   });
+  const rootJti = (decode(rootReceipt.jws).payload as DecodedClaims).jti;
 
-  console.log('   Step ID:', rootStepId);
-  console.log('   Parents: [] (root step)');
+  console.log('   JTI:', rootJti);
+  console.log('   Parent JTI: (none; root step)');
   console.log('   Receipt:', rootReceipt.jws.slice(0, 50) + '...\n');
 
-  // Step 2a: Branch A (depends on root)
-  console.log('Step 2a: Branch A (parallel research task)');
-  const branchAContext: WorkflowContext = {
-    workflow_id: workflowId,
-    step_id: branchAStepId,
-    parent_step_ids: [rootStepId],
-    step_index: 1,
-    step_total: 4,
-    tool_name: 'mcp:research/deep-search',
-    framework: 'mcp',
-  };
-
-  const branchAReceipt = await issueWire01({
+  // Step 2a: Branch A (parent_jti = root)
+  console.log('Step 2a: Branch A (parallel research)');
+  const branchAReceipt = await issue({
     iss: 'https://research-agent.example.com',
-    aud: 'https://workflow.example.com',
-    amt: 500,
-    cur: 'USD',
-    rail: 'internal',
-    reference: 'research-001',
-    subject: 'https://workflow.example.com/tasks/research',
+    kind: 'evidence',
+    type: 'org.peacprotocol/payment',
+    pillars: ['commerce'],
+    sub: 'https://workflow.example.com/tasks/research',
+    extensions: {
+      'org.peacprotocol/commerce': {
+        payment_rail: 'internal',
+        amount_minor: '500',
+        currency: 'USD',
+        reference: 'research-001',
+      },
+      'org.peacprotocol/correlation': {
+        workflow_id: workflowId,
+        parent_jti: rootJti,
+      },
+    },
     privateKey,
     kid: 'key-2026-01',
-    workflow_context: branchAContext,
   });
+  const branchAJti = (decode(branchAReceipt.jws).payload as DecodedClaims).jti;
 
-  console.log('   Step ID:', branchAStepId);
-  console.log('   Parents:', [rootStepId]);
-  console.log('   Tool: mcp:research/deep-search');
+  console.log('   JTI:', branchAJti);
+  console.log('   Parent JTI:', rootJti);
   console.log('   Receipt:', branchAReceipt.jws.slice(0, 50) + '...\n');
 
-  // Step 2b: Branch B (depends on root, parallel to Branch A)
-  console.log('Step 2b: Branch B (parallel analysis task)');
-  const branchBContext: WorkflowContext = {
-    workflow_id: workflowId,
-    step_id: branchBStepId,
-    parent_step_ids: [rootStepId],
-    step_index: 2,
-    step_total: 4,
-    tool_name: 'a2a:analysis/sentiment',
-    framework: 'a2a',
-  };
-
-  const branchBReceipt = await issueWire01({
+  // Step 2b: Branch B (parent_jti = root, parallel to Branch A)
+  console.log('Step 2b: Branch B (parallel analysis)');
+  const branchBReceipt = await issue({
     iss: 'https://analysis-agent.example.com',
-    aud: 'https://workflow.example.com',
-    amt: 300,
-    cur: 'USD',
-    rail: 'internal',
-    reference: 'analysis-001',
-    subject: 'https://workflow.example.com/tasks/analysis',
+    kind: 'evidence',
+    type: 'org.peacprotocol/payment',
+    pillars: ['commerce'],
+    sub: 'https://workflow.example.com/tasks/analysis',
+    extensions: {
+      'org.peacprotocol/commerce': {
+        payment_rail: 'internal',
+        amount_minor: '300',
+        currency: 'USD',
+        reference: 'analysis-001',
+      },
+      'org.peacprotocol/correlation': {
+        workflow_id: workflowId,
+        parent_jti: rootJti,
+      },
+    },
     privateKey,
     kid: 'key-2026-01',
-    workflow_context: branchBContext,
   });
+  const branchBJti = (decode(branchBReceipt.jws).payload as DecodedClaims).jti;
 
-  console.log('   Step ID:', branchBStepId);
-  console.log('   Parents:', [rootStepId]);
-  console.log('   Tool: a2a:analysis/sentiment');
+  console.log('   JTI:', branchBJti);
+  console.log('   Parent JTI:', rootJti);
   console.log('   Receipt:', branchBReceipt.jws.slice(0, 50) + '...\n');
 
-  // Step 3: Join step (depends on both branches)
-  console.log('Step 3: Join step (merge results from both branches)');
-  const joinContext: WorkflowContext = {
-    workflow_id: workflowId,
-    step_id: joinStepId,
-    parent_step_ids: [branchAStepId, branchBStepId], // Fork-join pattern
-    step_index: 3,
-    step_total: 4,
-    orchestrator_id: 'agent:demo-orchestrator',
-  };
-
-  const joinReceipt = await issueWire01({
+  // Step 3: Join step (depends_on captures both ancestor branches)
+  console.log('Step 3: Join step (fan-in: depends on both branches)');
+  const joinReceipt = await issue({
     iss: 'https://orchestrator.example.com',
-    aud: 'https://workflow.example.com',
-    amt: 200,
-    cur: 'USD',
-    rail: 'internal',
-    reference: 'merge-001',
-    subject: 'https://workflow.example.com/tasks/merge',
+    kind: 'evidence',
+    type: 'org.peacprotocol/payment',
+    pillars: ['commerce'],
+    sub: 'https://workflow.example.com/tasks/merge',
+    extensions: {
+      'org.peacprotocol/commerce': {
+        payment_rail: 'internal',
+        amount_minor: '200',
+        currency: 'USD',
+        reference: 'merge-001',
+      },
+      'org.peacprotocol/correlation': {
+        workflow_id: workflowId,
+        parent_jti: branchAJti,
+        depends_on: [branchBJti],
+      },
+    },
     privateKey,
     kid: 'key-2026-01',
-    workflow_context: joinContext,
   });
+  const joinJti = (decode(joinReceipt.jws).payload as DecodedClaims).jti;
 
-  console.log('   Step ID:', joinStepId);
-  console.log('   Parents:', [branchAStepId, branchBStepId]);
+  console.log('   JTI:', joinJti);
+  console.log('   Parent JTI:', branchAJti);
+  console.log('   Depends on:', [branchBJti]);
   console.log('   Receipt:', joinReceipt.jws.slice(0, 50) + '...\n');
 
-  // Verify all receipts and show workflow context
+  // Verify all receipts and show correlation metadata
   console.log('--- Verification ---\n');
 
   const receipts = [
@@ -181,33 +190,33 @@ async function main() {
     { name: 'Join', jws: joinReceipt.jws },
   ];
 
-  let totalAmount = 0;
+  let totalAmountMinor = 0n;
 
   for (const { name, jws } of receipts) {
     const result = await verifyLocal(jws, publicKey, {
-      issuer: undefined, // Allow any issuer for demo
-      audience: 'https://workflow.example.com',
+      issuer: undefined,
     });
 
     if (result.valid) {
-      const decoded = decode<PEACReceiptClaims>(jws);
-      const workflowCtx = decoded.payload.ext?.[WORKFLOW_EXTENSION_KEY] as
-        | WorkflowContext
-        | undefined;
+      const claims = result.claims as unknown as DecodedClaims;
+      const commerce = claims.extensions?.['org.peacprotocol/commerce'];
+      const correlation = claims.extensions?.['org.peacprotocol/correlation'];
 
       console.log(`${name}:`);
       console.log('   Valid: true');
-      console.log('   Amount:', decoded.payload.amt, decoded.payload.cur);
-      if (workflowCtx) {
-        console.log('   Workflow ID:', workflowCtx.workflow_id);
-        console.log('   Step ID:', workflowCtx.step_id);
-        console.log('   Is Root:', workflowCtx.parent_step_ids.length === 0 ? 'yes' : 'no');
-        if (workflowCtx.tool_name) {
-          console.log('   Tool:', workflowCtx.tool_name);
+      if (commerce?.amount_minor && commerce?.currency) {
+        console.log('   Amount:', commerce.amount_minor, commerce.currency);
+        totalAmountMinor += BigInt(commerce.amount_minor);
+      }
+      if (correlation) {
+        console.log('   Workflow ID:', correlation.workflow_id);
+        console.log('   JTI:', claims.jti);
+        console.log('   Parent JTI:', correlation.parent_jti ?? '(none)');
+        if (correlation.depends_on && correlation.depends_on.length > 0) {
+          console.log('   Depends on:', correlation.depends_on);
         }
       }
       console.log('');
-      totalAmount += decoded.payload.amt;
     } else {
       console.error(`${name}: Verification FAILED -`, result.code);
     }
@@ -216,10 +225,10 @@ async function main() {
   // Summary
   console.log('--- Workflow Summary ---\n');
   console.log('Workflow ID:', workflowId);
-  console.log('Total Steps:', 4);
-  console.log('Total Amount:', totalAmount, 'USD');
+  console.log('Total Receipts:', 4);
+  console.log('Total Amount (minor units):', totalAmountMinor.toString(), 'USD');
   console.log('');
-  console.log('DAG Structure:');
+  console.log('Causal structure (linked by JTI):');
   console.log('');
   console.log('   [Root]');
   console.log('     |');
@@ -230,6 +239,12 @@ async function main() {
   console.log('     +----+----+');
   console.log('          |');
   console.log('       [Join]');
+  console.log('');
+  console.log(
+    'Each receipt above links to its parent via `parent_jti` and to fan-in\n' +
+      'ancestors via `depends_on`. PEAC records the link; the orchestrator owns\n' +
+      'the rest of the workflow state.'
+  );
   console.log('');
 
   console.log('Done.');

--- a/examples/x402-node-server/demo.ts
+++ b/examples/x402-node-server/demo.ts
@@ -13,9 +13,8 @@
  * For production, see: https://x402.peacprotocol.org
  */
 
-import { issueWire01 } from '@peac/protocol';
-import { generateKeypair, verify } from '@peac/crypto';
-import { PEACReceiptClaims } from '@peac/schema';
+import { issue, verifyLocal } from '@peac/protocol';
+import { generateKeypair } from '@peac/crypto';
 
 // x402 v2 network identifiers (CAIP-2 format)
 const X402_NETWORKS = {
@@ -132,26 +131,25 @@ async function simulateX402Payment(
   paymentRequest: X402PaymentRequest,
   keys: { privateKey: Uint8Array; publicKey: Uint8Array }
 ): Promise<string> {
-  // Simulate payment confirmation
-  const paymentTxHash = `0x${Array.from({ length: 64 }, () => Math.floor(Math.random() * 16).toString(16)).join('')}`;
-
-  // Issue PEAC receipt with x402 evidence
-  const result = await issueWire01({
+  // PEAC records normalized payment fields. The x402 chain context (network, tx hash,
+  // recipient address, x402 dialect) lives in the upstream x402 system; this demo
+  // simulates the payment locally and only carries normalized commerce fields in the
+  // signed record.
+  const result = await issue({
     iss: CONFIG.issuerUrl,
-    aud: paymentRequest.resource,
-    amt: parseInt(paymentRequest.amount),
-    cur: 'USD',
-    rail: 'x402',
-    reference: `x402_${Date.now()}`,
-    asset: paymentRequest.asset,
-    env: 'live',
-    evidence: {
-      // x402-specific evidence
-      network: paymentRequest.network,
-      tx_hash: paymentTxHash,
-      recipient: paymentRequest.recipient,
-      // v2 dialect marker
-      x402_version: 'v2',
+    kind: 'evidence',
+    type: 'org.peacprotocol/payment',
+    pillars: ['commerce'],
+    sub: paymentRequest.resource,
+    extensions: {
+      'org.peacprotocol/commerce': {
+        payment_rail: 'x402',
+        amount_minor: paymentRequest.amount,
+        currency: 'USD',
+        reference: `x402_${Date.now()}`,
+        asset: paymentRequest.asset,
+        env: 'live',
+      },
     },
     privateKey: keys.privateKey,
     kid: 'x402-demo-2025',
@@ -207,17 +205,33 @@ async function agent(keys: {
     }
 
     // Step 4: Demonstrate offline verification
-    console.log('\n4. Verify receipt offline...');
-    const { payload } = await verify<PEACReceiptClaims>(receipt, keys.publicKey);
-    // Evidence is opaque (unknown) in v0.9 - cast for display
-    const evidence = payload.payment?.evidence as Record<string, unknown> | undefined;
-    console.log('   -> Receipt claims:');
-    console.log(`      iss: ${payload.iss}`);
-    console.log(`      aud: ${payload.aud}`);
-    console.log(`      amt: ${payload.amt} ${payload.cur}`);
-    console.log(`      rail: ${payload.payment?.rail}`);
-    console.log(`      network: ${evidence?.network}`);
-    console.log(`      tx_hash: ${evidence?.tx_hash}`);
+    console.log('\n4. Verify record offline...');
+    const result = await verifyLocal(receipt, keys.publicKey, { issuer: CONFIG.issuerUrl });
+    if (result.valid) {
+      const commerce = (
+        result.claims.extensions as
+          | {
+              'org.peacprotocol/commerce'?: {
+                payment_rail?: string;
+                amount_minor?: string;
+                currency?: string;
+                asset?: string;
+              };
+            }
+          | undefined
+      )?.['org.peacprotocol/commerce'];
+      console.log('   -> Verified claims:');
+      console.log(`      iss: ${result.claims.iss}`);
+      console.log(`      sub: ${result.claims.sub ?? '(none)'}`);
+      console.log(
+        `      amount_minor: ${commerce?.amount_minor ?? '?'} ${commerce?.currency ?? '?'}`
+      );
+      console.log(`      payment_rail: ${commerce?.payment_rail ?? '?'}`);
+      console.log(`      asset: ${commerce?.asset ?? '?'}`);
+      console.log('   -> x402 chain context (network, tx_hash, recipient) lives upstream.');
+    } else {
+      console.error(`   -> Verification failed: ${result.code}`);
+    }
   }
 
   console.log('\n=== Demo Complete ===\n');
@@ -229,7 +243,7 @@ async function main() {
 
   const verifyReceipt = async (jws: string): Promise<boolean> => {
     try {
-      const result = await verify(jws, publicKey);
+      const result = await verifyLocal(jws, publicKey, { issuer: CONFIG.issuerUrl });
       return result.valid;
     } catch {
       return false;

--- a/integrator-kits/a2a/fixtures/agent-card.example.json
+++ b/integrator-kits/a2a/fixtures/agent-card.example.json
@@ -18,7 +18,7 @@
         "description": "PEAC evidence carrier for agent-to-agent traceability",
         "required": false,
         "params": {
-          "supported_kinds": ["interaction-record+jwt", "peac-receipt/0.1"],
+          "supported_kinds": ["interaction-record+jwt"],
           "carrier_formats": ["embed", "reference"],
           "issuer_config_url": "https://agent.example.com/.well-known/peac-issuer.json"
         }


### PR DESCRIPTION
## Summary

Migrate current-compatible examples and sample fixtures from legacy Wire 0.1 issuance to current Wire records.

## Scope

- Migrates current-compatible MCP, payment, OTel, x402, Stripe, and workflow-correlation examples.
- Updates the A2A agent-card fixture to advertise current Wire only.
- Preserves MCP custom-type example semantics with the expected `type_unregistered` warning.
- Marks `rsl-collective` as legacy-only because current Wire does not define a canonical control/RSL extension profile.
- Marks `erc8004-feedback` as legacy-only because its exact-byte fixture is bound to conformance vectors.

## Behavior

No protocol behavior change.

No package API change.

No schema, registry, or conformance change.

Sandbox issuer behavior is unchanged and handled separately.

## Validation

- Migrated examples typecheck.
- Migrated examples run locally.
- `verifyLocal()` validates emitted current-Wire records.
- Legacy-only examples continue to run as legacy smokes.
- Standard gates pass.

## Compatibility

Legacy Wire 0.1 compatibility remains unchanged.

No Wire format change.

No signing-envelope change.
