### PR TITLE
chore(repo): align version coherence with publish manifest

### DIFF
--- a/scripts/check-version-coherence.sh
+++ b/scripts/check-version-coherence.sh
@@ -21,9 +21,38 @@ const ROOT_VERSION = root.version;
 console.log(`  Root version: ${ROOT_VERSION}`);
 
 const manifest = JSON.parse(fs.readFileSync('scripts/publish-manifest.json', 'utf8'));
-const publishable = new Set(manifest.packages || []);
+if (!Array.isArray(manifest.packages)) {
+  console.log('  FAIL: scripts/publish-manifest.json packages[] must be an array');
+  process.exit(1);
+}
+const publishable = new Set(manifest.packages);
 
 const found = new Map(); // name -> { version, file, private }
+const parseErrors = [];
+const duplicates = [];
+
+function recordPackageManifest(file) {
+  let pkg;
+  try {
+    pkg = JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (err) {
+    parseErrors.push(`${file}: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+
+  if (!pkg.name) return;
+
+  if (found.has(pkg.name)) {
+    duplicates.push(`${pkg.name}: ${found.get(pkg.name).file} and ${file}`);
+    return;
+  }
+
+  found.set(pkg.name, {
+    version: pkg.version || '',
+    file,
+    private: pkg.private === true,
+  });
+}
 
 function walk(dir) {
   let entries;
@@ -38,18 +67,7 @@ function walk(dir) {
     if (e.isDirectory()) {
       walk(p);
     } else if (e.isFile() && e.name === 'package.json') {
-      try {
-        const pkg = JSON.parse(fs.readFileSync(p, 'utf8'));
-        if (pkg.name) {
-          found.set(pkg.name, {
-            version: pkg.version || '',
-            file: p,
-            private: pkg.private === true,
-          });
-        }
-      } catch {
-        // ignore malformed manifests
-      }
+      recordPackageManifest(p);
     }
   }
 }
@@ -60,6 +78,16 @@ for (const base of ['packages', 'apps', 'surfaces']) {
 
 let bad = 0;
 let ok = 0;
+
+for (const error of parseErrors) {
+  console.log(`  FAIL: malformed package.json: ${error}`);
+  bad = 1;
+}
+
+for (const duplicate of duplicates) {
+  console.log(`  FAIL: duplicate package name: ${duplicate}`);
+  bad = 1;
+}
 
 for (const name of publishable) {
   const entry = found.get(name);

--- a/scripts/check-version-coherence.sh
+++ b/scripts/check-version-coherence.sh
@@ -1,62 +1,93 @@
 #!/usr/bin/env bash
 # scripts/check-version-coherence.sh
-# Verify all workspace packages share the same version.
+# Verify the npm release version surface is internally coherent.
 #
-# All packages in the monorepo must have the same version number.
-# This prevents partial publishes and version drift.
+# All publishable packages in scripts/publish-manifest.json must match
+# the root release version. Workspace-private packages are intentionally
+# excluded from npm release-version coherence; private:true is the publish
+# boundary, and private packages may carry independent version fields
+# without affecting the npm release surface.
 
 set -euo pipefail
 
 echo "== Version coherence check =="
 
-# Get root package version as reference
-ROOT_VERSION=$(node -e "console.log(require('./package.json').version)")
-echo "  Root version: $ROOT_VERSION"
+node - <<'NODE'
+const fs = require('fs');
+const path = require('path');
 
-bad=0
-checked=0
+const root = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+const ROOT_VERSION = root.version;
+console.log(`  Root version: ${ROOT_VERSION}`);
 
-for manifest in packages/*/package.json packages/rails/*/package.json packages/mappings/*/package.json packages/transport/*/package.json; do
-  [ -f "$manifest" ] || continue
+const manifest = JSON.parse(fs.readFileSync('scripts/publish-manifest.json', 'utf8'));
+const publishable = new Set(manifest.packages || []);
 
-  PKG_NAME=$(node -e "const p = require('./$manifest'); console.log(p.name || '')")
-  PKG_VERSION=$(node -e "const p = require('./$manifest'); console.log(p.version || '')")
+const found = new Map(); // name -> { version, file, private }
 
-  if [ -z "$PKG_NAME" ] || [ -z "$PKG_VERSION" ]; then
-    continue
-  fi
+function walk(dir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const e of entries) {
+    if (['node_modules', 'dist', '.turbo', '.git'].includes(e.name)) continue;
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      walk(p);
+    } else if (e.isFile() && e.name === 'package.json') {
+      try {
+        const pkg = JSON.parse(fs.readFileSync(p, 'utf8'));
+        if (pkg.name) {
+          found.set(pkg.name, {
+            version: pkg.version || '',
+            file: p,
+            private: pkg.private === true,
+          });
+        }
+      } catch {
+        // ignore malformed manifests
+      }
+    }
+  }
+}
 
-  checked=$((checked + 1))
+for (const base of ['packages', 'apps', 'surfaces']) {
+  if (fs.existsSync(base)) walk(base);
+}
 
-  if [ "$PKG_VERSION" != "$ROOT_VERSION" ]; then
-    echo "  FAIL: $PKG_NAME has version $PKG_VERSION (expected $ROOT_VERSION)"
-    bad=1
-  fi
-done
+let bad = 0;
+let ok = 0;
 
-# Also check apps
-for manifest in apps/*/package.json; do
-  [ -f "$manifest" ] || continue
+for (const name of publishable) {
+  const entry = found.get(name);
+  if (!entry) {
+    console.log(`  FAIL: ${name} listed in publish-manifest but not found in workspace`);
+    bad = 1;
+    continue;
+  }
+  if (entry.private) {
+    console.log(`  FAIL: ${name} is private:true but listed in publish-manifest packages[]`);
+    bad = 1;
+    continue;
+  }
+  if (entry.version !== ROOT_VERSION) {
+    console.log(
+      `  FAIL: ${name} has version ${entry.version} (expected ${ROOT_VERSION}) at ${entry.file}`
+    );
+    bad = 1;
+    continue;
+  }
+  ok += 1;
+}
 
-  PKG_NAME=$(node -e "const p = require('./$manifest'); console.log(p.name || '')")
-  PKG_VERSION=$(node -e "const p = require('./$manifest'); console.log(p.version || '')")
+if (bad === 0) {
+  console.log(`  OK: all ${ok} publish-manifest packages have version ${ROOT_VERSION}`);
+} else {
+  console.log('  Version coherence check FAILED');
+}
 
-  if [ -z "$PKG_NAME" ] || [ -z "$PKG_VERSION" ]; then
-    continue
-  fi
-
-  checked=$((checked + 1))
-
-  if [ "$PKG_VERSION" != "$ROOT_VERSION" ]; then
-    echo "  FAIL: $PKG_NAME has version $PKG_VERSION (expected $ROOT_VERSION)"
-    bad=1
-  fi
-done
-
-if [ "$bad" -eq 0 ]; then
-  echo "  OK: All $checked packages have version $ROOT_VERSION"
-else
-  echo "  Version coherence check FAILED"
-fi
-
-exit $bad
+process.exit(bad);
+NODE


### PR DESCRIPTION
## Summary

Aligns the version-coherence gate with the publish-manifest package surface.

## Scope

- Checks release-version coherence for packages listed in `scripts/publish-manifest.json packages[]`.
- Excludes workspace-private packages from npm release-version coherence.
- Keeps the publish manifest unchanged.

## Boundary

No package versions changed. No publish-surface change. No runtime, schema, registry, conformance, CLI, or release-facts change.

## Why

After package privacy was aligned with the publish manifest, workspace-private packages are no longer part of the public npm release surface. The release gate should verify the publishable package set, not every private workspace package.

## Validation

- `bash scripts/check-version-coherence.sh`
- `pnpm gate:fast`
- `pnpm exec vitest run tests/tooling/workspace-package-privacy.test.ts tests/tooling/package-surface-audit.test.ts`
- `pnpm format:check`
- `git diff --check`
- `bash scripts/ci/forbid-strings.sh`
