### PR TITLE
v0.14.2: Provisioning Lifecycle Records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,83 @@ All notable changes to PEAC Protocol will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.14.1] - 2026-05-07
+## [0.14.2] - 2026-05-10
+
+Provisioning Lifecycle Records.
+
+A signed-record format for reported provisioning lifecycle events from
+external systems. Caller systems (agents, agent-driven workflows,
+control planes, CLIs, or providers themselves) report what happened
+when services, accounts, resources, credentials, payment authorizations,
+budgets, subscriptions, domains, or deployments are provisioned through
+external providers; PEAC records that report through a portable, signed
+interaction record.
+
+Public API: extended (additive only).
+Wire format: unchanged.
+Package surface: unchanged published-package count (36).
+Extension keys: 15 → 16 extension groups; 30 → 40 receipt types
+(additive). 21 new stable error codes under the `provisioning.*`
+namespace.
+Default observable behavior: unchanged for existing surfaces.
+
+### Added
+
+- **Provisioning lifecycle extension namespace.** New
+  `org.peacprotocol/provisioning-lifecycle` extension namespace with
+  10 `*-observed` receipt-type URIs covering catalog, provider-link,
+  account, resource, credential, payment-authorization, budget,
+  subscription, domain, and deployment events. Schema validator with
+  recursive credential-material walker (depth-aware,
+  structure-bounded, vendor-neutral pattern panel). 21 stable error
+  codes (20 validator-emitted plus 1 fixture-loader-only). New
+  normative spec `docs/specs/PROVISIONING-LIFECYCLE-PROFILE.md`.
+  Conformance Section 31 `PROV-LIFE-001..010`.
+- **Provisioning lifecycle examples.** New generic example
+  `examples/provisioning-lifecycle/` (10 fixtures, one per
+  `*-observed` event family) with `pnpm issue` and `pnpm verify`
+  scripts. New concrete sanitized demo
+  `examples/agent-provisioning-demo/` using the canonical extension
+  namespace; replaces the prior vendor-named example directory.
+- **Operator recipe.**
+  `docs/SOLUTIONS/verify-agent-provisioning.md` walks an auditor or
+  reviewer through verifying reported provisioning lifecycle records
+  offline.
+- **Cross-language parity corpus.** New
+  `specs/conformance/parity-corpus/provisioning-lifecycle/` (29
+  vectors: 10 positive plus 19 negative) self-describes each
+  expected stable error code in `expected.errors[]`. Enrolled in the
+  Go SDK parity loader.
+- **Repository hygiene.** New `scripts/verify-example-source-gate.mjs`
+  (wired into `scripts/gate.sh` fast and full modes) checks committed
+  examples for live-shaped secrets and retired vocabulary. New
+  `tests/tooling/workspace-package-privacy.test.ts` enforces that
+  every `@peac/*` workspace package with `private!==true` is listed
+  in `scripts/publish-manifest.json packages[]`, and that private
+  packages do not carry `publishConfig`.
+- **Stricter parity-corpus contract.** The v0.14.x sibling-family
+  convention now carries an extension-level expected-error column for
+  schema-validator profiles; the wire-envelope canonical-truth test
+  filters family-scoped extension prefixes so corpora can
+  self-describe without breaking envelope-layer parity.
+
+### Changed
+
+- `@peac/cli`: hardened command handlers eliminate file-system-race
+  patterns in command-output write paths.
+- `packages/mappings/ucp`: prototype-pollution regression test added
+  to lock the inline-blocklist barrier shape.
+- `integrator-kits/stripe-projects/README.md`: modernized to the
+  canonical extension namespace and 10 type URIs.
+- 14 `@peac/*` workspace packages flipped from `private:false` to
+  `private:true` to align metadata with `scripts/publish-manifest.json`
+  (the public package surface stays at 36).
+
+### Security
+
+- Bumped `hono`, `fast-uri`, and `ip-address` to patched versions.
+
+## [0.14.1]
 
 Execution Surfaces + Observational Lifecycle Records.
 
@@ -92,7 +168,7 @@ Default observable behavior: unchanged for existing surfaces.
 - See `docs/release-notes/v0.14.1.md` for the per-surface
   walkthrough.
 
-## [0.14.0] - 2026-05-02
+## [0.14.0]
 
 Bounded Validation Gate.
 
@@ -137,7 +213,7 @@ preserving byte-equivalent behavior across the covered runtime matrix.
   extension-key change, or default-path behavior change.
 - npm `next` only. No `latest` promotion in this release.
 
-## [0.13.4] - 2026-05-02
+## [0.13.4]
 
 Validation Readiness and Runtime Invariants. This release is
 behavior-preserving. It strengthens runtime-invariant verification
@@ -221,7 +297,7 @@ change, extension-key change, or default-path behavior change.
 - OpenAPI verify contract: unchanged. OpenAPI 3.1.x unchanged.
 - npm dist-tag: `next` only.
 
-## [0.13.3] - 2026-05-01
+## [0.13.3]
 
 Documentation and internal test-infrastructure release. No public API change. No wire-format change. No new public package. No publish-manifest change. Published to npm `next` only.
 
@@ -242,7 +318,7 @@ Documentation and internal test-infrastructure release. No public API change. No
 - Active publish-manifest count: 36 (unchanged from v0.13.2).
 - npm dist-tag: `next` only.
 
-## [0.13.2] - 2026-05-01
+## [0.13.2]
 
 Internal foundations release. No public API change. No wire format change. No new public package. No publish-manifest change. Published to npm `next` only.
 
@@ -281,7 +357,7 @@ Internal foundations release. No public API change. No wire format change. No ne
 
 - All 16 open Dependabot alerts present at the start of the v0.13.2 window were closed. Closures: `handlebars` (1 critical, 3 high, 2 medium, 1 low — all dev-only via `ts-jest` upgrade); `hono` (1 medium runtime; reachability audit confirmed `hono/jsx` is not imported, upgraded for hygiene); 8 dev-only alerts via range-scoped `pnpm.overrides` (`defu`, `vite` ×2, `esbuild`, `next`, `postcss`, `undici` ×2). 0 open Dependabot alerts on the release commit.
 
-## [0.13.1] - 2026-04-27
+## [0.13.1]
 
 Internal foundations release. No public API change. No wire format change. No new public package. Published to npm `next` only.
 
@@ -302,7 +378,7 @@ Internal foundations release. No public API change. No wire format change. No ne
 - Wire format (`peac-receipt/0.1` envelope, `interaction-record+jwt` JWS `typ`): unchanged.
 - OpenAPI verify contract, error code count (186), extension group count (12), and active publish-manifest count (36): unchanged.
 
-## [0.13.0] - Unreleased
+## [0.13.0]
 
 Doctrine cleanup, scheduled deprecation removals, and v0.13.0 baseline artifacts. Records-first wording across active surfaces; legacy `peac.receipt/0.9` quarantined to historical-marker contexts; `ProofMethodSchema` and A2A v0.3.0 compatibility removed; `@peac/core` and `@peac/pref` archived; legacy `POST /verify` removed from the active OpenAPI contract while the runtime alias continues to serve `/v1/verify`-shape responses with `Deprecation`, `Sunset`, and `Link` headers through the advertised Sunset; published normative resource-limits spec, standards ledger, v0.13.0 baseline snapshot, error-emission audit, and mutation-testing posture. No wire format change. No new signing envelope. No new public package.
 
@@ -351,7 +427,7 @@ Doctrine cleanup, scheduled deprecation removals, and v0.13.0 baseline artifacts
 - `@peac/core` is not in the v0.13.0 active publish manifest. Historical npm versions `<=0.9.14` remain installable for verify-only use of historical `peac.receipt/0.9` records.
 - `@peac/pref` is not in the v0.13.0 active publish manifest. Historical npm versions `<=0.12.14` remain installable. Migration target: `@peac/mappings-content-signals`.
 
-## [0.12.14] - 2026-04-22
+## [0.12.14]
 
 Policy binding and privacy-aware verification. Typed document binding for terms and policy, publisher-supplied canonical digest support, privacy-aware deployment guidance, and verifier privacy defaults including JWKS cache retention caps and a no-raw-personal-data minimization mode. Documentation, tests, and tooling only. No wire, schema, kernel, crypto, or protocol public-API change.
 
@@ -391,7 +467,7 @@ The following items are deferred to v0.13.0:
 - Package-surface reduction program with measurable gate.
 - Hosted Issue GA decision.
 
-## [0.12.13] - 2026-04-20
+## [0.12.13]
 
 Compliance mappings, verifier contract alignment, portable proof workflows, and Go adapter follow-through. Documentation, tests, workflows, and SDK support tooling only. No wire, schema, kernel, crypto, or protocol public-API change.
 
@@ -437,7 +513,7 @@ The following items are deferred to v0.13.0:
 - Package-surface reduction program with measurable gate.
 - Hosted Issue GA decision.
 
-## [0.12.12] - 2026-04-19
+## [0.12.12]
 
 Docs, compatibility, and trust artifacts release. No wire format, schema, kernel, crypto, protocol public API, or normative behavior changes. Layer 4 + tooling + docs only.
 
@@ -476,7 +552,7 @@ The following items are deferred to v0.12.13:
 - Commerce lifecycle grouping export under `packages/audit/`.
 - External audit prep scaffolding; Python SDK decision gate.
 
-## [0.12.11] - 2026-04-15
+## [0.12.11]
 
 ### Added
 
@@ -516,7 +592,7 @@ The following items are deferred to v0.12.13:
 - Extended JCS parity test expansion.
 - TypeDoc + PageFind searchable API reference build pipeline.
 
-## [0.12.10] - 2026-04-14
+## [0.12.10]
 
 ### Added
 
@@ -548,7 +624,7 @@ The following items are deferred to v0.12.13:
 - EU AI Act Annex IV mapping: v0.12.12
 - ISO 42001 Clause 8 mapping: v0.12.12
 
-## [0.12.9] - 2026-04-11
+## [0.12.9]
 
 ### Added
 
@@ -585,7 +661,7 @@ The following items are deferred to v0.12.13:
 - Payment Identifier extension, gas sponsoring, Bazaar discovery, SIWX: tracked for a future release
 - Runnable `x402-upto-evidence` example: deferred to a follow-up PR to avoid pre-release truth-surface drift
 
-## [0.12.8] - 2026-04-10
+## [0.12.8]
 
 ### Added
 
@@ -627,7 +703,7 @@ The Go SDK core types and functions have been rewritten for the Interaction Reco
 - Hosted Issue GA (non-provisional): v0.13.0
 - Formal conformance registry registration for 25 pending IDs: v0.12.9
 
-## [0.12.7] - 2026-04-08
+## [0.12.7]
 
 Coherence, trust, and installability release. No new protocol surface.
 
@@ -669,7 +745,7 @@ Coherence, trust, and installability release. No new protocol surface.
 
 ---
 
-## [0.12.6] - 2026-04-01
+## [0.12.6]
 
 x402 V2 support, DID resolution, A2A OAuth, gRPC transport, receipt URL middleware, and supply-chain provenance mappings.
 
@@ -701,7 +777,7 @@ x402 V2 support, DID resolution, A2A OAuth, gRPC transport, receipt URL middlewa
 
 ---
 
-## [0.12.4] - 2026-03-25
+## [0.12.4]
 
 ### Theme: Commerce Evidence + Integration Depth
 
@@ -747,7 +823,7 @@ PEAC as the neutral portable evidence layer across paymentauth/MPP, ACP, x402, S
 - Go/Python SDK: deferred to v0.12.6 (gated on external signal)
 - A2A v1.0 OAuth PKCE, A2A v1.0 gRPC binding: deferred to v0.12.6
 
-## [0.12.5] - 2026-03-27
+## [0.12.5]
 
 ### Theme: Commerce Hardening + Interop Proofs
 
@@ -787,7 +863,7 @@ Cross-rail conformance parity, settlement semantic equivalence, and naming truth
 
 ## [Unreleased]
 
-## [0.12.3] - 2026-03-17
+## [0.12.3]
 
 ### Added
 
@@ -848,7 +924,7 @@ profiles, and introduces shared protocol-grade validators.
 - Commerce events vocabulary expansion: v0.12.3+
 - Profile capability signaling: v0.12.3+
 
-## [0.12.1] - 2026-03-13
+## [0.12.1]
 
 ### x402 Upstream Wire Sync
 
@@ -902,7 +978,7 @@ Aligns `@peac/adapter-x402` with the current x402 offer-receipt extension wire s
 
 See `docs/guides/x402-migration-0.12.1.md` for field-by-field migration guidance.
 
-## [0.12.0] - 2026-03-08
+## [0.12.0]
 
 ### Interaction Record Format 0.2 (Stable)
 
@@ -998,7 +1074,7 @@ full Wire 0.2 feature set.
 - Remaining 5 pillar extension groups (consent, compliance, privacy, safety, provenance): deferred to v0.12.1+
 - Go SDK: deferred to v0.13.0+
 
-## [0.12.0-preview.2] - 2026-03-06
+## [0.12.0-preview.2]
 
 ### Interaction Record Format 0.2 Preview (Hardening)
 
@@ -1098,7 +1174,7 @@ stable promotion.
 - Public API surface lock: deferred to v0.12.0 stable
 - Migration guide: deferred to v0.12.0 stable
 
-## [0.12.0-preview.1] - 2026-03-03
+## [0.12.0-preview.1]
 
 ### Interaction Record Format 0.2 Preview
 
@@ -1146,7 +1222,7 @@ dist-tag for early adoption testing.
 - **Deprecated:** `WIRE_TYPE` and `WIRE_VERSION` constants in `@peac/kernel`
 - **Deprecated:** `JWSHeader` Zod schema alias (use `Wire01JWSHeaderSchema`)
 
-## [0.11.3] - 2026-03-02
+## [0.11.3]
 
 ### Identity, Zero Trust, and Enterprise Readiness
 
@@ -1247,7 +1323,7 @@ merge, and governance framework alignment mappings.
 - OpenAI adapter streaming: deferred to v0.12.1
 - ActorBinding/ProofMethod schema unification: deferred to v0.12.0
 
-## [0.11.2] - 2026-02-25
+## [0.11.2]
 
 ### Content Signals + Evidence Locators
 
@@ -1329,7 +1405,7 @@ inference adapter, and MCP Registry distribution surfaces.
 - `next_action` and `retryable` are error metadata fields, not wire format fields
 - `receipt_url` is a carrier metadata field, not a wire format field
 
-## [0.11.1] - 2026-02-24
+## [0.11.1]
 
 ### Evidence Carrier Contract + A2A Mapping
 
@@ -1435,7 +1511,7 @@ support and content-addressed receipt references.
 - **OWASP ASI-04** (Supply Chain): Carrier validation as defense
 - **CVE-2026-25536**: MCP SDK floor remains >= 1.26.0
 
-## [0.11.0] - 2026-02-22
+## [0.11.0]
 
 ### Infrastructure Modernization + Enterprise Readiness
 
@@ -1543,7 +1619,7 @@ If you import schemas from `@peac/schema`, align your Zod major to v4:
 - **Zod ^4.3.6**: Full migration from 3.25.x
 - **OWASP ASI-01 through ASI-10**: Alignment mapping in `docs/security/OWASP-ASI-MAPPING.md`
 
-## [0.10.14] - 2026-02-22
+## [0.10.14]
 
 ### Quality Hardening and Zod 4 Preparation
 
@@ -1620,7 +1696,7 @@ package, and lays the groundwork for the Zod 4 migration in v0.11.0.
 - Design decisions: DD-59 (per-fixture versioning), DD-60 (kernel
   constraints), DD-101 (editorial hygiene), DD-118 (Polish Bucket)
 
-## [0.10.13] - 2026-02-19
+## [0.10.13]
 
 ### MCP Server for AI Agents
 
@@ -1669,7 +1745,7 @@ bundle receipts locally: no API keys, no network required.
 - Capability tokens deferred to v0.11.x (HTTP transport)
 - All audit HIGH vulnerabilities are dev-only (eslint/wrangler chains)
 
-## [0.10.12] - 2026-02-16
+## [0.10.12]
 
 ### OpenClaw Activation, Durable Capture, and RFC 9421 Proof Profile
 
@@ -1750,7 +1826,7 @@ specification with conformance vectors and an extension schema.
 - RFC 9421 proof capture is a profile (doc + vectors), not a runtime dependency
 - No new registry entries required (uses existing `http.request` op type)
 
-## [0.10.11] - 2026-02-14
+## [0.10.11]
 
 ### Runtime Dependencies and x402 Payment Rail
 
@@ -1812,7 +1888,7 @@ v2), expands the registry spec, and adds the Stripe x402 payment rail adapter.
 - Wire format `peac-receipt/0.1` remains FROZEN
 - No API surface changes to existing packages
 
-## [0.10.10] - 2026-02-11
+## [0.10.10]
 
 ### Dev Toolchain Modernization
 
@@ -1869,7 +1945,7 @@ Node.js baseline to 22 LTS. No runtime, API, or wire format changes.
 - No runtime dependency changes
 - No API surface changes
 
-## [0.10.9] - 2026-02-07
+## [0.10.9]
 
 ### Foundation Hardening: Architecture, CI, and Server Reliability
 
@@ -1995,7 +2071,7 @@ deferred from v0.10.8 (`middleware-core`, `middleware-express`, `adapter-opencla
   exhaustion under sustained load
 - Publish-manifest closure check prevents broken dependency chains on npm
 
-## [0.10.8] - 2026-02-07
+## [0.10.8]
 
 ### Adoption Release: Middleware, Conformance, and Infrastructure
 
@@ -2058,7 +2134,7 @@ testing tools, and infrastructure apps (sandbox issuer, browser verifier, verify
   (Hono's c.json() always overrides Content-Type to application/json)
 - Security headers now applied on all error paths including early-return 429/413
 
-## [0.10.7] - 2026-02-04
+## [0.10.7]
 
 ### Interaction Evidence Extension
 
@@ -2157,7 +2233,7 @@ normative validation precedence and semantic decisions (array rejection, empty-a
 - Interaction evidence stored in extensions, NOT top-level `evidence.interaction`
 - Extension key: `org.peacprotocol/interaction@0.1`
 
-## [0.10.5] - 2026-01-30
+## [0.10.5]
 
 ### npm Publish Script Hardening
 
@@ -2186,7 +2262,7 @@ Fixes for reliable incremental OIDC Trusted Publishing rollout.
 - During OIDC rollout: Keep `--strict=false`, add packages to manifest as you configure them
 - Once all packages configured: Switch to `--strict=true` in workflow
 
-## [0.10.4] - 2026-01-29
+## [0.10.4]
 
 ### GitHub Actions npm Publish with OIDC Trusted Publishing
 
@@ -2243,7 +2319,7 @@ Secure, automated npm publishing via GitHub Actions with OIDC Trusted Publishing
 - See `docs/release/SETUP-GUIDE.md` for complete setup instructions
 - Tag format: `vX.Y.Z` triggers publish workflow
 
-## [0.10.3] - 2026-01-29
+## [0.10.3]
 
 ### x402 Adapter v0.2 Polish
 
@@ -2300,7 +2376,7 @@ Production hardening for the x402 offer/receipt adapter with deterministic verif
 - CAIP-2 reference segment allows hyphens (was restricted to alphanumeric)
 - Uses `TextEncoder` for byte length (no Node.js `Buffer` dependency)
 
-## [0.10.2] - 2026-01-27
+## [0.10.2]
 
 ### Workflow Correlation
 
@@ -2350,7 +2426,7 @@ Multi-agent orchestration support. Receipts now carry workflow context for DAG r
 - **docs/SPEC_INDEX.md** - Attestations and Extensions section (Agent Identity, Attribution, Dispute, Workflow Correlation)
 - **docs/CANONICAL_DOCS_INDEX.md** - Four normative specification entries added
 
-## [0.10.1] - 2026-01-27
+## [0.10.1]
 
 ### SSRF-Safe Network Utilities
 
@@ -2368,7 +2444,7 @@ New package for protocol-grade network operations with SSRF prevention.
   - 284 tests covering security, audit, and edge cases
   - Group folder pattern: `packages/net/node/` for future transport expansion
 
-## [0.10.0] - 2026-01-14
+## [0.10.0]
 
 ### Wire Format Normalization
 
@@ -2468,7 +2544,7 @@ This release normalizes all wire format identifiers to the `peac-<artifact>/<maj
 - **README.md** - Records-first positioning with glossary
 - **Conformance fixtures** - Updated with new format specifications
 
-## [0.9.31] - 2026-01-13
+## [0.9.31]
 
 ### Added
 
@@ -2498,7 +2574,7 @@ This release normalizes all wire format identifiers to the `peac-<artifact>/<maj
 - Security and Correctness Notes section in @peac/mappings-ucp README
 - UCP webhook Express example in `examples/ucp-webhook-express/`
 
-## [0.9.30] - 2026-01-12
+## [0.9.30]
 
 ### Added
 
@@ -2555,7 +2631,7 @@ This release normalizes all wire format identifiers to the `peac-<artifact>/<maj
 - #264: Crypto testkit subpath export and export-surface guard
 - #265: CI bundle vector drift gate
 
-## [0.9.29] - 2026-01-10
+## [0.9.29]
 
 ### Added
 
@@ -2600,7 +2676,7 @@ This release normalizes all wire format identifiers to the `peac-<artifact>/<maj
 - Go SDK packages not published to pkg.go.dev yet (local import only)
 - Cross-language conformance with TypeScript SDK maintained
 
-## [0.9.28] - 2026-01-09
+## [0.9.28]
 
 ### Added
 
@@ -2666,7 +2742,7 @@ The following items were originally planned for v0.9.28 but deferred to future r
 - All packages bumped to 0.9.28
 - Cross-referenced with quality audit: `reference/V0928_QUALITY_AUDIT.md`
 
-## [0.9.27] - 2026-01-07
+## [0.9.27]
 
 ### Added
 
@@ -2723,7 +2799,7 @@ The following items were originally planned for v0.9.28 but deferred to future r
   - Attestation temporal validity rules
 - **ROADMAP.md**: Updated to show v0.9.26 as current release
 
-## [0.9.26] - 2026-01-04
+## [0.9.26]
 
 ### Added
 
@@ -2772,7 +2848,7 @@ The following items were originally planned for v0.9.28 but deferred to future r
 - Guard script enhanced with attribution package exclusions for `issued_at` field
 - Publish list updated: 31 public packages (added `@peac/attribution`)
 
-## [0.9.25] - 2026-01-04
+## [0.9.25]
 
 ### Added
 
@@ -2824,7 +2900,7 @@ The following items were originally planned for v0.9.28 but deferred to future r
 - `@peac/schema` exports agent identity types from main entry point
 - `sdks/README.md` updated to reflect Go SDK availability (v0.9.25+)
 
-## [0.9.24] - 2026-01-03
+## [0.9.24]
 
 ### Added
 
@@ -2875,7 +2951,7 @@ The following items were originally planned for v0.9.28 but deferred to future r
 - `undeclared` is internal-only, never valid on wire (explicit `PEAC-Purpose: undeclared` returns 400)
 - Unknown purpose tokens preserved but cannot affect enforcement (forward-compat without bypass risk)
 
-## [0.9.23] - 2025-12-31
+## [0.9.23]
 
 ### Added
 
@@ -2909,7 +2985,7 @@ The following items were originally planned for v0.9.28 but deferred to future r
 - `formatRateLimit()` added for round-trip serialization
 - `EnforcementContext` simplified to only `receiptVerified` (deferred: humanAttested, customRequirementMet)
 
-## [0.9.22] - 2025-12-31
+## [0.9.22]
 
 ### Added
 
@@ -2940,7 +3016,7 @@ The following items were originally planned for v0.9.28 but deferred to future r
 - `TelemetryConfig.hashSalt` added for privacy-preserving identifier hashing
 - Protocol package now depends on `@peac/telemetry` (workspace dependency)
 
-## [0.9.21] - 2025-12-31
+## [0.9.21]
 
 ### Added
 
@@ -2969,7 +3045,7 @@ The following items were originally planned for v0.9.28 but deferred to future r
 - **Cycle detection**: Prevents infinite loops in nested object validation
 - **Node count cap**: Limits total JSON nodes to prevent memory exhaustion
 
-## [0.9.20] - 2025-12-30
+## [0.9.20]
 
 ### Added
 
@@ -2998,7 +3074,7 @@ The following items were originally planned for v0.9.28 but deferred to future r
 - The 3 adapter packages were never published to npm, so the rename has no migration impact
 - Existing code using `rail: "x402.<vendor>"` pattern should migrate to `rail: "x402"` + `facilitator: "<vendor>"`
 
-## [0.9.19] - 2025-12-24
+## [0.9.19]
 
 ### Added
 
@@ -3035,7 +3111,7 @@ The following items were originally planned for v0.9.28 but deferred to future r
 - x402 payment headers are headers-only (no body parsing, no Response dependency)
 - VPA hashing uses HMAC-SHA256; changing hash key changes all hashes (audit trail impact)
 
-## [0.9.18] - 2025-12-19
+## [0.9.18]
 
 ### Added
 
@@ -3098,7 +3174,7 @@ If you used `ai_search`:
 - For **AI search summaries / RAG grounding**: use `ai_input` (RSL: `ai-input`)
 - For **AI indexing / embedding index creation**: use `ai_index` (RSL: `ai-index`)
 
-## [0.9.17] - 2025-12-14
+## [0.9.17]
 
 ### Added
 
@@ -3141,7 +3217,7 @@ response.setHeader('PEAC-Receipt', result.jws);
 // result.subject_snapshot available if provided in opts
 ```
 
-## [0.9.16] - 2025-12-07
+## [0.9.16]
 
 ### Added
 
@@ -3155,7 +3231,7 @@ response.setHeader('PEAC-Receipt', result.jws);
 - `@peac/schema` now exports CAL, PaymentEvidence, and SubjectProfile validators
 - PROTOCOL-BEHAVIOR version set to 0.9.16 and extended with Section 8.4 privacy guidance
 
-## [0.9.15] - 2025-11-26
+## [0.9.15]
 
 ### Changed
 
@@ -3194,7 +3270,7 @@ import { enforce, verify } from '@peac/protocol';
 import type { Receipt } from '@peac/kernel';
 ```
 
-## [0.9.14] - 2025-09-27
+## [0.9.14]
 
 ### Changed
 
@@ -3217,7 +3293,7 @@ import type { Receipt } from '@peac/kernel';
 - `verify()`: Use `verifyReceipt()` instead
 - `verifyBulk()`: Use `verifyReceipt()` in a loop
 
-## [0.9.13.2] - 2025-09-17
+## [0.9.13.2]
 
 Intent: Zero-friction local enforcement/verification via a loopback sidecar.
 
@@ -3256,7 +3332,7 @@ Intent: Zero-friction local enforcement/verification via a loopback sidecar.
 
 - Wire protocol 0.9.13; additive, non-breaking. Embedded enforcement remains fallback
 
-## [0.9.10-beta] - 2025-01-29
+## [0.9.10-beta]
 
 ### Added
 
@@ -3284,7 +3360,7 @@ Intent: Zero-friction local enforcement/verification via a loopback sidecar.
 - Receipt verification supports multiple keys with `kid` matching
 - Rate limiting now properly enforces RFC 9457 compliant headers
 
-## [0.9.6] - 2024-12-18
+## [0.9.6]
 
 ### Added
 

--- a/docs/release-notes/v0.14.2.md
+++ b/docs/release-notes/v0.14.2.md
@@ -1,0 +1,142 @@
+# v0.14.2 — Provisioning Lifecycle Records
+
+PEAC records what an external system reports happened when services,
+accounts, resources, credentials, payment authorizations, budgets,
+subscriptions, domains, or deployments are provisioned through external
+providers. Caller systems (agents, agent-driven workflows, control
+planes, CLIs, or providers themselves) report what happened; PEAC
+records that report through a portable, signed interaction record.
+
+This release adds the provisioning lifecycle extension namespace,
+schema validator, conformance corpus, examples, operator recipe, and
+related repository hygiene. No new public CLI verb. No new publishable
+package. No wire format change. No registry expansion beyond the new
+extension namespace and its 10 type URIs.
+
+## Highlights
+
+- New `org.peacprotocol/provisioning-lifecycle` extension namespace
+  with 10 `*-observed` receipt-type URIs.
+- Schema validator with recursive credential-material walker; 21
+  stable error codes under the `provisioning.*` namespace.
+- 29-vector cross-language parity corpus that self-describes its
+  expected error codes per vector.
+- Generic example, concrete sanitized demo, and an operator recipe.
+- Repository hygiene: new public-example source gate; package-privacy
+  invariant test; CLI command-handler hardening.
+
+## New record surface: provisioning lifecycle
+
+The `org.peacprotocol/provisioning-lifecycle` extension namespace
+records observation of provisioning lifecycle events. Ten receipt-type
+URIs cover the major event families:
+
+```
+org.peacprotocol/provisioning-catalog-observed
+org.peacprotocol/provisioning-provider-link-observed
+org.peacprotocol/provisioning-account-observed
+org.peacprotocol/provisioning-resource-observed
+org.peacprotocol/provisioning-credential-observed
+org.peacprotocol/provisioning-payment-authorization-observed
+org.peacprotocol/provisioning-budget-observed
+org.peacprotocol/provisioning-subscription-observed
+org.peacprotocol/provisioning-domain-observed
+org.peacprotocol/provisioning-deployment-observed
+```
+
+The `*-observed` suffix makes the observer scope explicit at the
+record-type layer. PEAC records what the issuer reports happened.
+Authorization, legal acceptance, credential validation, payment
+processing, provider-state claims, settlement, credential-vault
+management, and runtime operation remain responsibilities of the
+upstream systems and their operators.
+
+The schema validator emits 21 stable error codes under the
+`provisioning.*` namespace covering inline-credential rejection,
+nested forbidden key names, opaque-ref grammar violations, storage
+surface and material redaction enums, event-kind and sub-event closed
+enums, scheme-id grammar, unrecognized fields, amount-minor canonical
+form, RFC 3339 timestamp formats, ISO 4217 currency, structural
+bounds (depth, nodes, string size), the U+FFFD replacement character,
+and required-field presence. The recursive credential-material walker
+is depth-aware and structure-bounded (default max depth 32, max nodes
+10000, max string size 8192 bytes). The pattern panel is
+vendor-neutral by design (`jwt_compact`, `bearer_token`,
+`pem_private_key`, `env_assignment`,
+`connection_string_with_credentials`); provider-prefix scanning belongs
+to the public-artifact layer rather than the protocol schema.
+
+## Conformance and parity
+
+Conformance Section 31 `PROV-LIFE-001..010` adds 10 requirement IDs
+covering the validator's structured-error contract.
+
+The new parity corpus at
+`specs/conformance/parity-corpus/provisioning-lifecycle/` is the first
+v0.14.x family that self-describes both wire-envelope acceptance and
+extension-level expected error codes. Negative vectors carry
+`expected.errors[0].code = "provisioning.<X>"` so cross-language
+implementations can read the JSON corpus directly. The wire-envelope
+canonical-truth test in `@peac/protocol` filters dotted extension-level
+codes via a family-scoped allowlist; unregistered dotted codes throw
+a hard error to catch accidental misclassification.
+
+The Go SDK parity loader floor enrols `provisioning-lifecycle` (29
+vectors total: 10 positive plus 19 negative).
+
+## Examples and operator recipe
+
+- [`examples/provisioning-lifecycle/`](../../examples/provisioning-lifecycle/)
+  — vendor-neutral generic demonstration with one fixture per
+  `*-observed` event family, `pnpm issue`, and `pnpm verify`
+  scripts.
+- [`examples/agent-provisioning-demo/`](../../examples/agent-provisioning-demo/)
+  — concrete sanitized demo showing an agent or operator-driven
+  provisioning workflow (workspace init, resource provisioning,
+  credential issuance, credential rotation) recorded through the
+  canonical extension namespace.
+- [`docs/SOLUTIONS/verify-agent-provisioning.md`](../SOLUTIONS/verify-agent-provisioning.md)
+  — operator recipe for verifying reported provisioning lifecycle
+  records offline.
+
+## Repository hygiene
+
+- New `scripts/verify-example-source-gate.mjs` checks committed
+  examples, recipes, and parity corpora for live-shaped secrets and
+  retired vocabulary. Wired into `scripts/gate.sh` fast and full
+  modes.
+- New `tests/tooling/workspace-package-privacy.test.ts` enforces
+  three invariants on every `@peac/*` workspace package: packages
+  with `private!==true` must be listed in
+  `scripts/publish-manifest.json packages[]`; packages in the
+  manifest must have `private!==true`; private packages must not
+  carry `publishConfig`.
+- 14 `@peac/*` workspace packages flipped from `private:false` to
+  `private:true` to align metadata with the public package surface
+  (which stays at 36 publishable packages).
+- `@peac/cli` command handlers hardened against file-system-race
+  patterns in command-output write paths.
+- `packages/mappings/ucp` adds a prototype-pollution regression
+  test.
+- `integrator-kits/stripe-projects/README.md` modernized to the
+  canonical extension namespace and 10 type URIs.
+
+## Public surface
+
+No new CLI command. No public schema or wire-format change. No new
+publishable npm package. The 36-package publishable surface is
+unchanged from v0.14.1.
+
+## Compatibility
+
+- Wire format: unchanged.
+- Public API: additive only (new exports under `@peac/schema` for
+  `validateProvisioningLifecycle`, `PROVISIONING_LIFECYCLE_*`, and
+  related types; new extension namespace registered in
+  `@peac/kernel` generated registries).
+- Default observable behavior: unchanged for existing surfaces.
+
+## Validation
+
+`docs/releases/facts.json` records the canonical metric values for
+this release.

--- a/docs/releases/current.json
+++ b/docs/releases/current.json
@@ -1,8 +1,8 @@
 {
   "description": "PEAC release manifest: CI-enforceable source of truth for release state",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "wire_format_version": "0.2",
-  "dist_tag": "latest",
+  "dist_tag": "next",
   "registries_version": "0.6.0",
-  "errors_version": "0.14.1"
+  "errors_version": "0.14.2"
 }

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -1,13 +1,13 @@
 {
   "description": "Canonical source of truth for PEAC Protocol release metrics. Website, docs, and release notes consume this file. CI validates derived metrics (tests, build_targets, published_packages, conformance_*) against actual build output. Mutable release-state fields (release_date, dist_tag) are maintained by scripts/stamp-release-state.mjs per docs/RELEASING.md.",
   "schema_version": "1.0.0",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "wire_format_version": "0.2",
-  "dist_tag": "latest",
-  "release_date": "2026-05-08",
+  "dist_tag": "next",
+  "release_date": "2026-05-10",
   "metrics": {
-    "tests": 9782,
-    "test_files": 422,
+    "tests": 10078,
+    "test_files": 433,
     "published_packages": 36,
     "build_targets": 103,
     "conformance_requirement_ids": 260,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/monorepo",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "private": true,
   "description": "Portable signed records for agent, API, MCP, and cross-runtime interactions.",
   "repository": {

--- a/packages/adapters/core/package.json
+++ b/packages/adapters/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-core",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Shared utilities for PEAC payment rail adapters and commerce mappings (Result types, validators, payment-proof contracts, mapper-boundary finality guard)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/did/package.json
+++ b/packages/adapters/did/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-did",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "DID document resolution for PEAC receipt verification (did:key, did:web)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/eat/package.json
+++ b/packages/adapters/eat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-eat",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "EAT (Entity Attestation Token, RFC 9711) passport decoder and PEAC claim mapper",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/managed-agents/package.json
+++ b/packages/adapters/managed-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-managed-agents",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Vendor-neutral managed agent runtime event adapter for PEAC interaction evidence",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/adapters/openai-compatible/package.json
+++ b/packages/adapters/openai-compatible/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-openai-compatible",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "OpenAI-compatible chat completion adapter for PEAC interaction evidence (hash-first)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/openclaw/package.json
+++ b/packages/adapters/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-openclaw",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "OpenClaw adapter for PEAC interaction evidence capture",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/runtime-governance/package.json
+++ b/packages/adapters/runtime-governance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-runtime-governance",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Runtime governance adapter for PEAC interaction records with AGT mapper",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/adapters/x402/package.json
+++ b/packages/adapters/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "x402 offer/receipt verification, term-matching, and PEAC record mapping",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/audit",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Audit logging and case bundle generation for PEAC protocol disputes",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/capture/core/package.json
+++ b/packages/capture/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/capture-core",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Runtime-neutral capture pipeline for PEAC interaction evidence",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/capture/node/package.json
+++ b/packages/capture/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/capture-node",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Node.js durable storage for PEAC capture pipeline (filesystem spool store and dedupe index)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/cli",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "PEAC protocol command-line tools",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/contracts",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "PEAC canonical error codes and verification mode contracts",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/control/package.json
+++ b/packages/control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/control",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "PEAC Protocol Control - control engine interfaces and validation",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/crypto",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Ed25519 JWS signing and verification for PEAC protocol",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/http-signatures/package.json
+++ b/packages/http-signatures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/http-signatures",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "RFC 9421 HTTP Message Signatures parsing and verification",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/jwks-cache/package.json
+++ b/packages/jwks-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/jwks-cache",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Edge-safe JWKS fetch and cache with SSRF protection",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/kernel",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "PEAC protocol kernel - normative constants, errors, and registries",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/kernel/src/error-categories.generated.ts
+++ b/packages/kernel/src/error-categories.generated.ts
@@ -3,7 +3,7 @@
  *
  * AUTO-GENERATED from specs/kernel/errors.json
  * DO NOT EDIT MANUALLY - run: npx tsx scripts/codegen-errors.ts
- * Spec version: 0.14.1
+ * Spec version: 0.14.2
  */
 
 /**

--- a/packages/kernel/src/errors.generated.ts
+++ b/packages/kernel/src/errors.generated.ts
@@ -3,7 +3,7 @@
  *
  * AUTO-GENERATED from specs/kernel/errors.json
  * DO NOT EDIT MANUALLY - run: npx tsx scripts/codegen-errors.ts
- * Spec version: 0.14.1
+ * Spec version: 0.14.2
  */
 
 import type { ErrorDefinition } from './types.js';

--- a/packages/mappings/a2a/package.json
+++ b/packages/mappings/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-a2a",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Agent-to-Agent Protocol (A2A) integration for PEAC",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/mappings/acp/package.json
+++ b/packages/mappings/acp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-acp",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Agentic Commerce Protocol (ACP) integration for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/content-signals/package.json
+++ b/packages/mappings/content-signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-content-signals",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Content use policy signal parsing for PEAC (robots.txt, tdmrep.json, Content-Usage)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/mappings/intoto/package.json
+++ b/packages/mappings/intoto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-intoto",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "in-toto v1.0 attestation mapping for PEAC provenance extension",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/mcp/package.json
+++ b/packages/mappings/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-mcp",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Model Context Protocol (MCP) integration for PEAC",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/mappings/paymentauth/package.json
+++ b/packages/mappings/paymentauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-paymentauth",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "HTTP Payment authentication scheme (paymentauth/MPP) mapping for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/slsa/package.json
+++ b/packages/mappings/slsa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-slsa",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "SLSA v1.2 provenance mapping for PEAC provenance extension",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/ucp/package.json
+++ b/packages/mappings/ucp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-ucp",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Google Universal Commerce Protocol (UCP) mapping to PEAC receipts and dispute evidence",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp-server/manifest.json
+++ b/packages/mcp-server/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "peac-mcp-server",
   "display_name": "PEAC Protocol",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Verify, inspect, decode, issue, and bundle PEAC receipts. Portable, offline-verifiable evidence for AI agent interactions.",
   "long_description": "PEAC Protocol provides cryptographically signed, offline-verifiable receipts that record what happened during automated interactions. Each receipt is a compact JWS (JSON Web Signature) using Ed25519 signatures. This MCP server exposes 5 tools for receipt operations: verify (signature + claims), inspect (metadata without verification), decode (raw JWS structure), issue (sign new receipts), and create_bundle (portable evidence directories).",
   "author": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mcp-server",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "PEAC receipt operations as MCP tools (verify, inspect, decode, issue, bundle)",
   "mcpName": "io.github.peacprotocol/peac",
   "main": "dist/index.cjs",

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "subfolder": "packages/mcp-server"
   },
-  "version": "0.14.1",
+  "version": "0.14.2",
   "websiteUrl": "https://www.peacprotocol.org",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@peac/mcp-server",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "transport": {
         "type": "stdio"
       }
@@ -22,7 +22,7 @@
     {
       "registryType": "npm",
       "identifier": "@peac/mcp-server",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:3000/mcp"

--- a/packages/mcp-server/src/infra/constants.ts
+++ b/packages/mcp-server/src/infra/constants.ts
@@ -3,7 +3,7 @@
  */
 
 export const SERVER_NAME = 'peac-mcp-server';
-export const SERVER_VERSION = '0.14.1';
+export const SERVER_VERSION = '0.14.2';
 export const MCP_PROTOCOL_VERSION = '2025-11-25';
 export const DEFAULT_MAX_JWS_BYTES = 16_384; // 16 KB
 export const DEFAULT_MAX_RESPONSE_BYTES = 65_536; // 64 KB

--- a/packages/middleware-core/package.json
+++ b/packages/middleware-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/middleware-core",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Framework-agnostic middleware primitives for PEAC receipt issuance",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/middleware-express/package.json
+++ b/packages/middleware-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/middleware-express",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Express.js middleware for automatic PEAC receipt issuance",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/net/node/package.json
+++ b/packages/net/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/net-node",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "SSRF-safe network utilities for PEAC Protocol with DNS resolution pinning (Node.js only)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/policy-kit/package.json
+++ b/packages/policy-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/policy-kit",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "PEAC Policy Kit - deterministic policy evaluation for CAL semantics",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/protocol",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "PEAC protocol implementation - receipt issuance and verification",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/rails/x402/package.json
+++ b/packages/rails/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-x402",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "x402 payment rail adapter for PEAC protocol",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/schema",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "PEAC Protocol JSON schemas, OpenAPI specs, and TypeScript types",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/telemetry",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Telemetry interfaces and no-op implementation for PEAC protocol",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/transport/grpc/package.json
+++ b/packages/transport/grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-grpc",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "PEAC gRPC transport layer with carrier adapter and HTTP StatusCode parity",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/scripts/publish-manifest.json
+++ b/scripts/publish-manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Single source of truth for PEAC Protocol npm publish order",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "lastUpdated": "2026-05-10",
   "totalPackages": 36,
   "packages": [

--- a/specs/conformance/fixtures/inventory.json
+++ b/specs/conformance/fixtures/inventory.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://www.peacprotocol.org/schemas/conformance/inventory.schema.json",
-  "generated_at": "2026-05-07T17:25:40.224Z",
-  "version": "0.14.1",
-  "schema_version": "0.14.1",
+  "generated_at": "2026-05-10T15:25:41.330Z",
+  "version": "0.14.2",
+  "schema_version": "0.14.2",
   "total_fixtures": 688,
   "total_with_requirements": 243,
   "total_unmapped": 445,

--- a/specs/kernel/error-categories.json
+++ b/specs/kernel/error-categories.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.peacprotocol.org/schemas/kernel/error-categories.schema.json",
   "$comment": "AUTO-GENERATED from specs/kernel/errors.json - DO NOT EDIT MANUALLY",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "source_file": "specs/kernel/errors.json",
   "categories": [
     "attribution",

--- a/specs/kernel/errors.json
+++ b/specs/kernel/errors.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "PEAC error codes - normative source of truth",
   "errors": [
     {

--- a/tests/tooling/package-surface-audit.test.ts
+++ b/tests/tooling/package-surface-audit.test.ts
@@ -98,11 +98,11 @@ describe('publish-manifest surface audit', () => {
     expect(manifest.totalPackages).toBe(V0_13_1_TARGET_COUNT);
   });
 
-  it('manifest version is either current release (0.14.0) or target (0.14.1)', () => {
+  it('manifest version is either current release (0.14.1) or target (0.14.2)', () => {
     // Version stamping belongs to release prep. Accept either the current
     // released value or the next-release target to keep the gate robust
     // across the release lifecycle.
-    expect(['0.14.0', '0.14.1']).toContain(manifest.version);
+    expect(['0.14.1', '0.14.2']).toContain(manifest.version);
   });
 
   it('totalPackages field matches packages[] length', () => {


### PR DESCRIPTION
## PEAC Protocol v0.14.2 Provisioning Lifecycle Records.

## Scope

- Bumps the 36 publishable packages to `0.14.2`.
- Updates MCP server version metadata (`SERVER_VERSION`, `manifest.json`, `server.json`).
- Updates release facts, current release state, publish-manifest version metadata, changelog, and release notes.
- Updates generated kernel error/version artifacts (`errors.generated.ts`, `error-categories.generated.ts`, `specs/kernel/errors.json`, `specs/kernel/error-categories.json`) and regenerated conformance fixture inventory.
- Keeps the public npm package count unchanged at 36.

## Release mode

Mode 2. v0.14.2 is prepared for publish to `next` first. After publish/install verification, a follow-up stamp/promote PR will sync `dist_tag: latest` if promotion occurs.

## Public surface

No new npm packages. No wire-format change. No package-surface expansion. No source behavior change in this release-prep PR beyond release/version metadata and generated release artifacts.

## Validation

- `git diff --check`: clean
- `pnpm format:check`: clean
- `pnpm test`: 10078 / 10078 passed (433 files)
- `pnpm conformance:test`: 637 / 637 passed (17 files)
- `pnpm verify:codegen-drift`: clean
- `pnpm verify:registries-schema`: clean
- `pnpm verify:release`: 25 / 25 passed
- `pnpm verify:surface-status`: clean
- `pnpm verify:distribution`: clean
- `pnpm gate:fast`: all gates passed
- `bash scripts/ci/forbid-strings.sh`: clean
- `node scripts/verify-dist-private-leaks.mjs`: 36 packages scanned, 0 leaks
- `node scripts/verify-fetch-cleanup.mjs`: clean
- `pnpm exec tsx scripts/extract-api-contract.ts --check`: clean
- `bash scripts/check-publish-list.sh`: clean
