### PR TITLE
chore(deps): bump hono, fast-uri, ip-address to patched versions

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -38,7 +38,7 @@
     "@peac/receipts": "workspace:*",
     "@peac/resolver-http": "workspace:*",
     "@peac/schema": "workspace:*",
-    "hono": "^4.12.15",
+    "hono": "^4.12.18",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/sandbox-issuer/package.json
+++ b/apps/sandbox-issuer/package.json
@@ -20,7 +20,7 @@
     "@peac/middleware-core": "workspace:*",
     "@peac/protocol": "workspace:*",
     "@peac/schema": "workspace:*",
-    "hono": "^4.12.15",
+    "hono": "^4.12.18",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -157,7 +157,9 @@
       "path-to-regexp@>=8.0.0": ">=8.4.0",
       "yaml": "2.8.3",
       "@hono/node-server": ">=1.19.13",
-      "hono": ">=4.12.12",
+      "hono": ">=4.12.18",
+      "fast-uri@<3.1.2": ">=3.1.2",
+      "ip-address@<=10.1.0": ">=10.1.1",
       "protobufjs": ">=8.0.1",
       "defu": ">=6.1.5",
       "esbuild@<0.25.0": ">=0.25.0",
@@ -180,7 +182,10 @@
       "esbuild@<0.25.0": "Range-scoped to <0.25.0 only (forces patched 0.25.0+, fixes GHSA-67mh-4wv8-2f99 dev-server CORS bypass). Dev-only via wrangler / @esbuild-plugins/node-globals-polyfill peer / @esbuild-plugins/node-modules-polyfill peer (all ship esbuild 0.17.19). Newer esbuild instances at 0.25.12+ already pulled by vitest/tsx are unaffected.",
       "undici@<6.24.0": "Range-scoped to <6.24.0 only (forces patched 6.24.0+, fixes GHSA-4992-7rv2-5pvq CRLF injection via upgrade and GHSA-2mjp-6q6p-2qxm HTTP request/response smuggling). Dev-only via wrangler -> miniflare which bundles undici 5.29.0. @peac/net-node already uses undici 6.24.0+ (production path unaffected).",
       "postcss@<8.5.10": "Range-scoped to <8.5.10 only (forces patched 8.5.10+, fixes GHSA-qx2v-qp2m-jg93 XSS via unescaped </style> in CSS Stringify output). Dev-only via next 15.5.x (bundles postcss 8.4.31 internally) and vite. Workspace doesn't import postcss directly; affects build tooling only.",
-      "vite@<6.4.2": "Range-scoped to <6.4.2 only (forces patched 6.4.2+, fixes GHSA-p9ff-h696-f583 arbitrary file read via dev server WebSocket and GHSA-4w7w-66w2-5vf9 path traversal in optimized deps .map handling). Dev-only via vitest/@vitest/coverage-v8. pnpm resolves the override to vite 8.0.10 in practice; full test suite passes."
+      "vite@<6.4.2": "Range-scoped to <6.4.2 only (forces patched 6.4.2+, fixes GHSA-p9ff-h696-f583 arbitrary file read via dev server WebSocket and GHSA-4w7w-66w2-5vf9 path traversal in optimized deps .map handling). Dev-only via vitest/@vitest/coverage-v8. pnpm resolves the override to vite 8.0.10 in practice; full test suite passes.",
+      "hono": "Bumped from >=4.12.12 to >=4.12.18 to pull patches for CVE-2026-44455 (bodyLimit() bypass for chunked / unknown-length requests), CVE-2026-44456 (hono/jsx unvalidated JSX tag names), CVE-2026-44457 (CSS declaration injection via Style Object Values in JSX SSR), CVE-2026-44458 (Cache Middleware ignores Vary: Authorization / Vary: Cookie), and CVE-2026-44459 (improper validation of NumericDate JWT claims). Prod dep via apps/api, apps/sandbox-issuer, packages/mcp-server, packages/server.",
+      "fast-uri@<3.1.2": "Range-scoped to <3.1.2 only (forces patched 3.1.2+, fixes CVE-2026-6321 path traversal via percent-encoded dot segments and CVE-2026-6322 host confusion via percent-encoded authority delimiters). Transitive prod dep via ajv / ajv-formats (in @peac/protocol, @peac/receipts, apps/api) and @modelcontextprotocol/sdk (in @peac/mcp-server).",
+      "ip-address@<=10.1.0": "Range-scoped to <=10.1.0 only (forces patched 10.1.1+, fixes CVE-2026-42338 XSS in Address6 HTML-emitting methods). Transitive prod dep via @modelcontextprotocol/sdk -> express-rate-limit."
     }
   },
   "lint-staged": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -37,7 +37,7 @@
     "@hono/node-server": "^1.19.13",
     "@peac/protocol": "workspace:*",
     "@peac/schema": "workspace:*",
-    "hono": "^4.12.15"
+    "hono": "^4.12.18"
   },
   "devDependencies": {
     "@types/node": "^22.19.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,9 @@ overrides:
   path-to-regexp@>=8.0.0: '>=8.4.0'
   yaml: 2.8.3
   '@hono/node-server': '>=1.19.13'
-  hono: '>=4.12.12'
+  hono: '>=4.12.18'
+  fast-uri@<3.1.2: '>=3.1.2'
+  ip-address@<=10.1.0: '>=10.1.1'
   protobufjs: '>=8.0.1'
   defu: '>=6.1.5'
   esbuild@<0.25.0: '>=0.25.0'
@@ -107,7 +109,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: '>=1.19.13'
-        version: 1.19.13(hono@4.12.15)
+        version: 1.19.13(hono@4.12.18)
       '@peac/crypto':
         specifier: workspace:*
         version: link:../../packages/crypto
@@ -133,8 +135,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/schema
       hono:
-        specifier: '>=4.12.12'
-        version: 4.12.15
+        specifier: '>=4.12.18'
+        version: 4.12.18
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -168,7 +170,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: '>=1.19.13'
-        version: 1.19.13(hono@4.12.15)
+        version: 1.19.13(hono@4.12.18)
       '@peac/crypto':
         specifier: workspace:*
         version: link:../../packages/crypto
@@ -182,8 +184,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/schema
       hono:
-        specifier: '>=4.12.12'
-        version: 4.12.15
+        specifier: '>=4.12.18'
+        version: 4.12.18
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1986,7 +1988,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: '>=1.19.13'
-        version: 1.19.13(hono@4.12.15)
+        version: 1.19.13(hono@4.12.18)
       '@peac/protocol':
         specifier: workspace:*
         version: link:../protocol
@@ -1994,8 +1996,8 @@ importers:
         specifier: workspace:*
         version: link:../schema
       hono:
-        specifier: '>=4.12.12'
-        version: 4.12.15
+        specifier: '>=4.12.18'
+        version: 4.12.18
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -3701,13 +3703,13 @@ packages:
       - '@emnapi/runtime'
     dev: true
 
-  /@hono/node-server@1.19.13(hono@4.12.15):
+  /@hono/node-server@1.19.13(hono@4.12.18):
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.12'
+      hono: '>=4.12.18'
     dependencies:
-      hono: 4.12.15
+      hono: 4.12.18
     dev: false
 
   /@humanfs/core@0.19.1:
@@ -4478,7 +4480,7 @@ packages:
       '@cfworker/json-schema':
         optional: true
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.15)
+      '@hono/node-server': 1.19.13(hono@4.12.18)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -4488,7 +4490,7 @@ packages:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.0(express@5.2.1)
-      hono: 4.12.15
+      hono: 4.12.18
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -6314,7 +6316,7 @@ packages:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7513,7 +7515,7 @@ packages:
       express: '>= 4.11'
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.2.0
     dev: false
 
   /express@4.22.1:
@@ -7616,8 +7618,8 @@ packages:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
     dev: true
 
-  /fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  /fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   /fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
@@ -7978,8 +7980,8 @@ packages:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
     dev: true
 
-  /hono@4.12.15:
-    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+  /hono@4.12.18:
+    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
     engines: {node: '>=16.9.0'}
     dev: false
 
@@ -8064,8 +8066,8 @@ packages:
     engines: {node: '>=10.13.0'}
     dev: true
 
-  /ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  /ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
     dev: false
 


### PR DESCRIPTION
## Summary

Resolves the 8 advisories that `pnpm audit --prod` reports on `main` HEAD: 2 high in `fast-uri`, 5 moderate + 1 low in `hono`, and 1 moderate in `ip-address`. After this PR, `pnpm audit --prod` reports 0 high / 0 moderate / 0 low / 0 critical.

## Scope

- `package.json` (root)
  - `hono` override: `>=4.12.12` -> `>=4.12.18` (CVE-2026-44455/56/57/58/59)
  - new `fast-uri@<3.1.2: >=3.1.2` override (CVE-2026-6321/6322)
  - new `ip-address@<=10.1.0: >=10.1.1` override (CVE-2026-42338)
  - matching `overridesComments` entries describing each advisory
- `apps/api/package.json`, `apps/sandbox-issuer/package.json`, `packages/server/package.json`
  - direct `hono` dep bumped from `^4.12.15` to `^4.12.18` to match the override floor
- `pnpm-lock.yaml` regenerated by `pnpm install`

`archive/bridge/package.json` is left untouched per the archive-only policy.

## Behavior

No public API change. No new package. No wire format change. No code change in any source file. Pure dependency hygiene.

## Validation

- `pnpm audit --prod`           -> 0 high / 0 moderate / 0 low / 0 critical
- `pnpm format:check`           -> OK
- `pnpm build`                  -> green (turbo cache full)
- `pnpm test`                   -> 9782 passed across 422 files
- `pnpm gate:fast`              -> all gates passed
- `pnpm verify:release`         -> 25 passed / 0 failed / 1 skipped (gate report skip is expected)
- `bash scripts/ci/forbid-strings.sh` -> OK
