### PR TITLE
chore(release): prepare v0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,87 @@ All notable changes to PEAC Protocol will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.3] - 2026-05-17
+
+Agent Action, Commerce Mandate, and Gateway Export Records.
+
+Three new signed-record surfaces for reported agent-action events,
+commerce-lifecycle events scoped to a mandate, and payment-gateway
+settlement/recovery observations. Caller systems (agents, harnesses,
+runtimes, payment gateways, facilitators) report what they observed;
+PEAC records that report through a portable, signed interaction
+record any party can verify offline.
+
+Public API: extended (additive only).
+Wire format: unchanged.
+Package surface: unchanged published-package count (36).
+Extension keys: 16 → 19 extension groups; 40 → 61 receipt types
+(additive). 30 new conformance requirement IDs across three new
+conformance sections.
+Default observable behavior: unchanged for existing surfaces.
+
+### Added
+
+- **Agent action extension namespace.** New
+  `org.peacprotocol/agent-action` extension namespace with 6
+  `*-observed` receipt-type URIs (invoked / delegated / approved /
+  denied / cancelled / timed-out). Schema validator with stable error
+  codes under the `agent.action.*` namespace. New normative spec
+  `docs/specs/AGENT-ACTION-RECORDS.md`. Conformance Section 32
+  `AGENT-ACT-001..010`.
+- **Commerce mandate extension namespace.** New
+  `org.peacprotocol/commerce-mandate` extension namespace with 7
+  `*-observed` receipt-type URIs (mandate / authorization / capture /
+  void / refund / settlement / budget). Schema validator with 16
+  stable error codes under the `commerce.mandate.*` namespace.
+  Profile-local non-negative-amount-minor refine wrapper.
+  Finality-synthesis boundary blocks `settlement_state` on every
+  non-settlement event kind. New normative spec
+  `docs/specs/COMMERCE-MANDATE-RECORDS.md`. Conformance Section 33
+  `COMM-MAN-001..010`.
+- **Gateway export extension namespace.** New
+  `org.peacprotocol/gateway-export` extension namespace with 8
+  `*-observed` receipt-type URIs covering a 7-state
+  settlement/recovery model plus 1 facilitator-timeout trigger
+  observation. Schema validator with 23 stable error codes under the
+  `gateway.export.*` namespace, 19 forbidden top-level payment-data
+  keys, real UTF-8 byte limits via `TextEncoder`, optional EIP-3009
+  four-tuple references, and a `valid_before_unix_seconds`
+  safe-integer-bounded field. New normative spec
+  `docs/specs/GATEWAY-EXPORT-RECORDS.md`. Conformance Section 34
+  `GATE-EXP-001..010`.
+- **Three runnable example packages and operator recipes.** New
+  `examples/agent-action-records/`, `examples/commerce-mandate-records/`,
+  and `examples/gateway-export-records/` packages with deterministic
+  synthetic fixtures and end-to-end `pnpm issue` + `pnpm verify`
+  round-trips. New operator recipes under `docs/SOLUTIONS/` for each
+  profile.
+- **`@peac/schema` barrel re-exports.** 21 new top-level exports
+  (15 types + 6 value exports) for the three new profile constants
+  and validators.
+
+### Changed
+
+- **ACP mapper boundary fix.** `packages/mappings-acp`
+  `fromACPCheckoutSuccess` now requires `amount_minor: string`
+  (replacing the prior `total_amount: number` field) and an explicit
+  `env` field. New local `ACPMapperBoundaryError` class with 11
+  stable codes. BigInt safe-integer guards on every amount
+  conversion. Shared private `isValidHttpsResourceUri` helper across
+  all five ACP mapper paths.
+- **Repository hygiene.** Test-only clock pin on the
+  `apps/api/tests/report-format.test.ts` byte-stability test (no
+  production behavior change). `api-contract.test.ts`
+  extension-key constants count bumped 24 → 27. Pack-install smoke
+  extended to verify v0.14.3 profile exports through packed
+  `@peac/schema`.
+- **Dependency overrides.** `protobufjs` override pinned to exact
+  `8.0.2` (closes 7 protobufjs Dependabot advisories across the
+  `8.0.0..8.0.1` range). New defensive `@protobufjs/utf8: 1.1.1`
+  override. Reachability is private-example-only via
+  `@peac/example-telemetry-otel@0.0.0`; no published runtime package
+  depends on protobufjs.
+
 ## [0.14.2] - 2026-05-10
 
 Provisioning Lifecycle Records.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-api",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "description": "PEAC Protocol API server with OpenAPI 3.1, RFC 9457 Problem Details, and content negotiation",
   "type": "module",
   "main": "dist/index.js",

--- a/apps/sandbox-issuer/package.json
+++ b/apps/sandbox-issuer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-sandbox-issuer",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "description": "PEAC Protocol Sandbox Issuer - Test record issuance for development",
   "type": "module",
   "main": "dist/node.js",

--- a/apps/verifier/package.json
+++ b/apps/verifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/app-verifier",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "description": "PEAC Protocol Browser Verifier - Client-side receipt verification",
   "type": "module",
   "private": true,

--- a/docs/release-notes/v0.14.3.md
+++ b/docs/release-notes/v0.14.3.md
@@ -1,0 +1,217 @@
+# v0.14.3 — Agent Action, Commerce Mandate, and Gateway Export Records
+
+PEAC records what an external system reports happened when an agent
+invokes an action, when a commerce mandate progresses through
+authorization, capture, refund, settlement, or budget evaluation, and
+when a payment gateway observes payment-submission, facilitator
+timeout, or settlement-recovery events. Caller systems (agents,
+harnesses, runtimes, payment gateways, facilitators, or downstream
+reviewers) report what they observed; PEAC records that report through
+a portable, signed interaction record that any party can verify
+offline.
+
+This release adds three new extension namespaces, three new schema
+validators, three new normative profile specs, three new conformance
+sections, three runnable examples, three operator recipes, and the
+top-level `@peac/schema` barrel re-exports needed to consume each
+profile through a single import path. No new public CLI verb. No new
+publishable package. No wire format change.
+
+## Highlights
+
+- Three new `org.peacprotocol/*` extension namespaces:
+  - `org.peacprotocol/agent-action` (6 `*-observed` type URIs)
+  - `org.peacprotocol/commerce-mandate` (7 `*-observed` type URIs)
+  - `org.peacprotocol/gateway-export` (8 `*-observed` type URIs)
+- Three normative profile specs under `docs/specs/`.
+- Conformance Sections 32 (`AGENT-ACT-001..010`), 33
+  (`COMM-MAN-001..010`), and 34 (`GATE-EXP-001..010`).
+- Three new cross-language parity corpus families bringing the total
+  to 11 families.
+- ACP mapper boundary fix (`packages/mappings-acp`) requiring
+  `amount_minor: string` and explicit-finality semantics on
+  delegated-payment observations.
+- Three new generic-OSS-neutral runnable example packages with
+  end-to-end `pnpm issue` + `pnpm verify` round-trips.
+- Three new operator-facing verification recipes under
+  `docs/SOLUTIONS/`.
+- Pre-release dependency cleanup: protobufjs override pinned to the
+  patched version through a private-example reachability path.
+
+## New record surface: agent action
+
+The `org.peacprotocol/agent-action` extension namespace records
+observation of agent action events. Six receipt-type URIs cover the
+major action-lifecycle event families:
+
+```text
+org.peacprotocol/agent-action-invoked-observed
+org.peacprotocol/agent-action-delegated-observed
+org.peacprotocol/agent-action-approved-observed
+org.peacprotocol/agent-action-denied-observed
+org.peacprotocol/agent-action-cancelled-observed
+org.peacprotocol/agent-action-timed-out-observed
+```
+
+The `*-observed` suffix makes the observer scope explicit at the
+record-type layer. PEAC records what the issuer reports happened.
+Execution, scheduling, decision-making, and orchestration remain
+upstream responsibilities. The validator emits stable error codes
+under the `agent.action.*` namespace covering inline-content
+rejection, opaque-reference grammar, required-field presence, event
+kind, and timestamp formats.
+
+## New record surface: commerce mandate
+
+The `org.peacprotocol/commerce-mandate` extension namespace records
+observation of commerce-lifecycle events scoped to a mandate. Seven
+receipt-type URIs cover the major commerce event families:
+
+```text
+org.peacprotocol/commerce-mandate-observed
+org.peacprotocol/commerce-authorization-observed
+org.peacprotocol/commerce-capture-observed
+org.peacprotocol/commerce-void-observed
+org.peacprotocol/commerce-refund-observed
+org.peacprotocol/commerce-settlement-observed
+org.peacprotocol/commerce-budget-observed
+```
+
+Authorization, processing, settlement, mandate enforcement, finality
+computation, budget evaluation, and rail validation remain upstream
+responsibilities. The validator emits 16 stable error codes under the
+`commerce.mandate.*` namespace. Money fields use a profile-local
+non-negative-amount-minor refine wrapper over the shared
+`AmountMinorStringSchema` (numeric, decimal, comma-formatted, empty,
+or negative values reject). The single-canonical-money-field doctrine
+holds: the validator rejects any `value_minor` or other
+money-shaped key besides `amount_minor`. The
+finality-synthesis boundary blocks `settlement_state` on any event
+kind other than `commerce-settlement-observed`.
+
+## New record surface: gateway export
+
+The `org.peacprotocol/gateway-export` extension namespace records
+payment-gateway observations spanning a 7-state settlement/recovery
+model plus one facilitator-timeout trigger observation. Eight
+receipt-type URIs cover the full surface:
+
+```text
+org.peacprotocol/gateway-payment-submitted-observed
+org.peacprotocol/gateway-facilitator-timeout-observed
+org.peacprotocol/gateway-settlement-unresolved-observed
+org.peacprotocol/gateway-settlement-polling-observed
+org.peacprotocol/gateway-settlement-confirmed-observed
+org.peacprotocol/gateway-settlement-confirmed-late-observed
+org.peacprotocol/gateway-settlement-failed-observed
+org.peacprotocol/gateway-settlement-failed-orphaned-observed
+```
+
+Settlement, routing, on-chain verification, recovery policy, and
+dispute resolution remain upstream responsibilities. The validator
+emits 23 stable error codes under the `gateway.export.*` namespace
+covering inline-payment-data rejection (19 forbidden top-level keys),
+opaque-reference grammar, required-field presence, event kind,
+amount-minor canonical form, optional EIP-3009 four-tuple references,
+optional `valid_before_unix_seconds` (safe-integer-bounded),
+timeout-profile enum (`datacenter` / `east_africa_3g` /
+`west_africa_3g` / `custom`), polling-strategy enum, count and
+millisecond bounds, UTF-8 byte limits via `TextEncoder`, and
+`upstream_artifact_digest` (sha256-hex). Caller-reported labels carry
+no PEAC inference about geography, network quality, or settlement
+guarantees. A reviewer reading a `gateway-facilitator-timeout-observed`
+record sees a discrete observable boundary signal that may precede
+unresolved recovery; the record does not by itself claim that
+recovery began.
+
+## ACP mapper boundary fix
+
+`packages/mappings-acp` now requires explicit-finality semantics for
+delegated-payment observations used by the commerce-mandate profile.
+The
+`fromACPCheckoutSuccess` mapper now requires `amount_minor: string`
+(replacing the prior `total_amount: number` field) and an explicit
+`env` field. A new local `ACPMapperBoundaryError` class with 11
+stable codes preserves source-of-error attribution at the mapper
+layer. BigInt safe-integer guards run on every amount conversion. A
+shared private `isValidHttpsResourceUri` helper applies across all
+five ACP mapper paths (literal `https://`, non-empty hostname, reject
+embedded credentials).
+
+## Conformance and parity
+
+Three new conformance sections add 30 requirement IDs total:
+
+- Section 32 `AGENT-ACT-001..010` (agent-action validator contract)
+- Section 33 `COMM-MAN-001..010` (commerce-mandate validator contract)
+- Section 34 `GATE-EXP-001..010` (gateway-export validator contract)
+
+Three new parity corpus families self-describe both wire-envelope
+acceptance and extension-level expected error codes (matching the
+v0.14.2 provisioning-lifecycle pattern):
+
+- `specs/conformance/parity-corpus/agent-action/`
+- `specs/conformance/parity-corpus/commerce-mandate/`
+- `specs/conformance/parity-corpus/gateway-export/`
+
+The cross-language parity floor now stands at 11 families.
+
+## Examples and operator recipes
+
+Three new runnable example packages, each with deterministic synthetic
+fixtures and end-to-end `pnpm issue` + `pnpm verify` round-trips:
+
+- [`examples/agent-action-records/`](../../examples/agent-action-records/)
+  — 6 fixtures, one per agent-action event kind.
+- [`examples/commerce-mandate-records/`](../../examples/commerce-mandate-records/)
+  — 7 fixtures, one per commerce-lifecycle event kind.
+- [`examples/gateway-export-records/`](../../examples/gateway-export-records/)
+  — 8 fixtures covering 7 settlement/recovery states plus 1
+  facilitator-timeout trigger observation.
+
+Three new operator-facing recipes under
+[`docs/SOLUTIONS/`](../SOLUTIONS/) walk through offline verification
+of each profile's signed records.
+
+## Repository hygiene
+
+- `@peac/schema` top-level barrel adds 21 new exports (15 types + 6
+  value exports) for the three new profile constants and validators,
+  enabling single-import-path consumption from external packages.
+- `tests/tooling/api-contract.test.ts` extension-key constants count
+  bumped from 24 to 27 to track the three new observation surfaces.
+- `apps/api/tests/report-format.test.ts` byte-stability test pinned
+  to a fixed clock to remove a pre-existing 1ms timing race; no
+  production report-format behavior change.
+- `scripts/pack-install-smoke.sh` adds a profile-exports smoke that
+  verifies the three new extension keys and validator functions
+  through the packed `@peac/schema` tarball.
+- `package.json` overrides: `protobufjs` pinned to exact `8.0.2`
+  (closes 7 protobufjs Dependabot advisories across the
+  `8.0.0..8.0.1` range); new defensive `@protobufjs/utf8: 1.1.1`
+  override (closes `GHSA-q6x5-8v7m-xcrf` defensively against
+  re-entry through another transitive path). Reachability is
+  private-example-only
+  via `@peac/example-telemetry-otel@0.0.0`; no published runtime
+  package depends on protobufjs.
+
+## Public surface
+
+No new CLI command. No base Wire-format change. Existing schema
+behavior is unchanged; the public schema surface is additive through
+three extension validators and top-level `@peac/schema` exports. No
+new publishable npm package. The 36-package publishable surface is
+unchanged from v0.14.2.
+
+## Compatibility
+
+- Wire format: unchanged.
+- Public API: additive only (new exports under `@peac/schema` for the
+  three new profile constants and validators; new extension namespaces
+  registered in `@peac/kernel` generated registries).
+- Default observable behavior: unchanged for existing surfaces.
+
+## Validation
+
+`docs/releases/facts.json` records the canonical metric values for
+this release.

--- a/docs/releases/current.json
+++ b/docs/releases/current.json
@@ -1,8 +1,8 @@
 {
   "description": "PEAC release manifest: CI-enforceable source of truth for release state",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "wire_format_version": "0.2",
-  "dist_tag": "latest",
+  "dist_tag": "next",
   "registries_version": "0.6.0",
-  "errors_version": "0.14.2"
+  "errors_version": "0.14.3"
 }

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -1,13 +1,13 @@
 {
   "description": "Canonical source of truth for PEAC Protocol release metrics. Website, docs, and release notes consume this file. CI validates derived metrics (tests, build_targets, published_packages, conformance_*) against actual build output. Mutable release-state fields (release_date, dist_tag) are maintained by scripts/stamp-release-state.mjs per docs/RELEASING.md.",
   "schema_version": "1.0.0",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "wire_format_version": "0.2",
-  "dist_tag": "latest",
-  "release_date": "2026-05-11",
+  "dist_tag": "next",
+  "release_date": "2026-05-17",
   "metrics": {
-    "tests": 10078,
-    "test_files": 433,
+    "tests": 10635,
+    "test_files": 439,
     "published_packages": 36,
     "build_targets": 106,
     "conformance_requirement_ids": 290,

--- a/docs/specs/CONFORMANCE-MATRIX.md
+++ b/docs/specs/CONFORMANCE-MATRIX.md
@@ -1,7 +1,7 @@
 # PEAC Conformance Matrix
 
 > **Generated**: Do not edit manually. Source: `node scripts/conformance/generate-matrix.mjs`
-> **Version**: 0.14.1
+> **Version**: 0.14.3
 
 ## Wire 0.2 Protocol Requirements
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/monorepo",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "private": true,
   "description": "Portable signed records for agent, API, MCP, and cross-runtime interactions.",
   "repository": {

--- a/packages/adapters/core/package.json
+++ b/packages/adapters/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-core",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Shared utilities for PEAC payment rail adapters and commerce mappings (Result types, validators, payment-proof contracts, mapper-boundary finality guard)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/did/package.json
+++ b/packages/adapters/did/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-did",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "DID document resolution for PEAC receipt verification (did:key, did:web)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/eat/package.json
+++ b/packages/adapters/eat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-eat",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "EAT (Entity Attestation Token, RFC 9711) passport decoder and PEAC claim mapper",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/managed-agents/package.json
+++ b/packages/adapters/managed-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-managed-agents",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Vendor-neutral managed agent runtime event adapter for PEAC interaction evidence",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/adapters/openai-compatible/package.json
+++ b/packages/adapters/openai-compatible/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-openai-compatible",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "OpenAI-compatible chat completion adapter for PEAC interaction evidence (hash-first)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/openclaw/package.json
+++ b/packages/adapters/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-openclaw",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "OpenClaw adapter for PEAC interaction evidence capture",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/adapters/runtime-governance/package.json
+++ b/packages/adapters/runtime-governance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-runtime-governance",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Runtime governance adapter for PEAC interaction records with AGT mapper",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/adapters/x402/daydreams/package.json
+++ b/packages/adapters/x402/daydreams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402-daydreams",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "Daydreams AI inference event normalizer for PEAC protocol",
   "main": "dist/index.js",

--- a/packages/adapters/x402/fluora/package.json
+++ b/packages/adapters/x402/fluora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402-fluora",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "Fluora MCP marketplace event normalizer for PEAC protocol",
   "main": "dist/index.js",

--- a/packages/adapters/x402/package.json
+++ b/packages/adapters/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "x402 offer/receipt verification, term-matching, and PEAC record mapping",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapters/x402/pinata/package.json
+++ b/packages/adapters/x402/pinata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/adapter-x402-pinata",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "Pinata private IPFS objects event normalizer for PEAC protocol",
   "main": "dist/index.js",

--- a/packages/attribution/package.json
+++ b/packages/attribution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/attribution",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "PEAC attribution attestation - content derivation and usage proofs",
   "type": "module",

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/audit",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Audit logging and case bundle generation for PEAC protocol disputes",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/capture/core/package.json
+++ b/packages/capture/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/capture-core",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Runtime-neutral capture pipeline for PEAC interaction evidence",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/capture/node/package.json
+++ b/packages/capture/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/capture-node",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Node.js durable storage for PEAC capture pipeline (filesystem spool store and dedupe index)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/cli",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "PEAC protocol command-line tools",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/compat",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "PEAC Protocol - workspace-private package contract for the migration-class taxonomy and the archival-export reader/writer/validator. Not published. Not a public protocol surface. Not a stable cross-organization interchange format. Not imported by any published package. Version tracks the workspace-wide value enforced by scripts/check-version-coherence.sh.",
   "type": "module",

--- a/packages/conformance-harness/package.json
+++ b/packages/conformance-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/conformance-harness",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "Conformance test harness for PEAC protocol fixtures",
   "main": "dist/index.cjs",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/contracts",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "PEAC canonical error codes and verification mode contracts",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/control/package.json
+++ b/packages/control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/control",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "PEAC Protocol Control - control engine interfaces and validation",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/crypto",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Ed25519 JWS signing and verification for PEAC protocol",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/http-signatures/package.json
+++ b/packages/http-signatures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/http-signatures",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "RFC 9421 HTTP Message Signatures parsing and verification",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/jwks-cache/package.json
+++ b/packages/jwks-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/jwks-cache",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Edge-safe JWKS fetch and cache with SSRF protection",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/kernel",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "PEAC protocol kernel - normative constants, errors, and registries",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/kernel/src/error-categories.generated.ts
+++ b/packages/kernel/src/error-categories.generated.ts
@@ -3,7 +3,7 @@
  *
  * AUTO-GENERATED from specs/kernel/errors.json
  * DO NOT EDIT MANUALLY - run: npx tsx scripts/codegen-errors.ts
- * Spec version: 0.14.2
+ * Spec version: 0.14.3
  */
 
 /**

--- a/packages/kernel/src/errors.generated.ts
+++ b/packages/kernel/src/errors.generated.ts
@@ -3,7 +3,7 @@
  *
  * AUTO-GENERATED from specs/kernel/errors.json
  * DO NOT EDIT MANUALLY - run: npx tsx scripts/codegen-errors.ts
- * Spec version: 0.14.2
+ * Spec version: 0.14.3
  */
 
 import type { ErrorDefinition } from './types.js';

--- a/packages/mappings/a2a/package.json
+++ b/packages/mappings/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-a2a",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Agent-to-Agent Protocol (A2A) integration for PEAC",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/mappings/acp/package.json
+++ b/packages/mappings/acp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-acp",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Agentic Commerce Protocol (ACP) integration for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/aipref/package.json
+++ b/packages/mappings/aipref/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-aipref",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "IETF AIPREF vocabulary mapping for PEAC",
   "main": "dist/index.js",

--- a/packages/mappings/content-signals/package.json
+++ b/packages/mappings/content-signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-content-signals",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Content use policy signal parsing for PEAC (robots.txt, tdmrep.json, Content-Usage)",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/mappings/intoto/package.json
+++ b/packages/mappings/intoto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-intoto",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "in-toto v1.0 attestation mapping for PEAC provenance extension",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/mcp/package.json
+++ b/packages/mappings/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-mcp",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Model Context Protocol (MCP) integration for PEAC",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/mappings/paymentauth/package.json
+++ b/packages/mappings/paymentauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-paymentauth",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "HTTP Payment authentication scheme (paymentauth/MPP) mapping for PEAC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/rsl/package.json
+++ b/packages/mappings/rsl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-rsl",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "RSL (Robots Specification Layer) mapping for PEAC",
   "main": "dist/index.js",

--- a/packages/mappings/slsa/package.json
+++ b/packages/mappings/slsa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-slsa",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "SLSA v1.2 provenance mapping for PEAC provenance extension",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mappings/tap/package.json
+++ b/packages/mappings/tap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-tap",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "Visa Trusted Agent Protocol mapping to PEAC control evidence",
   "type": "module",

--- a/packages/mappings/ucp/package.json
+++ b/packages/mappings/ucp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mappings-ucp",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Google Universal Commerce Protocol (UCP) mapping to PEAC receipts and dispute evidence",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp-server/manifest.json
+++ b/packages/mcp-server/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "peac-mcp-server",
   "display_name": "PEAC Protocol",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Verify, inspect, decode, issue, and bundle PEAC receipts. Portable, offline-verifiable evidence for AI agent interactions.",
   "long_description": "PEAC Protocol provides cryptographically signed, offline-verifiable receipts that record what happened during automated interactions. Each receipt is a compact JWS (JSON Web Signature) using Ed25519 signatures. This MCP server exposes 5 tools for receipt operations: verify (signature + claims), inspect (metadata without verification), decode (raw JWS structure), issue (sign new receipts), and create_bundle (portable evidence directories).",
   "author": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/mcp-server",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "PEAC receipt operations as MCP tools (verify, inspect, decode, issue, bundle)",
   "mcpName": "io.github.peacprotocol/peac",
   "main": "dist/index.cjs",

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "subfolder": "packages/mcp-server"
   },
-  "version": "0.14.2",
+  "version": "0.14.3",
   "websiteUrl": "https://www.peacprotocol.org",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@peac/mcp-server",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "transport": {
         "type": "stdio"
       }
@@ -22,7 +22,7 @@
     {
       "registryType": "npm",
       "identifier": "@peac/mcp-server",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:3000/mcp"

--- a/packages/mcp-server/src/infra/constants.ts
+++ b/packages/mcp-server/src/infra/constants.ts
@@ -3,7 +3,7 @@
  */
 
 export const SERVER_NAME = 'peac-mcp-server';
-export const SERVER_VERSION = '0.14.2';
+export const SERVER_VERSION = '0.14.3';
 export const MCP_PROTOCOL_VERSION = '2025-11-25';
 export const DEFAULT_MAX_JWS_BYTES = 16_384; // 16 KB
 export const DEFAULT_MAX_RESPONSE_BYTES = 65_536; // 64 KB

--- a/packages/middleware-core/package.json
+++ b/packages/middleware-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/middleware-core",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Framework-agnostic middleware primitives for PEAC receipt issuance",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/middleware-express/package.json
+++ b/packages/middleware-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/middleware-express",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Express.js middleware for automatic PEAC receipt issuance",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/net/node/package.json
+++ b/packages/net/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/net-node",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "SSRF-safe network utilities for PEAC Protocol with DNS resolution pinning (Node.js only)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/pay402/package.json
+++ b/packages/pay402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/pay402",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "Generic HTTP 402 adapter with multi-rail payment negotiation",
   "type": "module",

--- a/packages/policy-kit/package.json
+++ b/packages/policy-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/policy-kit",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "PEAC Policy Kit - deterministic policy evaluation for CAL semantics",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/privacy/package.json
+++ b/packages/privacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/privacy",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "Privacy pillar for PEAC protocol - k-anonymity, privacy-preserving hashing, data protection",
   "main": "dist/index.js",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/protocol",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "PEAC protocol implementation - receipt issuance and verification",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/rails/card/package.json
+++ b/packages/rails/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-card",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "Card payment rail adapter for PEAC protocol (Flowglad, Stripe Billing, Lago)",
   "main": "dist/index.js",

--- a/packages/rails/razorpay/package.json
+++ b/packages/rails/razorpay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-razorpay",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "Razorpay payment rail adapter for PEAC protocol (UPI, cards, netbanking)",
   "main": "dist/index.js",

--- a/packages/rails/stripe/package.json
+++ b/packages/rails/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-stripe",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "Stripe payment rail adapter for PEAC protocol",
   "main": "dist/index.js",

--- a/packages/rails/x402/package.json
+++ b/packages/rails/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/rails-x402",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "x402 payment rail adapter for PEAC protocol",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/receipts/package.json
+++ b/packages/receipts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/receipts",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "PEAC Protocol receipt builders, parsers, and validators with CBOR support",
   "type": "module",

--- a/packages/record-core/package.json
+++ b/packages/record-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/record-core",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "PEAC Protocol - workspace-private metadata package. Not published. The canonical codec / record-core implementation lives at packages/protocol/src/_internal/record-core/ and is imported via relative paths from inside @peac/protocol; this package does NOT duplicate that source. Version tracks the workspace-wide value enforced by scripts/check-version-coherence.sh; the workspace-wide bump to 0.13.1 happens in the v0.13.1 release-prep PR.",
   "type": "module",

--- a/packages/registries/package.json
+++ b/packages/registries/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/registries",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "PEAC Protocol - workspace-private internal facade re-grouping public @peac/kernel constants for internal-consumer ergonomics. Not published. Version tracks the workspace-wide value enforced by scripts/check-version-coherence.sh; the workspace-wide bump to 0.13.1 happens in the v0.13.1 release-prep PR.",
   "type": "module",

--- a/packages/resolver-http/package.json
+++ b/packages/resolver-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/resolver-http",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "PEAC Protocol - workspace-private resolver-http composition layer introduced in v0.13.2 PR A per Revision 4 §7. Composes published primitives (@peac/net-node, @peac/jwks-cache, @peac/kernel, @peac/crypto, @peac/schema) behind a private verifier-oriented interface for parity testing against @peac/protocol's existing self-contained resolver path on shared local fixtures. NEVER published. NEVER referenced by published packages. P0 invariants: @peac/protocol must NOT import / depend on / re-export from / emit reference to this package; @peac/resolver-http runtime source must NOT import @peac/protocol (parity test files MAY). @peac/jwks-cache and @peac/net-node are reused as published primitives, not modified, not merged, not renamed in v0.13.2 (denylist seeded by v0.13.1 PR A in tests/tooling/protocol-private-imports.test.ts and friends).",
   "type": "module",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/schema",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "PEAC Protocol JSON schemas, OpenAPI specs, and TypeScript types",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/server",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "PEAC verification server with DoS protection and rate limiting",
   "main": "dist/index.js",

--- a/packages/telemetry-otel/package.json
+++ b/packages/telemetry-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/telemetry-otel",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "OpenTelemetry adapter for PEAC telemetry",
   "keywords": [

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/telemetry",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Telemetry interfaces and no-op implementation for PEAC protocol",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/transport/grpc/package.json
+++ b/packages/transport/grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-grpc",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "PEAC gRPC transport layer with carrier adapter and HTTP StatusCode parity",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/transport/http/package.json
+++ b/packages/transport/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-http",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "PEAC HTTP transport layer - headers, middleware, DPoP L3/L4",
   "type": "module",

--- a/packages/transport/ws/package.json
+++ b/packages/transport/ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/transport-ws",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "PEAC WebSocket transport layer (placeholder for v0.9.17+)",
   "type": "module",

--- a/packages/worker-core/package.json
+++ b/packages/worker-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-core",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "Runtime-neutral TAP verification handler for edge workers",
   "type": "module",

--- a/packages/worker-shared/package.json
+++ b/packages/worker-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-shared",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "Shared runtime-neutral TAP verification logic for edge worker surfaces",
   "type": "module",

--- a/scripts/conformance/build-registry.mjs
+++ b/scripts/conformance/build-registry.mjs
@@ -21,7 +21,7 @@ function hash(fragment) {
   return 'sha256:' + createHash('sha256').update(fragment, 'utf-8').digest('hex');
 }
 
-const VERSION = '0.14.1';
+const VERSION = '0.14.3';
 
 // Section slug mapping (markdown anchor format)
 const SECTION_ANCHORS = {

--- a/scripts/publish-manifest.json
+++ b/scripts/publish-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Single source of truth for PEAC Protocol npm publish order",
-  "version": "0.14.2",
-  "lastUpdated": "2026-05-10",
+  "version": "0.14.3",
+  "lastUpdated": "2026-05-17",
   "totalPackages": 36,
   "packages": [
     "@peac/kernel",

--- a/specs/conformance/commerce/acp-delegated-payment/manifest.json
+++ b/specs/conformance/commerce/acp-delegated-payment/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "commerce/acp-delegated-payment",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "section": 26,
   "subsection": "acp-delegated-payment",
   "description": "Conformance vectors for fromACPDelegatedPaymentObservation in @peac/mappings-acp. Validates the mapper-boundary finality-synthesis guard and settlement-proof discriminator applied to ACP delegated-payment observations across the closed observed_payment_state enum and across strictness modes.",

--- a/specs/conformance/commerce/manifest.json
+++ b/specs/conformance/commerce/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "commerce",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "section": 26,
   "description": "Conformance vectors for the mapper-boundary finality-synthesis guard exported by @peac/adapter-core. Documents the C-001 through C-020 requirement IDs that govern the no-finality-synthesis rule across all PEAC commerce mappings (paymentauth, ACP, UCP, Stripe SPT, x402).",
   "spec_revision": "docs/specs/COMMERCE-EVIDENCE.md (v0.12.11)",

--- a/specs/conformance/commerce/paymentauth/manifest.json
+++ b/specs/conformance/commerce/paymentauth/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "commerce/paymentauth",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "section": 26,
   "subsection": "paymentauth",
   "description": "Conformance vectors for the v0.12.11 paymentauth commerce evidence mapping.",

--- a/specs/conformance/commerce/x402/manifest.json
+++ b/specs/conformance/commerce/x402/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "commerce/x402",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "section": 26,
   "subsection": "x402",
   "description": "Conformance vectors for the v0.12.11 x402 commerce evidence mapping.",

--- a/specs/conformance/erc8004-mapping/vector-wrapper.json
+++ b/specs/conformance/erc8004-mapping/vector-wrapper.json
@@ -2,7 +2,7 @@
   "$schema": "../common/conformance-vector.schema.json",
   "name": "erc8004-feedback-hash-wrapper",
   "description": "ERC-8004 feedbackHash computation from Pattern B wrapper file via JCS canonicalization",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "input": {
     "file": "golden-wrapper.json",
     "description": "ERC-8004 wrapper file referencing a PEAC receipt (Pattern B integration)"

--- a/specs/conformance/erc8004-mapping/vector.json
+++ b/specs/conformance/erc8004-mapping/vector.json
@@ -2,7 +2,7 @@
   "$schema": "../common/conformance-vector.schema.json",
   "name": "erc8004-feedback-hash",
   "description": "ERC-8004 feedbackHash computation from PEAC receipt via JCS canonicalization",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "input": {
     "file": "golden-receipt.json",
     "description": "PEAC receipt in peac-receipt/0.1 wire format"

--- a/specs/conformance/fixtures/inventory.json
+++ b/specs/conformance/fixtures/inventory.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://www.peacprotocol.org/schemas/conformance/inventory.schema.json",
-  "generated_at": "2026-05-10T15:25:41.330Z",
-  "version": "0.14.2",
-  "schema_version": "0.14.2",
+  "generated_at": "2026-05-17T04:00:09.090Z",
+  "version": "0.14.3",
+  "schema_version": "0.14.3",
   "total_fixtures": 688,
   "total_with_requirements": 243,
   "total_unmapped": 445,

--- a/specs/conformance/parity-corpus/a2a-handoff/vectors.json
+++ b/specs/conformance/parity-corpus/a2a-handoff/vectors.json
@@ -1,7 +1,7 @@
 {
   "family": "a2a-handoff",
   "description": "A2A handoff observation parity vectors. Covers the 10 type URIs of org.peacprotocol/a2a-handoff (Agent Card observation + 9 task / human lifecycle events) plus 5 envelope-level vectors that exercise extension-content edge cases (digest-only card_ref violation, decision-vocabulary injection, legacy signature shape, type/event mismatch, opaque-ref grammar violation on task_id). Per the parity-corpus convention established by runtime-governance vector rg-007, all vectors here assert envelope-level canonical agreement (LEFT/RIGHT verifier agreement on the wire envelope) and set expected.accepted=true; the actual semantic rejection of the extension content lives at the Layer 3 validator surface (validateA2AHandoff exported from @peac/schema, exercised by packages/schema/__tests__/extensions/a2a-handoff-shape.test.ts and a2a-handoff-registry.test.ts).",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "generator": "manual; a2a-handoff v0.1 floor",
   "vectors": [
     {

--- a/specs/conformance/parity-corpus/cli-execution/vectors.json
+++ b/specs/conformance/parity-corpus/cli-execution/vectors.json
@@ -1,7 +1,7 @@
 {
   "family": "cli-execution",
   "description": "CLI execution observation parity vectors. Six deterministic JSON observation payloads exercising CLI-EXEC-001..006 schema-shape semantics. Every vector is INTERNALLY VALID against CliExecutionSchema; semantic-rejection cases (path-leak, raw-without-unsafe, env-not-in-allowlist, stream-ref inconsistency, shell_mode without shell_ref, etc.) live in the schema validator tests at packages/schema/__tests__/extensions/cli-execution.test.ts. The corpus exists to pin a deterministic floor of canonical observation shapes for cross-language conformance.",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "generator": "manual; cli-execution v0.1 floor",
   "vectors": [
     {

--- a/specs/conformance/parity-corpus/commerce-bridges/vectors.json
+++ b/specs/conformance/parity-corpus/commerce-bridges/vectors.json
@@ -1,7 +1,7 @@
 {
   "family": "commerce-bridges",
   "description": "Commerce evidence parity vectors covering one envelope shape per upstream family (x402, ACP, paymentauth, Stripe SPT). Each vector uses the canonical commerce extension schema (payment_rail / amount_minor / currency / event), where event values are restricted to the canonical lifecycle enum (authorization|capture|settlement|refund|void|chargeback). Bridge-specific upstream artifact preservation lives in adapter packages, not the canonical envelope; this corpus tests envelope validation only.",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "generator": "manual; v0.13.1 PR C floor",
   "vectors": [
     {

--- a/specs/conformance/parity-corpus/default-flows/vectors.json
+++ b/specs/conformance/parity-corpus/default-flows/vectors.json
@@ -1,7 +1,7 @@
 {
   "family": "default-flows",
   "description": "Wire 0.2 happy-path parity vectors. Every vector is accepted by the canonical validator chain (kernel constraints + Wire 0.2 envelope schema). Used to assert that the bounded shadow-mode validator foundation reaches zero divergence with the existing path on accepted records. All extension shapes follow the canonical typed extension-group schemas in @peac/schema/wire-02-extensions/.",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "generator": "manual; v0.13.1 PR C floor",
   "vectors": [
     {

--- a/specs/conformance/parity-corpus/jose-hardening/vectors.json
+++ b/specs/conformance/parity-corpus/jose-hardening/vectors.json
@@ -1,7 +1,7 @@
 {
   "family": "jose-hardening",
   "description": "Wire 0.2 JOSE rejection parity vectors. Each vector supplies a malformed JOSE protected header that the canonical hardening function (validateWire02Header in @peac/crypto) MUST reject. The bounded shadow-mode validator foundation must reach zero divergence with the existing JOSE hardening path on every vector. Error codes are the actual CryptoError codes thrown by the canonical path; they do NOT carry a structured path field.",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "generator": "manual; v0.13.1 PR C floor",
   "vectors": [
     {

--- a/specs/conformance/parity-corpus/lifecycle-observation/vectors.json
+++ b/specs/conformance/parity-corpus/lifecycle-observation/vectors.json
@@ -1,7 +1,7 @@
 {
   "family": "lifecycle-observation",
   "description": "Lifecycle observation parity vectors. Nine positive deterministic JSON observation payloads (one per event_kind) covering approval / evaluation / experiment / workflow_transition / mode_observed semantics. Per the parity-corpus convention established by runtime-governance vector rg-007 and reused by a2a-handoff and cli-execution, all vectors here assert envelope-level canonical agreement (LEFT/RIGHT verifier agreement on the wire envelope) and set expected.accepted=true; semantic rejection of extension content (forbidden top-level keys, opaque-ref grammar violations, approver_ref PII priority, missing/malformed observed_at, unknown event_kind) lives at the Layer 3 validator surface (validateLifecycleObservation exported from @peac/schema, exercised by packages/schema/__tests__/extensions/lifecycle-observation.test.ts).",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "generator": "manual; lifecycle-observation v0.1 floor",
   "vectors": [
     {
@@ -26,7 +26,9 @@
           }
         }
       },
-      "expected": { "accepted": true }
+      "expected": {
+        "accepted": true
+      }
     },
     {
       "id": "lo-002-approval-granted",
@@ -51,7 +53,9 @@
           }
         }
       },
-      "expected": { "accepted": true }
+      "expected": {
+        "accepted": true
+      }
     },
     {
       "id": "lo-003-approval-denied",
@@ -75,7 +79,9 @@
           }
         }
       },
-      "expected": { "accepted": true }
+      "expected": {
+        "accepted": true
+      }
     },
     {
       "id": "lo-004-evaluation-started",
@@ -98,7 +104,9 @@
           }
         }
       },
-      "expected": { "accepted": true }
+      "expected": {
+        "accepted": true
+      }
     },
     {
       "id": "lo-005-evaluation-completed",
@@ -122,7 +130,9 @@
           }
         }
       },
-      "expected": { "accepted": true }
+      "expected": {
+        "accepted": true
+      }
     },
     {
       "id": "lo-006-experiment-assigned",
@@ -147,7 +157,9 @@
           }
         }
       },
-      "expected": { "accepted": true }
+      "expected": {
+        "accepted": true
+      }
     },
     {
       "id": "lo-007-experiment-result",
@@ -173,7 +185,9 @@
           }
         }
       },
-      "expected": { "accepted": true }
+      "expected": {
+        "accepted": true
+      }
     },
     {
       "id": "lo-008-workflow-transition",
@@ -197,7 +211,9 @@
           }
         }
       },
-      "expected": { "accepted": true }
+      "expected": {
+        "accepted": true
+      }
     },
     {
       "id": "lo-009-mode-observed",
@@ -220,7 +236,9 @@
           }
         }
       },
-      "expected": { "accepted": true }
+      "expected": {
+        "accepted": true
+      }
     },
     {
       "id": "lo-010-approval-with-policy-and-rubric",
@@ -248,7 +266,9 @@
           }
         }
       },
-      "expected": { "accepted": true }
+      "expected": {
+        "accepted": true
+      }
     },
     {
       "id": "lo-011-mode-observed-templated-flow",
@@ -273,7 +293,9 @@
           }
         }
       },
-      "expected": { "accepted": true }
+      "expected": {
+        "accepted": true
+      }
     }
   ]
 }

--- a/specs/conformance/parity-corpus/provisioning-lifecycle/vectors.json
+++ b/specs/conformance/parity-corpus/provisioning-lifecycle/vectors.json
@@ -1,7 +1,7 @@
 {
   "family": "provisioning-lifecycle",
   "description": "Provisioning lifecycle parity vectors. 10 positive vectors (one per *-observed event family) plus 19 negative vectors (one per validator-emitted stable error code under provisioning.*). Every vector is envelope-accepted (expected.accepted = true). Negative vectors additionally declare expected.errors[] for the provisioning-lifecycle extension validator. The wire-envelope canonical-truth test in @peac/protocol filters these dotted extension-level codes; the schema-validator corpus test in @peac/schema reads them directly. Two stable codes are not exercised by corpus vectors: provisioning.invalid_utf8 (fixture-loader-only) and provisioning.structure_too_deep (kernel and extension walker share the same depth cap; round-tripping through parity-vector comparison is path-sensitive and brittle). Both are covered by schema unit tests.",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "generator": "manual; provisioning-lifecycle Profile 0.1 floor",
   "vectors": [
     {

--- a/specs/conformance/parity-corpus/runtime-governance/vectors.json
+++ b/specs/conformance/parity-corpus/runtime-governance/vectors.json
@@ -1,7 +1,7 @@
 {
   "family": "runtime-governance",
   "description": "Managed-runtime wedge parity vectors. Covers the 6 observation-specific type URIs from @peac/adapter-runtime-governance plus one negative vector (malformed observation extension). The bounded validator foundation must reach zero divergence with the existing path on every vector.",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "generator": "manual; v0.13.1 PR C floor",
   "vectors": [
     {

--- a/specs/conformance/requirement-ids.json
+++ b/specs/conformance/requirement-ids.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://www.peacprotocol.org/schemas/conformance/requirement-registry.schema.json",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "spec_file": "docs/specs/WIRE-0.2.md",
   "sections": [
     {
@@ -15,8 +15,8 @@
           "source_fragment": "Issuers MUST emit this form",
           "source_fragment_hash": "sha256:0ad5b045ab78f4e9109ba8037bc1f1279ceac8a58fe748136751984969ffbbef",
           "enforcement_class": "issuance",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-MEDIA-002",
@@ -25,8 +25,8 @@
           "source_fragment": "Verifiers MUST accept; normalized to compact form",
           "source_fragment_hash": "sha256:2192ce1ab3f1ba59c7488f2aff9fba90fd7c08e68c7bc636ada4606da7d049a7",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -36,8 +36,8 @@
           "source_fragment": "The full media type form `application/interaction-record+jwt` is accepted by verifiers and MUST be normalized to the compact form `interaction-record+jwt` before returning the decoded header.",
           "source_fragment_hash": "sha256:536c2b007a3b8591d4bff457718ff298d28fa896762b1392affa342a07d29ae1",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -47,8 +47,8 @@
           "source_fragment": "Issuers MUST NOT emit the full media type form.",
           "source_fragment_hash": "sha256:c5251f9b638b45a73e848b71c5121e797cd7dd4f5fa43720d0aa47ec10f1f117",
           "enforcement_class": "issuance",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-MEDIA-005",
@@ -57,8 +57,8 @@
           "source_fragment": "Verifiers MUST enforce coherence between the JWS `typ` header and the `peac_version` payload claim",
           "source_fragment_hash": "sha256:b00235eb16c6c6a0db81c566721b4d1271c741923e2f69b30a880c11ea380652",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_WIRE_VERSION_MISMATCH"
         },
         {
@@ -68,8 +68,8 @@
           "source_fragment": "**Strict** (default): `typ` MUST be present and MUST match `interaction-record+jwt`",
           "source_fragment_hash": "sha256:feea1d7debb179f57fa31ebcb0853a4bbf1118989b05b69bcbcd187e6a101d12",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -79,8 +79,8 @@
           "source_fragment": "`typ` MUST be present and MUST match `interaction-record+jwt` (or its full media type form)",
           "source_fragment_hash": "sha256:5f3a5b55d3012cef50a6cc2699a13ed3e7c1c4d827d2e7da7d292ccdde202a62",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         }
       ]
@@ -97,8 +97,8 @@
           "source_fragment": "unknown top-level fields MUST be rejected",
           "source_fragment_hash": "sha256:0a219ef551e19ac56debd23c4e58fb3585a277c6b8105a879d34dea9f25c947c",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -108,8 +108,8 @@
           "source_fragment": "`peac_version`     | `\"0.2\"` (literal)             | REQUIRED",
           "source_fragment_hash": "sha256:7bdfc7c71a0079dd9be6c98c8291a9ffa977cca29b6b8838a60878b51c107b92",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_MISSING_REQUIRED_CLAIM"
         },
         {
@@ -119,8 +119,8 @@
           "source_fragment": "`kind`             | `\"evidence\"` or `\"challenge\"` | REQUIRED",
           "source_fragment_hash": "sha256:6eb7afd03f82e66ffa5dd05154f3d0228d33c328943720a06108d3a9cac74d8e",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_MISSING_REQUIRED_CLAIM"
         },
         {
@@ -130,8 +130,8 @@
           "source_fragment": "`type`             | string                        | REQUIRED",
           "source_fragment_hash": "sha256:04573792998fc65838c8c6fc9aef4666f58911e5cff321bac00e0aec0b668902",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_MISSING_REQUIRED_CLAIM"
         },
         {
@@ -141,8 +141,8 @@
           "source_fragment": "`iss`              | string                        | REQUIRED",
           "source_fragment_hash": "sha256:3b33b4c628f84218b3f3e8dd580a836a3c24100c33180a7d894dad1042631694",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_MISSING_REQUIRED_CLAIM"
         },
         {
@@ -152,8 +152,8 @@
           "source_fragment": "`iat`              | integer                       | REQUIRED",
           "source_fragment_hash": "sha256:3e51ea5e7d687be0295340ff1a9dd984de20e63a61df2a585950bd783b2ec310",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_MISSING_REQUIRED_CLAIM"
         },
         {
@@ -163,8 +163,8 @@
           "source_fragment": "`jti`              | string (1 to 256 chars)       | REQUIRED",
           "source_fragment_hash": "sha256:f3da034768ff8233af700a8b83e1313bbca770d99cc6c9dafd17ea9f8d647016",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_MISSING_REQUIRED_CLAIM"
         },
         {
@@ -174,8 +174,8 @@
           "source_fragment": "`sub`              | string                        | OPTIONAL",
           "source_fragment_hash": "sha256:368037b5dd9d9d45debe0a28810244010f647c080e2a87cef3976872e8b70110",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-ENV-009",
@@ -184,8 +184,8 @@
           "source_fragment": "`pillars`          | array of EvidencePillar       | OPTIONAL",
           "source_fragment_hash": "sha256:3c1fb8b3d1405472cdc66d347203e9949eb7706e07a0d903dac2cfb45b5d6bf8",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-ENV-010",
@@ -194,8 +194,8 @@
           "source_fragment": "`actor`            | ActorBinding                  | OPTIONAL",
           "source_fragment_hash": "sha256:82aadd69066785dd8f44acf578fc2686a1eb5359e96065c46d848ed587871ba7",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-ENV-011",
@@ -204,8 +204,8 @@
           "source_fragment": "`policy`           | PolicyBlock                   | OPTIONAL",
           "source_fragment_hash": "sha256:93901a0cd62d30b95f49a9d0eb0d6d3d78f49abc35917291f9e42fa29014fa2d",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-ENV-012",
@@ -214,8 +214,8 @@
           "source_fragment": "`representation`   | RepresentationFields          | OPTIONAL",
           "source_fragment_hash": "sha256:6c21b884daef697f596d1265e5f0999ebf30c663d83827b4f67e7669c4910f00",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-ENV-013",
@@ -224,8 +224,8 @@
           "source_fragment": "`occurred_at`      | string (ISO 8601 / RFC 3339)  | OPTIONAL",
           "source_fragment_hash": "sha256:09c416e1f615c62bb03424221e6e49fdb76bff6dcd054246b39be359b1bbc0dc",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-ENV-014",
@@ -234,8 +234,8 @@
           "source_fragment": "`purpose_declared` | string                        | OPTIONAL",
           "source_fragment_hash": "sha256:6eaa35ce74a62fb8287bc7bac0555baadf18e1c1539561f8e65410c88376b37d",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-ENV-015",
@@ -244,8 +244,8 @@
           "source_fragment": "`extensions`       | `Record<string, unknown>`     | OPTIONAL",
           "source_fragment_hash": "sha256:357a034ff5acf71dcf7e5e8fe4f9fdaf855c6bf05daa76a6e38b3e4ed2581b3a",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-ENV-016",
@@ -254,8 +254,8 @@
           "source_fragment": "Every Wire 0.2 receipt MUST include `peac_version`, `kind`, `type`, `iss`, `iat`, and `jti`.",
           "source_fragment_hash": "sha256:0b6a7094c1677c40ed1ba6e0062d68e7292dcd6676cc994fbc78f6ff1b667acd",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_MISSING_REQUIRED_CLAIM"
         },
         {
@@ -265,8 +265,8 @@
           "source_fragment": "`digest`  | string       | REQUIRED",
           "source_fragment_hash": "sha256:f7fadd5e4ff154c09df1e7c997f3803c05e6cef1636627d589ec4004c8a9f359",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -276,8 +276,8 @@
           "source_fragment": "`uri`     | string (URL) | OPTIONAL",
           "source_fragment_hash": "sha256:7d3200d8cbdda3ad2ae9ead49df440e01aee4693ba47544472aad9b246887ccb",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-ENV-019",
@@ -286,8 +286,8 @@
           "source_fragment": "`version` | string       | OPTIONAL",
           "source_fragment_hash": "sha256:847a8b8d08050a0821bac204dc0bbf29a2231edce770275418c00b91a99a2983",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-ENV-020",
@@ -296,8 +296,8 @@
           "source_fragment": "MUST start with `https://`",
           "source_fragment_hash": "sha256:b00cc865588cf7afea2762339afffbe7f4d1c2b3e6c6d4111e36e236a86d7c82",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -307,8 +307,8 @@
           "source_fragment": "Implementations MUST NOT trigger automatic fetch on encountering this URL (DD-55: no implicit network I/O).",
           "source_fragment_hash": "sha256:b9b373c3855d77993558e4f640698b8787d0e60280fadd1dde24a15960d15489",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-ENV-022",
@@ -317,8 +317,8 @@
           "source_fragment": "`content_hash`   | string  | OPTIONAL",
           "source_fragment_hash": "sha256:ffc021c0e538456d445d8e0fd7907844f984bd3b2412383fdeb4571b818c2ce2",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-ENV-023",
@@ -327,8 +327,8 @@
           "source_fragment": "`content_type`   | string  | OPTIONAL",
           "source_fragment_hash": "sha256:8f93a5c91e507880fcc45133dfa7e96bff9c4f8c510111b1f8c3c6874093fb08",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-ENV-024",
@@ -337,8 +337,8 @@
           "source_fragment": "`content_length` | integer | OPTIONAL",
           "source_fragment_hash": "sha256:63efd3cc5bed5ce343e37a669cc8180be7fe1c50120e344dd4530ade9e75cfb2",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-ENV-025",
@@ -347,8 +347,8 @@
           "source_fragment": "`id`          | string       | REQUIRED",
           "source_fragment_hash": "sha256:7af6f0226cae75167152cdf21cde68c2404c4426144560742442a95657425fa8",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -358,8 +358,8 @@
           "source_fragment": "`proof_type`  | string       | REQUIRED",
           "source_fragment_hash": "sha256:d5411eee9d574e04dee5f6e9aedb0b0180b61b166072ae80872f18da4e4a365b",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -369,8 +369,8 @@
           "source_fragment": "`origin`      | string (URL) | REQUIRED",
           "source_fragment_hash": "sha256:86b8b2cc2bdf87a2a388173218f0d12c91b64d6798610263e0cdcf6af59f226e",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         }
       ]
@@ -387,8 +387,8 @@
           "source_fragment": "Implementations MUST preserve unrecognized but well-formed values.",
           "source_fragment_hash": "sha256:d5fcf9d57516607b494f8bd3c95ce1ddfe19e3d6e0b8d250ccc863843945c30c",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -398,8 +398,8 @@
           "source_fragment": "The `pillars` array MUST be sorted in ascending lexicographic order with no duplicates.",
           "source_fragment_hash": "sha256:df1dc0586b45fe1fe15460c398be50de688f5e41581c36d568d49dd69e0c48e4",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_PILLARS_NOT_SORTED"
         }
       ]
@@ -416,8 +416,8 @@
           "source_fragment": "The `occurred_at` field MUST NOT appear on challenge receipts. Its presence produces `E_OCCURRED_AT_ON_CHALLENGE`.",
           "source_fragment_hash": "sha256:0c9326365380c0f36b9dbfb09cdc93fee3b912350e093ca74646b8e9297c6d01",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_OCCURRED_AT_ON_CHALLENGE"
         },
         {
@@ -427,8 +427,8 @@
           "source_fragment": "Challenges SHOULD include the challenge extension group (Section 13) with a `challenge_type` and an RFC 9457 `problem` body.",
           "source_fragment_hash": "sha256:5932bba9c1814ecb065c9d21064f3cb22737da09cc45c0ef7e878f632a4ed11e",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-KIND-003",
@@ -437,8 +437,8 @@
           "source_fragment": "A single `type` MAY appear with either kind.",
           "source_fragment_hash": "sha256:3419f8b63d75f9019a180b672532ecc9c75f5cbf783c2dda671bcad4428a727d",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         }
       ]
     },
@@ -454,8 +454,8 @@
           "source_fragment": "MUST contain at least one dot",
           "source_fragment_hash": "sha256:76c4e2721d93d12ee6f41526c906ec4b87f0288ded040b6135890fe9057a8d47",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -465,8 +465,8 @@
           "source_fragment": "MUST match /^[a-zA-Z0-9][a-zA-Z0-9.-]*$/",
           "source_fragment_hash": "sha256:791b7ed1eb8a412789e76442c9f37863918e9e151b0eff64644a282e4cd9917c",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -476,8 +476,8 @@
           "source_fragment": "MUST be non-empty",
           "source_fragment_hash": "sha256:527c9881eabc05d1d7e6260f1a1b8664ebe0d6d40fd4088eebf1dff57daf3b3c",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -487,8 +487,8 @@
           "source_fragment": "MUST match /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/",
           "source_fragment_hash": "sha256:bf6b1041585078132fc5c48276049653c2b301bd459438fb8e7a7feab4d1e78b",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -498,8 +498,8 @@
           "source_fragment": "MUST start with an alphanumeric character. MUST contain at least one dot",
           "source_fragment_hash": "sha256:397207842eeab8e97d7cf1b12b08bb5aecad68f329df64948541b1ad6cb37375",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -509,8 +509,8 @@
           "source_fragment": "MUST start with an alphanumeric character. Underscores are permitted",
           "source_fragment_hash": "sha256:e40d853063da5b3e4419a41096ee14abe7c0914d68adb9d7d5e6188a04ae7a52",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -520,8 +520,8 @@
           "source_fragment": "Reverse-DNS `type` values SHOULD be lowercase ASCII.",
           "source_fragment_hash": "sha256:f509acdb0fc7873553b33fc2146ef92ef1e68947699affd6d429f552b515c822",
           "enforcement_class": "warning_only",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "warning_code": "type_casing"
         },
         {
@@ -531,8 +531,8 @@
           "source_fragment": "Verifiers MAY emit a warning when a reverse-DNS form `type` contains uppercase characters.",
           "source_fragment_hash": "sha256:82f3f63095402c90f7253a7b44800a15443cd8b746fcf0b46d54111a5489e0ed",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         }
       ]
     },
@@ -548,8 +548,8 @@
           "source_fragment": "Unknown values MUST be rejected.",
           "source_fragment_hash": "sha256:8c52f393b3c95e4454171c4e23e5be62de76cd7bd5bf31d8ec15f37c78d32b3f",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -559,8 +559,8 @@
           "source_fragment": "When present, the array MUST contain at least one element.",
           "source_fragment_hash": "sha256:e162bdea04ccd79484ed4fb48f2165473212dce60525430aa4b68bbd260f50f0",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -570,8 +570,8 @@
           "source_fragment": "Values MUST be in ascending lexicographic order. Implementations MUST verify that each element is strictly greater than the preceding element.",
           "source_fragment_hash": "sha256:86f1129e192559d435a3a5a8370255aa8965646ea999041d5fb9b70727bd6bb3",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_PILLARS_NOT_SORTED"
         },
         {
@@ -581,8 +581,8 @@
           "source_fragment": "Duplicate values MUST be rejected.",
           "source_fragment_hash": "sha256:b7c4d9c9ae2146ab351623faced439570bac1f7f98521b9b5579c293f4e120c2",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_PILLARS_NOT_SORTED"
         },
         {
@@ -592,8 +592,8 @@
           "source_fragment": "A receipt MAY have a type that does not directly correspond to any single pillar",
           "source_fragment_hash": "sha256:a56684bbc8a9ff7a9bfa42261f273539d268b5477f3d6635c7bec6be19959005",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-PILLAR-006",
@@ -602,8 +602,8 @@
           "source_fragment": "MAY have multiple pillars for a single type",
           "source_fragment_hash": "sha256:04d1aa09ef34f8a86458ad894f71768f3af04849c95174a90415f13c7eddddbc",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         }
       ]
     },
@@ -619,8 +619,8 @@
           "source_fragment": "Scheme MUST be lowercase `https`.",
           "source_fragment_hash": "sha256:340af1900036f5018284f6a081f4dc3a36e211d166a762191023180ee44b22d7",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_ISS_NOT_CANONICAL"
         },
         {
@@ -630,8 +630,8 @@
           "source_fragment": "Host MUST be lowercase ASCII. Raw Unicode hostnames are rejected; punycode (`xn--` labels) is accepted.",
           "source_fragment_hash": "sha256:1c9b58031d3b52cce215f86f64bec955fd14c32c7e5d74b05220b431192b2542",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_ISS_NOT_CANONICAL"
         },
         {
@@ -641,8 +641,8 @@
           "source_fragment": "The default port 443 MUST NOT appear explicitly (`:443` is rejected).",
           "source_fragment_hash": "sha256:3fae3e5b2c05757490af983cbe35e0f6160b7f75b74ee1500f3cf2be0b79d341",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_ISS_NOT_CANONICAL"
         },
         {
@@ -652,8 +652,8 @@
           "source_fragment": "iss MUST equal the reconstructed origin exactly",
           "source_fragment_hash": "sha256:c25ef0d3c0299bf0f76e958e401ed2d599885b7d9d09de11537da46b8235361d",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_ISS_NOT_CANONICAL"
         },
         {
@@ -663,8 +663,8 @@
           "source_fragment": "Method: lowercase letters and digits only (`[a-z0-9]+`).",
           "source_fragment_hash": "sha256:58fedf785aee680dd1324e3a9db760e0aa065cdc231520306e2911dfa2aeee63",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_ISS_NOT_CANONICAL"
         },
         {
@@ -674,8 +674,8 @@
           "source_fragment": "Method-specific-id: non-empty, MUST NOT contain `/`, `?`, or `#`.",
           "source_fragment_hash": "sha256:51c1ff570c935c7f8caaf500bc17d030d7ad7be72f353afe7f210b55b352ee4e",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_ISS_NOT_CANONICAL"
         },
         {
@@ -685,8 +685,8 @@
           "source_fragment": "All schemes other than `https` and `did` produce `E_ISS_NOT_CANONICAL`.",
           "source_fragment_hash": "sha256:ca4f7e9f5736e15df7917a6edb6966b1d8146d70375f77e40046330a81fb7371",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_ISS_NOT_CANONICAL"
         },
         {
@@ -696,8 +696,8 @@
           "source_fragment": "callers MUST always provide the `publicKey: Uint8Array` parameter directly.",
           "source_fragment_hash": "sha256:3436a530fe006ecff1bf43c79a68c1e040d107240271776d47662981b1bfe93c",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         }
       ]
     },
@@ -713,8 +713,8 @@
           "source_fragment": "The value MUST be a valid ISO 8601 / RFC 3339 datetime string with a timezone offset.",
           "source_fragment_hash": "sha256:df73c9e7fca543026e966859413423de0442bd96c8ed261b15f43bd5ae021b42",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         }
       ]
@@ -731,8 +731,8 @@
           "source_fragment": "Ed25519 only (RFC 8032); all other algorithms MUST be rejected",
           "source_fragment_hash": "sha256:02add0106196163c312ea724c73b8a398b70e16c846a31998383155df9ebfc8e",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -742,8 +742,8 @@
           "source_fragment": "REQUIRED; identifies the signing key in the issuer JWKS",
           "source_fragment_hash": "sha256:b01833bfb4f89976769b4795b7f3c70ceda6ecbeef7f97a1b6bec82dc3567574",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_JWS_MISSING_KID"
         },
         {
@@ -753,8 +753,8 @@
           "source_fragment": "Presence of any of the following MUST cause a hard error:",
           "source_fragment_hash": "sha256:e82c8ed352530ef59384ee45ddff7bb287ce4ad2fb9665312e36e8259db5adf3",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_JWS_EMBEDDED_KEY"
         },
         {
@@ -764,8 +764,8 @@
           "source_fragment": "`crit`                | `E_JWS_CRIT_REJECTED`",
           "source_fragment_hash": "sha256:0f2c91b9be324183d7aafcf21b012b2f08f2657b9b74e63ab0e2825bd2f181ec",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_JWS_CRIT_REJECTED"
         },
         {
@@ -775,8 +775,8 @@
           "source_fragment": "`b64` (value `false`) | `E_JWS_B64_REJECTED`",
           "source_fragment_hash": "sha256:624cf60abbefea8de74cf653a1ef02edf889c0c038140d8ff8847143230d2b10",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_JWS_B64_REJECTED"
         },
         {
@@ -786,8 +786,8 @@
           "source_fragment": "`zip`                 | `E_JWS_ZIP_REJECTED`",
           "source_fragment_hash": "sha256:0f0bf8574d920ff36ed3109b49c75595078687eccdca3543b5ba3683bee24f6c",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_JWS_ZIP_REJECTED"
         },
         {
@@ -797,8 +797,8 @@
           "source_fragment": "`kid` MUST be present and non-empty. Absent or empty `kid` produces `E_JWS_MISSING_KID`.",
           "source_fragment_hash": "sha256:23e75820922e5b31ecfb9de61623529017fb72e27752185e52a0a80ab277f28d",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_JWS_MISSING_KID"
         },
         {
@@ -808,8 +808,8 @@
           "source_fragment": "`kid` MUST NOT exceed 256 characters (DoS safety).",
           "source_fragment_hash": "sha256:0a2329aa89c09f8af6403f20ea63645a1f1d5de6a1f708f8540bcc1c54dcf42c",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_JWS_MISSING_KID"
         },
         {
@@ -819,8 +819,8 @@
           "source_fragment": "The total JWS compact serialization MUST NOT exceed 262,144 bytes (256 KB).",
           "source_fragment_hash": "sha256:558f335146dd4be605f9581b69c18e275ea5812034503e4da4d59d8435180527",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         }
       ]
@@ -837,8 +837,8 @@
           "source_fragment": "The option value MUST match the format `sha256:<64 lowercase hex>` or it is rejected with `E_INVALID_FORMAT`.",
           "source_fragment_hash": "sha256:8f97e7abf39967076fc9e9dc85f2b59d85db134c90dea3a8e36f32a8864716ea",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -848,8 +848,8 @@
           "source_fragment": "The `policy.uri` field MUST be an `https://` URL.",
           "source_fragment_hash": "sha256:861ad1d8e8729d7ff1e5840f90440935e51724249bd86643763a50fc0f44700d",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -859,8 +859,8 @@
           "source_fragment": "Implementations MUST NOT auto-fetch the policy document based on this URI",
           "source_fragment_hash": "sha256:4e5d22e97c5488174832969f3fd8ea56357488f0028ad7c99699ddac2739bde4",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         }
       ]
     },
@@ -876,8 +876,8 @@
           "source_fragment": "Extension keys MUST conform to the grammar: `<domain>/<segment>`.",
           "source_fragment_hash": "sha256:6059e4a23465efe86be0170f488cd7bbb6b973fa1a3e56ba147609d1ce4023bf",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_KEY"
         },
         {
@@ -887,8 +887,8 @@
           "source_fragment": "At least one dot (single-label domains are rejected).",
           "source_fragment_hash": "sha256:f6d1ef132993d981e99022245e0d295b21b18c4e9513521abd2a6740c42d9a87",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_KEY"
         },
         {
@@ -898,8 +898,8 @@
           "source_fragment": "MUST NOT exceed 63 characters",
           "source_fragment_hash": "sha256:7b1caa3cff16e013a5b9ede5e158d7b623430b36ccafdbe415446822164682d6",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_KEY"
         },
         {
@@ -909,8 +909,8 @@
           "source_fragment": "The segment MUST be non-empty.",
           "source_fragment_hash": "sha256:e0d5a69e348a4b316aea039d986d7bd08e7605a4b0f80b2370f905e9c49c2a9e",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_KEY"
         },
         {
@@ -920,8 +920,8 @@
           "source_fragment": "Matches `[a-z0-9][a-z0-9_-]*` (lowercase only).",
           "source_fragment_hash": "sha256:37dda7eeb76fd63c660ec12322002e352f8f422f633ce6ea98d4e88baa9ce698",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_KEY"
         },
         {
@@ -931,8 +931,8 @@
           "source_fragment": "`payment_rail` | string                                                                                    | REQUIRED | 128",
           "source_fragment_hash": "sha256:3b508ee815139f34dca10d8cd2d4f64a48bbd546654d56267f228322bb79cfa6",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -942,8 +942,8 @@
           "source_fragment": "`amount_minor` | string                                                                                    | REQUIRED | 64",
           "source_fragment_hash": "sha256:9aa4a38a7a2b5426e8760e107f2e063f719921d57b07e012122eca76f1827d41",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -953,8 +953,8 @@
           "source_fragment": "`currency`     | string                                                                                    | REQUIRED | 16",
           "source_fragment_hash": "sha256:2ef4df7bacdd47eb333023b0b03802107195d6b1aa270e88047e224e7325786b",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -964,8 +964,8 @@
           "source_fragment": "The `amount_minor` field MUST be a base-10 integer string.",
           "source_fragment_hash": "sha256:60d7724ef11256b4581a89df925ebf7053dd181bd58d69e63af99c44c702a8d1",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -975,8 +975,8 @@
           "source_fragment": "Issuers SHOULD use a distinct receipt `type`",
           "source_fragment_hash": "sha256:3bfc0a15f74f0a378f2e93041895f67ebad51cd15f57265bcf90821b88c2f3c9",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-EXT-011",
@@ -985,8 +985,8 @@
           "source_fragment": "`resource` | string                             | REQUIRED",
           "source_fragment_hash": "sha256:973a53405252385d13f9245cbebaccc8d01c99d007d7fcb09038a7cd07a81b9c",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -996,8 +996,8 @@
           "source_fragment": "`action`   | string                             | REQUIRED",
           "source_fragment_hash": "sha256:c7ba9eff8c89184e97601edd690d45c431a43d584834d3c8b27e45f74fb6b840",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1007,8 +1007,8 @@
           "source_fragment": "`decision` | `\"allow\"`, `\"deny\"`, or `\"review\"` | REQUIRED",
           "source_fragment_hash": "sha256:bef10f106f2bac40c8141b22dda5bb136abd20498637ce2dd068ddc8ce503f94",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1018,8 +1018,8 @@
           "source_fragment": "`trace_id` MUST match `/^[0-9a-f]{32}$/` (exactly 32 lowercase hex characters).",
           "source_fragment_hash": "sha256:4fe34442550458f59fada0230ed5e6db557d1addbe027a4415ed530b506a722f",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1029,8 +1029,8 @@
           "source_fragment": "`span_id` MUST match `/^[0-9a-f]{16}$/` (exactly 16 lowercase hex characters).",
           "source_fragment_hash": "sha256:b3c1e979b846dfcd3c6a31537274ef7a007917397abe3c126eb799819014563f",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1040,8 +1040,8 @@
           "source_fragment": "MUST be preserved (not silently dropped).",
           "source_fragment_hash": "sha256:069778ce9d7309fcd0c5bc56292cffa09146e9c1958084db5eea737e6c7fe1fc",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1051,8 +1051,8 @@
           "source_fragment": "MUST trigger an `unknown_extension_preserved` warning at the protocol layer",
           "source_fragment_hash": "sha256:7218b5a436c7bbde6657707d94d0ce89c320fd83fda5e243418138f331ffeb78",
           "enforcement_class": "warning_only",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "warning_code": "unknown_extension_preserved"
         },
         {
@@ -1062,8 +1062,8 @@
           "source_fragment": "MUST NOT cause a validation error.",
           "source_fragment_hash": "sha256:7df9acd0d60c081513e8caa9c952e64e310407fca9496a4f840fa6571fb281a5",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1073,8 +1073,8 @@
           "source_fragment": "`consent_basis` string REQUIRED: identifies the legal basis for consent.",
           "source_fragment_hash": "sha256:09cea66f777b829db5404215c7020f251a2e18ac3791e0265969860d8ec6295a",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1084,8 +1084,8 @@
           "source_fragment": "`consent_status` enum REQUIRED: granted, withdrawn, denied, expired.",
           "source_fragment_hash": "sha256:0e8149e310a1aec19d7ee48c683afce8c76860d844f6a483eefa096733990a0e",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1095,8 +1095,8 @@
           "source_fragment": "`data_categories` string[] optional: data categories covered by the consent record.",
           "source_fragment_hash": "sha256:9ac85070d70f8d9becb39c1314ac94009de20c705d08df722bb8cc94b30e1033",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-EXT-022",
@@ -1105,8 +1105,8 @@
           "source_fragment": "`retention_period` Iso8601DurationSchema optional: uses the parser-grade ISO 8601 duration validator.",
           "source_fragment_hash": "sha256:8179de2cbe6b1146a51c7fe8ef40b948b1500d81b8ca3dcbb35b34020e69b973",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-EXT-024",
@@ -1115,8 +1115,8 @@
           "source_fragment": "`.strict()` rejects unknown properties: the consent extension uses `.strict()` mode; unrecognized fields are rejected.",
           "source_fragment_hash": "sha256:31c6461e793edbc660beaa25967694a0d8dc7888496da38352c0e99042006b0f",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1126,8 +1126,8 @@
           "source_fragment": "`data_classification` string REQUIRED: identifies the classification level of the data.",
           "source_fragment_hash": "sha256:3bb849ef447715eb5110fa541847aa2dd380243e6293100a5a2a25fcf34396bb",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1137,8 +1137,8 @@
           "source_fragment": "`processing_basis` string optional: legal basis for data processing.",
           "source_fragment_hash": "sha256:66d47d95bf463063ff7eaf1365426ee0758cb94a4e5993f646664a31b926a02b",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-EXT-033",
@@ -1147,8 +1147,8 @@
           "source_fragment": "`retention_mode` enum optional: time_bound, indefinite, session_only.",
           "source_fragment_hash": "sha256:3cbf29cbc11839404cab2d998b3048e60576fa01f67912c68cf25ad70ab246be",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1158,8 +1158,8 @@
           "source_fragment": "`recipient_scope` enum optional: internal, processor, third_party, public.",
           "source_fragment_hash": "sha256:e6d3ca15130c834f7fe34fa81a01914e4f8625d7cb9c7fd753edb6f3c1ab6de8",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1169,8 +1169,8 @@
           "source_fragment": "`anonymization_method` string optional: method applied for de-identification.",
           "source_fragment_hash": "sha256:5d9df644e04721e6d15151ecc58ae9382985fbde9a80657662fd1026565c7b27",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-EXT-036",
@@ -1179,8 +1179,8 @@
           "source_fragment": "`transfer_mechanism` string optional: cross-border data transfer mechanism.",
           "source_fragment_hash": "sha256:85075e07e7bab318149b81ad9393e984054dc15006cf1f8457f2b6da3f911648",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-EXT-037",
@@ -1189,8 +1189,8 @@
           "source_fragment": "`review_status` enum REQUIRED: reviewed, pending, flagged, not_applicable.",
           "source_fragment_hash": "sha256:bbb4ea179df8a616d537805b0f5dab41eb5e952484a4210a6695112e8a5daedf",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1200,8 +1200,8 @@
           "source_fragment": "`risk_level` enum optional: unacceptable, high, limited, minimal.",
           "source_fragment_hash": "sha256:81e8c421221f1011ccf56f564f9d333314fa94705325d4ea18d094f1de2166e8",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1211,8 +1211,8 @@
           "source_fragment": "`assessment_method` string optional: describes the review methodology used.",
           "source_fragment_hash": "sha256:d4b463389daa264e05b666424eccc181b855a239564d4dd40f6d7c79bf8e945e",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-EXT-040",
@@ -1221,8 +1221,8 @@
           "source_fragment": "`safety_measures` string[] optional max 32 items: safety measures applied.",
           "source_fragment_hash": "sha256:a5bb4c064c702ae509f68a3732389d4cd4298962cb4b89978366ffa2f4d53106",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-EXT-041",
@@ -1231,8 +1231,8 @@
           "source_fragment": "`incident_ref` string optional: reference to an incident report.",
           "source_fragment_hash": "sha256:40afb5bd14bfeeb154224a5d68bc85904875d9549f5b9355363301e47a7a73a1",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-EXT-042",
@@ -1241,8 +1241,8 @@
           "source_fragment": "`model_ref` string optional: identifies the AI model under review.",
           "source_fragment_hash": "sha256:ab7c36421d23ee44cb93c1286466a8471d54678307175ff1dc532c7b2bbd917f",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-EXT-043",
@@ -1251,8 +1251,8 @@
           "source_fragment": "`framework` string REQUIRED: identifies the regulatory or standards framework evaluated.",
           "source_fragment_hash": "sha256:84a1e8f85d718faae95fff55d60b823fe507b09e2e9812699e5cf9ef51718997",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1262,8 +1262,8 @@
           "source_fragment": "`compliance_status` enum REQUIRED: compliant, non_compliant, partial, under_review, exempt.",
           "source_fragment_hash": "sha256:9ef31d79e0a23985bf608a81be4b609ffcb6aa8a53b48ace54e19a7b6ad6612d",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1273,8 +1273,8 @@
           "source_fragment": "`audit_date` ISO 8601 date optional: structural date validation (YYYY-MM-DD).",
           "source_fragment_hash": "sha256:493767e96d33aca475e6d6745e30087f76a774dbd84c07df8d5919a5259137ce",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-EXT-046",
@@ -1283,8 +1283,8 @@
           "source_fragment": "`validity_period` ISO 8601 duration optional: uses the parser-grade ISO 8601 duration validator.",
           "source_fragment_hash": "sha256:7e24cb7558329bf4fddb184bfc7c6c4b80a92759aa19f1e799a7ca16ee99aa92",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-EXT-047",
@@ -1293,8 +1293,8 @@
           "source_fragment": "`evidence_ref` SHA-256 digest optional: uses `Sha256DigestSchema` for typed digest validation.",
           "source_fragment_hash": "sha256:8e2d1ecc65139b8cb02d4824511714220bff8fde072a3848d163201249e704e6",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-EXT-048",
@@ -1303,8 +1303,8 @@
           "source_fragment": "`.strict()` rejects unknown properties: the compliance extension uses `.strict()` mode; unrecognized fields are rejected.",
           "source_fragment_hash": "sha256:122f818833eeb49b4977c5f3e76e68f9a03a079e16404b56f180dadbf1a350c9",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1314,8 +1314,8 @@
           "source_fragment": "`source_type` string REQUIRED: identifies the derivation type.",
           "source_fragment_hash": "sha256:311e9b372eb9f8fe50cf91784fe1e345870a95771918ad6895e2d9303cca5f3b",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1325,8 +1325,8 @@
           "source_fragment": "`source_ref` string optional: opaque source reference identifier.",
           "source_fragment_hash": "sha256:7130696c116901b704490060724bb144fb692416f7f16c371ec7dab8cd0d67b9",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-EXT-051",
@@ -1335,8 +1335,8 @@
           "source_fragment": "`custody_chain` CustodyEntry[] optional max 16 items: ordered chain of custody events.",
           "source_fragment_hash": "sha256:663e68e061ff0ee03650b86702694c298439ee9fc2e7654ef8acae1c0943490b",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-EXT-052",
@@ -1345,8 +1345,8 @@
           "source_fragment": "`slsa` SlsaLevel optional: structured SLSA-aligned metadata.",
           "source_fragment_hash": "sha256:1aecd99b250f6194ef512c5a699e31ae26e2d5a454ee9918e72d4340e847e288",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-EXT-053",
@@ -1355,8 +1355,8 @@
           "source_fragment": "`.strict()` rejects unknown properties: the provenance extension and all nested schemas use `.strict()` mode.",
           "source_fragment_hash": "sha256:32aec8d80ca7ce4426709dd18089bfb2d2df6cac0a883de2f932be4cc8c08352",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1366,8 +1366,8 @@
           "source_fragment": "`source_uri` and `build_provenance_uri` HTTPS URI hint optional: locator hints only; callers MUST NOT auto-fetch.",
           "source_fragment_hash": "sha256:369e48a0cbe003e4290b8817948023d341744cc3445ef5e0b5f8ab8eed06f68c",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-EXT-055",
@@ -1376,8 +1376,8 @@
           "source_fragment": "`creator_ref` string REQUIRED: identifies the creator.",
           "source_fragment_hash": "sha256:97a506548e347b92f202d916486f02f081581f73b7229f22d8729ac163cd6018",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1387,8 +1387,8 @@
           "source_fragment": "`license_spdx` SPDX expression optional: uses the parser-grade SPDX license expression validator.",
           "source_fragment_hash": "sha256:f897ef7cc16f279befa9d50e2ab61608cae47987a83f1d58ad397c26b1322c08",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-EXT-057",
@@ -1397,8 +1397,8 @@
           "source_fragment": "`content_signal_source` enum optional: tdmrep_json, content_signal_header, content_usage_header, robots_txt, custom.",
           "source_fragment_hash": "sha256:9eb9c06f5aa56fb2ec8867e4947fe4956c996a700abd68ff197b5e8636ce50f6",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1408,8 +1408,8 @@
           "source_fragment": "`content_digest` SHA-256 digest optional: uses `Sha256DigestSchema` for typed digest validation.",
           "source_fragment_hash": "sha256:f9df2fb27b768f7990151d341035a40494d3f42f9a7ccfaaf62d8955d5a06636",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-EXT-059",
@@ -1418,8 +1418,8 @@
           "source_fragment": "`.strict()` rejects unknown properties: the attribution extension uses `.strict()` mode; unrecognized fields are rejected.",
           "source_fragment_hash": "sha256:47003ad9870adb66488f4a3f28327ae249487ff2b91493cc970fd5999a484757",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1429,8 +1429,8 @@
           "source_fragment": "Not an identity attestation; records observed attribution metadata.",
           "source_fragment_hash": "sha256:f2ed1b90e528aceb625c676ba9908b997b7f433ed921d9b580a8e5b859c6c2c9",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-EXT-061",
@@ -1439,8 +1439,8 @@
           "source_fragment": "`external_purposes` string[] REQUIRED min 1 max 32 items: external/legal/business purpose labels.",
           "source_fragment_hash": "sha256:d11d9ae832701052b15c6ef52a73b3d48589b26cdf80209c83e16b24ee6d54dc",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1450,8 +1450,8 @@
           "source_fragment": "`compatible_purposes` string[] optional max 32 items: each item MUST match the machine-safe lowercase token grammar and items MUST be unique within the array.",
           "source_fragment_hash": "sha256:e7bc1dc712ff834e1bc20f285e8a203baff09363440d716573c15447a71c019d",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-EXT-063",
@@ -1460,8 +1460,8 @@
           "source_fragment": "`purpose_basis` string optional: legal or policy basis for the declared purposes.",
           "source_fragment_hash": "sha256:4d53de5af04b137171e9cedb767934d1cf8bd98206c1951bbd9f225e31b2b727",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-EXT-064",
@@ -1470,8 +1470,8 @@
           "source_fragment": "`.strict()` rejects unknown properties: the purpose extension uses `.strict()` mode; unrecognized fields are rejected.",
           "source_fragment_hash": "sha256:371bb62d235b518b0148847fc7b77a04af8a5c5853ee92a7bc36da63e6afd86a",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1481,8 +1481,8 @@
           "source_fragment": "Each item MUST match the machine-safe token grammar and items MUST be unique.",
           "source_fragment_hash": "sha256:4c0eaebcdbfa11fb123d581db002ef228de34c92b047ef7602c464097fa328c4",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1492,8 +1492,8 @@
           "source_fragment": "`peac_purpose_mapping` string optional: explicit bridge to a PEAC operational CanonicalPurpose token.",
           "source_fragment_hash": "sha256:82831a0e370e06ea44d5b13c3d87bc9c8a98ed0cbdaf3900a091e006bc70be5e",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-EXT-071",
@@ -1502,8 +1502,8 @@
           "source_fragment": "items MUST be unique within the array.",
           "source_fragment_hash": "sha256:dbcd6e3c158bfd4782f83f90d01a642a15c9d5f8c4c92d0d1fb79788d5242f7b",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1513,8 +1513,8 @@
           "source_fragment": "the expected extension group MUST be present in the extensions record in strict verification mode.",
           "source_fragment_hash": "sha256:003a2a08d3a25910733772e67d31234b1fcf65440bbb1077be8c5f79c8adac63",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT",
           "warning_code": "extension_group_missing"
         },
@@ -1525,8 +1525,8 @@
           "source_fragment": "In interop mode, its absence is a warning.",
           "source_fragment_hash": "sha256:003d4dde216ce42def198af46128132ef770cd831acf18b756055e87f3b66350",
           "enforcement_class": "warning_only",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "warning_code": "extension_group_missing"
         },
         {
@@ -1536,8 +1536,8 @@
           "source_fragment": "verifiers MUST report a mismatch in strict mode.",
           "source_fragment_hash": "sha256:871e93601acd89d873cc654906cf656628e4baf02fd2ac62e69a49c31e8a8190",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT",
           "warning_code": "extension_group_mismatch"
         },
@@ -1548,8 +1548,8 @@
           "source_fragment": "Custom or unmapped types are not subject to this check.",
           "source_fragment_hash": "sha256:fe8dd908e5178fb09f2e215c491f1278eae9dbfa70a2e5dc2ae7017679b5eded",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         }
       ]
     },
@@ -1565,8 +1565,8 @@
           "source_fragment": "`status`   | integer      | REQUIRED",
           "source_fragment_hash": "sha256:b4218e7ac57b5bf9763b94b4cbc7edcd1e360cf1162d9c083e6c3d29d9ad70d4",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1576,8 +1576,8 @@
           "source_fragment": "`type`     | string (URL) | REQUIRED",
           "source_fragment_hash": "sha256:336fe7122380cfb8ee818e73689d3a9f676b9a135dc07246969ffcee570861f0",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_EXTENSION_FORMAT"
         },
         {
@@ -1587,8 +1587,8 @@
           "source_fragment": "`title`    | string       | OPTIONAL",
           "source_fragment_hash": "sha256:0fdb18e80464e208d1e2bd5151107bb006e4d64a7fbda704d8e647dd5f275768",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-CHAL-004",
@@ -1597,8 +1597,8 @@
           "source_fragment": "`detail`   | string       | OPTIONAL",
           "source_fragment_hash": "sha256:3d2883122fa49b9184bb9d9556f984fd3cfbd6edde0bd91ed606e35c334d1f69",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-CHAL-005",
@@ -1607,8 +1607,8 @@
           "source_fragment": "`instance` | string       | OPTIONAL",
           "source_fragment_hash": "sha256:c91561a806f53774e3288522c42a21211f2af4e043dff9d66bccaa0dc7cdbe4a",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-CHAL-006",
@@ -1617,8 +1617,8 @@
           "source_fragment": "`resource`     | string                    | OPTIONAL",
           "source_fragment_hash": "sha256:8ec538f2f5c8884e2a91e5cfd0276438d1a7b5832a8aa99cb8e749a13e68efab",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-CHAL-007",
@@ -1627,8 +1627,8 @@
           "source_fragment": "`action`       | string                    | OPTIONAL",
           "source_fragment_hash": "sha256:4cd10b5a9f3e5524e6f5bec0b44bbd5df2d03415afc905ba00fa78ed3147800b",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         }
       ]
     },
@@ -1644,8 +1644,8 @@
           "source_fragment": "`code`    | string | REQUIRED | Stable warning code identifier",
           "source_fragment_hash": "sha256:aeae61c3e1f194cf11323fafd2810f55704efde214f3d7c2895911d4851100ae",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1655,8 +1655,8 @@
           "source_fragment": "`message` | string | REQUIRED | Human-readable description",
           "source_fragment_hash": "sha256:4ce4086f3c8535c97df31bdb2619e257c8349eeab809b32cd9c6ffee8226c01a",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1666,8 +1666,8 @@
           "source_fragment": "MUST NOT be used for conformance testing",
           "source_fragment_hash": "sha256:da9dc2e53c59e715f0c547855d47f703c8a27d41d9de01b2bfa62a13eb341792",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-WARN-004",
@@ -1676,8 +1676,8 @@
           "source_fragment": "New warning codes MAY be added in future versions.",
           "source_fragment_hash": "sha256:0abcd88cb76eec7c1920c54a8b350da9c165499ba7d77dea426811d852460e5a",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-WARN-005",
@@ -1686,8 +1686,8 @@
           "source_fragment": "Existing warning codes MUST NOT be removed or renamed.",
           "source_fragment_hash": "sha256:a20c727a06711424cf334d4735243ff0646b3c9da8613fe76369144eb60ece23",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-WARN-006",
@@ -1696,8 +1696,8 @@
           "source_fragment": "Consumers MUST tolerate unknown warning codes gracefully.",
           "source_fragment_hash": "sha256:533c1b7fd85aeed77615120ec8ab044c2d2f742d0cfdf302e3194045ba3b2cf9",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-WARN-007",
@@ -1706,8 +1706,8 @@
           "source_fragment": "Warnings MUST be sorted by `(pointer ascending, code ascending)`.",
           "source_fragment_hash": "sha256:09e1408513af162bf1c74da14026aa9195460703a39d6b2889080f705a248215",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1717,8 +1717,8 @@
           "source_fragment": "Conformance implementations MUST assert on `code` and `pointer` fields only.",
           "source_fragment_hash": "sha256:049af55e0fc391c97d96e42c7e44fc9675fde9145a696fd279e0ec74b9f3c9ac",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-WARN-009",
@@ -1727,8 +1727,8 @@
           "source_fragment": "The `message` field is implementation-defined and MUST NOT be used for conformance testing.",
           "source_fragment_hash": "sha256:168e30636fc4164b370eae96e9570de0f11cf64457f5cd35ed4a2107af978cc8",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         }
       ]
     },
@@ -1744,8 +1744,8 @@
           "source_fragment": "implementations MUST verify coherence between the JWS `typ` and the payload `peac_version` field",
           "source_fragment_hash": "sha256:21ef041cd2efe1ca1429cddbf3043f1c4b302b05586285af26b5de63d72ae21f",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_WIRE_VERSION_MISMATCH"
         },
         {
@@ -1755,8 +1755,8 @@
           "source_fragment": "Wire 0.1 route: payload MUST NOT contain `peac_version: \"0.2\"`.",
           "source_fragment_hash": "sha256:b45a1c576245f248194b3ce73626b45523725356900db2a5c87e03a5f63f54f0",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_WIRE_VERSION_MISMATCH"
         },
         {
@@ -1766,8 +1766,8 @@
           "source_fragment": "Wire 0.2 route: payload MUST contain `peac_version: \"0.2\"`.",
           "source_fragment_hash": "sha256:7131653b896b21b5c8805bec85fc1a2cdc940de336c16a31dfe98ea4b98f34cd",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_WIRE_VERSION_MISMATCH"
         }
       ]
@@ -1784,8 +1784,8 @@
           "source_fragment": "JWS `typ` MUST be present.",
           "source_fragment_hash": "sha256:5106f5d60d9724a46f15f75d921552e6e0f2fe0358b4cbda541d107e1b90df6d",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1795,8 +1795,8 @@
           "source_fragment": "`typ` MUST be a recognized value",
           "source_fragment_hash": "sha256:a73c3888ee9f366fdf3d620e23336b4e804bf6755a223267343b0d6e1beef229",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1806,8 +1806,8 @@
           "source_fragment": "Production deployments SHOULD use strict mode.",
           "source_fragment_hash": "sha256:2ce27e3de73b934a758c88791dacb2726042377fa19dfcb253f0b3fb98c0964d",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         }
       ]
     },
@@ -1823,8 +1823,8 @@
           "source_fragment": "Compact form: `interaction-record+jwt` (canonical; issuers MUST emit this form)",
           "source_fragment_hash": "sha256:66b3df3e98ef9e64b3479b15dbe8ba55de1e91d01a931cee8b0c5ee1ac27b5fa",
           "enforcement_class": "issuance",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-IDENT-002",
@@ -1833,8 +1833,8 @@
           "source_fragment": "Media-type form: `application/interaction-record+jwt` (verifiers MUST accept)",
           "source_fragment_hash": "sha256:0d694b4d700e7214b23c88b889d9f0cb47badf2cde00470cc04515ac54a9f69f",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1844,8 +1844,8 @@
           "source_fragment": "Implementations MUST NOT perform content-type parameter parsing",
           "source_fragment_hash": "sha256:79a9b6f7133f4ed3a663776297d1072b174115329d47ebffcde917ea063745a6",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1855,8 +1855,8 @@
           "source_fragment": "The `typ` header and `peac_version` payload claim MUST agree.",
           "source_fragment_hash": "sha256:c459e15f3358ed1350da5e97be4206679a06689aed5dbd988deaec86fb233528",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_WIRE_VERSION_MISMATCH"
         },
         {
@@ -1866,8 +1866,8 @@
           "source_fragment": "Production deployments SHOULD use strict mode, which rejects missing `typ`.",
           "source_fragment_hash": "sha256:ce03eb555707e7b685b512790116727b730bcbba9ac8220308cfeb701ff5ab20",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-IDENT-006",
@@ -1876,8 +1876,8 @@
           "source_fragment": "Future implementations MAY relax this to process unknown minor versions with a warning",
           "source_fragment_hash": "sha256:444f26b04d129b0690a5e2fc9674c470e655e45e0dae0497d89aa7728cd9e66f",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-IDENT-007",
@@ -1886,8 +1886,8 @@
           "source_fragment": "Multiple package versions MAY implement the same wire format version.",
           "source_fragment_hash": "sha256:b96a8e527c40171cb1d81ee42cce33e854ae56ba37aa1c66db9bf0a90c15b497",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         }
       ]
     },
@@ -1903,8 +1903,8 @@
           "source_fragment": "Implementations MUST perform steps in the order specified.",
           "source_fragment_hash": "sha256:4128f7475c53d98a4e70cac0671afc8a247bb7d0ec1b3798f66f60c3c661a9b8",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1914,8 +1914,8 @@
           "source_fragment": "A step that produces a hard error MUST terminate validation immediately",
           "source_fragment_hash": "sha256:1d89cea8c8aa48ad9023d83847f3f73ea95b63949aaf2d90c2c11afc3da7c74e",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1925,8 +1925,8 @@
           "source_fragment": "the verifier MUST NOT continue to subsequent steps.",
           "source_fragment_hash": "sha256:1e88d48481f5bc56e8231cdf4abc77fb1842aa24a31235c1a741bba223bc8271",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1936,8 +1936,8 @@
           "source_fragment": "`jws`          | string     | REQUIRED",
           "source_fragment_hash": "sha256:e91cc74e34001e7eea4cb856b9ff1aa6fa8973759561339aef88b0d983d76a30",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1947,8 +1947,8 @@
           "source_fragment": "`publicKey`    | Uint8Array | REQUIRED",
           "source_fragment_hash": "sha256:bb3957aeaab5c3d3acb727ca1df11272d2e8c190786fe3b6d57c683bad55173c",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1958,8 +1958,8 @@
           "source_fragment": "The `alg` header parameter MUST be `EdDSA`.",
           "source_fragment_hash": "sha256:a9a566b439e97cd88451d44f3c2cf0ae54e377b595daf3b548218c0c398137ab",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_INVALID_FORMAT"
         },
         {
@@ -1969,8 +1969,8 @@
           "source_fragment": "Kernel constraints are structural limits (field lengths, array sizes) enforced before schema parsing. Failure is fail-closed: return `E_CONSTRAINT_VIOLATION`.",
           "source_fragment_hash": "sha256:154b58e4f819d531f2e3ea87fb4a29e9c518407f07625328d820374d7e20b563",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_CONSTRAINT_VIOLATION"
         },
         {
@@ -1980,8 +1980,8 @@
           "source_fragment": "`iat` MUST NOT exceed `now + maxClockSkew`.",
           "source_fragment_hash": "sha256:07dec89d4303bb400bb8d20b5185c70755e217e255dd530fb107cdda1408cfd1",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_NOT_YET_VALID"
         },
         {
@@ -1991,8 +1991,8 @@
           "source_fragment": "The `jti` claim is REQUIRED (enforced by schema validation in Step 4).",
           "source_fragment_hash": "sha256:5494a3e5cde868771a2f1061c7394739dff025ab45c9b5ac6a42f49067529cad",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_MISSING_REQUIRED_CLAIM"
         },
         {
@@ -2002,8 +2002,8 @@
           "source_fragment": "Verifiers that maintain a replay cache SHOULD reject duplicate `jti`",
           "source_fragment_hash": "sha256:ae1e18480bea50183b3c9407bb7ba5d2264fc03a2bbbb4ba6d91a2c536953a97",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-VALID-011",
@@ -2012,8 +2012,8 @@
           "source_fragment": "Verifiers without a replay cache MAY skip this step",
           "source_fragment_hash": "sha256:9193f11f66a913d2032a76e80cdfd063863a8a803bde92c629d18b19d9dd91d1",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-VALID-012",
@@ -2022,8 +2022,8 @@
           "source_fragment": "implementations SHOULD map these to HTTP 400 Bad Request",
           "source_fragment_hash": "sha256:0b01c93a0a54fcdcb2d5f1d293a568b7f40233d53c6fad7dfb51ed57552fd7e5",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         }
       ]
     },
@@ -2039,8 +2039,8 @@
           "source_fragment": "The `jti` claim is REQUIRED on all Wire 0.2 receipts.",
           "source_fragment_hash": "sha256:460780907183f76a99ef33f4a22f6c3e81c94dbb02afb3cd91cbf9202bba9ba2",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_MISSING_REQUIRED_CLAIM"
         },
         {
@@ -2050,8 +2050,8 @@
           "source_fragment": "Issuers MUST ensure `jti` uniqueness across all receipts they produce.",
           "source_fragment_hash": "sha256:39a87e0be4d2b781f4888a8b30d69ec44a56dda023f22ef24599c53c63d6eb9b",
           "enforcement_class": "issuance",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-REPLAY-003",
@@ -2060,8 +2060,8 @@
           "source_fragment": "The `jti` value MUST be a non-empty string of 1 to 256 characters.",
           "source_fragment_hash": "sha256:1203bf2bc4c86cd5b41cd8ee3985f2654464f314fcf697cc889b8d578a495c90",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_MISSING_REQUIRED_CLAIM"
         },
         {
@@ -2071,8 +2071,8 @@
           "source_fragment": "Implementations SHOULD use at least 128 bits of entropy",
           "source_fragment_hash": "sha256:72a3f6caea40dfa3ede2d547c652e206824ee5172b34fb3e630ab2fec1267663",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-REPLAY-005",
@@ -2081,8 +2081,8 @@
           "source_fragment": "Verifiers that maintain a replay cache SHOULD reject duplicate `jti` from the same `iss`",
           "source_fragment_hash": "sha256:25f08ecd322bde687e84eae8066045c8a7be4c01d95dda79973bc2007b63a3b1",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-REPLAY-006",
@@ -2091,8 +2091,8 @@
           "source_fragment": "Verifiers without a replay cache (stateless deployments, edge functions, serverless) MAY skip replay detection.",
           "source_fragment_hash": "sha256:d9673740aa9379ad1afaafb490dfb31b976b32fb737baad7fd92c3ba41e9865a",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-REPLAY-007",
@@ -2101,8 +2101,8 @@
           "source_fragment": "Use `iat`-based expiry.",
           "source_fragment_hash": "sha256:0e012acf04d5dfb402653c296f4b8f6b88a3b9add432952abfb10006b85c31ca",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-REPLAY-008",
@@ -2111,8 +2111,8 @@
           "source_fragment": "A RECOMMENDED window is 2x `OCCURRED_AT_TOLERANCE_SECONDS` (600 seconds).",
           "source_fragment_hash": "sha256:0e48a4e3a328cdf6b91bc9cca1f544f447e8091e594c9df2690d8273400e89e3",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-REPLAY-009",
@@ -2121,8 +2121,8 @@
           "source_fragment": "Caches SHOULD be scoped per `iss`",
           "source_fragment_hash": "sha256:fa37f432cdec2c3e57e684d9b9fd170e7bad898a2d11fa18b94b5870f6655d72",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-REPLAY-010",
@@ -2131,8 +2131,8 @@
           "source_fragment": "Implementations MAY use bloom filters or probabilistic data structures",
           "source_fragment_hash": "sha256:9f49f49451d5a5b0feb62354f4737c44d041aa1dfa007d1fb86f708b50d41fa9",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-REPLAY-011",
@@ -2141,8 +2141,8 @@
           "source_fragment": "The `aud` claim is OPTIONAL in Wire 0.2.",
           "source_fragment_hash": "sha256:f4954bc439f94c9203e5eb67291f9e4a55b87ae3e3d924c4d78e311668ff5249",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-REPLAY-012",
@@ -2151,8 +2151,8 @@
           "source_fragment": "Verifiers that check `aud` SHOULD reject receipts not addressed to them.",
           "source_fragment_hash": "sha256:21689600c2bb21482e756b96ebb569b450e355b25156c70847e0a48bd55119be",
           "enforcement_class": "advisory",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1"
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3"
         },
         {
           "id": "WIRE02-REPLAY-013",
@@ -2161,8 +2161,8 @@
           "source_fragment": "Each receipt in an evidence bundle MUST have a unique `jti`.",
           "source_fragment_hash": "sha256:36cbe5e5b9a462edadfc673c9f3df0ea4a61d4608cf1392bdd7025bebb3f1d57",
           "enforcement_class": "hard_fail",
-          "introduced_in": "0.14.1",
-          "last_reviewed_in": "0.14.1",
+          "introduced_in": "0.14.3",
+          "last_reviewed_in": "0.14.3",
           "error_code": "E_MISSING_REQUIRED_CLAIM"
         }
       ]

--- a/specs/conformance/test-mappings.json
+++ b/specs/conformance/test-mappings.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Protocol-level test mappings for requirements not provable by fixtures alone",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "mappings": [
     {
       "requirement_id": "WIRE02-VALID-001",
@@ -426,7 +426,7 @@
       "requirement_id": "LIFE-OBS-010",
       "test_file": "docs/specs/LIFECYCLE-OBSERVATION-PROFILE.md",
       "test_description": "spec orchestrator-boundary text is normative and vendor-neutral",
-      "notes": "Section 8 of the profile spec carries the orchestrator boundary as normative prose with vendor-neutral nouns (orchestrators, workflow engines, evaluation systems, approval systems, agent runtimes); checked manually as part of spec review and pinned by repository search-and-replace discipline (no specific external project name appears in the normative \u00a78 text)."
+      "notes": "Section 8 of the profile spec carries the orchestrator boundary as normative prose with vendor-neutral nouns (orchestrators, workflow engines, evaluation systems, approval systems, agent runtimes); checked manually as part of spec review and pinned by repository search-and-replace discipline (no specific external project name appears in the normative §8 text)."
     },
     {
       "requirement_id": "PROV-LIFE-001",

--- a/specs/kernel/error-categories.json
+++ b/specs/kernel/error-categories.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.peacprotocol.org/schemas/kernel/error-categories.schema.json",
   "$comment": "AUTO-GENERATED from specs/kernel/errors.json - DO NOT EDIT MANUALLY",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "source_file": "specs/kernel/errors.json",
   "categories": [
     "attribution",

--- a/specs/kernel/errors.json
+++ b/specs/kernel/errors.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "PEAC error codes - normative source of truth",
   "errors": [
     {

--- a/surfaces/analytics/package.json
+++ b/surfaces/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/analytics",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "Analytics surface for PEAC Protocol - metrics API with k-anonymity protection",
   "type": "module",

--- a/surfaces/nextjs/middleware/package.json
+++ b/surfaces/nextjs/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/middleware-nextjs",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "PEAC TAP verifier and 402 access gate for Next.js Edge Runtime",
   "type": "module",

--- a/surfaces/workers/akamai/package.json
+++ b/surfaces/workers/akamai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-akamai",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "PEAC receipt verification worker for Akamai EdgeWorkers",
   "type": "module",

--- a/surfaces/workers/cloudflare/package.json
+++ b/surfaces/workers/cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-cloudflare",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "PEAC receipt verification worker for Cloudflare Workers",
   "type": "module",

--- a/surfaces/workers/fastly/package.json
+++ b/surfaces/workers/fastly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peac/worker-fastly",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "private": true,
   "description": "PEAC receipt verification worker for Fastly Compute",
   "type": "module",

--- a/tests/tooling/package-surface-audit.test.ts
+++ b/tests/tooling/package-surface-audit.test.ts
@@ -98,11 +98,11 @@ describe('publish-manifest surface audit', () => {
     expect(manifest.totalPackages).toBe(V0_13_1_TARGET_COUNT);
   });
 
-  it('manifest version is either current release (0.14.1) or target (0.14.2)', () => {
+  it('manifest version is either current release (0.14.2) or target (0.14.3)', () => {
     // Version stamping belongs to release prep. Accept either the current
     // released value or the next-release target to keep the gate robust
     // across the release lifecycle.
-    expect(['0.14.1', '0.14.2']).toContain(manifest.version);
+    expect(['0.14.2', '0.14.3']).toContain(manifest.version);
   });
 
   it('totalPackages field matches packages[] length', () => {


### PR DESCRIPTION
## Summary

Prepares PEAC Protocol v0.14.3 release state.

This release includes:

- Agent Action Records
- Commerce Mandate Records
- Gateway Export Records
- ACP mapper boundary fixes
- runnable profile examples and operator recipes
- additive top-level `@peac/schema` exports for the new profile validators
- pre-release protobufjs override cleanup

## Release scope

This PR updates release state only:

- package versions to `0.14.3`
- `SERVER_VERSION`
- release facts and current release metadata
- kernel version metadata and generated kernel artifacts
- package-surface audit version window
- changelog entry
- v0.14.3 release notes
- publish manifest date
- lockfile changes from version bump

## Public surface

- Public API: additive only
- Wire format: unchanged
- Published package count: unchanged at 36
- Extension groups: 19
- Receipt types: 61
- Conformance requirement IDs: 290
- Conformance sections: 32

## Scope boundaries

This PR does not add or change:

- schema behavior
- type URIs
- error codes
- conformance semantics
- examples
- SOLUTIONS recipes
- CLI behavior
- dependencies beyond release-prep/version-bump lockfile effects
- publish/tag state

## Verification

- `git diff --check`
- `pnpm format:check`
- `bash scripts/ci/forbid-strings.sh`
- `pnpm verify:release`
- `pnpm examples:check`
- `pnpm exec tsx scripts/extract-api-contract.ts --check`
- `pnpm verify:codegen-drift`
- `pnpm verify:registries-schema`
- `pnpm verify:no-widening`
- `./scripts/guard.sh`
- `bash scripts/gate.sh`
- `pnpm test`
