### PR TITLE
ci: add concurrency cancellation and audit gate detect-changes guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -454,7 +454,7 @@ jobs:
   # both, not universal byte-equivalence.
   #
   # Blocking matrix: Node 22 (Maintenance LTS) + Node 24 (Active LTS)
-  # × legacy_path 0/1 = 4 cells. Programmatic-option coverage runs
+  # x legacy_path 0/1 = 4 cells. Programmatic-option coverage runs
   # inside the Vitest test suite itself
   # (packages/protocol/__tests__/_internal/legacy-path-flag.test.ts),
   # not as an extra CI matrix axis.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       any_src: ${{ steps.filter.outputs.any_src }}
       stamp_any: ${{ steps.filter.outputs.stamp_any }}
       non_stamp: ${{ steps.filter.outputs.non_stamp }}
+      security_config: ${{ steps.filter.outputs.security_config }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -111,6 +112,12 @@ jobs:
               - '!docs/SURFACE_STATUS.md'
               - '!docs/PACKAGE_STATUS.md'
               - '**'
+            # Security/audit gate: changes to audit configuration, allowlist,
+            # surface package.json files, or audit gate tests.
+            security_config:
+              - 'security/**'
+              - 'surfaces/**/package.json'
+              - 'tests/scripts/**'
 
   # ---------------------------------------------------------------------------
   # Workflow lint: validates CI workflow files independently.
@@ -698,6 +705,12 @@ jobs:
     name: Audit Gate (Windows)
     runs-on: windows-latest
     timeout-minutes: 10
+    needs: detect-changes
+    if: |
+      needs.detect-changes.outputs.ci == 'true' ||
+      needs.detect-changes.outputs.root_config == 'true' ||
+      needs.detect-changes.outputs.any_src == 'true' ||
+      needs.detect-changes.outputs.security_config == 'true'
 
     steps:
       - name: Checkout

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '37 6 * * 1'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main, 'release/*']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -8,6 +8,10 @@ on:
       - 'README.md'
       - '.github/workflows/docs-quality.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docs-quality:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -32,7 +32,7 @@ jobs:
             echo "Use RFC 9421 headers instead: Signature-Input, Signature"
             exit 1
           fi
-          echo "✓ No forbidden headers found"
+          echo "OK: No forbidden headers found"
 
       - name: Verify RFC 9421 usage in edge guides
         run: |
@@ -45,7 +45,7 @@ jobs:
             echo "ERROR: Cloudflare guide missing Signature-Input header examples"
             exit 1
           fi
-          echo "✓ RFC 9421 usage verified"
+          echo "OK: RFC 9421 usage verified"
 
       - name: Check for placeholder text
         run: |
@@ -62,7 +62,7 @@ jobs:
             echo "ERROR: Found unresolved TODO/FIXME markers in docs"
             exit 1
           fi
-          echo "✓ No unresolved placeholders"
+          echo "OK: No unresolved placeholders"
 
       - name: Verify normative specs have Status field
         run: |
@@ -81,11 +81,11 @@ jobs:
 
             # Check for PROTOCOL-BEHAVIOR.md specifically (must be tested)
             if echo "$NORMATIVE_FILES" | grep -q "PROTOCOL-BEHAVIOR.md"; then
-              echo "✓ PROTOCOL-BEHAVIOR.md is normative (expected)"
+              echo "OK: PROTOCOL-BEHAVIOR.md is normative (expected)"
             fi
           fi
 
-          echo "✓ Normative spec check complete"
+          echo "OK: Normative spec check complete"
 
       - name: Check for performance claims without caveats
         run: |
@@ -97,7 +97,7 @@ jobs:
             echo "Add '(target)' suffix or 'These are design targets' note"
             exit 1
           fi
-          echo "✓ Performance claims properly qualified"
+          echo "OK: Performance claims properly qualified"
 
       - name: Verify error code format
         run: |
@@ -108,7 +108,7 @@ jobs:
             echo "Use E_* prefix: https://www.peacprotocol.org/problems/E_TAP_SIGNATURE_INVALID"
             exit 1
           fi
-          echo "✓ Error code format consistent"
+          echo "OK: Error code format consistent"
 
       - name: Check for contract package references
         run: |
@@ -118,7 +118,7 @@ jobs:
             echo "WARNING: Cloudflare guide does not reference @peac/contracts"
             echo "This is advisory - consider adding reference to canonical error source"
           fi
-          echo "✓ Contract references check complete"
+          echo "OK: Contract references check complete"
 
       - name: Summary
         run: |
@@ -128,10 +128,10 @@ jobs:
           echo "======================================"
           echo ""
           echo "All checks passed:"
-          echo "  ✓ No forbidden Payment-* headers"
-          echo "  ✓ RFC 9421 usage verified"
-          echo "  ✓ No unresolved placeholders"
-          echo "  ✓ Normative specs labeled"
-          echo "  ✓ Performance claims qualified"
-          echo "  ✓ Error code format consistent"
+          echo "  OK: No forbidden Payment-* headers"
+          echo "  OK: RFC 9421 usage verified"
+          echo "  OK: No unresolved placeholders"
+          echo "  OK: Normative specs labeled"
+          echo "  OK: Performance claims qualified"
+          echo "  OK: Error code format consistent"
           echo ""

--- a/.github/workflows/pr-metadata-lint.yml
+++ b/.github/workflows/pr-metadata-lint.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   lint-metadata:
     name: Check PR title and body


### PR DESCRIPTION
## Summary

Adds workflow-level concurrency cancellation to four workflows that were missing it, gates the Windows audit gate job on detect-changes to skip documentation-only PRs, and removes pre-existing non-ASCII characters from touched workflow files.

## Changes

**Concurrency cancellation added to:**

- \`codeql.yml\` - weekly schedule + PR + main push events could stack without cancellation
- \`dependency-review.yml\` - PRs on rapid force-push could queue duplicate runs
- \`docs-quality.yml\` - path-filtered but lacked cancellation; rapid edits queued duplicates
- \`pr-metadata-lint.yml\` - fires on \`opened\`, \`edited\`, \`synchronize\`; rapid title edits stacked runs

All four use \`group: \${{ github.workflow }}-\${{ github.event.pull_request.number || github.ref }}\` with \`cancel-in-progress: true\`.

**ci.yml changes:**

- Adds \`security_config\` detect-changes filter: \`security/**\`, \`surfaces/**/package.json\`, \`tests/scripts/**\`
- Gates \`ci-windows\` on \`ci || root_config || any_src || security_config\`

**ci-windows runs on all audit-relevant changes:**

| Path | Triggering filter |
|------|------------------|
| \`scripts/audit-gate.mjs\` | \`ci\` (covers \`scripts/**\`) and \`any_src\` |
| \`pnpm-lock.yaml\` | \`root_config\` |
| \`security/**\` (e.g., \`security/audit-allowlist.json\`) | \`security_config\` |
| \`surfaces/**/package.json\` | \`security_config\` |
| \`tests/scripts/**\` | \`security_config\` |
| Any package source change | \`any_src\` |

**ci-windows skips on** doc-only PRs (changes only to \`docs/**/*.md\`, \`packages/**/README.md\`, \`README.md\`).

**Non-ASCII cleanup:**

- \`docs-quality.yml\`: 14 pre-existing checkmark characters (U+2713) replaced with \`OK:\` prefix in echo statements. File was modified by this PR (concurrency block added), causing GitHub to flag the non-ASCII in its diff view.
- \`ci.yml\`: 1 pre-existing multiplication sign (U+00D7) in a comment replaced with \`x\`. Same reason.
- No behavioral change to any workflow step.

## Notes

- \`ci.yml\` already had a workflow-level concurrency group; no change needed there
- \`go-sdk.yml\` and \`bench-gate.yml\` already had concurrency groups; no change needed
- \`nightly.yml\` intentionally has no cancellation (scheduled + tag-push should not cancel each other)
- Workflow Lint in \`ci.yml\` currently only lints \`ci.yml\`; other workflows are not validated by it

## Validation

- \`actionlint\` passes on all five changed workflow files
- \`bash scripts/ci/forbid-strings.sh\` clean
- All changed files pass \`LC_ALL=C grep -RIn '[^ -~]'\` (zero non-ASCII in added lines)