### PR TITLE
docs(readme): clarify interoperability use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,19 @@ Portable signed records for API, MCP, agent, and cross-runtime interactions.
 
 ## What you can do with PEAC
 
-| If you...                                  | PEAC helps you...                                                                                                                                           | Start here                                                                        |
-| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| Run an API or HTTP service                 | issue signed interaction records with responses so clients can verify what happened later                                                                   | [API Provider Quickstart](docs/guides/quickstart-api-provider.md)                 |
-| Run an MCP server                          | attach signed records to tool calls and expose verification tools for operators                                                                             | [MCP Integration Kit](integrator-kits/mcp/README.md) or `npx -y @peac/mcp-server` |
-| Need to verify a record                    | verify a PEAC receipt offline with the issuer's public key                                                                                                  | [Agent Operator Quickstart](docs/guides/quickstart-agent-operator.md)             |
-| Operate managed runtimes                   | record governance observations from runtime control planes without making PEAC the control plane                                                            | [`@peac/adapter-runtime-governance`](packages/adapters/runtime-governance/)       |
-| Run agent-to-agent workflows               | record handoff events across agent-card discovery, task lifecycle, and human-review boundaries                                                              | [A2A Handoff Records](docs/specs/A2A-HANDOFF-RECORDS.md)                          |
-| Need command-execution records             | record unsigned observations with `peac observe command` or signed command-execution records with `peac record command`                                     | [CLI Carrier Profile](docs/specs/CLI-CARRIER-PROFILE.md)                          |
-| Need lifecycle records from another system | issue records for caller-reported evaluation, approval, experiment, and workflow events                                                                     | [Lifecycle Observation Profile](docs/specs/LIFECYCLE-OBSERVATION-PROFILE.md)      |
-| Need provisioning lifecycle records        | record reported catalog, provider-link, account, resource, credential, payment-authorization, budget, subscription, domain, and deployment lifecycle events | [Provisioning Lifecycle Records](docs/SOLUTIONS/verify-agent-provisioning.md)     |
+| If you...                                        | PEAC helps you...                                                                                                                                           | Start here                                                                        |
+| ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Run an API or HTTP service                       | issue signed interaction records with responses so clients can verify what happened later                                                                   | [API Provider Quickstart](docs/guides/quickstart-api-provider.md)                 |
+| Run metered APIs or agent-consumed services      | issue records for usage, access decisions, responses, and policy-visible outcomes that may need to be verified after the request                            | [API Provider Quickstart](docs/guides/quickstart-api-provider.md)                 |
+| Run an MCP server                                | attach signed records to tool calls and expose verification tools for operators                                                                             | [MCP Integration Kit](integrator-kits/mcp/README.md) or `npx -y @peac/mcp-server` |
+| Build agentic commerce or payment flows          | record evidence around x402, paymentauth / MPP, ACP, UCP commerce flows, AP2-style payment flows, settlement observations, and disputes                     | [Commerce evidence bundle](docs/SOLUTIONS/commerce-evidence-bundle.md)            |
+| Need to verify a record                          | verify a PEAC receipt offline with the issuer's public key                                                                                                  | [Agent Operator Quickstart](docs/guides/quickstart-agent-operator.md)             |
+| Operate managed runtimes or agent control planes | record runtime-governance observations without making PEAC the control plane                                                                                | [`@peac/adapter-runtime-governance`](packages/adapters/runtime-governance/)       |
+| Need audit evidence beside observability         | produce portable records that can be referenced alongside logs, traces, OpenTelemetry, SIEMs, and audit repositories without replacing them                 | [Where PEAC fits](docs/WHERE-IT-FITS.md)                                          |
+| Run agent-to-agent workflows                     | record handoff events across agent-card discovery, task lifecycle, and human-review boundaries                                                              | [A2A Handoff Records](docs/specs/A2A-HANDOFF-RECORDS.md)                          |
+| Need command-execution records                   | record unsigned observations with `peac observe command` or signed command-execution records with `peac record command`                                     | [CLI Carrier Profile](docs/specs/CLI-CARRIER-PROFILE.md)                          |
+| Need lifecycle records from another system       | issue records for caller-reported evaluation, approval, experiment, and workflow events                                                                     | [Lifecycle Observation Profile](docs/specs/LIFECYCLE-OBSERVATION-PROFILE.md)      |
+| Need provisioning lifecycle records              | record reported catalog, provider-link, account, resource, credential, payment-authorization, budget, subscription, domain, and deployment lifecycle events | [Provisioning Lifecycle Records](docs/SOLUTIONS/verify-agent-provisioning.md)     |
 
 Full path-by-role tree: [`docs/START_HERE.md`](docs/START_HERE.md).
 
@@ -57,17 +60,32 @@ Node 24 tested, Node 22+ compatible. Go middleware and examples supported (Go 1.
 
 Full loop: [`docs/HOW-IT-WORKS.md`](docs/HOW-IT-WORKS.md). Artifact vocabulary (record, receipt, bundle, report): [`docs/ARTIFACTS.md`](docs/ARTIFACTS.md). Where PEAC sits next to other systems: [`docs/WHERE-IT-FITS.md`](docs/WHERE-IT-FITS.md). Protocol scope: [`docs/WHAT-PEAC-STANDARDIZES.md`](docs/WHAT-PEAC-STANDARDIZES.md).
 
-## Solutions
+## Where PEAC fits
 
-Outcome-led recipes under [`docs/SOLUTIONS/`](docs/SOLUTIONS/):
+PEAC is useful when an action crosses a system, organization, protocol, agent, or settlement boundary and the local log is not enough.
 
-- [Runtime evidence export](docs/SOLUTIONS/runtime-evidence-export.md)
+| Surface                                 | What PEAC adds                                                                                                                           |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Metered APIs and HTTP services          | signed records for requests, responses, usage, and policy-visible outcomes                                                               |
+| MCP tools and agent runtimes            | records for tool calls, command execution, handoffs, and runtime observations                                                            |
+| Agentic commerce and automated payments | evidence around x402, paymentauth / MPP, ACP, UCP commerce flows, AP2-style payment flows, settlement observations, and disputes         |
+| Runtime governance and managed agents   | portable observations from Microsoft Agent Governance Toolkit, Claude Managed Agents, custom harnesses, and other runtime control planes |
+| Observability and audit systems         | verifiable records that complement logs, traces, OpenTelemetry, SIEMs, and audit repositories                                            |
+| Cross-protocol workflows                | a records layer beside A2A, MCP, x402, paymentauth / MPP, ACP, UCP / AP2, OpenTelemetry, SLSA, in-toto, and DID-based identity systems   |
+
+PEAC does not replace those systems. It gives them a portable records layer: what was reported, by whom, when, under which protocol context, and with which verifiable signature.
+
+## Use cases
+
+Practical recipes under [`docs/SOLUTIONS/`](docs/SOLUTIONS/):
+
 - [API record issuance](docs/SOLUTIONS/api-receipt-issuance.md)
 - [MCP tool-call records](docs/SOLUTIONS/mcp-tool-call-receipts.md)
 - [Commerce evidence bundle](docs/SOLUTIONS/commerce-evidence-bundle.md)
-- [Regulatory audit trail](docs/SOLUTIONS/regulatory-audit-trail.md)
 - [Cloudflare x402 + PEAC](docs/SOLUTIONS/cloudflare-x402-peac.md)
+- [Runtime evidence export](docs/SOLUTIONS/runtime-evidence-export.md)
 - [Provisioning lifecycle verification](docs/SOLUTIONS/verify-agent-provisioning.md)
+- [Regulatory audit trail](docs/SOLUTIONS/regulatory-audit-trail.md)
 
 ## Why PEAC
 
@@ -75,7 +93,7 @@ Modern systems often need proof that travels beyond the system that produced the
 
 - Logs are local. PEAC records are portable and independently verifiable.
 - Traces correlate execution. PEAC records preserve signed claims across organizational boundaries.
-- Auth, policy, and payment systems decide whether actions may happen. PEAC records what another system reported happened.
+- Auth, policy, runtime, and payment systems decide whether actions may happen. PEAC records what another system reported happened.
 
 ## Try it in 5 minutes
 
@@ -96,13 +114,14 @@ Modern systems often need proof that travels beyond the system that produced the
 - **MCP tools** — [`packages/mcp-server/`](packages/mcp-server/) evidence tools.
 - **Editor and plugin-pack surfaces** — Cursor, Codex, Claude Code, VS Code, Continue, Windsurf, OpenCode under [`surfaces/plugin-pack/`](surfaces/plugin-pack/); canonical [Smithery config](packages/mcp-server/smithery.yaml).
 - **Express middleware** — [`packages/middleware-express/`](packages/middleware-express/).
-- **Commerce mappings** — [`packages/adapters/x402/`](packages/adapters/x402/) (v1 + v2), [`packages/mappings/paymentauth/`](packages/mappings/paymentauth/) (paymentauth / MPP), [`packages/mappings/acp/`](packages/mappings/acp/) (ACP delegated payment).
-- **Runtime governance** — [`packages/adapters/runtime-governance/`](packages/adapters/runtime-governance/) records observations from managed runtimes including Microsoft Agent Governance Toolkit.
+- **Commerce and agentic-payment mappings** — x402 v1/v2, paymentauth / MPP, ACP delegated payment, and UCP commerce envelopes and AP2-style payment-flow records under [`packages/adapters/x402/`](packages/adapters/x402/), [`packages/mappings/paymentauth/`](packages/mappings/paymentauth/), [`packages/mappings/acp/`](packages/mappings/acp/), and [`packages/mappings/ucp/`](packages/mappings/ucp/).
+- **Runtime governance and managed agents** — [`packages/adapters/runtime-governance/`](packages/adapters/runtime-governance/) records observations from Microsoft Agent Governance Toolkit, Claude Managed Agents, and custom runtime control planes.
+- **Observability and audit linkage** — PEAC records can be referenced from traces, reports, bundles, and audit repositories without replacing OpenTelemetry, SIEMs, or log pipelines.
 - **A2A handoff records** — [`docs/specs/A2A-HANDOFF-RECORDS.md`](docs/specs/A2A-HANDOFF-RECORDS.md) and [`integrator-kits/a2a/`](integrator-kits/a2a/).
 - **CLI execution records** — `peac observe command`, `peac record command`, and [`docs/specs/CLI-CARRIER-PROFILE.md`](docs/specs/CLI-CARRIER-PROFILE.md).
 - **Lifecycle observation records** — `peac emit lifecycle` and [`docs/specs/LIFECYCLE-OBSERVATION-PROFILE.md`](docs/specs/LIFECYCLE-OBSERVATION-PROFILE.md).
 - **Provisioning lifecycle records** — [`examples/provisioning-lifecycle/`](examples/provisioning-lifecycle/), [`examples/agent-provisioning-demo/`](examples/agent-provisioning-demo/), and [`docs/SOLUTIONS/verify-agent-provisioning.md`](docs/SOLUTIONS/verify-agent-provisioning.md).
-- **Supply-chain mappings** — [`packages/mappings/intoto/`](packages/mappings/intoto/) and [`packages/mappings/slsa/`](packages/mappings/slsa/).
+- **Supply-chain and provenance mappings** — [`packages/mappings/intoto/`](packages/mappings/intoto/) and [`packages/mappings/slsa/`](packages/mappings/slsa/) for records that sit beside existing provenance systems.
 - **Reference verifier (self-hostable)** — [`apps/api/`](apps/api/) with deployment recipes under [`surfaces/reference-verifier/`](surfaces/reference-verifier/).
 
 Long tail (A2A, gRPC, DID, managed agents, and more): [`docs/README_LONG.md`](docs/README_LONG.md).
@@ -160,7 +179,7 @@ Full doctrine: [`docs/specs/VERSIONING.md`](docs/specs/VERSIONING.md).
 
 - [Start Here](docs/START_HERE.md) — path by role.
 - [How it works](docs/HOW-IT-WORKS.md), [Artifacts](docs/ARTIFACTS.md), [Where it fits](docs/WHERE-IT-FITS.md), [What PEAC standardizes](docs/WHAT-PEAC-STANDARDIZES.md).
-- [Solutions](docs/SOLUTIONS/) — outcome-led recipes.
+- [Use cases](docs/SOLUTIONS/) — practical recipes.
 - [Spec Index](docs/SPEC_INDEX.md) — normative specifications, including [Resource limits](docs/specs/RESOURCE-LIMITS.md).
 - [Standards ledger](docs/STANDARDS_LEDGER.md) — every external standard PEAC cites or implements, by status.
 - [Release-line baselines](docs/baselines/) — historical invariant snapshots and release-line references.


### PR DESCRIPTION
## Summary

Clarifies where PEAC fits across metered APIs, MCP, A2A, agentic commerce, runtime governance, observability, supply-chain provenance, and cross-protocol workflows.

## Scope

- Adds a concise `Where PEAC fits` section.
- Expands README onboarding rows for metered APIs, agentic commerce, runtime governance, and observability-adjacent audit evidence.
- Renames the README-facing `Solutions` section to `Use cases` while preserving the existing `docs/SOLUTIONS/` directory.
- Clarifies commerce, runtime-governance, observability, and provenance implementation surfaces.

## Boundary

README-only. No code, schema, registry, conformance, package metadata, release facts, CLI, dependency, or version changes. PEAC remains framed as a portable records layer beside other systems, not a replacement for them.

## Validation

- `pnpm format:check`
- `git diff --check`
- `node scripts/check-public-artifacts.mjs README.md`
- `bash scripts/ci/forbid-strings.sh`
- README local-link existence check
- README overclaim guard
