### PR TITLE
chore(release): stamp v0.14.1 latest promotion

### DIFF
--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable surface classification for PEAC Protocol workspace. CI fails if any workspace member is missing. See docs/PACKAGE_STATUS.md for human-readable view.",
   "version": "0.13.0",
-  "updated": "2026-05-07",
+  "updated": "2026-05-08",
   "states": {
     "default": "Current recommended path. Actively maintained, Wire 0.2 native.",
     "supported": "Actively maintained, published, production-ready. May not be on default quickstart path.",

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -2,7 +2,7 @@
 
 Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scripts/generate-surface-status.mjs`.
 
-**Version:** 0.13.0 | **Updated:** 2026-05-07
+**Version:** 0.13.0 | **Updated:** 2026-05-08
 
 ## Layer 1
 

--- a/docs/releases/current.json
+++ b/docs/releases/current.json
@@ -2,7 +2,7 @@
   "description": "PEAC release manifest: CI-enforceable source of truth for release state",
   "version": "0.14.1",
   "wire_format_version": "0.2",
-  "dist_tag": "next",
+  "dist_tag": "latest",
   "registries_version": "0.6.0",
   "errors_version": "0.14.1"
 }

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -3,8 +3,8 @@
   "schema_version": "1.0.0",
   "version": "0.14.1",
   "wire_format_version": "0.2",
-  "dist_tag": "next",
-  "release_date": "2026-05-07",
+  "dist_tag": "latest",
+  "release_date": "2026-05-08",
   "metrics": {
     "tests": 9782,
     "test_files": 422,


### PR DESCRIPTION
## Summary

Stamp v0.14.1 release metadata after latest promotion.

## Scope

- Updates release facts from `next` to `latest`.
- Aligns release and surface-status dates to the UTC promotion date.
- Regenerates generated status docs.

## Validation

Release metadata only. No source, schema, registry, conformance, dependency, lockfile, CHANGELOG, or release-notes change.
