### PR TITLE
fix(mappings-acp): enforce amount_minor and explicit finality

### DIFF
--- a/docs/specs/SCHEMA-NORMALIZATION.md
+++ b/docs/specs/SCHEMA-NORMALIZATION.md
@@ -248,10 +248,11 @@ Given an Agentic Commerce Protocol (ACP) checkout event and an x402 payment that
 const acpReceipt = fromACPCheckoutSuccess({
   checkout_id: 'checkout_abc',
   resource_uri: 'https://example.com/article/1',
-  total_amount: 500,
+  amount_minor: '500',
   currency: 'USD',
   payment_rail: 'x402',
   payment_reference: 'pay_123',
+  env: 'live',
 });
 
 // Direct x402 receipt

--- a/examples/rsl-collective/demo.ts
+++ b/examples/rsl-collective/demo.ts
@@ -108,10 +108,11 @@ async function demonstrateParity() {
   const acpEvent = {
     checkout_id: 'checkout_acp_parity',
     resource_uri: RESOURCE,
-    total_amount: AMOUNT,
+    amount_minor: String(AMOUNT),
     currency: CURRENCY,
     payment_rail: 'stripe',
     payment_reference: 'cs_acp_parity_123',
+    env: 'live' as const,
   };
   const acpInput = fromACPCheckoutSuccess(acpEvent);
 

--- a/packages/mappings/acp/src/index.ts
+++ b/packages/mappings/acp/src/index.ts
@@ -6,7 +6,9 @@
  */
 
 import type { JsonObject } from '@peac/kernel';
-import type { PaymentEvidence } from '@peac/schema';
+import { isValidAmountMinor, type PaymentEvidence } from '@peac/schema';
+import { assertExplicitFinality, type StrictnessMode } from '@peac/adapter-core';
+import { isValidHttpsResourceUri } from './validation.js';
 
 export * from './budget';
 
@@ -23,17 +25,79 @@ export {
 } from './carrier';
 
 /**
- * ACP Checkout Success Event
+ * ACP Checkout Success Event.
+ *
+ * Carrier-shape input for an ACP checkout-success observation. The amount is
+ * a base-10 integer string in the smallest currency unit (e.g. "9999" for
+ * $99.99) to preserve precision above Number.MAX_SAFE_INTEGER. The
+ * environment is asserted by upstream and never silently defaulted.
  */
 export interface ACPCheckoutSuccess {
   checkout_id: string;
   resource_uri: string;
-  total_amount: number;
+  /**
+   * Amount in smallest currency unit as a base-10 integer string.
+   * Validated against the shared AmountMinorStringSchema and must be
+   * non-negative. Decimals, empty strings, and numeric values are rejected.
+   */
+  amount_minor: string;
   currency: string;
   payment_rail: string;
   payment_reference: string;
+  /** Environment as asserted by upstream. Required: no silent default. */
+  env: 'live' | 'test';
   customer_id?: string;
   metadata?: Record<string, unknown>;
+}
+
+/**
+ * Optional knobs for fromACPCheckoutSuccess. Mode controls the
+ * mapper-boundary finality-synthesis guard (default `interop`).
+ */
+export interface ACPCheckoutSuccessOptions {
+  mode?: StrictnessMode;
+  warn?: (message: string) => void;
+}
+
+/**
+ * Stable error codes emitted by ACP mapper validation. Callers MAY switch
+ * on `code` to discriminate without parsing message text. Distinct from
+ * `@peac/adapter-core` MapperBoundaryError codes (which carry the finality-
+ * synthesis code only); kept local to avoid widening the adapter-core enum
+ * for ACP-specific validation concerns.
+ */
+export type ACPMapperBoundaryErrorCode =
+  | 'acp.checkout_invalid_event'
+  | 'acp.checkout_missing_checkout_id'
+  | 'acp.checkout_invalid_resource_uri'
+  | 'acp.checkout_legacy_total_amount'
+  | 'acp.checkout_invalid_amount_minor'
+  | 'acp.checkout_unsafe_amount_minor'
+  | 'acp.checkout_invalid_currency'
+  | 'acp.checkout_missing_payment_rail'
+  | 'acp.checkout_missing_payment_reference'
+  | 'acp.checkout_missing_env'
+  | 'acp.checkout_invalid_env';
+
+export interface ACPMapperBoundaryErrorInit {
+  code: ACPMapperBoundaryErrorCode;
+  field: string;
+  message: string;
+}
+
+/**
+ * Structured validation error thrown by ACP mapper input checks. Carries a
+ * stable `code` and `field` so callers can discriminate programmatically.
+ */
+export class ACPMapperBoundaryError extends Error {
+  readonly code: ACPMapperBoundaryErrorCode;
+  readonly field: string;
+  constructor(init: ACPMapperBoundaryErrorInit) {
+    super(init.message);
+    this.name = 'ACPMapperBoundaryError';
+    this.code = init.code;
+    this.field = init.field;
+  }
 }
 
 /**
@@ -47,38 +111,155 @@ export interface PEACReceiptInput {
 }
 
 /**
- * Convert ACP checkout success event to PEAC receipt input
+ * Convert ACP checkout success event to PEAC receipt input.
+ *
+ * Observational mapping only. fromACPCheckoutSuccess does NOT synthesize
+ * commerce finality: a checkout-success observation alone does not prove
+ * authorization, capture, settlement, refund, void, or chargeback. The
+ * mapper records checkout/payment evidence only; no `commerce_event`,
+ * `settlement_state`, `capture_state`, or `authorization_state` is emitted.
+ * Callers that have an explicit payment-bearing artifact should route
+ * through fromACPDelegatedPaymentObservation or fromACPPaymentObservation
+ * instead.
+ *
+ * Validation errors are thrown as ACPMapperBoundaryError with stable
+ * `code` and `field` so callers can discriminate programmatically.
  *
  * @param event - ACP checkout success event
+ * @param options - Optional strictness mode + warn sink
  * @returns PEAC receipt input ready for issue()
  */
-export function fromACPCheckoutSuccess(event: ACPCheckoutSuccess): PEACReceiptInput {
-  // Validate ACP event
+export function fromACPCheckoutSuccess(
+  event: ACPCheckoutSuccess,
+  options: ACPCheckoutSuccessOptions = {}
+): PEACReceiptInput {
+  if (event === null || typeof event !== 'object') {
+    throw new ACPMapperBoundaryError({
+      code: 'acp.checkout_invalid_event',
+      field: 'event',
+      message: 'ACP checkout event must be an object',
+    });
+  }
   if (!event.checkout_id) {
-    throw new Error('ACP checkout event missing checkout_id');
+    throw new ACPMapperBoundaryError({
+      code: 'acp.checkout_missing_checkout_id',
+      field: 'checkout_id',
+      message: 'ACP checkout event missing checkout_id',
+    });
   }
-  if (!event.resource_uri || !event.resource_uri.startsWith('https://')) {
-    throw new Error('ACP checkout event missing or invalid resource_uri (must be https://)');
+  if (!isValidHttpsResourceUri(event.resource_uri)) {
+    throw new ACPMapperBoundaryError({
+      code: 'acp.checkout_invalid_resource_uri',
+      field: 'resource_uri',
+      message:
+        'ACP checkout event missing or invalid resource_uri (must be an https:// URL with a hostname and no embedded credentials)',
+    });
   }
-  if (typeof event.total_amount !== 'number' || event.total_amount < 0) {
-    throw new Error('ACP checkout event invalid total_amount');
+  // Reject legacy numeric total_amount with a clear migration message.
+  const legacy = (event as unknown as { total_amount?: unknown }).total_amount;
+  if (legacy !== undefined) {
+    throw new ACPMapperBoundaryError({
+      code: 'acp.checkout_legacy_total_amount',
+      field: 'total_amount',
+      message:
+        'ACP checkout event uses legacy total_amount: number; pass amount_minor as a base-10 integer string instead (e.g. "9999")',
+    });
+  }
+  if (!isValidAmountMinor(event.amount_minor)) {
+    throw new ACPMapperBoundaryError({
+      code: 'acp.checkout_invalid_amount_minor',
+      field: 'amount_minor',
+      message:
+        'ACP checkout event invalid amount_minor (must be a base-10 integer string, e.g. "9999")',
+    });
+  }
+  if (event.amount_minor.startsWith('-')) {
+    throw new ACPMapperBoundaryError({
+      code: 'acp.checkout_invalid_amount_minor',
+      field: 'amount_minor',
+      message: 'ACP checkout event invalid amount_minor (must be non-negative)',
+    });
   }
   if (!event.currency || !/^[A-Z]{3}$/.test(event.currency)) {
-    throw new Error('ACP checkout event invalid currency (must be uppercase ISO 4217)');
+    throw new ACPMapperBoundaryError({
+      code: 'acp.checkout_invalid_currency',
+      field: 'currency',
+      message: 'ACP checkout event invalid currency (must be uppercase ISO 4217)',
+    });
   }
   if (!event.payment_rail) {
-    throw new Error('ACP checkout event missing payment_rail');
+    throw new ACPMapperBoundaryError({
+      code: 'acp.checkout_missing_payment_rail',
+      field: 'payment_rail',
+      message: 'ACP checkout event missing payment_rail',
+    });
   }
   if (!event.payment_reference) {
-    throw new Error('ACP checkout event missing payment_reference');
+    throw new ACPMapperBoundaryError({
+      code: 'acp.checkout_missing_payment_reference',
+      field: 'payment_reference',
+      message: 'ACP checkout event missing payment_reference',
+    });
+  }
+  if (event.env === undefined || event.env === null) {
+    throw new ACPMapperBoundaryError({
+      code: 'acp.checkout_missing_env',
+      field: 'env',
+      message: "ACP checkout event missing env (must be 'live' or 'test')",
+    });
+  }
+  if (event.env !== 'live' && event.env !== 'test') {
+    throw new ACPMapperBoundaryError({
+      code: 'acp.checkout_invalid_env',
+      field: 'env',
+      message: "ACP checkout event invalid env (must be 'live' or 'test')",
+    });
   }
 
-  // Build payment evidence from ACP event as JsonObject
-  const evidence: JsonObject = {};
+  // Safe-integer boundary for amount_minor -> Number conversion.
+  //
+  // PaymentEvidence.amount and PEACReceiptInput.amt carry the amount as a
+  // JS `number`. AmountMinorStringSchema accepts up to 39 digits, so we
+  // MUST refuse anything beyond Number.MAX_SAFE_INTEGER to avoid silently
+  // losing precision on the way back to a number. Use a string-preserving
+  // record profile for amounts beyond the safe-integer range, NOT this
+  // checkout-success mapper.
+  const amountMinorBig = BigInt(event.amount_minor);
+  if (amountMinorBig > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new ACPMapperBoundaryError({
+      code: 'acp.checkout_unsafe_amount_minor',
+      field: 'amount_minor',
+      message: `ACP checkout event amount_minor exceeds Number.MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER}); the legacy PEAC receipt input carries amount as a JS number and would lose precision. Use a string-preserving record profile for amounts beyond the safe-integer range.`,
+    });
+  }
+  const amountMinor = Number(amountMinorBig);
 
-  // Include ACP metadata in evidence
+  // Mapper-boundary finality-synthesis guard.
+  //
+  // fromACPCheckoutSuccess does NOT synthesize commerce finality. event is
+  // intentionally undefined here so Rule 1 (the finality-synthesis check)
+  // is a no-op: a checkout-success observation alone does not claim
+  // authorization, capture, settlement, refund, void, or chargeback. The
+  // guard call is retained to enforce Rules 2 and 3 (currency MUST be
+  // upstream-asserted, env MUST be explicit). A caller with a finality-
+  // bearing event must use a finality-aware mapper.
+  assertExplicitFinality(
+    {
+      event: undefined,
+      hasExplicitUpstreamArtifact: false,
+      currency: event.currency,
+      env: event.env,
+      envExplicit: true,
+    },
+    {
+      mode: options.mode,
+      warn: options.warn,
+      pointer: '/proofs/acp/checkout',
+    }
+  );
+
+  const evidence: JsonObject = {};
   if (event.metadata) {
-    // Cast metadata to JsonObject (Record<string, unknown> -> JsonObject)
     evidence.acp_metadata = event.metadata as JsonObject;
   }
   if (event.customer_id) {
@@ -91,16 +272,16 @@ export function fromACPCheckoutSuccess(event: ACPCheckoutSuccess): PEACReceiptIn
   const payment: PaymentEvidence = {
     rail: event.payment_rail,
     reference: event.payment_reference,
-    amount: event.total_amount,
+    amount: amountMinor,
     currency: event.currency,
-    asset: event.currency, // For ACP, asset is typically same as currency
-    env: 'live', // Default to live; ACP events should indicate if test
+    asset: event.currency,
+    env: event.env,
     evidence,
   };
 
   return {
     subject_uri: event.resource_uri,
-    amt: event.total_amount,
+    amt: amountMinor,
     cur: event.currency,
     payment,
   };

--- a/packages/mappings/acp/src/session.ts
+++ b/packages/mappings/acp/src/session.ts
@@ -15,6 +15,7 @@
 import type { JsonObject } from '@peac/kernel';
 import type { PaymentEvidence } from '@peac/schema';
 import { assertExplicitFinality, type StrictnessMode } from '@peac/adapter-core';
+import { isValidHttpsResourceUri } from './validation.js';
 
 /**
  * PEAC Receipt Input (for issue()).
@@ -117,8 +118,10 @@ export function fromACPSessionLifecycleEvent(event: ACPSessionEvent): SessionRec
   if (!event.session_id) {
     throw new Error('ACP session event missing session_id');
   }
-  if (!event.resource_uri || !event.resource_uri.startsWith('https://')) {
-    throw new Error('ACP session event missing or invalid resource_uri (must be https://)');
+  if (!isValidHttpsResourceUri(event.resource_uri)) {
+    throw new Error(
+      'ACP session event missing or invalid resource_uri (must be an https:// URL with a hostname and no embedded credentials)'
+    );
   }
 
   const evidence: JsonObject = {
@@ -172,8 +175,10 @@ export function fromACPPaymentObservation(
   if (!event.session_id) {
     throw new Error('ACP session event missing session_id');
   }
-  if (!event.resource_uri || !event.resource_uri.startsWith('https://')) {
-    throw new Error('ACP session event missing or invalid resource_uri (must be https://)');
+  if (!isValidHttpsResourceUri(event.resource_uri)) {
+    throw new Error(
+      'ACP session event missing or invalid resource_uri (must be an https:// URL with a hostname and no embedded credentials)'
+    );
   }
   if (!paymentArtifact.rail) {
     throw new Error('Payment artifact missing rail');
@@ -183,6 +188,14 @@ export function fromACPPaymentObservation(
   }
   if (!paymentArtifact.observed_payment_state) {
     throw new Error('Payment artifact missing observed_payment_state');
+  }
+  // paymentArtifact.amount is a number on the input boundary; reject NaN,
+  // Infinity, decimals, and unsafe integers before assigning to
+  // PaymentEvidence.amount to prevent signing imprecise numeric evidence.
+  if (!Number.isSafeInteger(paymentArtifact.amount)) {
+    throw new Error(
+      'Payment artifact amount must be a safe integer minor-unit value (no NaN, Infinity, decimals, or values outside Number.MIN_SAFE_INTEGER..Number.MAX_SAFE_INTEGER)'
+    );
   }
 
   const commerceEvent = PAYMENT_STATE_TO_COMMERCE_EVENT[paymentArtifact.observed_payment_state];
@@ -249,8 +262,10 @@ export function fromACPInterventionRequired(intervention: ACPIntervention): Sess
   if (!intervention.session_id) {
     throw new Error('ACP intervention missing session_id');
   }
-  if (!intervention.resource_uri || !intervention.resource_uri.startsWith('https://')) {
-    throw new Error('ACP intervention missing or invalid resource_uri (must be https://)');
+  if (!isValidHttpsResourceUri(intervention.resource_uri)) {
+    throw new Error(
+      'ACP intervention missing or invalid resource_uri (must be an https:// URL with a hostname and no embedded credentials)'
+    );
   }
 
   const evidence: JsonObject = {
@@ -382,9 +397,9 @@ export function fromACPDelegatedPaymentObservation(
   if (!observation.delegation_id) {
     throw new Error('ACP delegated-payment observation missing delegation_id');
   }
-  if (!observation.resource_uri || !observation.resource_uri.startsWith('https://')) {
+  if (!isValidHttpsResourceUri(observation.resource_uri)) {
     throw new Error(
-      'ACP delegated-payment observation missing or invalid resource_uri (must be https://)'
+      'ACP delegated-payment observation missing or invalid resource_uri (must be an https:// URL with a hostname and no embedded credentials)'
     );
   }
   if (!observation.principal) {
@@ -399,9 +414,9 @@ export function fromACPDelegatedPaymentObservation(
   if (!observation.observed_payment_state) {
     throw new Error('ACP delegated-payment observation missing observed_payment_state');
   }
-  if (!/^-?[0-9]+$/.test(observation.authorized_amount_minor)) {
+  if (!/^[0-9]+$/.test(observation.authorized_amount_minor)) {
     throw new Error(
-      'ACP delegated-payment observation authorized_amount_minor must be a base-10 integer string'
+      'ACP delegated-payment observation authorized_amount_minor must be a non-negative base-10 integer string'
     );
   }
 
@@ -466,7 +481,22 @@ export function fromACPDelegatedPaymentObservation(
   // No currency-aware scaling is applied; consumers that need major units
   // must convert downstream using the currency. The canonical minor string
   // remains available under evidence.authorized_amount_minor.
-  const amountMinor = parseInt(observation.authorized_amount_minor, 10);
+  //
+  // Safe-integer boundary for authorized_amount_minor -> Number conversion.
+  // PaymentEvidence.amount is a JS `number`; values above the safe-integer
+  // range would silently lose precision. Negative values are rejected at
+  // the regex layer above (authorized amounts are non-negative; refund
+  // semantics flow through observed_payment_state='refunded' on the
+  // session-payment-artifact path, not through delegated-payment).
+  // Callers with amounts beyond the safe-integer range must use a
+  // string-preserving record profile, not this mapper.
+  const amountMinorBig = BigInt(observation.authorized_amount_minor);
+  if (amountMinorBig > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error(
+      `ACP delegated-payment observation authorized_amount_minor (${observation.authorized_amount_minor}) exceeds Number.MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER}); converting to PaymentEvidence.amount would lose precision. Use a string-preserving record profile for amounts beyond the safe-integer range.`
+    );
+  }
+  const amountMinor = Number(amountMinorBig);
 
   const payment: PaymentEvidence = {
     rail: 'acp-delegated-payment',

--- a/packages/mappings/acp/src/validation.ts
+++ b/packages/mappings/acp/src/validation.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared ACP mapper validation helpers.
+ */
+
+/**
+ * Type guard for an https:// URL string with a non-empty hostname.
+ *
+ * Requires the literal "https://" prefix in addition to a parsed `https:`
+ * protocol so opaque-path forms like "https:example.com" are rejected.
+ * Embedded credentials (userinfo) are rejected to avoid signing a
+ * resource_uri that carries secrets.
+ */
+export function isValidHttpsResourceUri(value: unknown): value is string {
+  if (typeof value !== 'string' || value.length === 0) return false;
+  if (!value.startsWith('https://')) return false;
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === 'https:' &&
+      url.hostname.length > 0 &&
+      url.username.length === 0 &&
+      url.password.length === 0
+    );
+  } catch {
+    return false;
+  }
+}

--- a/packages/mappings/acp/tests/acp.test.ts
+++ b/packages/mappings/acp/tests/acp.test.ts
@@ -7,10 +7,30 @@ import {
   fromACPCheckoutSuccess,
   attachReceiptToACPResponse,
   extractReceiptFromACPResponse,
+  ACPMapperBoundaryError,
   type ACPCheckoutSuccess,
+  type ACPMapperBoundaryErrorCode,
 } from '../src/index';
 import { issueWire01 } from '../../../protocol/src/issue';
 import { generateKeypair } from '../../../crypto/src/jws';
+
+function expectAcpError(
+  fn: () => unknown,
+  code: ACPMapperBoundaryErrorCode,
+  field: string
+): ACPMapperBoundaryError {
+  let captured: unknown;
+  try {
+    fn();
+  } catch (err) {
+    captured = err;
+  }
+  expect(captured).toBeInstanceOf(ACPMapperBoundaryError);
+  const e = captured as ACPMapperBoundaryError;
+  expect(e.code).toBe(code);
+  expect(e.field).toBe(field);
+  return e;
+}
 
 describe('ACP integration', () => {
   describe('fromACPCheckoutSuccess', () => {
@@ -18,10 +38,11 @@ describe('ACP integration', () => {
       const acpEvent: ACPCheckoutSuccess = {
         checkout_id: 'checkout_abc123',
         resource_uri: 'https://api.example.com/resources/456',
-        total_amount: 9999,
+        amount_minor: '9999',
         currency: 'USD',
         payment_rail: 'stripe',
         payment_reference: 'cs_test_123',
+        env: 'live',
         customer_id: 'cus_xyz',
         metadata: {
           order_id: 'order_789',
@@ -37,6 +58,7 @@ describe('ACP integration', () => {
       expect(receiptInput.payment.reference).toBe('cs_test_123');
       expect(receiptInput.payment.amount).toBe(9999);
       expect(receiptInput.payment.currency).toBe('USD');
+      expect(receiptInput.payment.env).toBe('live');
       expect(receiptInput.payment.evidence).toMatchObject({
         checkout_id: 'checkout_abc123',
         customer_id: 'cus_xyz',
@@ -50,10 +72,11 @@ describe('ACP integration', () => {
       const acpEvent: ACPCheckoutSuccess = {
         checkout_id: 'checkout_minimal',
         resource_uri: 'https://api.example.com/resource',
-        total_amount: 1000,
+        amount_minor: '1000',
         currency: 'EUR',
         payment_rail: 'x402',
         payment_reference: 'inv_123',
+        env: 'live',
       };
 
       const receiptInput = fromACPCheckoutSuccess(acpEvent);
@@ -65,55 +88,477 @@ describe('ACP integration', () => {
       expect(receiptInput.payment.reference).toBe('inv_123');
     });
 
-    it('should reject ACP event without checkout_id', () => {
-      const acpEvent = {
+    it('should preserve test env when asserted by upstream', () => {
+      const acpEvent: ACPCheckoutSuccess = {
+        checkout_id: 'checkout_sandbox',
         resource_uri: 'https://api.example.com/resource',
-        total_amount: 9999,
+        amount_minor: '500',
         currency: 'USD',
         payment_rail: 'stripe',
-        payment_reference: 'cs_123',
-      } as ACPCheckoutSuccess;
+        payment_reference: 'cs_test_sandbox',
+        env: 'test',
+      };
 
-      expect(() => fromACPCheckoutSuccess(acpEvent)).toThrow('missing checkout_id');
+      const receiptInput = fromACPCheckoutSuccess(acpEvent);
+      expect(receiptInput.payment.env).toBe('test');
     });
 
-    it('should reject ACP event with non-https resource_uri', () => {
-      const acpEvent = {
-        checkout_id: 'checkout_123',
-        resource_uri: 'http://api.example.com/resource', // HTTP not allowed
-        total_amount: 9999,
-        currency: 'USD',
-        payment_rail: 'stripe',
-        payment_reference: 'cs_123',
-      } as ACPCheckoutSuccess;
-
-      expect(() => fromACPCheckoutSuccess(acpEvent)).toThrow('invalid resource_uri');
-    });
-
-    it('should reject ACP event with invalid currency', () => {
-      const acpEvent = {
+    describe('structured validation errors', () => {
+      const base = {
         checkout_id: 'checkout_123',
         resource_uri: 'https://api.example.com/resource',
-        total_amount: 9999,
-        currency: 'usd', // Must be uppercase
+        amount_minor: '9999',
+        currency: 'USD',
         payment_rail: 'stripe',
-        payment_reference: 'cs_123',
-      } as ACPCheckoutSuccess;
+        payment_reference: 'cs_test_123',
+        env: 'live' as const,
+      };
 
-      expect(() => fromACPCheckoutSuccess(acpEvent)).toThrow('invalid currency');
+      it('rejects null event with acp.checkout_invalid_event', () => {
+        expectAcpError(
+          () => fromACPCheckoutSuccess(null as unknown as ACPCheckoutSuccess),
+          'acp.checkout_invalid_event',
+          'event'
+        );
+      });
+
+      it('rejects undefined event with acp.checkout_invalid_event', () => {
+        expectAcpError(
+          () => fromACPCheckoutSuccess(undefined as unknown as ACPCheckoutSuccess),
+          'acp.checkout_invalid_event',
+          'event'
+        );
+      });
+
+      it('rejects non-object event (string) with acp.checkout_invalid_event', () => {
+        expectAcpError(
+          () => fromACPCheckoutSuccess('not-an-event' as unknown as ACPCheckoutSuccess),
+          'acp.checkout_invalid_event',
+          'event'
+        );
+      });
+
+      it('rejects missing checkout_id with acp.checkout_missing_checkout_id', () => {
+        const { checkout_id: _drop, ...rest } = base;
+        expectAcpError(
+          () => fromACPCheckoutSuccess(rest as unknown as ACPCheckoutSuccess),
+          'acp.checkout_missing_checkout_id',
+          'checkout_id'
+        );
+      });
+
+      it('rejects lowercase currency with acp.checkout_invalid_currency', () => {
+        expectAcpError(
+          () =>
+            fromACPCheckoutSuccess({
+              ...base,
+              currency: 'usd',
+            } as unknown as ACPCheckoutSuccess),
+          'acp.checkout_invalid_currency',
+          'currency'
+        );
+      });
+
+      it('rejects missing payment_rail with acp.checkout_missing_payment_rail', () => {
+        const { payment_rail: _drop, ...rest } = base;
+        expectAcpError(
+          () => fromACPCheckoutSuccess(rest as unknown as ACPCheckoutSuccess),
+          'acp.checkout_missing_payment_rail',
+          'payment_rail'
+        );
+      });
+
+      it('rejects missing payment_reference with acp.checkout_missing_payment_reference', () => {
+        const { payment_reference: _drop, ...rest } = base;
+        expectAcpError(
+          () => fromACPCheckoutSuccess(rest as unknown as ACPCheckoutSuccess),
+          'acp.checkout_missing_payment_reference',
+          'payment_reference'
+        );
+      });
+    });
+
+    describe('amount_minor validation', () => {
+      const base = {
+        checkout_id: 'checkout_123',
+        resource_uri: 'https://api.example.com/resource',
+        currency: 'USD',
+        payment_rail: 'stripe',
+        payment_reference: 'cs_test_123',
+        env: 'live' as const,
+      };
+
+      it('rejects legacy numeric total_amount with acp.checkout_legacy_total_amount', () => {
+        expectAcpError(
+          () =>
+            fromACPCheckoutSuccess({
+              ...base,
+              total_amount: 9999,
+            } as unknown as ACPCheckoutSuccess),
+          'acp.checkout_legacy_total_amount',
+          'total_amount'
+        );
+      });
+
+      it('rejects missing amount_minor with acp.checkout_invalid_amount_minor', () => {
+        expectAcpError(
+          () => fromACPCheckoutSuccess(base as unknown as ACPCheckoutSuccess),
+          'acp.checkout_invalid_amount_minor',
+          'amount_minor'
+        );
+      });
+
+      it('rejects numeric amount_minor with acp.checkout_invalid_amount_minor', () => {
+        expectAcpError(
+          () =>
+            fromACPCheckoutSuccess({
+              ...base,
+              amount_minor: 9999,
+            } as unknown as ACPCheckoutSuccess),
+          'acp.checkout_invalid_amount_minor',
+          'amount_minor'
+        );
+      });
+
+      it('rejects empty-string amount_minor with acp.checkout_invalid_amount_minor', () => {
+        expectAcpError(
+          () =>
+            fromACPCheckoutSuccess({
+              ...base,
+              amount_minor: '',
+            } as ACPCheckoutSuccess),
+          'acp.checkout_invalid_amount_minor',
+          'amount_minor'
+        );
+      });
+
+      it('rejects decimal amount_minor with acp.checkout_invalid_amount_minor', () => {
+        expectAcpError(
+          () =>
+            fromACPCheckoutSuccess({
+              ...base,
+              amount_minor: '99.99',
+            } as ACPCheckoutSuccess),
+          'acp.checkout_invalid_amount_minor',
+          'amount_minor'
+        );
+      });
+
+      it('rejects comma-formatted amount_minor with acp.checkout_invalid_amount_minor', () => {
+        expectAcpError(
+          () =>
+            fromACPCheckoutSuccess({
+              ...base,
+              amount_minor: '9,999',
+            } as ACPCheckoutSuccess),
+          'acp.checkout_invalid_amount_minor',
+          'amount_minor'
+        );
+      });
+
+      it('rejects negative amount_minor with acp.checkout_invalid_amount_minor', () => {
+        const e = expectAcpError(
+          () =>
+            fromACPCheckoutSuccess({
+              ...base,
+              amount_minor: '-100',
+            } as ACPCheckoutSuccess),
+          'acp.checkout_invalid_amount_minor',
+          'amount_minor'
+        );
+        expect(e.message).toMatch(/non-negative/);
+      });
+
+      it('accepts zero amount_minor (free checkout)', () => {
+        const result = fromACPCheckoutSuccess({
+          ...base,
+          amount_minor: '0',
+        } as ACPCheckoutSuccess);
+        expect(result.amt).toBe(0);
+        expect(result.payment.amount).toBe(0);
+      });
+    });
+
+    describe('amount_minor safe-integer boundary', () => {
+      const base = {
+        checkout_id: 'checkout_123',
+        resource_uri: 'https://api.example.com/resource',
+        currency: 'USD',
+        payment_rail: 'stripe',
+        payment_reference: 'cs_test_123',
+        env: 'live' as const,
+      };
+
+      it('accepts Number.MAX_SAFE_INTEGER as string', () => {
+        const result = fromACPCheckoutSuccess({
+          ...base,
+          amount_minor: '9007199254740991',
+        });
+        expect(result.amt).toBe(Number.MAX_SAFE_INTEGER);
+        expect(result.payment.amount).toBe(Number.MAX_SAFE_INTEGER);
+      });
+
+      it('rejects Number.MAX_SAFE_INTEGER + 1 with acp.checkout_unsafe_amount_minor', () => {
+        expectAcpError(
+          () =>
+            fromACPCheckoutSuccess({
+              ...base,
+              amount_minor: '9007199254740992',
+            }),
+          'acp.checkout_unsafe_amount_minor',
+          'amount_minor'
+        );
+      });
+
+      it('rejects 39-digit amount_minor with acp.checkout_unsafe_amount_minor', () => {
+        expectAcpError(
+          () =>
+            fromACPCheckoutSuccess({
+              ...base,
+              amount_minor: '999999999999999999999999999999999999999',
+            }),
+          'acp.checkout_unsafe_amount_minor',
+          'amount_minor'
+        );
+      });
+
+      it('rejects mid-range unsafe amount with acp.checkout_unsafe_amount_minor', () => {
+        expectAcpError(
+          () =>
+            fromACPCheckoutSuccess({
+              ...base,
+              amount_minor: '99999999999999999',
+            }),
+          'acp.checkout_unsafe_amount_minor',
+          'amount_minor'
+        );
+      });
+    });
+
+    describe('resource_uri validation', () => {
+      const base = {
+        checkout_id: 'checkout_123',
+        amount_minor: '9999',
+        currency: 'USD',
+        payment_rail: 'stripe',
+        payment_reference: 'cs_test_123',
+        env: 'live' as const,
+      };
+
+      it('accepts a well-formed https URL with hostname and path', () => {
+        expect(() =>
+          fromACPCheckoutSuccess({
+            ...base,
+            resource_uri: 'https://example.com/resource',
+          })
+        ).not.toThrow();
+      });
+
+      it('accepts an https URL with no path (hostname only)', () => {
+        expect(() =>
+          fromACPCheckoutSuccess({
+            ...base,
+            resource_uri: 'https://example.com',
+          })
+        ).not.toThrow();
+      });
+
+      it('rejects http:// resource_uri with acp.checkout_invalid_resource_uri', () => {
+        expectAcpError(
+          () =>
+            fromACPCheckoutSuccess({
+              ...base,
+              resource_uri: 'http://example.com/resource',
+            }),
+          'acp.checkout_invalid_resource_uri',
+          'resource_uri'
+        );
+      });
+
+      it('rejects "https://" (no hostname) with acp.checkout_invalid_resource_uri', () => {
+        expectAcpError(
+          () =>
+            fromACPCheckoutSuccess({
+              ...base,
+              resource_uri: 'https://',
+            }),
+          'acp.checkout_invalid_resource_uri',
+          'resource_uri'
+        );
+      });
+
+      it('rejects "not-a-url" with acp.checkout_invalid_resource_uri', () => {
+        expectAcpError(
+          () =>
+            fromACPCheckoutSuccess({
+              ...base,
+              resource_uri: 'not-a-url',
+            }),
+          'acp.checkout_invalid_resource_uri',
+          'resource_uri'
+        );
+      });
+
+      it('rejects empty-string resource_uri with acp.checkout_invalid_resource_uri', () => {
+        expectAcpError(
+          () =>
+            fromACPCheckoutSuccess({
+              ...base,
+              resource_uri: '',
+            }),
+          'acp.checkout_invalid_resource_uri',
+          'resource_uri'
+        );
+      });
+
+      it('rejects missing resource_uri with acp.checkout_invalid_resource_uri', () => {
+        const { ...rest } = base;
+        expectAcpError(
+          () => fromACPCheckoutSuccess(rest as unknown as ACPCheckoutSuccess),
+          'acp.checkout_invalid_resource_uri',
+          'resource_uri'
+        );
+      });
+
+      it('rejects ws:// scheme with acp.checkout_invalid_resource_uri', () => {
+        expectAcpError(
+          () =>
+            fromACPCheckoutSuccess({
+              ...base,
+              resource_uri: 'ws://example.com/socket',
+            }),
+          'acp.checkout_invalid_resource_uri',
+          'resource_uri'
+        );
+      });
+
+      it('rejects opaque-path "https:example.com" (no //) with acp.checkout_invalid_resource_uri', () => {
+        expectAcpError(
+          () =>
+            fromACPCheckoutSuccess({
+              ...base,
+              resource_uri: 'https:example.com',
+            }),
+          'acp.checkout_invalid_resource_uri',
+          'resource_uri'
+        );
+      });
+
+      it('rejects credential-bearing https URL (username) with acp.checkout_invalid_resource_uri', () => {
+        expectAcpError(
+          () =>
+            fromACPCheckoutSuccess({
+              ...base,
+              resource_uri: 'https://user:pass@example.com/resource',
+            }),
+          'acp.checkout_invalid_resource_uri',
+          'resource_uri'
+        );
+      });
+
+      it('rejects username-only credential https URL with acp.checkout_invalid_resource_uri', () => {
+        expectAcpError(
+          () =>
+            fromACPCheckoutSuccess({
+              ...base,
+              resource_uri: 'https://user@example.com/resource',
+            }),
+          'acp.checkout_invalid_resource_uri',
+          'resource_uri'
+        );
+      });
+    });
+
+    describe('env (finality-boundary) validation', () => {
+      const base = {
+        checkout_id: 'checkout_123',
+        resource_uri: 'https://api.example.com/resource',
+        amount_minor: '9999',
+        currency: 'USD',
+        payment_rail: 'stripe',
+        payment_reference: 'cs_test_123',
+      };
+
+      it('rejects missing env with acp.checkout_missing_env', () => {
+        expectAcpError(
+          () => fromACPCheckoutSuccess(base as unknown as ACPCheckoutSuccess),
+          'acp.checkout_missing_env',
+          'env'
+        );
+      });
+
+      it("rejects env values outside 'live' | 'test' with acp.checkout_invalid_env", () => {
+        expectAcpError(
+          () =>
+            fromACPCheckoutSuccess({
+              ...base,
+              env: 'production',
+            } as unknown as ACPCheckoutSuccess),
+          'acp.checkout_invalid_env',
+          'env'
+        );
+      });
+
+      it('passes the finality guard with explicit currency + env (strict mode)', () => {
+        const evt = { ...base, env: 'live' as const };
+        expect(() => fromACPCheckoutSuccess(evt, { mode: 'strict' })).not.toThrow();
+      });
+    });
+
+    describe('non-finality invariant', () => {
+      // fromACPCheckoutSuccess does NOT synthesize commerce finality. A
+      // checkout-success observation alone does not prove authorization,
+      // capture, settlement, refund, void, or chargeback. The mapper records
+      // checkout/payment evidence only and MUST NOT emit any of these
+      // finality-bearing fields. This block locks that invariant.
+      const base = {
+        checkout_id: 'checkout_123',
+        resource_uri: 'https://api.example.com/resource',
+        amount_minor: '9999',
+        currency: 'USD',
+        payment_rail: 'stripe',
+        payment_reference: 'cs_test_123',
+        env: 'live' as const,
+      };
+
+      it('does not emit commerce_event in evidence', () => {
+        const result = fromACPCheckoutSuccess(base);
+        expect(result.payment.evidence).not.toHaveProperty('commerce_event');
+      });
+
+      it('does not emit settlement_state in evidence', () => {
+        const result = fromACPCheckoutSuccess(base);
+        expect(result.payment.evidence).not.toHaveProperty('settlement_state');
+      });
+
+      it('does not emit capture_state in evidence', () => {
+        const result = fromACPCheckoutSuccess(base);
+        expect(result.payment.evidence).not.toHaveProperty('capture_state');
+      });
+
+      it('does not emit authorization_state in evidence', () => {
+        const result = fromACPCheckoutSuccess(base);
+        expect(result.payment.evidence).not.toHaveProperty('authorization_state');
+      });
+
+      it('does not emit observed_payment_state in evidence', () => {
+        const result = fromACPCheckoutSuccess(base);
+        expect(result.payment.evidence).not.toHaveProperty('observed_payment_state');
+      });
     });
   });
 
-  describe('Golden Vector A: ACP → PEAC Receipt', () => {
+  describe('Golden Vector A: ACP -> PEAC Receipt', () => {
     it('should produce a valid PEAC receipt from ACP checkout (Stripe)', async () => {
       // ACP checkout success event (Stripe)
       const acpEvent: ACPCheckoutSuccess = {
         checkout_id: 'checkout_golden_stripe',
         resource_uri: 'https://api.example.com/api/resource/123',
-        total_amount: 9999,
+        amount_minor: '9999',
         currency: 'USD',
         payment_rail: 'stripe',
         payment_reference: 'cs_test_golden_stripe',
+        env: 'live',
         customer_id: 'cus_golden',
         metadata: {
           order_id: 'order_golden_stripe',
@@ -157,10 +602,11 @@ describe('ACP integration', () => {
       const acpEvent: ACPCheckoutSuccess = {
         checkout_id: 'checkout_golden_x402',
         resource_uri: 'https://api.example.com/api/resource/456',
-        total_amount: 9999,
+        amount_minor: '9999',
         currency: 'USD',
         payment_rail: 'x402',
         payment_reference: 'inv_test_golden_x402',
+        env: 'live',
         customer_id: 'cus_golden',
         metadata: {
           order_id: 'order_golden_x402',

--- a/packages/mappings/acp/tests/delegated-payment.test.ts
+++ b/packages/mappings/acp/tests/delegated-payment.test.ts
@@ -155,6 +155,78 @@ describe('fromACPDelegatedPaymentObservation: amount semantics (minor units)', (
   });
 });
 
+describe('fromACPDelegatedPaymentObservation: authorized_amount_minor non-negative + safe-integer boundary', () => {
+  // Refund / chargeback semantics flow through the session-payment-artifact
+  // path with observed_payment_state='refunded'; delegated-payment carries
+  // only authorized | settled | pending | failed | revoked states, so
+  // authorized_amount_minor is non-negative by design.
+
+  it('accepts "0" as authorized_amount_minor', () => {
+    const out = fromACPDelegatedPaymentObservation(
+      makeObservation({ authorized_amount_minor: '0' })
+    );
+    expect(out.payment.amount).toBe(0);
+    expect(out.amt).toBe(0);
+  });
+
+  it('accepts Number.MAX_SAFE_INTEGER as authorized_amount_minor', () => {
+    const out = fromACPDelegatedPaymentObservation(
+      makeObservation({ authorized_amount_minor: '9007199254740991' })
+    );
+    expect(out.payment.amount).toBe(Number.MAX_SAFE_INTEGER);
+    expect(out.amt).toBe(Number.MAX_SAFE_INTEGER);
+    expect(out.payment.evidence?.authorized_amount_minor).toBe('9007199254740991');
+  });
+
+  it('rejects Number.MAX_SAFE_INTEGER + 1 with a precision-loss error', () => {
+    expect(() =>
+      fromACPDelegatedPaymentObservation(
+        makeObservation({ authorized_amount_minor: '9007199254740992' })
+      )
+    ).toThrow(/exceeds Number\.MAX_SAFE_INTEGER/);
+  });
+
+  it('rejects 39-digit authorized_amount_minor with a precision-loss error', () => {
+    expect(() =>
+      fromACPDelegatedPaymentObservation(
+        makeObservation({
+          authorized_amount_minor: '999999999999999999999999999999999999999',
+        })
+      )
+    ).toThrow(/exceeds Number\.MAX_SAFE_INTEGER/);
+  });
+
+  it('rejects "-1" as authorized_amount_minor', () => {
+    expect(() =>
+      fromACPDelegatedPaymentObservation(makeObservation({ authorized_amount_minor: '-1' }))
+    ).toThrow(/non-negative/);
+  });
+
+  it('rejects "-100" as authorized_amount_minor', () => {
+    expect(() =>
+      fromACPDelegatedPaymentObservation(makeObservation({ authorized_amount_minor: '-100' }))
+    ).toThrow(/non-negative/);
+  });
+
+  it('rejects negative 39-digit authorized_amount_minor', () => {
+    expect(() =>
+      fromACPDelegatedPaymentObservation(
+        makeObservation({
+          authorized_amount_minor: '-999999999999999999999999999999999999999',
+        })
+      )
+    ).toThrow(/non-negative/);
+  });
+
+  it('rejects "-9007199254740991" (negative MIN_SAFE_INTEGER form)', () => {
+    expect(() =>
+      fromACPDelegatedPaymentObservation(
+        makeObservation({ authorized_amount_minor: '-9007199254740991' })
+      )
+    ).toThrow(/non-negative/);
+  });
+});
+
 describe('fromACPDelegatedPaymentObservation: terminal/non-finality states', () => {
   for (const state of ['pending', 'failed', 'revoked'] as DelegatedPaymentState[]) {
     it(`MUST NOT emit a commerce event for observed_payment_state=${state}`, () => {
@@ -245,5 +317,51 @@ describe('fromACPDelegatedPaymentObservation: input validation', () => {
     expect(() =>
       fromACPDelegatedPaymentObservation(makeObservation({ payment_method_token_ref: '' }))
     ).toThrow(/payment_method_token_ref/);
+  });
+});
+
+describe('fromACPDelegatedPaymentObservation: resource_uri hardening', () => {
+  it('accepts a well-formed https URL', () => {
+    expect(() =>
+      fromACPDelegatedPaymentObservation(
+        makeObservation({ resource_uri: 'https://example.com/resource' })
+      )
+    ).not.toThrow();
+  });
+
+  it('rejects http://', () => {
+    expect(() =>
+      fromACPDelegatedPaymentObservation(
+        makeObservation({ resource_uri: 'http://example.com/resource' })
+      )
+    ).toThrow(/resource_uri/);
+  });
+
+  it('rejects "https://" with no hostname', () => {
+    expect(() =>
+      fromACPDelegatedPaymentObservation(makeObservation({ resource_uri: 'https://' }))
+    ).toThrow(/resource_uri/);
+  });
+
+  it('rejects opaque-path "https:example.com"', () => {
+    expect(() =>
+      fromACPDelegatedPaymentObservation(makeObservation({ resource_uri: 'https:example.com' }))
+    ).toThrow(/resource_uri/);
+  });
+
+  it('rejects credential-bearing https URL (user:pass@)', () => {
+    expect(() =>
+      fromACPDelegatedPaymentObservation(
+        makeObservation({ resource_uri: 'https://user:pass@example.com/resource' })
+      )
+    ).toThrow(/resource_uri/);
+  });
+
+  it('rejects username-only credential https URL (user@)', () => {
+    expect(() =>
+      fromACPDelegatedPaymentObservation(
+        makeObservation({ resource_uri: 'https://user@example.com/resource' })
+      )
+    ).toThrow(/resource_uri/);
   });
 });

--- a/packages/mappings/acp/tests/session.test.ts
+++ b/packages/mappings/acp/tests/session.test.ts
@@ -321,18 +321,19 @@ describe('fromACPInterventionRequired', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Existing fromACPCheckoutSuccess unchanged
+// fromACPCheckoutSuccess regression on the amount_minor + env contract
 // ---------------------------------------------------------------------------
 
 describe('fromACPCheckoutSuccess (regression)', () => {
-  it('should still work as before', () => {
+  it('should accept the canonical amount_minor + env shape', () => {
     const result = fromACPCheckoutSuccess({
       checkout_id: 'chk_123',
       resource_uri: 'https://shop.example.com/order/123',
-      total_amount: 2500,
+      amount_minor: '2500',
       currency: 'USD',
       payment_rail: 'stripe',
       payment_reference: 'pi_abc',
+      env: 'live',
     });
 
     expect(result.subject_uri).toBe('https://shop.example.com/order/123');
@@ -340,5 +341,194 @@ describe('fromACPCheckoutSuccess (regression)', () => {
     expect(result.cur).toBe('USD');
     expect(result.payment.rail).toBe('stripe');
     expect(result.payment.reference).toBe('pi_abc');
+    expect(result.payment.env).toBe('live');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hardened resource_uri validation across all session paths
+// ---------------------------------------------------------------------------
+
+describe('resource_uri hardening: fromACPSessionLifecycleEvent', () => {
+  it('accepts a well-formed https URL', () => {
+    expect(() =>
+      fromACPSessionLifecycleEvent(
+        makeSessionEvent('created', { resource_uri: 'https://example.com/resource' })
+      )
+    ).not.toThrow();
+  });
+
+  it('rejects http://', () => {
+    expect(() =>
+      fromACPSessionLifecycleEvent(
+        makeSessionEvent('created', { resource_uri: 'http://example.com/resource' })
+      )
+    ).toThrow(/resource_uri/);
+  });
+
+  it('rejects "https://" with no hostname', () => {
+    expect(() =>
+      fromACPSessionLifecycleEvent(makeSessionEvent('created', { resource_uri: 'https://' }))
+    ).toThrow(/resource_uri/);
+  });
+
+  it('rejects opaque-path "https:example.com"', () => {
+    expect(() =>
+      fromACPSessionLifecycleEvent(
+        makeSessionEvent('created', { resource_uri: 'https:example.com' })
+      )
+    ).toThrow(/resource_uri/);
+  });
+
+  it('rejects credential-bearing https URL (user:pass@)', () => {
+    expect(() =>
+      fromACPSessionLifecycleEvent(
+        makeSessionEvent('created', { resource_uri: 'https://user:pass@example.com/resource' })
+      )
+    ).toThrow(/resource_uri/);
+  });
+
+  it('rejects username-only credential https URL (user@)', () => {
+    expect(() =>
+      fromACPSessionLifecycleEvent(
+        makeSessionEvent('created', { resource_uri: 'https://user@example.com/resource' })
+      )
+    ).toThrow(/resource_uri/);
+  });
+});
+
+describe('resource_uri hardening: fromACPPaymentObservation', () => {
+  it('accepts a well-formed https URL', () => {
+    const event = makeSessionEvent('completed', { resource_uri: 'https://example.com/order/1' });
+    expect(() => fromACPPaymentObservation(event, makePaymentArtifact())).not.toThrow();
+  });
+
+  it('rejects http://', () => {
+    const event = makeSessionEvent('completed', { resource_uri: 'http://example.com/order/1' });
+    expect(() => fromACPPaymentObservation(event, makePaymentArtifact())).toThrow(/resource_uri/);
+  });
+
+  it('rejects "https://" with no hostname', () => {
+    const event = makeSessionEvent('completed', { resource_uri: 'https://' });
+    expect(() => fromACPPaymentObservation(event, makePaymentArtifact())).toThrow(/resource_uri/);
+  });
+
+  it('rejects opaque-path "https:example.com"', () => {
+    const event = makeSessionEvent('completed', { resource_uri: 'https:example.com' });
+    expect(() => fromACPPaymentObservation(event, makePaymentArtifact())).toThrow(/resource_uri/);
+  });
+
+  it('rejects credential-bearing https URL (user:pass@)', () => {
+    const event = makeSessionEvent('completed', {
+      resource_uri: 'https://user:pass@example.com/order/1',
+    });
+    expect(() => fromACPPaymentObservation(event, makePaymentArtifact())).toThrow(/resource_uri/);
+  });
+
+  it('rejects username-only credential https URL (user@)', () => {
+    const event = makeSessionEvent('completed', {
+      resource_uri: 'https://user@example.com/order/1',
+    });
+    expect(() => fromACPPaymentObservation(event, makePaymentArtifact())).toThrow(/resource_uri/);
+  });
+});
+
+describe('resource_uri hardening: fromACPInterventionRequired', () => {
+  const base = {
+    session_id: 'sess_abc',
+    type: 'identity_verification',
+  };
+
+  it('accepts a well-formed https URL', () => {
+    expect(() =>
+      fromACPInterventionRequired({ ...base, resource_uri: 'https://example.com/resource' })
+    ).not.toThrow();
+  });
+
+  it('rejects http://', () => {
+    expect(() =>
+      fromACPInterventionRequired({ ...base, resource_uri: 'http://example.com/resource' })
+    ).toThrow(/resource_uri/);
+  });
+
+  it('rejects "https://" with no hostname', () => {
+    expect(() => fromACPInterventionRequired({ ...base, resource_uri: 'https://' })).toThrow(
+      /resource_uri/
+    );
+  });
+
+  it('rejects opaque-path "https:example.com"', () => {
+    expect(() =>
+      fromACPInterventionRequired({ ...base, resource_uri: 'https:example.com' })
+    ).toThrow(/resource_uri/);
+  });
+
+  it('rejects credential-bearing https URL (user:pass@)', () => {
+    expect(() =>
+      fromACPInterventionRequired({
+        ...base,
+        resource_uri: 'https://user:pass@example.com/resource',
+      })
+    ).toThrow(/resource_uri/);
+  });
+
+  it('rejects username-only credential https URL (user@)', () => {
+    expect(() =>
+      fromACPInterventionRequired({ ...base, resource_uri: 'https://user@example.com/resource' })
+    ).toThrow(/resource_uri/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// paymentArtifact.amount safe-integer guard (fromACPPaymentObservation)
+// ---------------------------------------------------------------------------
+
+describe('fromACPPaymentObservation: paymentArtifact.amount safe-integer guard', () => {
+  it('accepts 1000', () => {
+    const event = makeSessionEvent('completed');
+    const artifact = makePaymentArtifact({ amount: 1000 });
+    expect(() => fromACPPaymentObservation(event, artifact)).not.toThrow();
+  });
+
+  it('accepts Number.MAX_SAFE_INTEGER', () => {
+    const event = makeSessionEvent('completed');
+    const artifact = makePaymentArtifact({ amount: Number.MAX_SAFE_INTEGER });
+    expect(() => fromACPPaymentObservation(event, artifact)).not.toThrow();
+  });
+
+  it('accepts 0', () => {
+    const event = makeSessionEvent('completed');
+    const artifact = makePaymentArtifact({ amount: 0 });
+    expect(() => fromACPPaymentObservation(event, artifact)).not.toThrow();
+  });
+
+  it('rejects 12.34 (non-integer)', () => {
+    const event = makeSessionEvent('completed');
+    const artifact = makePaymentArtifact({ amount: 12.34 });
+    expect(() => fromACPPaymentObservation(event, artifact)).toThrow(/safe integer/);
+  });
+
+  it('rejects Number.MAX_SAFE_INTEGER + 1', () => {
+    const event = makeSessionEvent('completed');
+    const artifact = makePaymentArtifact({ amount: Number.MAX_SAFE_INTEGER + 1 });
+    expect(() => fromACPPaymentObservation(event, artifact)).toThrow(/safe integer/);
+  });
+
+  it('rejects Infinity', () => {
+    const event = makeSessionEvent('completed');
+    const artifact = makePaymentArtifact({ amount: Infinity });
+    expect(() => fromACPPaymentObservation(event, artifact)).toThrow(/safe integer/);
+  });
+
+  it('rejects -Infinity', () => {
+    const event = makeSessionEvent('completed');
+    const artifact = makePaymentArtifact({ amount: -Infinity });
+    expect(() => fromACPPaymentObservation(event, artifact)).toThrow(/safe integer/);
+  });
+
+  it('rejects NaN', () => {
+    const event = makeSessionEvent('completed');
+    const artifact = makePaymentArtifact({ amount: NaN });
+    expect(() => fromACPPaymentObservation(event, artifact)).toThrow(/safe integer/);
   });
 });

--- a/tests/parity/core-claims.test.ts
+++ b/tests/parity/core-claims.test.ts
@@ -49,10 +49,11 @@ describe('Cross-Mapping Core Claims Parity', () => {
       const acpStripeEvent = {
         checkout_id: 'checkout_stripe_parity',
         resource_uri: RESOURCE_URI,
-        total_amount: AMOUNT,
+        amount_minor: String(AMOUNT),
         currency: CURRENCY,
         payment_rail: 'stripe',
         payment_reference: 'cs_stripe_parity_123',
+        env: 'live' as const,
         customer_id: 'cus_stripe',
         metadata: { stripe_specific: 'data' },
       };
@@ -61,10 +62,11 @@ describe('Cross-Mapping Core Claims Parity', () => {
       const acpX402Event = {
         checkout_id: 'checkout_x402_parity',
         resource_uri: RESOURCE_URI,
-        total_amount: AMOUNT,
+        amount_minor: String(AMOUNT),
         currency: CURRENCY,
         payment_rail: 'x402',
         payment_reference: 'inv_x402_parity_456',
+        env: 'live' as const,
         customer_id: 'cus_x402',
         metadata: { x402_specific: 'different_data' },
       };


### PR DESCRIPTION
## Summary

Fixes the ACP mapper boundary before the commerce-mandate profile work.

This PR:

- replaces ACP checkout `total_amount: number` input with `amount_minor: string`
- rejects legacy `total_amount` input
- requires explicit `env`
- validates `amount_minor` as a non-negative minor-unit string
- rejects unsafe `amount_minor` values before converting to legacy numeric PEAC receipt fields
- adds explicit finality-boundary checks for checkout success mapping
- ensures checkout success does not synthesize authorization, capture, settlement, refund, void, or chargeback finality
- rejects negative `authorized_amount_minor` in delegated-payment observations
- protects delegated-payment `authorized_amount_minor` before conversion to `PaymentEvidence.amount`
- requires `paymentArtifact.amount` to be a safe integer
- hardens `resource_uri` validation across ACP mapper paths

## Breaking mapper input change

`fromACPCheckoutSuccess` now expects:

```ts
amount_minor: "1999",
env: "live"
```

Legacy input is rejected:

```ts
total_amount: 19.99
```

with `acp.checkout_legacy_total_amount`.

## Validation behavior

This PR rejects:

- numeric, decimal, empty, negative, or unsafe `amount_minor`
- legacy `total_amount`
- missing or invalid `env`
- malformed `resource_uri`
- non-HTTPS resource URIs
- `https:` opaque-path forms without `//`
- resource URIs with embedded credentials
- negative or unsafe delegated-payment `authorized_amount_minor`
- unsafe or non-integer `paymentArtifact.amount`

## Scope boundaries

This PR does not add commerce-mandate records.

It does not change:

- gateway-export records
- agent-action records
- CLI behavior
- release files
- package versions
- dependencies
- lockfiles
- wire format
- signing envelope

## Verification

- `git diff --check`
- `pnpm format:check`
- `bash scripts/ci/forbid-strings.sh`
- ASCII scan across changed files
- `pnpm --filter '@peac/mappings-acp...' build`
- `pnpm --filter '@peac/mappings-acp' test`
- `pnpm exec vitest run tests/parity/core-claims.test.ts tests/conformance/commerce-boundaries.spec.ts tests/conformance/commerce-rails.spec.ts tests/conformance/cross-rail-truth.spec.ts`
- `pnpm --filter '@peac/example-rsl-collective' typecheck`
- `pnpm typecheck:core`
- `pnpm verify:codegen-drift`
- `pnpm verify:registries-schema`
- `pnpm verify:no-widening`
- `pnpm exec tsx scripts/extract-api-contract.ts --check`
- `./scripts/guard.sh`
- `pnpm test`

Local full test result: 435 test files, 10,276 tests passing.
