### PR TITLE
chore(release): stamp v0.14.2 release date and dist_tag

### DIFF
--- a/docs/releases/current.json
+++ b/docs/releases/current.json
@@ -2,7 +2,7 @@
   "description": "PEAC release manifest: CI-enforceable source of truth for release state",
   "version": "0.14.2",
   "wire_format_version": "0.2",
-  "dist_tag": "next",
+  "dist_tag": "latest",
   "registries_version": "0.6.0",
   "errors_version": "0.14.2"
 }

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -3,8 +3,8 @@
   "schema_version": "1.0.0",
   "version": "0.14.2",
   "wire_format_version": "0.2",
-  "dist_tag": "next",
-  "release_date": "2026-05-10",
+  "dist_tag": "latest",
+  "release_date": "2026-05-11",
   "metrics": {
     "tests": 10078,
     "test_files": 433,


### PR DESCRIPTION
## Summary

Stamps v0.14.2 release state after npm publish and promotion.

## Changes

- `docs/releases/facts.json`: `release_date` 2026-05-10 → 2026-05-11 (actual UTC publish date); `dist_tag` next → latest.
- `docs/releases/current.json`: `dist_tag` next → latest.

## Validation

- `pnpm verify:release`: 25/25 PASS.
- `pnpm format:check`: clean.
- `pnpm verify:surface-status`: clean.
- `bash scripts/ci/forbid-strings.sh`: clean.

## Compatibility

No source, schema, wire format, or package behavior changes.