### PR TITLE
chore(release): stamp REPO_SURFACE_STATUS updated for v0.14.3

### DIFF
--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable surface classification for PEAC Protocol workspace. CI fails if any workspace member is missing. See docs/PACKAGE_STATUS.md for human-readable view.",
   "version": "0.13.0",
-  "updated": "2026-05-08",
+  "updated": "2026-05-17",
   "states": {
     "default": "Current recommended path. Actively maintained, Wire 0.2 native.",
     "supported": "Actively maintained, published, production-ready. May not be on default quickstart path.",

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -2,7 +2,7 @@
 
 Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scripts/generate-surface-status.mjs`.
 
-**Version:** 0.13.0 | **Updated:** 2026-05-08
+**Version:** 0.13.0 | **Updated:** 2026-05-17
 
 ## Layer 1
 


### PR DESCRIPTION
## Summary

Stamps `REPO_SURFACE_STATUS.json::updated` and regenerated
`docs/SURFACE_STATUS.md` after the v0.14.3 release window.

Resolves the YELLOW from `verify-release-closeout --stage promote`
indicating `updated` was 227h old.

## Scope

This PR changes only:

- `REPO_SURFACE_STATUS.json`
- `docs/SURFACE_STATUS.md`

Date stamp only. No source code, schema, or normative changes.

## Verification

- `pnpm format:check`
- `pnpm verify:release`
- `node scripts/stamp-release-state.mjs --publish` (regenerates derived
  surface-status docs)
