### PR TITLE
docs: align environment and upstream references

### DIFF
--- a/docs/SUPPORTED_ENVIRONMENTS.md
+++ b/docs/SUPPORTED_ENVIRONMENTS.md
@@ -14,7 +14,7 @@
 
 | Version  | Status      | Notes                                                                |
 | -------- | ----------- | -------------------------------------------------------------------- |
-| Go 1.22+ | **Partial** | `sdks/go/`: Wire 0.1 issue and verify only. Wire 0.2 parity planned. |
+| Go 1.26+ | **Partial** | `sdks/go/`: Wire 0.1 issue and verify only. Wire 0.2 parity planned. |
 
 ## Python
 

--- a/docs/adapters/x402.md
+++ b/docs/adapters/x402.md
@@ -46,7 +46,7 @@ The x402 Offer/Receipt extension defines a payment handshake. PEAC adds an
 evidence and verification layer above that handshake. The boundary is
 intentional and load-bearing for audit reasoning.
 
-| What PEAC enforces                                                               | Where                                                     |
+| What this adapter validates                                                      | Where                                                     |
 | -------------------------------------------------------------------------------- | --------------------------------------------------------- |
 | Wire shape and required fields (discriminated union, required strings, bounds)   | [`verify.ts`](../../packages/adapters/x402/src/verify.ts) |
 | Term-matching: `network`, `asset`, `payTo`, `amount`, `scheme` (string equality) | `matchAcceptTerms` at `verify.ts:750-776`                 |
@@ -54,7 +54,7 @@ intentional and load-bearing for audit reasoning.
 | Receipt recency and clock-skew tolerance                                         | `verifyReceipt` in `verify.ts`                            |
 | Opt-in cryptographic verification (EIP-712 / JWS format)                         | Layer C callers; adapter exposes crypto hooks             |
 
-| What PEAC does NOT enforce                                                                    | Where this lives                               |
+| What this adapter does not validate                                                           | Where this lives                               |
 | --------------------------------------------------------------------------------------------- | ---------------------------------------------- |
 | On-chain settlement finality                                                                  | Facilitator and chain                          |
 | Scheme-specific invariants (for example, `upto` single-use, time bounds, facilitator binding) | x402 scheme layer                              |

--- a/docs/internal/ZOD4-MIGRATION-PLAN.md
+++ b/docs/internal/ZOD4-MIGRATION-PLAN.md
@@ -190,7 +190,7 @@ within v0.11.0.
 
 ### Current state
 
-- **SDK:** `@modelcontextprotocol/sdk@~1.27.0` (tilde pin)
+- **SDK:** `@modelcontextprotocol/sdk@~1.28.0` (tilde pin)
 - **Protocol:** `2025-11-25` (current stable)
 - **Zod peer dep:** SDK v1.x requires Zod 3.25+ (backward compatible with both Zod 3 and Zod 4)
 

--- a/docs/privacy/RETENTION-AND-DELETION.md
+++ b/docs/privacy/RETENTION-AND-DELETION.md
@@ -161,7 +161,7 @@ favor minimization. Operators override per-deployment.
   long-lived report index server-side; each request is computed and
   returned. Deployments that wrap the reference verifier in a report
   store MUST implement deletion against that store themselves, keyed
-  by `receipt_ref`. PEAC owns the contract (purge by `receipt_ref`
+  by `receipt_ref`. PEAC specifies the contract (purge by `receipt_ref`
   list, derived layer only, signed evidence untouched). Storage and
   access control are operator-owned. See §2 for the
   evidence-vs-derived deletion model.

--- a/docs/specs/INTEROP.md
+++ b/docs/specs/INTEROP.md
@@ -253,7 +253,7 @@ peac export robots peac-policy.yaml > robots-ai-snippet.txt
 
 PEAC works alongside existing systems:
 
-- AIPREF defines preferences; PEAC enforces them
+- AIPREF defines preferences; PEAC records preference-relevant evidence
 - Payment rails handle transactions; PEAC captures evidence
 - Agent protocols define communication; PEAC proves decisions
 

--- a/integrator-kits/paymentauth/README.md
+++ b/integrator-kits/paymentauth/README.md
@@ -96,5 +96,9 @@ PEAC `PEAC-Receipt` and paymentauth `Payment-Receipt` can appear on the same HTT
 ## Reference
 
 - `@peac/mappings-paymentauth`: envelope parsing, evidence mapping, carrier adapter
-- paymentauth spec: `draft-ryan-httpauth-payment` (active individual draft)
+- paymentauth spec: `draft-ryan-httpauth-payment-01` (active individual draft)
 - MPP ecosystem: https://mpp.dev/
+- MPP TypeScript SDK: https://github.com/wevm/mppx
+- MPP specs: https://github.com/tempoxyz/mpp-specs
+
+For TypeScript MPP clients, see the `mppx` SDK from the MPP ecosystem. PEAC does not depend on `mppx`; PEAC records paymentauth / MPP observations as portable records.

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -423,7 +423,7 @@ For example, v0.9.29 would have tags:
 
 ## Requirements
 
-- Go 1.21 or later
+- Go 1.26 or later
 - `golang.org/x/crypto` for Ed25519
 
 ## License


### PR DESCRIPTION
## Summary

Aligns a small set of environment, upstream-reference, and public-scope wording in preparation for v0.14.1 release prep.

## Scope

- Aligns stale Go floor references to Go 1.26+.
- Updates the tracked MCP SDK pin note to match the workspace pin.
- Adds the active `draft-ryan-httpauth-payment-01` revision to the paymentauth integrator README.
- Adds neutral MPP SDK/spec links without adding a PEAC dependency or implementation claim.
- Refines a small set of public wording from ownership/enforcement language toward records-layer and adapter-scoped wording.

## Behavior

Docs-only.

No runtime behavior change.

No package API change.

No schema, registry, conformance, dependency, lockfile, release-note, or CHANGELOG change.

## Validation

- `pnpm format:check`
- `git diff --check`
- `pnpm gate:fast`
- `pnpm gate`
- `pnpm typecheck:core`
- `pnpm conformance:test`
- `pnpm verify:codegen-drift`
- `pnpm verify:registries-schema`
- `pnpm verify:no-widening`
- `pnpm verify:release`
- `pnpm exec tsx scripts/extract-api-contract.ts --check`
- `bash scripts/ci/forbid-strings.sh`
- `bash scripts/release/api-surface-lock.sh`
- `node reference/scripts/verify-local-doc-truth.mjs --quiet`
- `node reference/scripts/verify-final-hygiene.mjs --quiet`
- hidden/bidi Unicode scan on committed files

## Compatibility

No Wire format change.

No signing-envelope change.

No source-code change.

No dependency change.

No release-publishing change.
