### PR TITLE
fix(cli): harden command-handler file writes

### DIFF
--- a/packages/cli/src/commands/bridge/start.ts
+++ b/packages/cli/src/commands/bridge/start.ts
@@ -4,7 +4,15 @@
 
 import { Command } from 'commander';
 import { spawn } from 'child_process';
-import { writeFileSync, mkdirSync, accessSync, openSync, readFileSync } from 'fs';
+import {
+  writeFileSync,
+  mkdirSync,
+  accessSync,
+  openSync,
+  closeSync,
+  readFileSync,
+  constants as fsConstants,
+} from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 
@@ -70,17 +78,32 @@ export function startCommand() {
           process.exit(code || 0);
         });
       } else {
-        // Run in background
+        // Run in background. Open the log file once with explicit POSIX flags and
+        // pass the same descriptor for both stdout and stderr; spawn(2) duplicates
+        // the fd into the child, so the parent can release its copy after the
+        // child process has been created.
         const logFile = join(logsDir, 'bridge.log');
-        const out = openSync(logFile, 'a');
-        const err = openSync(logFile, 'a');
+        const logFd = openSync(
+          logFile,
+          fsConstants.O_WRONLY | fsConstants.O_APPEND | fsConstants.O_CREAT,
+          0o640
+        );
 
         const args = ['node', bridgePath];
-        const bridge = spawn(args[0], args.slice(1), {
-          detached: true,
-          stdio: ['ignore', out, err],
-          env,
-        });
+        let bridge: ReturnType<typeof spawn>;
+        try {
+          bridge = spawn(args[0], args.slice(1), {
+            detached: true,
+            stdio: ['ignore', logFd, logFd],
+            env,
+          });
+        } finally {
+          try {
+            closeSync(logFd);
+          } catch {
+            // ignore close-on-cleanup errors
+          }
+        }
 
         bridge.unref();
 

--- a/packages/cli/src/commands/bridge/stop.ts
+++ b/packages/cli/src/commands/bridge/stop.ts
@@ -3,10 +3,14 @@
  */
 
 import { Command } from 'commander';
-import { readFileSync, unlinkSync, existsSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { spawn } from 'child_process';
+import {
+  readFileUtf8Snapshot,
+  rewriteJsonFileAtomic,
+  unlinkIfExists,
+} from '../../lib/safe-file.js';
 
 // Windows-safe process termination
 async function killProcess(pid: number, signal?: string): Promise<void> {
@@ -44,20 +48,27 @@ export function stopCommand() {
     const pidFile = join(peacDir, 'bridge.pid');
     const configFile = join(peacDir, 'bridge.json');
 
-    // Check if PID file exists
-    if (!existsSync(pidFile)) {
-      console.log('Bridge is not running (no PID file found)');
+    // Read PID from file via fd-bound snapshot. Errno discrimination is the
+    // single source of truth for the missing-file path: ENOENT means the
+    // bridge is not running.
+    let pidStr: string;
+    try {
+      pidStr = readFileUtf8Snapshot(pidFile).trim();
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        console.log('Bridge is not running (no PID file found)');
+        return;
+      }
+      console.error('Failed to stop bridge:', (err as Error).message);
       return;
     }
 
     try {
-      // Read PID from file
-      const pidStr = readFileSync(pidFile, 'utf-8').trim();
       const pid = parseInt(pidStr, 10);
 
       if (isNaN(pid)) {
         console.error('Invalid PID in bridge.pid file');
-        unlinkSync(pidFile);
+        unlinkIfExists(pidFile);
         return;
       }
 
@@ -67,7 +78,7 @@ export function stopCommand() {
       } catch (error: any) {
         if (error.code === 'ESRCH') {
           console.log('Bridge process not found (cleaning up stale PID file)');
-          unlinkSync(pidFile);
+          unlinkIfExists(pidFile);
           return;
         }
         throw error;
@@ -104,31 +115,28 @@ export function stopCommand() {
         }
       }
 
-      // Clean up PID file
-      unlinkSync(pidFile);
+      // Clean up PID file (ENOENT-tolerant)
+      unlinkIfExists(pidFile);
 
-      // Update config file
-      if (existsSync(configFile)) {
-        try {
-          const config = JSON.parse(readFileSync(configFile, 'utf-8'));
+      // Update config file via atomic temp+rename. Returns silently if the
+      // config file does not exist; partial writes cannot corrupt the existing
+      // config because rename(2) is atomic on the same filesystem.
+      try {
+        rewriteJsonFileAtomic(configFile, (config) => {
           delete config.pid;
           delete config.started_at;
           delete config.log_file;
           config.stopped_at = new Date().toISOString();
-
-          writeFileSync(configFile, JSON.stringify(config, null, 2));
-        } catch (error) {
-          // Config update failed, but bridge was stopped
-          console.warn('Failed to update config file, but bridge was stopped');
-        }
+        });
+      } catch {
+        // Config update failed, but bridge was stopped
+        console.warn('Failed to update config file, but bridge was stopped');
       }
     } catch (error: any) {
       console.error('Failed to stop bridge:', error.message);
 
-      // Clean up potentially stale PID file
-      if (existsSync(pidFile)) {
-        unlinkSync(pidFile);
-      }
+      // Clean up potentially stale PID file (ENOENT-tolerant)
+      unlinkIfExists(pidFile);
     }
   });
 }

--- a/packages/cli/src/commands/bundle.ts
+++ b/packages/cli/src/commands/bundle.ts
@@ -23,6 +23,7 @@ import {
   type JsonWebKeySet,
   type CreateDisputeBundleOptions,
 } from '@peac/audit';
+import { readFileBufferSnapshot, readFileUtf8Snapshot } from '../lib/safe-file.js';
 
 /**
  * Global options for bundle commands
@@ -74,35 +75,42 @@ function outputError(
 }
 
 /**
- * Read receipts from a directory or files
+ * Read receipts from a directory or files. Uses fd-bound read for the
+ * single-file case so existence and content read happen atomically; on
+ * EISDIR the helper signals a directory path and we fall back to
+ * readdirSync + per-file fd-bound reads. The directory listing path is
+ * not subject to a check-then-read race because each per-file read is
+ * itself fd-bound via readFileUtf8Snapshot.
  */
 function readReceipts(receiptsPath: string): string[] {
   const receipts: string[] = [];
-  const stat = fs.statSync(receiptsPath);
 
-  if (stat.isDirectory()) {
-    // Read all .jws files in directory
-    const files = fs.readdirSync(receiptsPath);
-    for (const file of files) {
-      if (file.endsWith('.jws')) {
-        const content = fs.readFileSync(path.join(receiptsPath, file), 'utf8').trim();
-        receipts.push(content);
+  let singleFile: string | undefined;
+  try {
+    singleFile = readFileUtf8Snapshot(receiptsPath);
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e.code === 'EISDIR') {
+      const files = fs.readdirSync(receiptsPath);
+      for (const file of files) {
+        if (file.endsWith('.jws')) {
+          receipts.push(readFileUtf8Snapshot(path.join(receiptsPath, file)).trim());
+        }
       }
+      return receipts;
     }
-  } else {
-    // Single file - read it
-    const content = fs.readFileSync(receiptsPath, 'utf8').trim();
-    receipts.push(content);
+    throw err;
   }
 
+  receipts.push(singleFile.trim());
   return receipts;
 }
 
 /**
- * Read JWKS from file
+ * Read JWKS from file via a single fd-bound read.
  */
 function readJwks(keysPath: string): JsonWebKeySet {
-  const content = fs.readFileSync(keysPath, 'utf8');
+  const content = readFileUtf8Snapshot(keysPath);
   return JSON.parse(content) as JsonWebKeySet;
 }
 
@@ -125,20 +133,30 @@ bundle
     const globalOpts = getGlobalOptions(cmd);
 
     try {
-      // Validate input paths exist
-      if (!fs.existsSync(options.receipts)) {
-        outputError('Receipts path not found', { path: options.receipts }, globalOpts);
-        process.exit(1);
+      // Read inputs via fd-bound helpers; existence and content read happen atomically.
+      // ENOENT is translated to a user-facing not-found error per input path; other
+      // errno values fall through to the outer error path.
+      let receipts: string[];
+      try {
+        receipts = readReceipts(options.receipts);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          outputError('Receipts path not found', { path: options.receipts }, globalOpts);
+          process.exit(1);
+        }
+        throw err;
       }
 
-      if (!fs.existsSync(options.keys)) {
-        outputError('JWKS file not found', { path: options.keys }, globalOpts);
-        process.exit(1);
+      let keys: JsonWebKeySet;
+      try {
+        keys = readJwks(options.keys);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          outputError('JWKS file not found', { path: options.keys }, globalOpts);
+          process.exit(1);
+        }
+        throw err;
       }
-
-      // Read inputs
-      const receipts = readReceipts(options.receipts);
-      const keys = readJwks(options.keys);
 
       if (receipts.length === 0) {
         outputError('No receipts found', { path: options.receipts }, globalOpts);
@@ -148,11 +166,15 @@ bundle
       // Read policy if provided
       let policy: string | undefined;
       if (options.policy) {
-        if (!fs.existsSync(options.policy)) {
-          outputError('Policy file not found', { path: options.policy }, globalOpts);
-          process.exit(1);
+        try {
+          policy = readFileUtf8Snapshot(options.policy);
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+            outputError('Policy file not found', { path: options.policy }, globalOpts);
+            process.exit(1);
+          }
+          throw err;
         }
-        policy = fs.readFileSync(options.policy, 'utf8');
       }
 
       // Create bundle
@@ -228,14 +250,17 @@ bundle
     const globalOpts = getGlobalOptions(cmd);
 
     try {
-      // Validate bundle exists
-      if (!fs.existsSync(bundlePath)) {
-        outputError('Bundle file not found', { path: bundlePath }, globalOpts);
-        process.exit(1);
+      // Read bundle via fd-bound snapshot; existence and content read happen atomically.
+      let zipBuffer: Buffer;
+      try {
+        zipBuffer = readFileBufferSnapshot(bundlePath);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          outputError('Bundle file not found', { path: bundlePath }, globalOpts);
+          process.exit(1);
+        }
+        throw err;
       }
-
-      // Read bundle
-      const zipBuffer = fs.readFileSync(bundlePath);
 
       // Verify bundle - offline by default, online if explicitly requested
       const offline = !options.online;
@@ -302,14 +327,17 @@ bundle
     const globalOpts = getGlobalOptions(cmd);
 
     try {
-      // Validate bundle exists
-      if (!fs.existsSync(bundlePath)) {
-        outputError('Bundle file not found', { path: bundlePath }, globalOpts);
-        process.exit(1);
+      // Read bundle via fd-bound snapshot; existence and content read happen atomically.
+      let zipBuffer: Buffer;
+      try {
+        zipBuffer = readFileBufferSnapshot(bundlePath);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          outputError('Bundle file not found', { path: bundlePath }, globalOpts);
+          process.exit(1);
+        }
+        throw err;
       }
-
-      // Read bundle
-      const zipBuffer = fs.readFileSync(bundlePath);
       const result = await readDisputeBundle(zipBuffer);
 
       if (!result.ok) {

--- a/packages/cli/src/commands/policy.ts
+++ b/packages/cli/src/commands/policy.ts
@@ -47,6 +47,7 @@ import {
   ProfileError,
   type ProfileId,
 } from '@peac/policy-kit';
+import { writeFileNoOverwrite } from '../lib/safe-file.js';
 
 /**
  * Global options for policy commands
@@ -126,16 +127,6 @@ policy
         const outputPath =
           options.output || (format === 'json' ? 'peac-policy.json' : 'peac-policy.yaml');
 
-        // Check if file exists and --force/--yes not set
-        if (fs.existsSync(outputPath) && !options.force && !globalOpts.yes) {
-          outputError(
-            `File already exists: ${outputPath}`,
-            { path: outputPath, hint: 'Use --force or --yes to overwrite' },
-            globalOpts
-          );
-          process.exit(1);
-        }
-
         let content: string;
         let policyName: string;
 
@@ -160,7 +151,28 @@ policy
           policyName = 'Example Policy';
         }
 
-        fs.writeFileSync(outputPath, content, 'utf-8');
+        // Atomic write: refuse to overwrite an existing target unless --force or
+        // --yes is set. The no-overwrite path uses POSIX O_CREAT | O_EXCL via
+        // writeFileNoOverwrite, which surfaces EEXIST without ever inspecting
+        // the target with a separate existence probe.
+        const allowOverwrite = options.force === true || globalOpts.yes === true;
+        try {
+          if (allowOverwrite) {
+            fs.writeFileSync(outputPath, content, { encoding: 'utf-8', flag: 'w' });
+          } else {
+            writeFileNoOverwrite(outputPath, content, { encoding: 'utf-8' });
+          }
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+            outputError(
+              `File already exists: ${outputPath}`,
+              { path: outputPath, hint: 'Use --force or --yes to overwrite' },
+              globalOpts
+            );
+            process.exit(1);
+          }
+          throw err;
+        }
 
         if (globalOpts.json) {
           output(

--- a/packages/cli/src/commands/reconcile.ts
+++ b/packages/cli/src/commands/reconcile.ts
@@ -18,6 +18,7 @@ import * as fs from 'fs';
 import { readDisputeBundle, type DisputeBundleContents } from '@peac/audit';
 import { computeReceiptRef } from '@peac/schema';
 import { decode } from '@peac/crypto';
+import { readFileBufferSnapshot } from '../lib/safe-file.js';
 
 // =============================================================================
 // TYPES
@@ -163,25 +164,47 @@ async function readBundle(
   bundlePath: string,
   label: string
 ): Promise<{ ok: true; value: DisputeBundleContents } | { ok: false; error: string }> {
-  if (!fs.existsSync(bundlePath)) {
-    return { ok: false, error: `Bundle file not found: ${bundlePath}` };
-  }
-
-  const stat = fs.statSync(bundlePath);
-  if (stat.size > MAX_BUNDLE_SIZE) {
-    return { ok: false, error: `Bundle ${label} exceeds 16 MB size limit (${stat.size} bytes)` };
-  }
-
-  // Path traversal prevention: resolve to absolute and check it stays within expected directory
-  const resolved = fs.realpathSync(bundlePath);
-  if (resolved !== bundlePath && !resolved.startsWith(process.cwd())) {
-    // Allow if the path is a valid absolute path
-    if (!fs.existsSync(resolved)) {
-      return { ok: false, error: `Path traversal detected for ${label}` };
+  // Path traversal prevention: resolve to absolute and check it stays within expected directory.
+  // Preserve the historical behavior verbatim: the realpath check below mirrors the v0.11.3+
+  // intent and is intentionally non-strict for absolute paths whose realpath equals the input.
+  let resolved: string;
+  try {
+    resolved = fs.realpathSync(bundlePath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { ok: false, error: `Bundle file not found: ${bundlePath}` };
     }
+    return { ok: false, error: `Failed to read ${label}: ${(err as Error).message}` };
+  }
+  if (resolved !== bundlePath && !resolved.startsWith(process.cwd())) {
+    // If the realpath escapes cwd and the input was not already absolute,
+    // surface it as a path-traversal error. realpathSync raises ENOENT for a
+    // missing file, so the resolved path here is known to exist.
+    return { ok: false, error: `Path traversal detected for ${label}` };
   }
 
-  const zipBuffer = fs.readFileSync(bundlePath);
+  // fd-bound read with size validation. Errno discrimination handles the
+  // missing/wrong-type/oversize failure surfaces the caller observes.
+  let zipBuffer: Buffer;
+  try {
+    zipBuffer = readFileBufferSnapshot(bundlePath, { maxBytes: MAX_BUNDLE_SIZE });
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & { actualSize?: number };
+    if (e.code === 'ENOENT') {
+      return { ok: false, error: `Bundle file not found: ${bundlePath}` };
+    }
+    if (e.code === 'EISDIR') {
+      return { ok: false, error: `Bundle ${label} is not a regular file: ${bundlePath}` };
+    }
+    if (e.code === 'E_PEAC_FILE_TOO_LARGE') {
+      return {
+        ok: false,
+        error: `Bundle ${label} exceeds 16 MB size limit (${e.actualSize ?? 'unknown'} bytes)`,
+      };
+    }
+    return { ok: false, error: `Failed to read ${label}: ${(err as Error).message}` };
+  }
+
   const result = await readDisputeBundle(zipBuffer);
   if (!result.ok) {
     return { ok: false, error: `Failed to read ${label}: ${result.error.message}` };

--- a/packages/cli/src/lib/safe-file.ts
+++ b/packages/cli/src/lib/safe-file.ts
@@ -1,0 +1,233 @@
+/**
+ * Internal file-IO helpers for @peac/cli command handlers.
+ *
+ * Package-private; not exported from any package barrel and not part of
+ * the public CLI API. Mirrors the syscall-style conventions already in
+ * use in `output-preflight.ts`: named imports from `node:fs`,
+ * fd-bound reads, errno discrimination via `NodeJS.ErrnoException`, and
+ * `closeSync` always wrapped in `try`/`finally` with secondary errors
+ * swallowed so they do not mask the primary error.
+ *
+ * The helpers exist to remove TOCTOU patterns where an existence probe
+ * (`existsSync` / `accessSync` / `statSync`) is followed by a file
+ * operation (`readFileSync` / `writeFileSync` / `openSync` / `unlinkSync`)
+ * on the same path. The atomic alternative is a single syscall that
+ * discriminates outcome via errno: success means the operation worked;
+ * `ENOENT` means the file is missing; `EACCES` means the file is
+ * unreadable / unwritable; `EISDIR` / `ENOTDIR` means the path is the
+ * wrong type.
+ *
+ * Each helper takes a path string. Internal use of file descriptors is
+ * hidden from the caller. Callers receive plain return values on success
+ * and `NodeJS.ErrnoException`-shaped errors on failure that they can
+ * inspect via `e.code === 'ENOENT' | 'EACCES' | 'EEXIST' | 'EISDIR' |
+ * 'ENOTDIR'` and translate into user-facing wording.
+ */
+
+import {
+  closeSync,
+  constants as fsConstants,
+  fstatSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { randomBytes } from 'node:crypto';
+
+/**
+ * Read the entire file at `path` as a UTF-8 string via a single
+ * fd-bound `open`/`fstat`/`read`/`close` sequence.
+ *
+ * Throws an `ErrnoException`-shaped error on failure. Callers
+ * discriminate via `e.code`:
+ *   - `ENOENT`: file does not exist
+ *   - `EISDIR`: path resolves to a directory
+ *   - `EACCES`: not readable
+ */
+export function readFileUtf8Snapshot(path: string): string {
+  let fd: number | undefined;
+  try {
+    fd = openSync(path, fsConstants.O_RDONLY);
+    const stat = fstatSync(fd);
+    if (stat.isDirectory()) {
+      throw makeErrnoError('EISDIR', `is a directory: ${path}`);
+    }
+    return readFileSync(fd, 'utf8');
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        // ignore close-on-cleanup errors
+      }
+    }
+  }
+}
+
+/**
+ * Read the entire file at `path` as a `Buffer` via a single fd-bound
+ * `open`/`fstat`/`read`/`close` sequence. Optionally enforces a maximum
+ * byte size. The size limit is checked twice: once against the `fstat`
+ * size before reading (cheap fast-fail) and once against the actual
+ * read length (defends against the file growing between `fstat` and the
+ * subsequent `readFileSync`).
+ *
+ * Throws on failure:
+ *   - `ENOENT`: file does not exist
+ *   - `EISDIR`: path resolves to a directory
+ *   - `EACCES`: not readable
+ *   - `E_PEAC_FILE_TOO_LARGE`: file exceeds `options.maxBytes`
+ */
+export function readFileBufferSnapshot(path: string, options?: { maxBytes?: number }): Buffer {
+  let fd: number | undefined;
+  try {
+    fd = openSync(path, fsConstants.O_RDONLY);
+    const stat = fstatSync(fd);
+    if (stat.isDirectory()) {
+      throw makeErrnoError('EISDIR', `is a directory: ${path}`);
+    }
+    if (options?.maxBytes !== undefined && stat.size > options.maxBytes) {
+      throw makeFileTooLargeError(path, stat.size, options.maxBytes);
+    }
+    const data = readFileSync(fd);
+    if (options?.maxBytes !== undefined && data.length > options.maxBytes) {
+      throw makeFileTooLargeError(path, data.length, options.maxBytes);
+    }
+    return data;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        // ignore close-on-cleanup errors
+      }
+    }
+  }
+}
+
+function makeFileTooLargeError(
+  path: string,
+  actualSize: number,
+  maxBytes: number
+): NodeJS.ErrnoException & { actualSize?: number; maxBytes?: number } {
+  const err = new Error(
+    `file size ${actualSize} bytes exceeds limit ${maxBytes} bytes: ${path}`
+  ) as NodeJS.ErrnoException & { actualSize?: number; maxBytes?: number };
+  err.code = 'E_PEAC_FILE_TOO_LARGE';
+  err.actualSize = actualSize;
+  err.maxBytes = maxBytes;
+  return err;
+}
+
+/**
+ * Write `data` to `path` atomically without overwriting an existing
+ * file. Uses POSIX `O_CREAT | O_EXCL | O_WRONLY` semantics via Node's
+ * `'wx'` flag. The path either gets created with the supplied content
+ * or the call throws `EEXIST`.
+ *
+ * Callers translate `EEXIST` into user-facing wording (e.g. "use --force
+ * to overwrite").
+ */
+export function writeFileNoOverwrite(
+  path: string,
+  data: string | Buffer,
+  options?: { encoding?: BufferEncoding; mode?: number }
+): void {
+  const encoding: BufferEncoding | null =
+    typeof data === 'string' ? (options?.encoding ?? 'utf8') : null;
+  writeFileSync(path, data, {
+    encoding,
+    flag: 'wx',
+    mode: options?.mode,
+  });
+}
+
+/**
+ * Rewrite a JSON config file atomically. If the file does not exist
+ * (ENOENT), returns silently: there is no config to rewrite. Otherwise
+ * the existing content is parsed, `mutate(config)` is invoked, and the
+ * mutated config is written via a sibling temp file plus
+ * `renameSync`. The final target path is never partially written.
+ *
+ * Existing file permissions on the target are preserved across the
+ * rename. If the existing mode cannot be observed, the temp file is
+ * created with a restrictive `0o600` fallback so a config rewrite never
+ * accidentally widens the permission set.
+ *
+ * Cleans up the temp file if rename fails. Read failures other than
+ * `ENOENT` propagate to the caller.
+ */
+export function rewriteJsonFileAtomic(
+  path: string,
+  mutate: (config: Record<string, unknown>) => void
+): void {
+  let raw: string;
+  let preservedMode = 0o600;
+  let fd: number | undefined;
+  try {
+    fd = openSync(path, fsConstants.O_RDONLY);
+    const stat = fstatSync(fd);
+    if (stat.isDirectory()) {
+      throw makeErrnoError('EISDIR', `is a directory: ${path}`);
+    }
+    const observedMode = stat.mode & 0o777;
+    if (observedMode !== 0) preservedMode = observedMode;
+    raw = readFileSync(fd, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw err;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        // ignore close-on-cleanup errors
+      }
+    }
+  }
+
+  const config = JSON.parse(raw) as Record<string, unknown>;
+
+  mutate(config);
+
+  const parent = dirname(path);
+  const tempName = `.${process.pid}.${Date.now()}.${randomBytes(6).toString('hex')}.tmp`;
+  const tempPath = join(parent, tempName);
+
+  try {
+    writeFileSync(tempPath, JSON.stringify(config, null, 2), {
+      encoding: 'utf8',
+      flag: 'wx',
+      mode: preservedMode,
+    });
+    renameSync(tempPath, path);
+  } catch (err) {
+    try {
+      unlinkSync(tempPath);
+    } catch {
+      // best-effort temp cleanup; ignore secondary errors
+    }
+    throw err;
+  }
+}
+
+/**
+ * Remove the file at `path` if it exists. Swallows `ENOENT`. All
+ * other errors propagate to the caller.
+ */
+export function unlinkIfExists(path: string): void {
+  try {
+    unlinkSync(path);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+}
+
+function makeErrnoError(code: string, message: string): NodeJS.ErrnoException {
+  const err = new Error(message) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}

--- a/packages/cli/tests/no-toctou-pattern.test.ts
+++ b/packages/cli/tests/no-toctou-pattern.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Regression test: assert the check-then-use file-system race patterns
+ * removed from the CLI command handlers stay removed.
+ *
+ * The test reads each source file as text and asserts the absence of the
+ * specific paired patterns previously present (existsSync / accessSync /
+ * statSync followed by readFileSync / writeFileSync / openSync on the same
+ * path). It does not enforce a blanket ban on every `existsSync` call:
+ * directory-existence guards used to drive `mkdirSync` remain acceptable
+ * (`peac policy generate` uses two of those). What it forbids is the
+ * specific check-then-read or check-then-write pair that produces the
+ * race window.
+ *
+ * If a future change reintroduces any of the patterns asserted below,
+ * this test fails before the static analyzer reports them on the next scan.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC = join(HERE, '..', 'src');
+const COMMANDS = join(SRC, 'commands');
+
+function readSource(rel: string): string {
+  return readFileSync(join(COMMANDS, rel), 'utf8');
+}
+
+describe('TOCTOU pattern regression for CLI command handlers', () => {
+  it('policy.ts: init action does not check-then-write outputPath', () => {
+    const src = readSource('policy.ts');
+    // The pre-fix pattern guarded a writeFileSync(outputPath, ...) with
+    // existsSync(outputPath); the atomic 'wx' flag now discriminates at
+    // write time.
+    expect(src).not.toMatch(/fs\.existsSync\(outputPath\)/);
+  });
+
+  it('reconcile.ts: readBundle does not check-then-read bundlePath', () => {
+    const src = readSource('reconcile.ts');
+    expect(src).not.toMatch(/fs\.existsSync\(bundlePath\)/);
+    expect(src).not.toMatch(/fs\.statSync\(bundlePath\)/);
+    // The dropped inner branch was `if (!fs.existsSync(resolved))`.
+    expect(src).not.toMatch(/fs\.existsSync\(resolved\)/);
+  });
+
+  it('bundle.ts: command actions do not pre-check options.{receipts,keys,policy}', () => {
+    const src = readSource('bundle.ts');
+    expect(src).not.toMatch(/fs\.existsSync\(options\.receipts\)/);
+    expect(src).not.toMatch(/fs\.existsSync\(options\.keys\)/);
+    expect(src).not.toMatch(/fs\.existsSync\(options\.policy\)/);
+    // `bundle verify` and `bundle info` argument was named `bundlePath`.
+    expect(src).not.toMatch(/fs\.existsSync\(bundlePath\)/);
+    // readReceipts no longer relies on a separate statSync to discriminate type.
+    expect(src).not.toMatch(/fs\.statSync\(receiptsPath\)/);
+  });
+
+  it('bridge/start.ts: log file is opened ONCE, not twice on the same path', () => {
+    const src = readSource(join('bridge', 'start.ts'));
+    // The pre-fix pattern was two consecutive openSync(logFile, 'a')
+    // calls. After the fix there is at most one openSync call binding
+    // logFile, and it uses explicit POSIX flags.
+    const matches = src.match(/openSync\(\s*logFile\b/g) ?? [];
+    expect(matches.length).toBeLessThanOrEqual(1);
+    // The bare `'a'` flag form is replaced with explicit O_WRONLY|O_APPEND|O_CREAT.
+    expect(src).not.toMatch(/openSync\(\s*logFile,\s*['"]a['"]/);
+  });
+
+  it('bridge/stop.ts: pidFile and configFile are not pre-checked before read/write', () => {
+    const src = readSource(join('bridge', 'stop.ts'));
+    expect(src).not.toMatch(/existsSync\(pidFile\)/);
+    expect(src).not.toMatch(/existsSync\(configFile\)/);
+  });
+});

--- a/packages/cli/tests/safe-file.test.ts
+++ b/packages/cli/tests/safe-file.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Unit tests for the package-private file-IO helpers in
+ * `packages/cli/src/lib/safe-file.ts`. Each helper covers the success
+ * path plus the errno branches that the command-handler call sites
+ * discriminate on (`ENOENT`, `EISDIR`, `EEXIST`, `E_PEAC_FILE_TOO_LARGE`).
+ *
+ * Tests run inside per-test temp directories created via
+ * `mkdtempSync` so they do not depend on or mutate any shared state.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  readFileBufferSnapshot,
+  readFileUtf8Snapshot,
+  rewriteJsonFileAtomic,
+  unlinkIfExists,
+  writeFileNoOverwrite,
+} from '../src/lib/safe-file.js';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'peac-cli-safe-file-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('readFileUtf8Snapshot', () => {
+  it('returns file contents on success', () => {
+    const target = join(dir, 'a.txt');
+    writeFileSync(target, 'hello\n', 'utf8');
+
+    expect(readFileUtf8Snapshot(target)).toBe('hello\n');
+  });
+
+  it('throws ENOENT for a missing file', () => {
+    expect(() => readFileUtf8Snapshot(join(dir, 'missing.txt'))).toThrow(
+      expect.objectContaining({ code: 'ENOENT' })
+    );
+  });
+
+  it('throws EISDIR when the path resolves to a directory', () => {
+    const subdir = join(dir, 'subdir');
+    mkdirSync(subdir);
+
+    expect(() => readFileUtf8Snapshot(subdir)).toThrow(expect.objectContaining({ code: 'EISDIR' }));
+  });
+});
+
+describe('readFileBufferSnapshot', () => {
+  it('returns a buffer on success', () => {
+    const target = join(dir, 'binary.bin');
+    writeFileSync(target, Buffer.from([0xde, 0xad, 0xbe, 0xef]));
+
+    const buf = readFileBufferSnapshot(target);
+    expect(Buffer.isBuffer(buf)).toBe(true);
+    expect(buf.length).toBe(4);
+    expect(buf[0]).toBe(0xde);
+  });
+
+  it('rejects oversized files with E_PEAC_FILE_TOO_LARGE before reading', () => {
+    const target = join(dir, 'big.bin');
+    writeFileSync(target, Buffer.alloc(2048));
+
+    expect(() => readFileBufferSnapshot(target, { maxBytes: 1024 })).toThrow(
+      expect.objectContaining({ code: 'E_PEAC_FILE_TOO_LARGE' })
+    );
+  });
+
+  it('accepts files within maxBytes', () => {
+    const target = join(dir, 'small.bin');
+    writeFileSync(target, Buffer.alloc(512));
+
+    expect(readFileBufferSnapshot(target, { maxBytes: 1024 }).length).toBe(512);
+  });
+
+  it('throws ENOENT for a missing file', () => {
+    expect(() => readFileBufferSnapshot(join(dir, 'missing.bin'))).toThrow(
+      expect.objectContaining({ code: 'ENOENT' })
+    );
+  });
+});
+
+describe('writeFileNoOverwrite', () => {
+  it('creates the target file when it does not exist', () => {
+    const target = join(dir, 'new.txt');
+
+    writeFileNoOverwrite(target, 'data', { encoding: 'utf8' });
+
+    expect(readFileSync(target, 'utf8')).toBe('data');
+  });
+
+  it('throws EEXIST when the target already exists', () => {
+    const target = join(dir, 'existing.txt');
+    writeFileSync(target, 'pre-existing', 'utf8');
+
+    expect(() => writeFileNoOverwrite(target, 'data')).toThrow(
+      expect.objectContaining({ code: 'EEXIST' })
+    );
+    expect(readFileSync(target, 'utf8')).toBe('pre-existing');
+  });
+
+  it('writes Buffer payloads', () => {
+    const target = join(dir, 'buf.bin');
+    writeFileNoOverwrite(target, Buffer.from([0x01, 0x02, 0x03]));
+
+    const written = readFileSync(target);
+    expect(written.length).toBe(3);
+    expect(written[1]).toBe(0x02);
+  });
+});
+
+describe('rewriteJsonFileAtomic', () => {
+  it('returns silently when the target does not exist', () => {
+    const target = join(dir, 'absent.json');
+
+    rewriteJsonFileAtomic(target, () => {
+      throw new Error('mutate must not run when file is absent');
+    });
+
+    expect(existsSync(target)).toBe(false);
+  });
+
+  it('rewrites an existing config atomically', () => {
+    const target = join(dir, 'config.json');
+    writeFileSync(target, JSON.stringify({ keep: true, drop_me: 1 }), 'utf8');
+
+    rewriteJsonFileAtomic(target, (config) => {
+      delete config.drop_me;
+      config.added = 'value';
+    });
+
+    const after = JSON.parse(readFileSync(target, 'utf8'));
+    expect(after).toEqual({ keep: true, added: 'value' });
+  });
+
+  it('does not leave a sibling temp file behind on success', () => {
+    const target = join(dir, 'config.json');
+    writeFileSync(target, '{"x":1}', 'utf8');
+
+    rewriteJsonFileAtomic(target, (config) => {
+      config.x = 2;
+    });
+
+    const siblings = readdirSync(dir).filter((name) => name.endsWith('.tmp'));
+    expect(siblings).toEqual([]);
+  });
+});
+
+describe('unlinkIfExists', () => {
+  it('removes the file when it exists', () => {
+    const target = join(dir, 'doomed.txt');
+    writeFileSync(target, 'bye', 'utf8');
+
+    unlinkIfExists(target);
+
+    expect(existsSync(target)).toBe(false);
+  });
+
+  it('returns silently when the file does not exist', () => {
+    const target = join(dir, 'never-existed.txt');
+
+    expect(() => unlinkIfExists(target)).not.toThrow();
+    expect(existsSync(target)).toBe(false);
+  });
+
+  it('propagates errors other than ENOENT', () => {
+    if (process.platform === 'win32') return; // chmod semantics differ on Windows
+    const subdir = join(dir, 'locked');
+    mkdirSync(subdir);
+    const target = join(subdir, 'inside.txt');
+    writeFileSync(target, 'data');
+    chmodSync(subdir, 0o500); // read+exec only; cannot remove children
+
+    try {
+      expect(() => unlinkIfExists(target)).toThrow();
+    } finally {
+      chmodSync(subdir, 0o700);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Hardens CLI command-handler file operations against check-then-use file-system race patterns by replacing existence/type probes with operation-specific atomic file handling.

## Scope

- `packages/cli/src/commands/policy.ts`
  - `policy init` now refuses overwrite atomically through the no-overwrite helper.
- `packages/cli/src/commands/reconcile.ts`
  - bundle reads use fd-bound snapshot reads while preserving existing path semantics.
- `packages/cli/src/commands/bundle.ts`
  - receipt, JWKS, policy, verify, and info reads use fd-bound reads and actual-operation error handling.
- `packages/cli/src/commands/bridge/start.ts`
  - bridge log file is opened once and the same fd is passed to stdout/stderr.
  - the existing bridge-path pre-check is intentionally preserved because local verification showed `node <missing-script>` exits as a child runtime error rather than emitting a spawn-level `error`.
- `packages/cli/src/commands/bridge/stop.ts`
  - PID/config cleanup is ENOENT-tolerant and config rewrite uses temp-file plus same-directory rename.
- `packages/cli/src/lib/safe-file.ts`
  - package-private helper only; not exported from the public CLI surface.
- `packages/cli/tests/safe-file.test.ts`
- `packages/cli/tests/no-toctou-pattern.test.ts`

## Behavior

No public CLI surface change. No new commands. No new flags. No package, registry, schema, spec, docs, examples, or lockfile changes.

User-facing behavior is preserved. `policy init` still exits non-zero with `File already exists: <path>` when overwrite is not allowed, and `--force` still overwrites.

## Validation

- `pnpm format:check`
- `git diff --check`
- `pnpm --filter '@peac/cli' test`
- `pnpm --filter '@peac/cli' build`
- built CLI smoke test for `policy init` fresh-create / no-overwrite refusal / `--force`
- `pnpm gate:fast`
- `pnpm verify:release`
- `bash scripts/ci/forbid-strings.sh`

## Compatibility

No wire format change. No public API change. No new package. No new emitted error code.
