### PR TITLE
chore(release): stamp v0.14.3 latest promotion

### DIFF
--- a/docs/releases/current.json
+++ b/docs/releases/current.json
@@ -2,7 +2,7 @@
   "description": "PEAC release manifest: CI-enforceable source of truth for release state",
   "version": "0.14.3",
   "wire_format_version": "0.2",
-  "dist_tag": "next",
+  "dist_tag": "latest",
   "registries_version": "0.6.0",
   "errors_version": "0.14.3"
 }

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -3,7 +3,7 @@
   "schema_version": "1.0.0",
   "version": "0.14.3",
   "wire_format_version": "0.2",
-  "dist_tag": "next",
+  "dist_tag": "latest",
   "release_date": "2026-05-17",
   "metrics": {
     "tests": 10635,


### PR DESCRIPTION
## Summary

Stamps v0.14.3 dist-tag promotion to `latest`.

Updates the mutable release-state fields after the npm `next -> latest`
promotion via `promote-latest.yml`:

- `docs/releases/facts.json::dist_tag`: `next -> latest`
- `docs/releases/current.json::dist_tag`: `next -> latest`

Generated via `scripts/stamp-release-state.mjs --promote`.

## Scope

This PR changes only:

- `docs/releases/facts.json`
- `docs/releases/current.json`

No source code, schema, or normative changes.

## Context

- v0.14.3 tag pushed: `fd33c66f`
- npm publish to `next`: succeeded
- npm promote to `latest`: succeeded
- npm dist-tags now: `{latest: 0.14.3, next: 0.14.3}` across all 36 packages

## Verification

- `pnpm format:check`
- `pnpm verify:release`
- `bash scripts/ci/forbid-strings.sh`
