### PR TITLE
feat(sandbox-issuer): support latest Wire issuance

### DIFF
--- a/apps/sandbox-issuer/README.md
+++ b/apps/sandbox-issuer/README.md
@@ -2,8 +2,9 @@
 
 Test record issuer for local development and integration testing.
 
-Issues signed interaction records with Ed25519 stable keys. Supports `interaction-record+jwt` (Wire 0.2) and `peac-receipt/0.1` (Wire 0.1 legacy).
-Not for production use.
+Issues signed current Wire records (`interaction-record+jwt`) with Ed25519 stable keys via the validated `@peac/protocol.issue()` path. Wire 0.1 protocol compatibility remains available elsewhere in the protocol; the sandbox issuer no longer advertises or emits `peac-receipt/0.1`. Not for production use.
+
+Records use the example custom type URI `org.example/sandbox-test`. Registry-aware verification (e.g., `verifyLocal()` from `@peac/protocol`) will surface a `type_unregistered` warning, which is informational.
 
 ## Quick start
 
@@ -28,19 +29,28 @@ pnpm start
 ```bash
 curl -X POST http://127.0.0.1:3100/api/v1/issue \
   -H "Content-Type: application/json" \
-  -d '{"aud": "https://example.com"}'
+  -d '{"sub": "https://example.com"}'
 ```
 
 Request body (strict whitelist: no arbitrary claims):
 
-| Field        | Type         | Required | Description                                    |
-| ------------ | ------------ | -------- | ---------------------------------------------- |
-| `aud`        | string (URL) | yes      | Audience: who will verify                      |
-| `sub`        | string       | no       | Subject identifier                             |
-| `purpose`    | string       | no       | Declared purpose                               |
-| `expires_in` | number       | no       | Seconds until expiry (default 3600, max 86400) |
+| Field     | Type         | Required | Description                       |
+| --------- | ------------ | -------- | --------------------------------- |
+| `sub`     | string (URL) | yes      | Subject: what the record is about |
+| `purpose` | string       | no       | Declared purpose                  |
 
-The server sets `iss`, `iat`, `exp`, and `rid` automatically.
+The server sets `iss`, `iat`, `jti`, `kind`, and `type` automatically. `expires_in` is not supported for current Wire records; sending it returns a 422 with the detail `expires_in is not supported for current Wire records`. The legacy `aud` request field is also rejected by the strict schema.
+
+The response field `receipt_id` carries the Wire 0.2 `jti` of the issued record:
+
+```json
+{
+  "receipt": "<compact JWS>",
+  "receipt_id": "<jti>",
+  "issuer": "<iss>",
+  "key_id": "<kid>"
+}
+```
 
 ## Key stability
 

--- a/apps/sandbox-issuer/package.json
+++ b/apps/sandbox-issuer/package.json
@@ -18,6 +18,7 @@
     "@hono/node-server": "^1.19.13",
     "@peac/crypto": "workspace:*",
     "@peac/middleware-core": "workspace:*",
+    "@peac/protocol": "workspace:*",
     "@peac/schema": "workspace:*",
     "hono": "^4.12.15",
     "zod": "^4.3.6"

--- a/apps/sandbox-issuer/src/routes/discovery.ts
+++ b/apps/sandbox-issuer/src/routes/discovery.ts
@@ -18,7 +18,7 @@ export async function issuerConfigHandler(c: Context) {
     version: 'peac-issuer/0.1',
     issuer: issuerUrl,
     jwks_uri: `${issuerUrl}/.well-known/jwks.json`,
-    receipt_versions: ['interaction-record+jwt', 'peac-receipt/0.1'],
+    receipt_versions: ['interaction-record+jwt'],
     algorithms: ['EdDSA'],
     ...(isEphemeral ? { sandbox_mode: 'ephemeral' } : {}),
   };

--- a/apps/sandbox-issuer/src/routes/issue.ts
+++ b/apps/sandbox-issuer/src/routes/issue.ts
@@ -3,15 +3,22 @@
  *
  * POST /api/v1/issue
  *
- * Strict whitelist schema -- server computes iss, iat, exp, rid.
+ * Strict whitelist schema: server computes iss, iat, jti, kind, type.
  * No arbitrary claims passthrough (prevents receipt minting oracle).
+ *
+ * Issues current Wire records via @peac/protocol.issue(), which validates
+ * Wire 0.2 claims against the canonical schema before signing. The sandbox
+ * uses an example custom type URI (org.example/sandbox-test); registry-aware
+ * verification will surface a type_unregistered warning, which is informational.
  */
 
 import type { Context } from 'hono';
-import { sign } from '@peac/crypto';
+import { issue } from '@peac/protocol';
 import { resolveKeys } from '../keys.js';
 import { IssueRequestSchema, MAX_BODY_SIZE } from '../schemas.js';
 import { resolveIssuerUrl } from '../config.js';
+
+const SANDBOX_TYPE = 'org.example/sandbox-test' as const;
 
 export async function issueHandler(c: Context) {
   // Content-Length pre-check (fast reject before reading body)
@@ -71,6 +78,20 @@ export async function issueHandler(c: Context) {
     );
   }
 
+  // Pre-parse explicit rejection of expires_in to guide migrations from Wire 0.1.
+  // Generic strict-schema 422 for unknown keys is also fine for other legacy fields.
+  if (typeof body === 'object' && body !== null && 'expires_in' in body) {
+    return c.json(
+      {
+        type: 'https://www.peacprotocol.org/errors/validation_error',
+        title: 'Validation Error',
+        status: 422,
+        detail: 'expires_in is not supported for current Wire records',
+      },
+      422
+    );
+  }
+
   const parsed = IssueRequestSchema.safeParse(body);
   if (!parsed.success) {
     const issues = parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`);
@@ -85,30 +106,71 @@ export async function issueHandler(c: Context) {
     );
   }
 
-  const { aud, sub, purpose, expires_in } = parsed.data;
+  const { sub, purpose } = parsed.data;
   const issuerUrl = resolveIssuerUrl(c);
   const keys = await resolveKeys();
-  const now = Math.floor(Date.now() / 1000);
-  const rid = crypto.randomUUID();
 
-  // Build claims -- server sets everything except caller-provided fields
-  const claims: Record<string, unknown> = {
-    iss: issuerUrl,
-    aud,
-    iat: now,
-    exp: now + expires_in,
-    rid,
-  };
+  // Generate jti up-front so the response surfaces it stably as receipt_id.
+  // Wire02ClaimsSchema accepts any 1-256 char string for jti; randomUUID is sufficient.
+  const jti = crypto.randomUUID();
 
-  if (sub) claims.sub = sub;
-  if (purpose) claims.purpose_declared = [purpose];
-
-  // Sign
-  const receipt = await sign(claims, keys.privateKey, keys.kid);
+  // Validated current-Wire issuance via @peac/protocol.issue(). The function
+  // validates Wire02ClaimsSchema before signing, so the sandbox cannot mint
+  // structurally invalid records. Issuance errors (e.g., a non-canonical iss
+  // URL when PEAC_ISSUER_URL is unset and the request origin is non-https)
+  // are surfaced as Problem Details rather than bare 500s.
+  let receipt: string;
+  try {
+    const result = await issue({
+      iss: issuerUrl,
+      kind: 'evidence',
+      type: SANDBOX_TYPE,
+      sub,
+      jti,
+      ...(purpose ? { purpose_declared: purpose } : {}),
+      privateKey: keys.privateKey,
+      kid: keys.kid,
+    });
+    receipt = result.jws;
+  } catch (err) {
+    // Known PEAC IssueError carries a structured peacError with http_status.
+    // Client-class errors (4xx) surface as Problem Details with the inner
+    // message; the message is the schema/canonical-form description and is
+    // safe to expose. Server-class or unknown errors return a generic 500
+    // without leaking err.message (which could include internal paths).
+    if (err && typeof err === 'object' && 'peacError' in err) {
+      const peacError = (err as { peacError?: { http_status?: number } }).peacError;
+      const httpStatus = peacError?.http_status;
+      if (typeof httpStatus === 'number' && httpStatus >= 400 && httpStatus < 500) {
+        const detail =
+          err instanceof Error && typeof err.message === 'string' && err.message.length > 0
+            ? err.message
+            : 'Issuance validation failed';
+        return c.json(
+          {
+            type: 'https://www.peacprotocol.org/errors/validation_error',
+            title: 'Validation Error',
+            status: httpStatus,
+            detail,
+          },
+          httpStatus as 400
+        );
+      }
+    }
+    return c.json(
+      {
+        type: 'https://www.peacprotocol.org/errors/issuance_error',
+        title: 'Issuance Error',
+        status: 500,
+        detail: 'Internal issuance failure',
+      },
+      500
+    );
+  }
 
   return c.json({
     receipt,
-    receipt_id: rid,
+    receipt_id: jti,
     issuer: issuerUrl,
     key_id: keys.kid,
   });

--- a/apps/sandbox-issuer/src/schemas.ts
+++ b/apps/sandbox-issuer/src/schemas.ts
@@ -1,36 +1,22 @@
 /**
  * Request validation schemas
  *
- * Strict whitelist -- only explicitly allowed fields are accepted.
- * Server computes iss, iat, exp, rid. No arbitrary claims passthrough.
+ * Strict whitelist: only explicitly allowed fields are accepted.
+ * Server computes iss, iat, jti, kind, type. No arbitrary claims passthrough.
  */
 
 import { z } from 'zod';
 
 const MAX_URL_LENGTH = 2048;
 const MAX_STRING_LENGTH = 256;
-const MAX_EXP_SECONDS = 86400; // 24 hours
-const DEFAULT_EXP_SECONDS = 3600; // 1 hour
 
 export const IssueRequestSchema = z
   .object({
-    /** Audience URL (required) -- who will verify this receipt */
-    aud: z.string().url().max(MAX_URL_LENGTH),
-
-    /** Subject identifier (optional) */
-    sub: z.string().max(MAX_STRING_LENGTH).optional(),
+    /** Subject identifier URL (required): what the record is about */
+    sub: z.string().url().max(MAX_URL_LENGTH),
 
     /** Declared purpose (optional) */
     purpose: z.string().max(MAX_STRING_LENGTH).optional(),
-
-    /** Expiration in seconds from now (optional, default 1h, max 24h) */
-    expires_in: z
-      .number()
-      .int()
-      .positive()
-      .max(MAX_EXP_SECONDS)
-      .optional()
-      .default(DEFAULT_EXP_SECONDS),
   })
   .strict();
 

--- a/apps/sandbox-issuer/tests/issue.test.ts
+++ b/apps/sandbox-issuer/tests/issue.test.ts
@@ -2,16 +2,18 @@
  * Issue endpoint tests
  *
  * Tests the POST /api/v1/issue flow including request validation,
- * record issuance, and round-trip verification.
+ * record issuance, and round-trip verification using verifyLocal()
+ * from @peac/protocol.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { app } from '../src/app.js';
-import { verify } from '@peac/crypto';
+import { verifyLocal } from '@peac/protocol';
 import { resolveKeys, resetKeyCache } from '../src/keys.js';
 import { resetRateLimitStore } from '../src/middleware/rate-limit.js';
 
 const TEST_ISSUER_URL = 'https://test-issuer.example.com';
+const TEST_SUBJECT = 'https://example.com';
 
 function req(body: unknown, headers?: Record<string, string>) {
   return new Request('http://localhost/api/v1/issue', {
@@ -32,62 +34,56 @@ describe('POST /api/v1/issue', () => {
     delete process.env.PEAC_ISSUER_URL;
   });
 
-  it('should issue a valid receipt', async () => {
-    const res = await app.fetch(req({ aud: 'https://example.com' }));
+  it('should issue a valid record', async () => {
+    const res = await app.fetch(req({ sub: TEST_SUBJECT }));
     expect(res.status).toBe(200);
 
     const data = await res.json();
     expect(data.receipt).toBeDefined();
     expect(data.receipt_id).toBeDefined();
-    expect(data.issuer).toBe('https://test-issuer.example.com');
+    expect(data.issuer).toBe(TEST_ISSUER_URL);
     expect(data.key_id).toBeDefined();
   });
 
-  it('should verify the issued receipt round-trip', async () => {
+  it('should verify the issued record round-trip', async () => {
     const keys = await resolveKeys();
-    const res = await app.fetch(req({ aud: 'https://example.com' }));
+    const res = await app.fetch(req({ sub: TEST_SUBJECT }));
     const data = await res.json();
 
-    const result = await verify(data.receipt, keys.publicKey);
+    const result = await verifyLocal(data.receipt, keys.publicKey, { issuer: TEST_ISSUER_URL });
     expect(result.valid).toBe(true);
-    expect(result.payload).toMatchObject({
-      iss: 'https://test-issuer.example.com',
-      aud: 'https://example.com',
-    });
+    if (!result.valid) return;
+    expect(result.claims.iss).toBe(TEST_ISSUER_URL);
+    expect(result.claims.sub).toBe(TEST_SUBJECT);
+    expect(result.claims.kind).toBe('evidence');
+    expect(result.claims.type).toBe('org.example/sandbox-test');
+    expect(result.claims.jti).toBe(data.receipt_id);
+    expect(result.warnings.some((w) => w.code === 'type_unregistered')).toBe(true);
   });
 
-  it('should include sub when provided', async () => {
+  it('should include sub in record claims', async () => {
     const keys = await resolveKeys();
-    const res = await app.fetch(req({ aud: 'https://example.com', sub: 'user-123' }));
+    const res = await app.fetch(req({ sub: 'https://subject.example.com/user-123' }));
     const data = await res.json();
 
-    const result = await verify(data.receipt, keys.publicKey);
+    const result = await verifyLocal(data.receipt, keys.publicKey, { issuer: TEST_ISSUER_URL });
     expect(result.valid).toBe(true);
-    expect((result.payload as Record<string, unknown>).sub).toBe('user-123');
+    if (!result.valid) return;
+    expect(result.claims.sub).toBe('https://subject.example.com/user-123');
   });
 
-  it('should include purpose_declared when purpose provided', async () => {
+  it('should set purpose_declared as a string when purpose is provided', async () => {
     const keys = await resolveKeys();
-    const res = await app.fetch(req({ aud: 'https://example.com', purpose: 'test-access' }));
+    const res = await app.fetch(req({ sub: TEST_SUBJECT, purpose: 'test-access' }));
     const data = await res.json();
 
-    const result = await verify(data.receipt, keys.publicKey);
+    const result = await verifyLocal(data.receipt, keys.publicKey, { issuer: TEST_ISSUER_URL });
     expect(result.valid).toBe(true);
-    expect((result.payload as Record<string, unknown>).purpose_declared).toEqual(['test-access']);
+    if (!result.valid) return;
+    expect(result.claims.purpose_declared).toBe('test-access');
   });
 
-  it('should respect custom expires_in', async () => {
-    const keys = await resolveKeys();
-    const res = await app.fetch(req({ aud: 'https://example.com', expires_in: 600 }));
-    const data = await res.json();
-
-    const result = await verify(data.receipt, keys.publicKey);
-    expect(result.valid).toBe(true);
-    const payload = result.payload as Record<string, unknown>;
-    expect((payload.exp as number) - (payload.iat as number)).toBe(600);
-  });
-
-  it('should reject missing aud', async () => {
+  it('should reject missing sub', async () => {
     const res = await app.fetch(req({}));
     expect(res.status).toBe(422);
 
@@ -95,19 +91,27 @@ describe('POST /api/v1/issue', () => {
     expect(data.type).toContain('validation_error');
   });
 
-  it('should reject invalid aud URL', async () => {
-    const res = await app.fetch(req({ aud: 'not-a-url' }));
+  it('should reject invalid sub URL', async () => {
+    const res = await app.fetch(req({ sub: 'not-a-url' }));
     expect(res.status).toBe(422);
   });
 
   it('should reject unknown fields (strict schema)', async () => {
-    const res = await app.fetch(req({ aud: 'https://example.com', arbitrary_claim: 'value' }));
+    const res = await app.fetch(req({ sub: TEST_SUBJECT, arbitrary_claim: 'value' }));
     expect(res.status).toBe(422);
   });
 
-  it('should reject expires_in exceeding 24h', async () => {
-    const res = await app.fetch(req({ aud: 'https://example.com', expires_in: 86401 }));
+  it('should reject legacy aud field', async () => {
+    const res = await app.fetch(req({ sub: TEST_SUBJECT, aud: TEST_SUBJECT }));
     expect(res.status).toBe(422);
+  });
+
+  it('should reject expires_in with stable detail', async () => {
+    const res = await app.fetch(req({ sub: TEST_SUBJECT, expires_in: 600 }));
+    expect(res.status).toBe(422);
+
+    const data = await res.json();
+    expect(data.detail).toContain('expires_in is not supported for current Wire records');
   });
 
   it('should reject non-JSON body', async () => {
@@ -125,18 +129,30 @@ describe('POST /api/v1/issue', () => {
   });
 
   it('should reject oversized body via content-length', async () => {
-    const res = await app.fetch(
-      req({ aud: 'https://example.com' }, { 'content-length': '999999' })
-    );
+    const res = await app.fetch(req({ sub: TEST_SUBJECT }, { 'content-length': '999999' }));
     expect(res.status).toBe(413);
   });
 
   it('should set security headers on response', async () => {
-    const res = await app.fetch(req({ aud: 'https://example.com' }));
+    const res = await app.fetch(req({ sub: TEST_SUBJECT }));
     expect(res.headers.get('x-content-type-options')).toBe('nosniff');
     expect(res.headers.get('cache-control')).toBe('no-store');
     expect(res.headers.get('x-frame-options')).toBe('DENY');
     expect(res.headers.get('referrer-policy')).toBe('no-referrer');
     expect(res.headers.get('permissions-policy')).toContain('camera=()');
+  });
+
+  it('should return Problem Details when issuer configuration is not canonical', async () => {
+    process.env.PEAC_ISSUER_URL = 'http://not-canonical.example.com';
+
+    const res = await app.fetch(req({ sub: TEST_SUBJECT }));
+    expect(res.status).toBe(400);
+
+    const data = await res.json();
+    expect(data.type).toContain('validation_error');
+    expect(data.detail).toContain('iss is not in canonical form');
+    const serialized = JSON.stringify(data);
+    expect(serialized).not.toContain('privateKey');
+    expect(serialized).not.toContain('stack');
   });
 });

--- a/apps/sandbox-issuer/tests/rate-limit.test.ts
+++ b/apps/sandbox-issuer/tests/rate-limit.test.ts
@@ -9,11 +9,13 @@ import { app } from '../src/app.js';
 import { resetRateLimitStore } from '../src/middleware/rate-limit.js';
 import { resetKeyCache } from '../src/keys.js';
 
+const TEST_ISSUER_URL = 'https://test-issuer.example.com';
+
 function issueReq(headers?: Record<string, string>) {
   return new Request('http://localhost/api/v1/issue', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...headers },
-    body: JSON.stringify({ aud: 'https://example.com' }),
+    body: JSON.stringify({ sub: 'https://example.com' }),
   });
 }
 
@@ -21,10 +23,12 @@ describe('Rate limiting', () => {
   beforeEach(() => {
     resetRateLimitStore();
     resetKeyCache();
+    process.env.PEAC_ISSUER_URL = TEST_ISSUER_URL;
   });
 
   afterEach(() => {
     delete process.env.PEAC_TRUST_PROXY;
+    delete process.env.PEAC_ISSUER_URL;
   });
 
   it('should allow requests within the limit', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,9 @@ importers:
       '@peac/middleware-core':
         specifier: workspace:*
         version: link:../../packages/middleware-core
+      '@peac/protocol':
+        specifier: workspace:*
+        version: link:../../packages/protocol
       '@peac/schema':
         specifier: workspace:*
         version: link:../../packages/schema


### PR DESCRIPTION
## Summary

Migrates the sandbox issuer from legacy Wire 0.1 receipt issuance to current Wire record issuance.

## Scope

- Updates `POST /api/v1/issue` to issue current Wire records through `@peac/protocol.issue()`.
- Replaces the request body shape from legacy `aud` / `expires_in` to current `sub` plus optional `purpose`.
- Keeps the response field `receipt_id`, now corresponding to the issued record `jti`.
- Updates discovery to advertise `interaction-record+jwt` only.
- Adds sandbox tests for current-Wire issuance, verifier round-trip, legacy field rejection, issuer configuration errors, and rate-limit compatibility.
- Adds `@peac/protocol` as a sandbox issuer workspace dependency.

## Behavior

This changes sandbox issuer behavior.

The sandbox issuer now emits current Wire records only.

Wire 0.1 protocol compatibility remains unchanged elsewhere in the repository.

The sandbox issuer no longer advertises or emits `peac-receipt/0.1`.

## Validation

- `pnpm --filter '@peac/app-sandbox-issuer' build`
- `pnpm --filter '@peac/app-sandbox-issuer' test`
- `pnpm format:check`
- `git diff --check`
- `pnpm gate:fast`
- `pnpm gate`
- `pnpm typecheck:core`
- `pnpm conformance:test`
- `pnpm verify:codegen-drift`
- `pnpm verify:registries-schema`
- `pnpm verify:no-widening`
- `pnpm verify:release`
- `pnpm exec tsx scripts/extract-api-contract.ts --check`
- `bash scripts/ci/forbid-strings.sh`
- `bash scripts/release/api-surface-lock.sh`
- hidden/bidi Unicode scan on committed files
- canonical Trojan Source scanner on committed files

## Compatibility

No Wire format change.

No signing-envelope change.

No schema, registry, conformance, or package API change.

No external dependency upgrade.
