### PR TITLE
docs: v0.14.1 sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Portable signed records for agent, API, MCP, and cross-runtime interactions.
 - **I run an MCP server.** Attach signed records to tool calls. [MCP Integration Kit](integrator-kits/mcp/README.md) or `npx -y @peac/mcp-server`.
 - **I want to verify a receipt.** Verify offline with the issuer's public key. [Agent Operator Quickstart](docs/guides/quickstart-agent-operator.md).
 - **I want to prove my runtime decisions.** Record governance observations from managed runtimes. [`@peac/adapter-runtime-governance`](packages/adapters/runtime-governance/).
+- **I run agent-to-agent workflows.** Record A2A handoff events across agent-card discovery, task lifecycle, and human-review boundaries. [A2A Handoff Records](docs/specs/A2A-HANDOFF-RECORDS.md).
+- **I want to record command execution.** Use `peac observe command` for unsigned observations or `peac record command` for signed command-execution records. [CLI Carrier Profile](docs/specs/CLI-CARRIER-PROFILE.md).
+- **I need lifecycle records from another system.** Use `peac emit lifecycle` to issue records for caller-reported evaluation, approval, experiment, and workflow events. [Lifecycle Observation Profile](docs/specs/LIFECYCLE-OBSERVATION-PROFILE.md).
 
 Full path-by-role tree: [`docs/START_HERE.md`](docs/START_HERE.md).
 
@@ -60,6 +63,7 @@ Outcome-led recipes under [`docs/SOLUTIONS/`](docs/SOLUTIONS/):
 - [MCP tool-call records](docs/SOLUTIONS/mcp-tool-call-receipts.md)
 - [Commerce evidence bundle](docs/SOLUTIONS/commerce-evidence-bundle.md)
 - [Regulatory audit trail](docs/SOLUTIONS/regulatory-audit-trail.md)
+- [Cloudflare x402 + PEAC](docs/SOLUTIONS/cloudflare-x402-peac.md)
 
 ## Why PEAC
 
@@ -72,6 +76,7 @@ Outcome-led recipes under [`docs/SOLUTIONS/`](docs/SOLUTIONS/):
 - Verify a receipt locally with `verifyLocal()` or `pnpm dlx @peac/cli verify`.
 - Start the MCP server: `npx -y @peac/mcp-server`.
 - Run the x402 settlement mapping demo: `pnpm install && pnpm build && pnpm --filter @peac/example-x402-upto-evidence demo`.
+- Record a command execution observation: `pnpm dlx @peac/cli@next observe command -- echo hello`. For signed command records, use `peac record command` with an issuer key; see the [CLI Carrier Profile](docs/specs/CLI-CARRIER-PROFILE.md).
 - Open an editor plugin-pack under [`surfaces/plugin-pack/`](surfaces/plugin-pack/) (Cursor, Codex, Claude Code, VS Code, Continue, Windsurf, OpenCode).
 - Run the minimal example: `pnpm --filter @peac/example-minimal demo`.
 - Self-host the reference verifier: [`surfaces/reference-verifier/`](surfaces/reference-verifier/).
@@ -83,8 +88,11 @@ Outcome-led recipes under [`docs/SOLUTIONS/`](docs/SOLUTIONS/):
 - **MCP tools** — [`packages/mcp-server/`](packages/mcp-server/) evidence tools.
 - **Editor and plugin-pack surfaces** — Cursor, Codex, Claude Code, VS Code, Continue, Windsurf, OpenCode under [`surfaces/plugin-pack/`](surfaces/plugin-pack/); canonical [Smithery config](packages/mcp-server/smithery.yaml).
 - **Express middleware** — [`packages/middleware-express/`](packages/middleware-express/).
-- **Commerce mappings** — [`packages/adapters/x402/`](packages/adapters/x402/) (v1 + v2), [`packages/mappings/paymentauth/`](packages/mappings/paymentauth/) (paymentauth and MPP), [`packages/mappings/acp/`](packages/mappings/acp/) (ACP delegated payment).
+- **Commerce mappings** — [`packages/adapters/x402/`](packages/adapters/x402/) (v1 + v2), [`packages/mappings/paymentauth/`](packages/mappings/paymentauth/) (paymentauth / MPP), [`packages/mappings/acp/`](packages/mappings/acp/) (ACP delegated payment).
 - **Runtime governance** — [`packages/adapters/runtime-governance/`](packages/adapters/runtime-governance/) records observations from managed runtimes including Microsoft Agent Governance Toolkit.
+- **A2A handoff records** — [`docs/specs/A2A-HANDOFF-RECORDS.md`](docs/specs/A2A-HANDOFF-RECORDS.md) and [`integrator-kits/a2a/`](integrator-kits/a2a/).
+- **CLI execution records** — `peac observe command`, `peac record command`, and [`docs/specs/CLI-CARRIER-PROFILE.md`](docs/specs/CLI-CARRIER-PROFILE.md).
+- **Lifecycle observation records** — `peac emit lifecycle` and [`docs/specs/LIFECYCLE-OBSERVATION-PROFILE.md`](docs/specs/LIFECYCLE-OBSERVATION-PROFILE.md).
 - **Supply-chain mappings** — [`packages/mappings/intoto/`](packages/mappings/intoto/) and [`packages/mappings/slsa/`](packages/mappings/slsa/).
 - **Reference verifier (self-hostable)** — [`apps/api/`](apps/api/) with deployment recipes under [`surfaces/reference-verifier/`](surfaces/reference-verifier/).
 
@@ -92,12 +100,12 @@ Long tail (A2A, gRPC, DID, managed agents, and more): [`docs/README_LONG.md`](do
 
 ## Artifacts
 
-| Artifact                | Role                                                |
-| ----------------------- | --------------------------------------------------- |
-| `/.well-known/peac.txt` | Machine-readable terms                              |
-| `PEAC-Receipt`          | Signed interaction record on governed responses     |
-| `verifyLocal()`         | Offline verification once issuer keys are available |
-| `peac-bundle/0.1`       | Portable audit and dispute package                  |
+| Artifact                | Role                                                      |
+| ----------------------- | --------------------------------------------------------- |
+| `/.well-known/peac.txt` | Machine-readable terms                                    |
+| `PEAC-Receipt`          | HTTP response header carrying a signed interaction record |
+| `verifyLocal()`         | Offline verification once issuer keys are available       |
+| `peac-bundle/0.1`       | Portable audit and dispute package                        |
 
 ## CLI
 
@@ -110,7 +118,7 @@ pnpm add -D @peac/cli
 pnpm exec peac verify 'eyJhbGc...'
 ```
 
-Other commands: `peac conformance run`, `peac reconcile a.bundle b.bundle`, `peac policy init|validate|generate`, `peac doctor`. Reference: [`packages/cli/README.md`](packages/cli/README.md).
+Other commands: `peac observe command`, `peac record command`, `peac emit lifecycle`, `peac conformance run`, `peac reconcile a.bundle b.bundle`, `peac policy init|validate|generate`, `peac doctor`. Reference: [`packages/cli/README.md`](packages/cli/README.md).
 
 ## Protocol boundary
 
@@ -141,10 +149,10 @@ Full doctrine: [`docs/specs/VERSIONING.md`](docs/specs/VERSIONING.md).
 
 - [Start Here](docs/START_HERE.md) — path by role.
 - [How it works](docs/HOW-IT-WORKS.md), [Artifacts](docs/ARTIFACTS.md), [Where it fits](docs/WHERE-IT-FITS.md), [What PEAC standardizes](docs/WHAT-PEAC-STANDARDIZES.md).
-- [Solutions](docs/SOLUTIONS/) — five outcome-led recipes.
+- [Solutions](docs/SOLUTIONS/) — outcome-led recipes.
 - [Spec Index](docs/SPEC_INDEX.md) — normative specifications, including [Resource limits](docs/specs/RESOURCE-LIMITS.md).
 - [Standards ledger](docs/STANDARDS_LEDGER.md) — every external standard PEAC cites or implements, by status.
-- [Release-line baselines](docs/baselines/) — invariant snapshot for the current release line.
+- [Release-line baselines](docs/baselines/) — historical invariant snapshots and release-line references.
 - [Developer Guide](docs/README_LONG.md) — package catalog and extended examples.
 
 ## Contributing and license

--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -481,11 +481,11 @@
     },
     "apps/sandbox-issuer": {
       "npm": null,
-      "state": "compat-only",
-      "wire": "0.1",
+      "state": "internal",
+      "wire": "0.2",
       "layer": 5,
       "published": false,
-      "note": "Wire 0.1 test fixture generator. Kept for legacy integration tests."
+      "note": "Workspace-internal current-Wire sandbox issuer for integration tests and local demos."
     },
     "apps/bridge": {
       "npm": null,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,5 @@
 # PEAC Protocol Architecture
 
-**Version:** 0.12.9
 **Status:** Authoritative
 
 This document describes the kernel-first architecture of the PEAC Protocol monorepo.
@@ -62,7 +61,7 @@ CI runs the full test suite on Node 24 (primary) and Node 22 + 25 (compatibility
 
 - Wire format `peac-receipt/0.1` is the frozen legacy wire format identifier (v0.10.0+); the Interaction Record format (`interaction-record+jwt`) is current
 - JSON Schema at `specs/wire/peac-receipt-0.1.schema.json` is normative for Wire 0.1
-- Go SDK provides Wire 0.1 issuance, verification, and policy evaluation; additional implementations can follow the same specs
+- Go SDK provides Interaction Record (`interaction-record+jwt`) `Issue()` and `VerifyLocal()` with Ed25519, RFC 8785 JCS, and JOSE hardening; additional implementations can follow the same specs
 
 ---
 
@@ -136,7 +135,7 @@ peac/
 │   ├── middleware-core/    # Layer 3.5: Framework-agnostic receipt middleware
 │   ├── middleware-express/  # Layer 3.5: Express.js receipt middleware
 │   ├── server/             # Layer 5: HTTP verification server
-│   ├── mcp-server/         # Layer 5: MCP server (8 tools, stdio + HTTP)
+│   ├── mcp-server/         # Layer 5: MCP server (default + opt-in privileged tools, stdio + HTTP)
 │   ├── cli/                # Layer 5: Command-line tools
 │   ├── adapters/           # Layer 4: Evidence adapters
 │   │   ├── x402/           # x402 v1+v2 (Linux Foundation)
@@ -147,7 +146,7 @@ peac/
 │   ├── mappings/           # Layer 4: Protocol mappings
 │   │   ├── a2a/            # A2A v1.0.0 (Linux Foundation)
 │   │   ├── acp/            # Agentic Commerce Protocol (OpenAI/Stripe)
-│   │   ├── paymentauth/    # MPP/paymentauth (Stripe/Tempo)
+│   │   ├── paymentauth/    # paymentauth / MPP (Stripe/Tempo)
 │   │   ├── ucp/            # Unified Commerce Protocol (Google)
 │   │   ├── content-signals/ # Content signals observation
 │   │   ├── intoto/         # in-toto v1.0 provenance
@@ -179,17 +178,27 @@ peac/
 
 ---
 
-## Package Inventory (36 published packages as of v0.12.9)
+## Package Inventory
+
+The active package and surface inventory is generated from
+[`REPO_SURFACE_STATUS.json`](../REPO_SURFACE_STATUS.json) and summarized
+in [`docs/PACKAGE_STATUS.md`](PACKAGE_STATUS.md). Architecture-relevant
+surfaces are listed below; counts are intentionally not pinned in this
+doc to avoid release-pinned drift.
+
+For the OSS-neutral generic-core / profile / adapter / example boundary
+doctrine, see
+[`docs/architecture/ABSTRACTION-BOUNDARIES.md`](architecture/ABSTRACTION-BOUNDARIES.md).
 
 ### Core (Normative, Layers 0-3)
 
-| Package          | Layer | Description                                                                          |
-| ---------------- | ----- | ------------------------------------------------------------------------------------ |
-| `@peac/kernel`   | 0     | Zero-dependency constants, types, errors                                             |
-| `@peac/schema`   | 1     | Zod validators, Wire 0.2 extension groups (12 groups), type-to-extension enforcement |
-| `@peac/crypto`   | 2     | Ed25519 JWS, JCS canonicalization (RFC 8785), JOSE hardening                         |
-| `@peac/protocol` | 3     | `issue()`, `issueWire02()`, `verifyLocal()` with strict/interop profiles             |
-| `@peac/control`  | 3     | Constraint types and kernel constraint enforcement                                   |
+| Package          | Layer | Description                                                                                    |
+| ---------------- | ----- | ---------------------------------------------------------------------------------------------- |
+| `@peac/kernel`   | 0     | Zero-dependency constants, types, errors                                                       |
+| `@peac/schema`   | 1     | Zod validators, Wire 0.2 extension groups (15 extension groups), type-to-extension enforcement |
+| `@peac/crypto`   | 2     | Ed25519 JWS, JCS canonicalization (RFC 8785), JOSE hardening                                   |
+| `@peac/protocol` | 3     | `issue()`, `issueWire02()`, `verifyLocal()` with strict/interop profiles                       |
+| `@peac/control`  | 3     | Constraint types and kernel constraint enforcement                                             |
 
 ### Middleware (Layer 3.5)
 
@@ -215,7 +224,7 @@ peac/
 | -------------------------------- | ----- | ----------------------------------------------------------------- |
 | `@peac/mappings-a2a`             | 4     | A2A v1.0.0 artifact embedding + Agent Card discovery              |
 | `@peac/mappings-acp`             | 4     | Agentic Commerce Protocol session lifecycle + payment observation |
-| `@peac/mappings-paymentauth`     | 4     | MPP/paymentauth envelope-first HTTP Payment scheme parsing        |
+| `@peac/mappings-paymentauth`     | 4     | paymentauth / MPP envelope-first HTTP Payment scheme parsing      |
 | `@peac/mappings-ucp`             | 4     | Unified Commerce Protocol order-vs-payment separation             |
 | `@peac/mappings-content-signals` | 4     | Content signals observation (3-state, source precedence)          |
 | `@peac/mappings-intoto`          | 4     | in-toto v1.0 provenance mapping                                   |
@@ -232,11 +241,11 @@ peac/
 
 ### Applications (Layer 5)
 
-| Package            | Layer | Description                                                 |
-| ------------------ | ----- | ----------------------------------------------------------- |
-| `@peac/server`     | 5     | HTTP verification server                                    |
-| `@peac/mcp-server` | 5     | MCP server (8 tools, stdio + Streamable HTTP, RFC 9728 PRM) |
-| `@peac/cli`        | 5     | Command-line tools for receipts, policy, reconciliation     |
+| Package            | Layer | Description                                                                                                                                                        |
+| ------------------ | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `@peac/server`     | 5     | HTTP verification server                                                                                                                                           |
+| `@peac/mcp-server` | 5     | MCP server (default tools `peac_verify`/`peac_inspect`/`peac_decode` + opt-in privileged `peac_issue`/`peac_create_bundle`; stdio + Streamable HTTP, RFC 9728 PRM) |
+| `@peac/cli`        | 5     | Command-line tools for receipts, policy, reconciliation                                                                                                            |
 
 See `scripts/publish-manifest.json` and `REPO_SURFACE_STATUS.json` for the full authoritative package list. Additional published packages (rails, telemetry, audit, pillar-specific) are listed there.
 

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -1,6 +1,6 @@
 # Compatibility Matrix
 
-Current as of v0.12.13.
+Current as of v0.14.1.
 
 ## Wire Format Support
 
@@ -57,7 +57,7 @@ The **Adapter Readiness** column classifies each surface using the rubric below.
 | `@peac/mappings-mcp`               | MCP tool-call receipt attachment                                                 | v0.11.x  | **Shipped** | `conformance-fixture-only` [e1] |
 | `@peac/mappings-a2a`               | A2A v1.0 normalizer                                                              | v0.12.3  | **Shipped** | `conformance-fixture-only` [e1] |
 | `@peac/mappings-acp`               | ACP delegated-payment observation mapper                                         | v0.12.11 | **Shipped** | `conformance-fixture-only` [e4] |
-| `@peac/mappings-paymentauth`       | MPP / paymentauth payment-attempt and settlement mappers                         | v0.12.11 | **Shipped** | `conformance-fixture-only` [e4] |
+| `@peac/mappings-paymentauth`       | paymentauth / MPP payment-attempt and settlement mappers                         | v0.12.11 | **Shipped** | `conformance-fixture-only` [e4] |
 | `@peac/mappings-ucp`               | UCP / AP2 envelope mapping                                                       | v0.12.4  | **Shipped** | `conformance-fixture-only` [e1] |
 | `@peac/mappings-content-signals`   | Content signals observation mapping                                              | v0.11.2  | **Shipped** | `conformance-fixture-only` [e1] |
 | `@peac/mappings-aipref`            | AI preferences mapping                                                           | v0.12.4  | **Shipped** | `types-only` [e5]               |
@@ -83,7 +83,7 @@ One classification per Layer 4 surface. Under ambiguity between two defensible c
 | `experimental`             | Public but explicitly subject to change; `@experimental` JSDoc; breaking changes allowed with CHANGELOG note.                                                                | JSDoc tag.                                                                            |
 | `paused`                   | Intentionally not maintained in this release cycle; `paused_reason` and `resumption_target` recorded in the row.                                                             | Row-level rationale documented in the matrix.                                         |
 
-No Layer 4 surface in v0.12.13 is `live-upstream-tested`: no CI step exercises a live upstream endpoint today. Promotion from `conformance-fixture-only` to `live-upstream-tested` requires committing a recorded round-trip fixture stamped with the upstream release and wiring it into CI.
+No Layer 4 surface in v0.14.1 is `live-upstream-tested`: no CI step exercises a live upstream endpoint today. Promotion from `conformance-fixture-only` to `live-upstream-tested` requires committing a recorded round-trip fixture stamped with the upstream release and wiring it into CI.
 
 ### Evidence
 

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -56,16 +56,21 @@ When something happens that another party will need to verify, the issuer create
 ```typescript
 import { issue } from '@peac/protocol';
 
-const jws = await issue(
-  {
-    iss: 'https://api.example.com',
-    kind: 'evidence',
-    type: 'org.peacprotocol/api-receipt',
-    pillars: ['access'],
-    ext: { access: { path: '/api/v1/resource', method: 'GET', status: 200 } },
+const { jws } = await issue({
+  iss: 'https://api.example.com',
+  kind: 'evidence',
+  type: 'org.peacprotocol/api-receipt',
+  pillars: ['access'],
+  extensions: {
+    'org.peacprotocol/access': {
+      resource: '/api/v1/resource',
+      action: 'read',
+      decision: 'allow',
+    },
   },
-  privateKey
-);
+  privateKey,
+  kid: 'key-2026-01',
+});
 ```
 
 The output is a compact JWS string (three base64url parts separated by dots). The JOSE header carries `typ: interaction-record+jwt`, `alg: EdDSA`, and `kid` pointing at the key in the issuer's JWKS. The payload carries the claims: `iss`, `kind`, `type`, `pillars`, `iat`, `jti`, optional extensions, optional policy binding.
@@ -84,7 +89,7 @@ const result = await verifyLocal(jws, publicKey, {
 });
 
 if (result.valid) {
-  console.log(result.claims.type, result.claims.ext);
+  console.log(result.claims.type, result.claims.extensions);
 }
 ```
 
@@ -97,7 +102,7 @@ Under the hood, `verifyLocal()` checks:
 5. Policy binding (if `peac.policy` is present, three-state: `verified` / `failed` / `unavailable`).
 6. Timing bounds (`iat` / `nbf` / `exp` within configured clock skew).
 
-For the hosted path, `POST /v1/verify` on the reference verifier returns the same deterministic report (DD-210 shape). See [`packages/schema/openapi/verify.yaml`](../packages/schema/openapi/verify.yaml).
+For the hosted path, `POST /v1/verify` on the reference verifier returns the same deterministic verification report. See [`packages/schema/openapi/verify.yaml`](../packages/schema/openapi/verify.yaml).
 
 ## 4. Export and share
 
@@ -105,9 +110,13 @@ Records travel in several carriers depending on the surface:
 
 - **HTTP**: the `PEAC-Receipt` response header carries a compact JWS (up to 8 KiB in the header; larger records use `PEAC-Receipt-Ref` pointing at a fetchable resource).
 - **MCP**: the tool-call response `_meta` field carries `org.peacprotocol/receipt_jws` and `org.peacprotocol/receipt_ref` (up to 64 KiB embed).
-- **A2A**: the `metadata[extensionURI].carriers[]` array carries receipt records across Agent-to-Agent flows.
+- **A2A**: the `metadata[extensionURI].carriers[]` array carries receipt records across Agent-to-Agent flows; handoff observation records are described in [`docs/specs/A2A-HANDOFF-RECORDS.md`](specs/A2A-HANDOFF-RECORDS.md).
+- **CLI execution**: `peac observe command` emits an unsigned observation; `peac record command` issues a signed command-execution record using caller-provided issuer material. See [`docs/specs/CLI-CARRIER-PROFILE.md`](specs/CLI-CARRIER-PROFILE.md).
+- **Lifecycle observation**: `peac emit lifecycle` issues signed records for caller-reported lifecycle events. See [`docs/specs/LIFECYCLE-OBSERVATION-PROFILE.md`](specs/LIFECYCLE-OBSERVATION-PROFILE.md).
 - **Bundles**: `peac-bundle/0.1` packages multiple receipts, JWKS snapshots, and policy artifacts into a portable audit file. See [`docs/specs/EVIDENCE-CARRIER-CONTRACT.md`](specs/EVIDENCE-CARRIER-CONTRACT.md).
-- **Reports**: the reference verifier returns the deterministic DD-210 verification report; the extended `application/peac-report+json` shape adds timing, report ID, and failure reasons.
+- **Reports**: the reference verifier returns a deterministic verification report; the extended `application/peac-report+json` shape adds timing, report ID, and failure reasons.
+
+PEAC records observations across these carriers; it is not a shell framework, scheduler, eval platform, approval system, or orchestrator.
 
 ## Kinds and types
 

--- a/docs/PACKAGE_STATUS.md
+++ b/docs/PACKAGE_STATUS.md
@@ -74,12 +74,6 @@ Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scri
 | `packages/privacy`                     | -                                  | 0.2  | 6     |
 | `sdks/go`                              | -                                  | 0.2  | sdk   |
 
-## Compat-only (security/correctness fixes only)
-
-| Surface               | Wire | Note                                                                |
-| --------------------- | ---- | ------------------------------------------------------------------- |
-| `apps/sandbox-issuer` | 0.1  | Wire 0.1 test fixture generator. Kept for legacy integration tests. |
-
 ## Archived (non-default, may be removed)
 
 | Surface                              | Reason                                                                                                                                                                                                                                                                                                                      |

--- a/docs/README_LONG.md
+++ b/docs/README_LONG.md
@@ -40,21 +40,21 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for full design rationale.
 
 ## Integration paths
 
-### Commerce evidence integrations (v0.12.4+)
+### Commerce evidence integrations
 
-PEAC records evidence from commerce protocols without executing payments:
+PEAC records evidence from commerce protocols without executing payments. `paymentauth` is the PEAC code and registry term for the active `draft-ryan-httpauth-payment-01` HTTP Payment authentication scheme; MPP (Machine Payments Protocol) is the ecosystem prose name.
 
-| Protocol          | Package                      | What it records                                    |
-| ----------------- | ---------------------------- | -------------------------------------------------- |
-| paymentauth / MPP | `@peac/mappings-paymentauth` | HTTP 402 challenges, receipts, carrier coexistence |
-| ACP               | `@peac/mappings-acp`         | Session lifecycle, payment observations            |
-| Stripe SPT        | `@peac/rails-stripe`         | Delegation grants, PI observations                 |
-| x402              | `@peac/adapter-x402`         | Offer/receipt verification, v1/v2 read             |
-| UCP               | `@peac/mappings-ucp`         | Order-vs-payment separation                        |
+| Protocol                                      | Package                      | What it records                                    |
+| --------------------------------------------- | ---------------------------- | -------------------------------------------------- |
+| paymentauth / MPP (Machine Payments Protocol) | `@peac/mappings-paymentauth` | HTTP 402 challenges, receipts, carrier coexistence |
+| ACP                                           | `@peac/mappings-acp`         | Session lifecycle, payment observations            |
+| Stripe SPT                                    | `@peac/rails-stripe`         | Delegation grants, PI observations                 |
+| x402                                          | `@peac/adapter-x402`         | Offer/receipt verification, v1/v2 read             |
+| UCP                                           | `@peac/mappings-ucp`         | Order-vs-payment separation                        |
 
 See [Commerce Evidence Spec](specs/COMMERCE-EVIDENCE.md) and [Commerce Semantics](specs/COMMERCE-SEMANTICS.md) for boundary rules.
 
-### Identity and transport integrations (v0.12.6+)
+### Identity and transport integrations
 
 | Integration    | Package                                        | What it provides                                  |
 | -------------- | ---------------------------------------------- | ------------------------------------------------- |
@@ -63,6 +63,18 @@ See [Commerce Evidence Spec](specs/COMMERCE-EVIDENCE.md) and [Commerce Semantics
 | A2A OAuth      | `@peac/mappings-a2a`                           | PKCE S256, Device Code types, auth evidence       |
 | in-toto / SLSA | `@peac/mappings-intoto`, `@peac/mappings-slsa` | Supply-chain provenance mapping                   |
 | receipt_url    | `@peac/net-node`                               | Carrier-shaped receipt URL resolution middleware  |
+
+### Agent execution and lifecycle records
+
+v0.14.1 adds three record surfaces for agent and operator workflows:
+
+| Surface               | Entry point                                                                                                            | What it records                                                                                                                                                |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A2A handoff records   | [`docs/specs/A2A-HANDOFF-RECORDS.md`](specs/A2A-HANDOFF-RECORDS.md), [`integrator-kits/a2a/`](../integrator-kits/a2a/) | Agent-card discovery, task lifecycle, and human-review handoff events reported by A2A-adjacent systems                                                         |
+| CLI command execution | `peac observe command`, `peac record command`                                                                          | Command, working directory, binary, redacted argv/stdin/stdout/stderr metadata, and execution outcome. Signed records require caller-provided issuer material. |
+| Lifecycle observation | `peac emit lifecycle`                                                                                                  | Caller-reported evaluation, approval, experiment, mode, and workflow-transition events                                                                         |
+
+These are record/export surfaces. The CLI wrapper may spawn a caller-supplied child process to produce an observation; PEAC does not choose the command, schedule it, supervise it as a long-running process, authorize it, or orchestrate workflows. PEAC does not approve the action, score the runtime, or vouch for the truth of caller-reported lifecycle events.
 
 ### Settlement fields
 
@@ -148,12 +160,12 @@ See [packages/middleware-core/README.md](../packages/middleware-core/README.md) 
 
 ### x402 integration
 
-PEAC works as the receipts and verification layer for [x402](https://x402.org) payment flows. x402 handles the payment; PEAC proves it happened.
+PEAC works as the receipts and verification layer for [x402](https://x402.org) payment flows. x402 handles the payment; PEAC records verifiable evidence of the payment flow.
 
 1. Client requests a protected resource
 2. Server returns `402 Payment Required` with x402 payment details
 3. Client pays via x402 (Base/USDC or other supported networks)
-4. Server issues a signed `PEAC-Receipt` header proving payment
+4. Server issues a signed `PEAC-Receipt` header carrying payment evidence
 5. Client verifies the receipt offline
 
 **Package:** `@peac/rails-x402` (payment rail) and `@peac/adapter-x402` (evidence carrier).
@@ -264,12 +276,12 @@ See [docs/specs/PEAC-ISSUER.md](specs/PEAC-ISSUER.md).
 
 ### Wire formats
 
-**Interaction Record format** (`interaction-record+jwt`, stable on `latest`, v0.12.0+):
+**Interaction Record format** (`interaction-record+jwt`): current default format.
 
 - Two structural kinds: `evidence` and `challenge`
 - Open semantic `type` (reverse-DNS or absolute URI)
-- Multi-valued `pillars` from 10-value closed taxonomy
-- 12 typed extension groups with type-to-extension enforcement
+- Multi-valued `pillars` from the closed pillar taxonomy
+- 15 extension groups, each typed with type-to-extension enforcement
 - Policy binding: JCS (RFC 8785) + SHA-256 digest comparison
 - JOSE hardening: embedded keys rejected, `kid` required
 
@@ -287,15 +299,16 @@ Single `PEAC-Receipt` response header carries the signed JWS for both wire versi
 
 PEAC is transport-agnostic. Receipts travel via the binding appropriate to each protocol:
 
-| Binding                | How receipts travel                          | Status      |
-| ---------------------- | -------------------------------------------- | ----------- |
-| HTTP/REST              | Response header `PEAC-Receipt: <jws>`        | Implemented |
-| MCP                    | Tool result `_meta` (carrier format)         | Implemented |
-| A2A                    | Task/message metadata (extension URI)        | Implemented |
-| ACP (Agentic Commerce) | State transition metadata                    | Implemented |
-| UCP                    | Webhook verification metadata                | Implemented |
-| x402                   | Settlement response evidence                 | Implemented |
-| Queues/batches         | NDJSON receipts verified offline via bundles | Implemented |
+| Binding                | How receipts travel                                | Status      |
+| ---------------------- | -------------------------------------------------- | ----------- |
+| HTTP/REST              | Response header `PEAC-Receipt: <jws>`              | Implemented |
+| MCP                    | Tool result `_meta` (carrier format)               | Implemented |
+| A2A                    | Task/message metadata (extension URI)              | Implemented |
+| ACP (Agentic Commerce) | State transition metadata                          | Implemented |
+| UCP                    | Webhook verification metadata                      | Implemented |
+| x402                   | Settlement response evidence                       | Implemented |
+| Queues/batches         | NDJSON receipts verified offline via bundles       | Implemented |
+| CLI execution          | Local command observation and signed record output | Implemented |
 
 **Mapping packages:**
 
@@ -379,14 +392,15 @@ peac policy generate peac-policy.yaml --out dist --well-known
 
 **Adapters:**
 
-| Package                            | Description                                                                     |
-| ---------------------------------- | ------------------------------------------------------------------------------- |
-| `@peac/adapter-runtime-governance` | Runtime governance records (AGT first mapper, 6 observation-specific type URIs) |
-| `@peac/adapter-managed-agents`     | Managed agent session lifecycle records (6 event families)                      |
-| `@peac/adapter-x402`               | x402 record carrier (V1 + V2)                                                   |
-| `@peac/adapter-did`                | DID resolution (did:key, did:web, caching)                                      |
-| `@peac/adapter-openclaw`           | OpenClaw agent framework                                                        |
-| `@peac/adapter-openai-compatible`  | Hash-first inference receipt adapter                                            |
+| Package                            | Description                                          |
+| ---------------------------------- | ---------------------------------------------------- |
+| `@peac/adapter-runtime-governance` | Runtime governance observation records               |
+| `@peac/adapter-managed-agents`     | Managed agent session lifecycle records              |
+| `@peac/adapter-x402`               | x402 record carrier (V1 + V2)                        |
+| `@peac/adapter-did`                | DID resolution (did:key, did:web, caching)           |
+| `@peac/adapter-eat`                | Entity Attestation Token (RFC 9711) evidence adapter |
+| `@peac/adapter-openclaw`           | OpenClaw agent framework                             |
+| `@peac/adapter-openai-compatible`  | Hash-first inference receipt adapter                 |
 
 **Mappings:**
 
@@ -396,9 +410,13 @@ peac policy generate peac-policy.yaml --out dist --well-known
 | `@peac/mappings-mcp`             | MCP metadata carrier and budget management          |
 | `@peac/mappings-intoto`          | in-toto v1.0 attestation provenance mapping         |
 | `@peac/mappings-slsa`            | SLSA v1.2 provenance predicate mapping              |
-| `@peac/mappings-paymentauth`     | HTTP Payment auth evidence mapping                  |
+| `@peac/mappings-paymentauth`     | paymentauth / MPP payment evidence mapping          |
 | `@peac/mappings-acp`             | Agentic Commerce Protocol session mapping           |
+| `@peac/mappings-ucp`             | Google Universal Commerce Protocol mapping          |
 | `@peac/mappings-content-signals` | Content signal observation mapping                  |
+| `@peac/mappings-aipref`          | IETF AIPREF preference vocabulary mapping           |
+| `@peac/mappings-rsl`             | RSL usage token mapping                             |
+| `@peac/mappings-tap`             | Visa Trusted Agent Protocol mapping                 |
 
 **Infrastructure:** `@peac/contracts`, `@peac/http-signatures`, `@peac/jwks-cache`, `@peac/net-node`, `@peac/adapter-core`, `@peac/privacy`, `@peac/telemetry`, `@peac/telemetry-otel`, `@peac/transport-grpc`, `@peac/capture-core`, `@peac/capture-node`, `@peac/attribution`, `@peac/audit`, `@peac/policy-kit`.
 
@@ -411,7 +429,11 @@ peac policy generate peac-policy.yaml --out dist --well-known
 - [Spec Index](SPEC_INDEX.md): full normative spec set.
 - [Resource limits](specs/RESOURCE-LIMITS.md): normative invariant table for size, time, cache, SSRF, redirect, and timeout ceilings; each row cites the constant in source and a test.
 - [Standards ledger](STANDARDS_LEDGER.md): every external standard PEAC cites or implements, by category and status (Standards Track / Informational / IRTF Informational / BCP / FIPS / W3C Recommendation / International Standard / Regulatory / Draft / Watchlist).
-- [Release-line baselines](baselines/): invariant snapshot for the v0.13.0 release line (released-package surface, wire-format invariants, error-taxonomy inventory, mutation-testing posture).
+- [A2A handoff records](specs/A2A-HANDOFF-RECORDS.md): handoff observation profile with type URIs and signature-observation grammar.
+- [CLI carrier profile](specs/CLI-CARRIER-PROFILE.md): command-execution record carrier and security defaults.
+- [Lifecycle observation profile](specs/LIFECYCLE-OBSERVATION-PROFILE.md): caller-reported lifecycle events with opaque-reference grammar.
+- [Abstraction boundaries](architecture/ABSTRACTION-BOUNDARIES.md): generic-core, profile, adapter, and example boundary doctrine.
+- [Release-line baselines](baselines/): historical invariant snapshots and release-line references.
 - [Stability contract](STABILITY-CONTRACT.md): classification of every public surface PEAC publishes.
 - [Threat model](THREAT_MODEL.md): per-threat mitigation table with test coverage.
 - [Trust artifacts](TRUST-ARTIFACTS.md): index of security and stability artifacts.

--- a/docs/REFERENCE_ARCHITECTURES.md
+++ b/docs/REFERENCE_ARCHITECTURES.md
@@ -1,8 +1,8 @@
 # Reference Architectures
 
-> Version: 0.12.7 | Status: Current
+> Status: Current
 
-This document describes three canonical deployment patterns for PEAC Protocol evidence. Each pattern shows how receipts are issued, carried, and verified across organizational boundaries.
+This document describes canonical deployment patterns for PEAC Protocol evidence. Each pattern shows how receipts are issued, carried, and verified across organizational boundaries.
 
 For the package layering model, see [Architecture](ARCHITECTURE.md). For the normative issuance and verification flows, see [Protocol Behavior](specs/PROTOCOL-BEHAVIOR.md).
 
@@ -77,7 +77,7 @@ MCP Client (Claude, Cursor)     MCP Server (@peac/mcp-server)
 - Receipt is embedded in the MCP `_meta` response object (max 64 KB for MCP)
 - `receipt_ref` is `sha256(receipt_jws)` for compact reference
 - The MCP server is both the tool provider and the evidence issuer
-- Five tools: `peac_verify`, `peac_inspect`, `peac_decode`, `peac_issue`, `peac_create_bundle`
+- Default tools: `peac_verify`, `peac_inspect`, `peac_decode`. Privileged tools are opt-in: `peac_issue` (requires issuer key + ID), `peac_create_bundle` (requires bundle dir).
 - Transport: stdio (local) or streamable HTTP (session-isolated per CVE-2026-25536 defense)
 
 ### Packages involved
@@ -88,9 +88,9 @@ MCP Client (Claude, Cursor)     MCP Server (@peac/mcp-server)
 | 3     | `@peac/protocol`     | `issue()` and `verifyLocal()`                       |
 | 4     | `@peac/mappings-mcp` | MCP-specific carrier adapter; `_meta` key mapping   |
 
-## 3. A2A Handoff Evidence Flow
+## 3. A2A Handoff Record Flow
 
-Two agents exchange evidence during an Agent-to-Agent (A2A) task handoff. The receipt is carried in the A2A task metadata.
+Two agents exchange records during an Agent-to-Agent (A2A) task handoff. The receipt is carried in the A2A task metadata. Handoff observation records cover agent-card discovery, task lifecycle, and human-review boundaries; see [A2A Handoff Records spec](specs/A2A-HANDOFF-RECORDS.md).
 
 ```
 Agent A (Requester)         A2A Gateway          Agent B (Provider)
@@ -122,7 +122,7 @@ Agent A (Requester)         A2A Gateway          Agent B (Provider)
 - Receipt is carried in A2A task `metadata[extensionURI].carriers[]` (max 64 KB)
 - Agent B is the issuer; Agent A is the verifier
 - The A2A gateway routes but does not modify the evidence payload
-- Supports A2A v1.0 (Linux Foundation); v0.3.0 compatibility was deprecated in v0.12.3 and removed in v0.13.0 (DD-186)
+- Supports A2A v1.0 (Linux Foundation); v0.3.0 compatibility was removed in v0.13.0
 - OAuth PKCE (S256) for agent authentication; Device Code flow for non-browser agents
 
 ### Packages involved
@@ -132,6 +132,97 @@ Agent A (Requester)         A2A Gateway          Agent B (Provider)
 | 4     | `@peac/mappings-a2a` | A2A carrier adapter; metadata extraction and embedding             |
 | 3     | `@peac/protocol`     | `issue()` and `verifyLocal()`                                      |
 | 4     | `@peac/adapter-did`  | DID-based key resolution for agent identity (`did:key`, `did:web`) |
+
+## 4. CLI Command Execution Record Flow
+
+A local command is wrapped by the PEAC CLI to produce an observational record (unsigned JSON) or a signed CLI execution record. PEAC observes; it does not run a shell, supervise processes, or enforce permissions.
+
+```
+caller invokes wrapper      child command (shell:false)      record output
+  |                                |                              |
+  |  peac observe command --       |                              |
+  |     echo hello                |                              |
+  |------------------------------>| spawn(echo, ["hello"])        |
+  |                                |                              |
+  |                                |   stdout/stderr/exit code    |
+  |                                |----------------------------->|
+  |                                |                              |
+  |   capture per policy           |                              |
+  |   (hash/redact defaults)       |                              |
+  |                                |                              |
+  |   emit observation JSON       |                              |
+  |   (unsigned)                  |                              |
+  |   OR                           |                              |
+  |   issue signed JWS via         |                              |
+  |   issuer key (record command) |                              |
+```
+
+### Key characteristics
+
+- `peac observe command` emits an unsigned observation; `peac record command` emits a signed record using caller-provided issuer material
+- `shell: false` by default; `--shell-mode` required to acknowledge a shell binary
+- Hash/redact defaults for `argv`, `stdin`, `stdout`, `stderr`; double opt-in for raw capture
+- Deny-by-default env capture; explicit `--env-allow` allowlist; hashed values by default
+- Bounded byte ceilings on argv and stream samples; secret-scan on by default
+- PEAC observes command execution; it is not a shell runner, sandbox, supervisor, or permission system
+
+### Packages involved
+
+| Layer | Package          | Role                                                                                               |
+| ----- | ---------------- | -------------------------------------------------------------------------------------------------- |
+| 5     | `@peac/cli`      | `peac observe command` (unsigned observation), `peac record command` (signed execution record JWS) |
+| 3     | `@peac/protocol` | `issue()` for signed records                                                                       |
+| 1     | `@peac/schema`   | CLI execution record validators (`org.peacprotocol/cli-command-execution`)                         |
+
+Normative spec: [CLI Carrier Profile](specs/CLI-CARRIER-PROFILE.md). Conformance Section 29 (`CLI-EXEC-001..006`).
+
+---
+
+## 5. Lifecycle Observation Record Flow
+
+Another system reports a lifecycle event (evaluation, approval, experiment, mode change, workflow transition). The caller invokes `peac emit lifecycle` with caller-provided issuer material to issue a signed observation record. PEAC records what the caller reported; it does not approve, evaluate, score, schedule, transition, or orchestrate.
+
+```
+upstream system            caller invokes emit            signed record
+  |                              |                            |
+  | event happened (eval         |                            |
+  | completed, approval granted, |                            |
+  | experiment result, etc.)     |                            |
+  |----------------------------->|                            |
+  |                              |                            |
+  |                              |  peac emit lifecycle       |
+  |                              |    --type ...              |
+  |                              |    --observed-at ...       |
+  |                              |    --opaque-ref ...        |
+  |                              |                            |
+  |                              |  schema validation         |
+  |                              |  (no inline values;        |
+  |                              |  opaque-reference grammar) |
+  |                              |                            |
+  |                              |  issue signed JWS          |
+  |                              |  via issuer key            |
+  |                              |--------------------------->|
+```
+
+### Key characteristics
+
+- 9 event kinds: approval-requested/granted/denied, evaluation-started/completed, experiment-assigned/result, workflow-transition, mode-observed
+- Grammar-based no-inline-value invariant: 20 forbidden top-level keys; opaque-reference grammar (`ref:` / `urn:` / `did:` / `sha256:` / `peac:` / `https:`)
+- Observational-only: PEAC records what the caller reported; it does not assert truth, score, or decide
+- OBSERVER scope: vendor-neutral orchestrator boundary
+- OTel composition: PEAC may emit `peac.record.ref` alongside OTel spans; PEAC does not ship an OTel exporter or SDK dependency
+
+### Packages involved
+
+| Layer | Package          | Role                                                                                             |
+| ----- | ---------------- | ------------------------------------------------------------------------------------------------ |
+| 5     | `@peac/cli`      | `peac emit lifecycle` (signed lifecycle observation record)                                      |
+| 3     | `@peac/protocol` | `issue()` for signed records                                                                     |
+| 1     | `@peac/schema`   | Lifecycle observation validators (`org.peacprotocol/lifecycle-observation`); discriminated union |
+
+Normative spec: [Lifecycle Observation Profile](specs/LIFECYCLE-OBSERVATION-PROFILE.md). Conformance Section 30 (`LIFE-OBS-001..010`).
+
+---
 
 ## Cross-Cutting Patterns
 

--- a/docs/STABILITY-CONTRACT.md
+++ b/docs/STABILITY-CONTRACT.md
@@ -213,8 +213,9 @@ current behavior.
 | ----------------------------------------------------- | ----------- | ------------------------------------------------------------------ |
 | COSE/CBOR codec flag (`PEAC_EXPERIMENTAL_CODEC=cose`) | Not shipped | `experimental` once shipped; gated by an explicit roadmap decision |
 
-Security and semantic constraints pre-declared for these surfaces live in
-the [Threat model](THREAT_MODEL.md) forward-looking subsection.
+No public COSE/CBOR codec ships in this release. Security and semantic
+constraints for future codec surfaces are documented when public code
+lands.
 
 ## Internal-only flags
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -53,19 +53,39 @@ Key packages: `@peac/adapter-runtime-governance`, `@peac/adapter-managed-agents`
 
 ## I build A2A agents
 
-You want to carry receipts across Agent-to-Agent Protocol flows.
+You want to carry records across Agent-to-Agent Protocol flows, including handoff observations for agent-card discovery, task lifecycle, and human-review boundaries.
 
 1. Install: `pnpm add @peac/mappings-a2a @peac/protocol @peac/crypto`
-2. Read the [A2A Integration Kit](../integrator-kits/a2a/README.md)
+2. Read the [A2A Integration Kit](../integrator-kits/a2a/README.md) and the [A2A Handoff Records spec](specs/A2A-HANDOFF-RECORDS.md)
 3. See [examples/a2a-gateway-pattern](../examples/a2a-gateway-pattern/) for the gateway pattern
 
 Key packages: `@peac/mappings-a2a`, `@peac/protocol`.
+
+## I record command execution
+
+You want to create an observational record of a local command execution without turning PEAC into a shell runner or automation framework.
+
+1. Use `peac observe command` for unsigned local observations.
+2. Use `peac record command` with issuer material for signed command-execution records.
+3. Read the [CLI Carrier Profile](specs/CLI-CARRIER-PROFILE.md) for capture modes, redaction defaults, and signing requirements.
+
+Key package: `@peac/cli`.
+
+## I emit lifecycle events from another system
+
+You want to issue records for lifecycle events reported by another system, such as evaluation completion, approval, experiment result, mode change, or workflow transition.
+
+1. Use `peac emit lifecycle` with caller-provided issuer material.
+2. Read the [Lifecycle Observation Profile](specs/LIFECYCLE-OBSERVATION-PROFILE.md).
+3. Keep lifecycle records observational: PEAC records what another system reported; it does not approve, evaluate, score, schedule, transition, or orchestrate.
+
+Key package: `@peac/cli`.
 
 ## Integration areas
 
 ### Commerce and payment evidence
 
-You want verifiable evidence from commerce and payment flows across paymentauth / MPP, ACP, Stripe SPT, x402, or UCP. Prove what was offered, challenged, paid, or settled across organizational boundaries.
+You want verifiable evidence from commerce and payment flows across x402, paymentauth / MPP (Machine Payments Protocol), ACP, Stripe SPT, or UCP. Prove what was offered, challenged, paid, or settled across organizational boundaries.
 
 1. Choose your protocol:
    - **paymentauth / MPP**: [paymentauth Integration Kit](../integrator-kits/paymentauth/README.md)
@@ -119,7 +139,7 @@ PEAC is the records layer beneath runtime governance. It does not try to be the 
 - **PEAC is not a payment protocol.** x402, paymentauth / MPP, ACP, and Stripe SPT authorize and settle. PEAC carries verifiable observational evidence across them and never synthesizes payment finality from non-payment artifacts.
 - **PEAC is not an identity protocol or trust-score system.** DIDs, VCs, ERC-8004, and reputation layers own those functions. PEAC accepts `iss` in `https://` or `did:` form and never computes trust.
 - **PEAC is not an observability dashboard.** PEAC records are exportable to any observability system via `receipt_ref` as an OTel span attribute.
-- **PEAC will not become a CLI automation framework, eval platform, approval system, or orchestration / workflow engine.** Future releases extend PEAC to carry CLI execution evidence and observational lifecycle records (eval, approval, experiment, or workflow event exports emitted by other systems). Those are carrier extensions, not new PEAC categories; PEAC records what the upstream system attested and never evaluates, approves, experiments, or orchestrates itself.
+- **PEAC is not a CLI automation framework, eval platform, approval system, or orchestration / workflow engine.** PEAC now carries CLI command-execution records and caller-reported lifecycle observation records as record/export surfaces. PEAC records what the caller or upstream system reported; it does not choose commands, schedule work, run evaluations, decide approvals, transition workflows, or orchestrate systems.
 
 Full protocol scope and boundary: [`docs/WHAT-PEAC-STANDARDIZES.md`](WHAT-PEAC-STANDARDIZES.md) and [`docs/WHERE-IT-FITS.md`](WHERE-IT-FITS.md).
 

--- a/docs/SUPPORTED_ENVIRONMENTS.md
+++ b/docs/SUPPORTED_ENVIRONMENTS.md
@@ -12,15 +12,15 @@
 
 ## Go
 
-| Version  | Status      | Notes                                                                |
-| -------- | ----------- | -------------------------------------------------------------------- |
-| Go 1.26+ | **Partial** | `sdks/go/`: Wire 0.1 issue and verify only. Wire 0.2 parity planned. |
+| Version  | Status        | Notes                                                                                                                                                            |
+| -------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Go 1.26+ | **Supported** | `sdks/go/`: Interaction Record (`interaction-record+jwt`) `Issue()` and `VerifyLocal()` with Ed25519, RFC 8785 JCS, and JOSE hardening. Middleware experimental. |
 
 ## Python
 
-| Version      | Status          | Notes                                                           |
-| ------------ | --------------- | --------------------------------------------------------------- |
-| Python 3.10+ | **Not started** | API-first support via Hosted Verify OpenAPI. No native SDK yet. |
+| Version      | Status            | Notes                                                                                                                              |
+| ------------ | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Python 3.12+ | **Examples only** | API-first examples using Hosted Verify / reference verifier (`examples/python/`, `requires-python = ">=3.12"`). No native SDK yet. |
 
 ## Browser and Edge Runtimes
 
@@ -42,6 +42,6 @@
 ## Language Strategy
 
 - **TypeScript/Node.js** is the canonical OSS implementation path
-- **Go** receives minimum viable Wire 0.2 parity next
+- **Go** has core Wire 0.2 parity for Interaction Record issue/verify; middleware remains experimental
 - **Hosted Verify and Hosted Issue** serve as the language-agnostic entry point via OpenAPI
 - **Python** receives API-first support before any full SDK commitment

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -88,7 +88,6 @@ Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scri
 | Surface                        | npm                 | State        | Wire |
 | ------------------------------ | ------------------- | ------------ | ---- |
 | `apps/api`                     | -                   | default      | 0.2  |
-| `apps/sandbox-issuer`          | -                   | compat-only  | 0.1  |
 | `apps/verifier`                | -                   | default      | 0.2  |
 | `packages/cli`                 | `@peac/cli`         | default      | 0.2  |
 | `packages/conformance-harness` | -                   | supported    | 0.2  |

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -130,37 +130,26 @@ shipped behavior.
 - Resource-limit invariant table with per-row implementation, test, and
   baseline references.
 
-## Future carrier surfaces (pre-doctrine)
+## CLI execution and lifecycle observation surfaces
 
-The forthcoming public surfaces listed in the
-[Stability contract](STABILITY-CONTRACT.md) pre-doctrine section have not
-shipped. Their security contract is pre-declared here so that future
-implementation MUST honor the rules on day one.
+The CLI command-execution and observational lifecycle record surfaces
+have shipped. Their security contract is enforced by the rules below.
 
-- **No raw secret capture by default.** Any future CLI or lifecycle record
-  carrier defaults to redaction or hashing for `argv`, `stdin`, `stdout`,
-  and `stderr`. Raw capture is opt-in and declared by a documented
-  `capture_policy` entry.
-- **Hash-only default for stream captures.** `stdin` / `stdout` / `stderr`
-  are hashed, not stored verbatim, unless the caller explicitly enables
-  raw capture under a documented policy.
-- **Environment-variable allowlist plus value hashing.** No blanket
-  environment dump. Only explicitly-listed variables enter the record,
-  and even those are hashed by default.
-- **Explicit `argv_mode`.** A shell-string invocation must be recorded as
-  such. Hidden shell-expansion ambiguity is rejected.
-- **Bounded byte ceilings on command capture.** `argv` bytes, stream
-  bytes, and environment-variable reference counts all carry documented
-  upper bounds. Exceeding a bound truncates or hashes; it never silently
-  drops.
-- **Lifecycle records are observational-only.** Approval, evaluation,
-  experiment, and workflow records describe what another system
-  attested. They never imply PEAC made the decision, scored the runtime,
-  enforced the policy, or determined payment finality.
+| ID        | Threat                                            | Mitigation                                                                                                                                               | Test coverage                                                                                                                                                                                                                                                                                            |
+| --------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T-CLI-01  | Raw command, stream, or argument secret capture   | Hash/redact defaults for `argv`/`stdin`/`stdout`/`stderr`; explicit raw-capture acknowledgement; bounded byte ceilings; secret-scan guard on raw samples | [`packages/cli/tests/secret-scan.test.ts`](../packages/cli/tests/secret-scan.test.ts), [`packages/cli/tests/capture.test.ts`](../packages/cli/tests/capture.test.ts)                                                                                                                                     |
+| T-CLI-02  | Shell ambiguity or hidden shell expansion         | `shell: false` default; `--shell-mode` required to acknowledge a shell binary; command after `--` spawned as supplied                                    | [`packages/cli/tests/observe-command.test.ts`](../packages/cli/tests/observe-command.test.ts), [`packages/cli/tests/record-command.test.ts`](../packages/cli/tests/record-command.test.ts)                                                                                                               |
+| T-CLI-03  | Environment-variable leakage                      | Deny-by-default env capture; explicit `--env-allow` allowlist; hashed values by default; raw env requires double opt-in                                  | [`packages/cli/tests/observe-command.test.ts`](../packages/cli/tests/observe-command.test.ts), [`packages/cli/tests/capture.test.ts`](../packages/cli/tests/capture.test.ts)                                                                                                                             |
+| T-LIFE-01 | Lifecycle record overclaims decision truth        | Caller-reported event model; opaque-reference grammar; no inline scoring/finality synthesis; closed enum of forbidden top-level keys                     | [`packages/schema/__tests__/extensions/lifecycle-observation.test.ts`](../packages/schema/__tests__/extensions/lifecycle-observation.test.ts), [`packages/schema/__tests__/extensions/lifecycle-observation-shape.test.ts`](../packages/schema/__tests__/extensions/lifecycle-observation-shape.test.ts) |
+| T-LIFE-02 | PEAC mistaken for evaluator/approver/orchestrator | Profile boundary: PEAC issues records; upstream systems evaluate, approve, schedule, transition, or orchestrate                                          | [`docs/specs/LIFECYCLE-OBSERVATION-PROFILE.md`](specs/LIFECYCLE-OBSERVATION-PROFILE.md) §8 (orchestrator boundary, normative)                                                                                                                                                                            |
 
-Each rule above becomes a named threat ID with a concrete test file at the
-time the corresponding surface is implemented. No public CLI or lifecycle
-code ships ahead of this contract.
+Security defaults summary:
+
+- **No raw secret capture by default.** `argv`, `stdin`, `stdout`, `stderr` default to hash/redact modes; raw capture requires `--capture-mode raw` AND `--unsafe-allow-raw-capture` (double opt-in).
+- **Environment-variable allowlist plus value hashing.** No blanket environment dump. Only explicitly-listed variables enter the record, and even those are hashed by default. Raw env requires `--env-mode raw` AND `--unsafe-allow-raw-env`.
+- **Explicit shell mode.** Shell-binary detected without `--shell-mode` is a hard fail. Hidden shell-expansion ambiguity is rejected.
+- **Bounded byte ceilings on command capture.** `argv` bytes, stream bytes, and environment-variable reference counts all carry documented upper bounds. Exceeding a bound truncates or hashes; it never silently drops.
+- **Lifecycle records are observational-only.** Approval, evaluation, experiment, and workflow records describe what another system attested. They never imply PEAC made the decision, scored the runtime, enforced the policy, or determined payment finality.
 
 ## Related documents
 

--- a/docs/WHAT-PEAC-STANDARDIZES.md
+++ b/docs/WHAT-PEAC-STANDARDIZES.md
@@ -17,9 +17,9 @@ Evidence you can point at:
 - The JOSE hardening test suite at [`packages/protocol/__tests__/`](../packages/protocol/__tests__/) enforces the stability-contract rules (no embedded keys, no `crit`, no `zip`, Ed25519 only).
 - Cross-language parity: the Go SDK ([`sdks/go/`](../sdks/go/)) emits byte-equivalent JCS output against 22 shared fixtures.
 
-## 2. Cross-protocol record normalization across MCP, A2A, x402, ACP, paymentauth, and runtime-governance ecosystems
+## 2. Cross-protocol record normalization across MCP, A2A, CLI, lifecycle, x402, paymentauth / MPP, ACP, and runtime-governance ecosystems
 
-PEAC defines a single record shape that composes with every major agent, commerce, and runtime ecosystem PEAC integrates with. The adapter and mapping layer translates each ecosystem's native attestations into a Wire record, preserves the upstream artifact verbatim, and never synthesizes semantics the upstream did not claim.
+PEAC defines a single record shape that composes with the agent, commerce, and runtime ecosystems PEAC integrates with. The adapter and mapping layer translates each ecosystem's native attestations into a Wire record, preserves the upstream artifact verbatim, and never synthesizes semantics the upstream did not claim.
 
 Evidence you can point at:
 
@@ -33,7 +33,7 @@ PEAC records double as audit-trail entries suitable for the interaction-logging 
 
 Evidence you can point at:
 
-- [`docs/governance/`](governance/) carries the in-progress mapping from PEAC record fields to the relevant clauses and controls. The formal compliance mappings (ISO 42001 Clause 8, EU AI Act Annex IV) publish in a near-term release; the mapping directory is the forward link.
+- Governance and compliance mappings live under [`docs/governance/`](governance/) and [`docs/compliance/`](compliance/); their current status is documented in those directories.
 - The policy-binding three-state result (`verified` / `failed` / `unavailable`) is normatively specified at [`docs/specs/PROTOCOL-BEHAVIOR.md`](specs/PROTOCOL-BEHAVIOR.md) and preserves policy-digest traceability.
 - Records are portable in a bundle format (`peac-bundle/0.1`, spec at [`docs/specs/EVIDENCE-CARRIER-CONTRACT.md`](specs/EVIDENCE-CARRIER-CONTRACT.md)) so audit packages can be verified offline months or years after issuance.
 
@@ -45,7 +45,7 @@ PEAC is the records layer. It defines issuance, carriage, verification, and pres
 
 - **Decision logic.** Auth systems, policy engines, runtime-governance toolkits, and approval systems define the decision. PEAC records what they attested.
 - **Enforcement.** Runtime control planes define enforcement. PEAC records what was enforced.
-- **Execution.** Shell runners, task runners, and orchestration engines define execution. PEAC records what was executed where another system emits that observation; PEAC does not execute commands itself.
+- **Execution.** Shell runners, task runners, and orchestration engines define execution. The PEAC CLI wrapper may spawn a caller-supplied child process to produce an observation, but PEAC does not choose, schedule, supervise, authorize, or orchestrate command execution.
 - **Evaluation.** Eval platforms, experiment frameworks, and rubric managers define evaluation. PEAC records eval observations emitted by another system; PEAC does not run evaluations itself.
 - **Approval workflows.** Approval systems and reviewer queues define approval logic. PEAC records approval observations emitted by another system; PEAC does not route or decide approvals itself.
 - **Orchestration.** Workflow engines define orchestration. PEAC records workflow observations emitted by another system; PEAC does not orchestrate workflows itself.

--- a/docs/WHERE-IT-FITS.md
+++ b/docs/WHERE-IT-FITS.md
@@ -46,7 +46,7 @@ Payment rails authorize, settle, refund, and dispute. They carry the money.
 | Custody                      | Holds funds, manages refunds                                            | Never custodies funds                               |
 | Synthesizes payment finality | Yes (the rail is the source of truth)                                   | **No** — PEAC preserves upstream artifacts verbatim |
 
-PEAC's adapter layer (`@peac/adapter-x402`, `@peac/mappings-paymentauth`, `@peac/mappings-acp`, `@peac/rails-stripe`) preserves each rail's attestations verbatim and never synthesizes payment finality from non-payment artifacts. A mapper-boundary guard (`assertExplicitFinality` in `@peac/adapter-core`) blocks commerce records that attempt to imply a settled state the upstream did not claim.
+PEAC's adapter layer (`@peac/adapter-x402`, `@peac/mappings-paymentauth` for paymentauth / MPP, `@peac/mappings-acp`, `@peac/rails-stripe`) preserves each rail's attestations verbatim and never synthesizes payment finality from non-payment artifacts. A mapper-boundary guard (`assertExplicitFinality` in `@peac/adapter-core`) blocks commerce records that attempt to imply a settled state the upstream did not claim.
 
 **Boundary:** PEAC is not a payment protocol. It does not authorize, settle, custody, refund, or enforce scheme-specific invariants.
 
@@ -79,17 +79,17 @@ Where a native attestation exists, PEAC records its output as portable signed ev
 
 **Boundary:** PEAC does not replace native attestations. It makes them portable.
 
-## PEAC vs future CLI execution and lifecycle systems (planning context)
+## PEAC vs CLI execution and lifecycle systems
 
-Carrier breadth is planned to extend to CLI execution evidence and observational lifecycle records (eval completions, approvals, experiment results, workflow transitions) emitted by other systems. This is carrier breadth, not a new category.
+PEAC carries CLI command-execution records and caller-reported lifecycle observation records. These are record/export surfaces, not execution, evaluation, approval, scheduling, or orchestration systems.
 
-| Property           | CLI / lifecycle systems (Temporal, Airflow, OpenAI Evals, approval queues, shell runners, task runners) | PEAC records (future carrier breadth)                                       |
+| Property           | CLI / lifecycle systems (Temporal, Airflow, OpenAI Evals, approval queues, shell runners, task runners) | PEAC records                                                                |
 | ------------------ | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
 | Role               | Execute, schedule, orchestrate, evaluate, approve                                                       | Carry portable signed records of what the system attested                   |
 | Decision authority | The system                                                                                              | **Never PEAC**                                                              |
-| PEAC response      | Integrate as a future carrier extension                                                                 | Lifecycle records are observational-only; CLI evidence is non-orchestrating |
+| PEAC response      | Carry signed observational records from those systems                                                   | Lifecycle records are observational-only; CLI evidence is non-orchestrating |
 
-**Boundary (locked):** PEAC will not become a CLI automation framework, eval platform, approval system, or orchestration / workflow engine. Those categories stay occupied by their existing players. PEAC plans to carry signed records from those surfaces in a future release; the carrier work does not change the boundary.
+**Boundary (locked):** PEAC is not a CLI automation framework, eval platform, approval system, or orchestration / workflow engine. Those categories stay occupied by their existing players. The carrier work does not change the boundary.
 
 ## Reference
 


### PR DESCRIPTION
## Summary

Refresh public docs to reflect v0.14.1 shipped state.

## Scope

- v0.14.1 surfaces (A2A handoff, CLI execution, lifecycle observation)
- Architecture, compatibility, and supported-environments corrected (15 extension groups; Go SDK Wire 0.2; Python 3.12+ examples-only).
- Generated surface-status regenerated from `REPO_SURFACE_STATUS.json`.

## Validation

Docs-only. No source, schema, registry, conformance, dependency, version, CHANGELOG, or release-notes change.
