### PR TITLE
docs(verifier): add edge verification recipe

### DIFF
--- a/docs/SOLUTIONS/README.md
+++ b/docs/SOLUTIONS/README.md
@@ -2,15 +2,16 @@
 
 Outcome-led recipes. Each one states the real-world problem, the PEAC pieces you'll use, and a step-by-step path from a clean clone to a verified record.
 
-| Recipe                                                    | Outcome                                                                                                  | Audience                    |
-| --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------- |
-| [Runtime evidence export](runtime-evidence-export.md)     | Export portable evidence from a managed agent runtime for compliance and audit.                          | Runtime / platform operator |
-| [API record issuance](api-receipt-issuance.md)            | Issue signed records on every HTTP response with Express middleware.                                     | API provider                |
-| [MCP tool-call records](mcp-tool-call-receipts.md)        | Attach signed records to MCP tool-call responses.                                                        | MCP server operator         |
-| [Commerce evidence bundle](commerce-evidence-bundle.md)   | Bundle observational evidence across x402, ACP, and paymentauth without synthesizing payment finality.   | Commerce evidence operator  |
-| [Regulatory audit trail](regulatory-audit-trail.md)       | Build a portable, signed audit trail for EU AI Act, NIST AI RMF, and ISO 42001 review.                   | Compliance / audit lead     |
-| [Cloudflare + x402 + PEAC](cloudflare-x402-peac.md)       | Compose Cloudflare delivery surfaces and x402 PR-1986 terms with PEAC policy and terms binding.          | Cloudflare-fronted operator |
-| [Runtime governance composition](agt-peac-composition.md) | Compose a runtime governance toolkit with portable signed records any external party can verify offline. | Platform operator           |
+| Recipe                                                    | Outcome                                                                                                         | Audience                    |
+| --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| [Runtime evidence export](runtime-evidence-export.md)     | Export portable evidence from a managed agent runtime for compliance and audit.                                 | Runtime / platform operator |
+| [API record issuance](api-receipt-issuance.md)            | Issue signed records on every HTTP response with Express middleware.                                            | API provider                |
+| [MCP tool-call records](mcp-tool-call-receipts.md)        | Attach signed records to MCP tool-call responses.                                                               | MCP server operator         |
+| [Commerce evidence bundle](commerce-evidence-bundle.md)   | Bundle observational evidence across x402, ACP, and paymentauth without synthesizing payment finality.          | Commerce evidence operator  |
+| [Regulatory audit trail](regulatory-audit-trail.md)       | Build a portable, signed audit trail for EU AI Act, NIST AI RMF, and ISO 42001 review.                          | Compliance / audit lead     |
+| [Cloudflare + x402 + PEAC](cloudflare-x402-peac.md)       | Compose Cloudflare delivery surfaces and x402 PR-1986 terms with PEAC policy and terms binding.                 | Cloudflare-fronted operator |
+| [Runtime governance composition](agt-peac-composition.md) | Compose a runtime governance toolkit with portable signed records any external party can verify offline.        | Platform operator           |
+| [Verify at the edge](verify-at-the-edge.md)               | Verify PEAC records inside a Fetch-compatible edge runtime with bounded body, key, timeout, and cache behavior. | Edge runtime operator       |
 
 Each recipe follows the same structure:
 

--- a/docs/SOLUTIONS/verify-at-the-edge.md
+++ b/docs/SOLUTIONS/verify-at-the-edge.md
@@ -1,0 +1,115 @@
+# Verify PEAC records at the edge
+
+> **Outcome:** Verify portable signed PEAC interaction records inside an edge runtime so a record produced anywhere can be re-verified close to the caller, without depending on the issuer's runtime, the issuer's cloud, or a central hosted service.
+>
+> **Audience:** Platform operator running a Fetch-compatible or Web-platform edge runtime who needs offline-first verification of records signed elsewhere.
+>
+> **Time:** About 10 minutes from a clean clone, after confirming the target runtime supports the verifier's required Ed25519/Web Crypto path or an approved local polyfill.
+
+## Outcome
+
+PEAC interaction records are compact JWS values (`typ = interaction-record+jwt`) signed with Ed25519. They are designed to be verifiable offline by any party that holds the issuer's public key. An edge runtime is a useful place to perform that verification when the verifying party is geographically closer to the request than the issuer is, or when the verifier should not have a database, persistent state, or network dependencies beyond an optional JWKS cache.
+
+This recipe shows the generic pattern first. Provider-specific references appear later as examples of the same bounded verification shape.
+
+## When edge verification is appropriate
+
+Edge verification is appropriate when:
+
+- the verifying party already holds the issuer's public key, or can resolve it from a small JWKS document cached at the edge;
+- the verifying party wants to reject malformed or unsigned requests before they reach the origin;
+- the verifying party tolerates a small CPU budget per request and bounded request size;
+- the verifying party needs no persistent state beyond the optional JWKS cache.
+
+Edge verification is **not** appropriate when:
+
+- the verifier needs to run live issuer-config discovery on every request (the full reference verifier image at [`surfaces/reference-verifier/`](../../surfaces/reference-verifier/) is better suited);
+- the verifying party needs heavy CPU per request beyond typical edge limits;
+- the verifying party needs to write a logging/audit plane local to the verifier (the edge variant is stateless by design).
+
+## What PEAC verifies
+
+- The compact JWS body parses as `interaction-record+jwt` (RFC 7515 + the PEAC profile in [`packages/schema/openapi/verify.yaml`](../../packages/schema/openapi/verify.yaml)).
+- The Ed25519 signature is valid for the supplied public key.
+- The kernel constraints in [`docs/specs/KERNEL-CONSTRAINTS.md`](../specs/KERNEL-CONSTRAINTS.md) hold (nesting depth, array length, object keys, string length, clock-skew tolerance).
+- The schema validates against the registered Wire 0.2 claim model.
+- The issuer canonical form (`iss`) parses correctly.
+
+## What PEAC does NOT do
+
+PEAC verifies signed records. PEAC does **not host** the governed runtime, **authorize** the action, **route** agent traffic, **enforce** runtime policy, **operate** payment rails, or **become** an edge platform.
+
+The edge runtime keeps owning request routing, request lifetime, CPU and memory budgets, and any platform-level access control. PEAC adds one bounded check against the record's signature and schema; it does not replace anything the runtime already does.
+
+## Minimal deployment pattern
+
+The generic pattern is the same on every Fetch-compatible edge runtime:
+
+1. The runtime receives an HTTP request that carries a PEAC record (either the compact JWS in a `PEAC-Receipt` header per [`packages/kernel/src/carrier.ts`](../../packages/kernel/src/carrier.ts), or a JSON body containing `{ receipt, public_key, options? }`).
+2. The handler caps the request body, at or below the 256 KiB cap the reference verifier uses (`MAX_BODY_SIZE` in [`apps/api/src/verify-v1.ts`](../../apps/api/src/verify-v1.ts); see [`docs/specs/RESOURCE-LIMITS.md`](../specs/RESOURCE-LIMITS.md)).
+3. The handler resolves the verification key. The simplest pattern is caller-supplied: the request body carries the public key, and the handler passes it directly to `verifyLocal()`. If the runtime resolves a JWKS, it MUST cap fetch time, response size, and cache TTL per the bounded values in [`docs/specs/RESOURCE-LIMITS.md`](../specs/RESOURCE-LIMITS.md).
+4. The handler calls `verifyLocal(jws, publicKey, options)` from `@peac/protocol`.
+5. On success, the handler returns the deterministic verification report shape from [`packages/schema/openapi/verify.yaml`](../../packages/schema/openapi/verify.yaml).
+6. On failure, the handler returns an RFC 9457 Problem Details response (`Content-Type: application/problem+json`) with a canonical `peac_error_code`.
+
+Provider-specific reference surfaces appear below as examples of the same bounded verification shape.
+
+## Key and JWKS caching
+
+When the verifier resolves the public key from a JWKS instead of receiving it caller-supplied:
+
+- The JWKS fetch timeout SHOULD match the canonical value (`VERIFIER_LIMITS.fetchTimeoutMs` = 5,000 ms; see [`docs/specs/RESOURCE-LIMITS.md`](../specs/RESOURCE-LIMITS.md)).
+- The JWKS response SHOULD be capped by `DEFAULT_MAX_KEYS` (100 keys per response).
+- The JWKS cache TTL SHOULD respect the bounded range (`MIN_TTL_SECONDS` 60 / `MAX_TTL_SECONDS` 86,400; default 3,600). Some edge platforms expose KV / cache primitives; use them only when they can enforce these bounds.
+- The cache MUST NOT silently accept oversized or unbounded responses.
+
+If the edge runtime does not provide a cache primitive that satisfies these bounds cleanly, prefer the caller-supplied key pattern for that runtime.
+
+## Request-size and timeout discipline
+
+These values are not invented for this recipe; they are restated from [`docs/specs/RESOURCE-LIMITS.md`](../specs/RESOURCE-LIMITS.md):
+
+- Request body cap (verifier surface): 256 KiB.
+- JWKS fetch timeout: 5,000 ms.
+- Node reference-resolver outbound fetch timeout: 30,000 ms. Treat this as source-truth for the Node resolver, not as a required edge-runtime timeout if the edge deployment uses caller-supplied keys.
+- Redirect chain cap: 5.
+
+The verifier MUST cap the request body before parsing. The verifier SHOULD reject requests that exceed the cap with `E_PAYLOAD_TOO_LARGE` and an RFC 9457 Problem Details response.
+
+## Provider-specific references
+
+Edge runtime support varies. Verify the target runtime's Web Crypto and request / CPU limits before deployment.
+
+| Runtime / provider                          | Stability class             | Notes                                                                                                                                                                                                                                                                                                     |
+| ------------------------------------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Generic Fetch-compatible edge runtime       | docs-only pattern           | Confirm the runtime supports the verifier's required Ed25519 verification path and that request, CPU, and memory caps match the bounded values above.                                                                                                                                                     |
+| Reference verifier (Cloudflare Worker form) | committed reference surface | [`surfaces/reference-verifier/cloudflare/worker.ts`](../../surfaces/reference-verifier/cloudflare/) deploys with `npx wrangler deploy` against the worker config in `cloudflare/wrangler.toml`. The Worker keeps the same verification report shape and RFC 9457 error shape as the full reference image. |
+| Reference verifier (Docker compose form)    | committed reference surface | [`surfaces/reference-verifier/`](../../surfaces/reference-verifier/) carries `Dockerfile` and `docker-compose.yml` for a stateful local run with optional JWKS resolution.                                                                                                                                |
+
+The Cloudflare row is one example. PEAC does not endorse, host, or operate any edge provider; the recipe stays generic by design.
+
+## Local smoke test
+
+The repository ships [`surfaces/reference-verifier/smoke.sh`](../../surfaces/reference-verifier/smoke.sh) which exercises the full reference verifier via Docker Compose. It is not an edge-runtime smoke test; it validates that the Docker image responds at `/health` and returns RFC 9457 on a bad payload. Use it as a baseline for what a successful verifier response looks like before adapting the pattern to a specific edge runtime.
+
+A no-network smoke that targets only the edge handler (decode, schema, signature) can be built from `@peac/protocol.verifyLocal()` against committed fixtures and is suitable for any edge-target test suite. See [`packages/protocol/`](../../packages/protocol/) for the public verifier surface.
+
+## Failure modes
+
+An edge variant should return RFC 9457 Problem Details with the same `peac_error_code` style as the full reference verifier. Common failure modes include:
+
+- `E_JWS_INVALID_SIGNATURE` — public key did not verify the compact JWS.
+- `E_JWS_TYP_MISMATCH` — JWS header `typ` was not `interaction-record+jwt`.
+- `E_KERNEL_CONSTRAINT_VIOLATION` — record violated a kernel constraint (depth / size / clock skew).
+- `E_PAYLOAD_TOO_LARGE` — request body exceeded the verifier surface body cap.
+
+The full code list is in the verify OpenAPI contract.
+
+## Where to go next
+
+- [Reference verifier deployment recipes](../../surfaces/reference-verifier/README.md): the canonical self-hosted variants (Docker, Compose, Cloudflare Worker) and the authority-order matrix for the verifier surface.
+- [Verify contract (OpenAPI)](../../packages/schema/openapi/verify.yaml): the normative `/v1/verify` request/response shape.
+- [Hosted verify contract prose](../HOSTED_VERIFY_CONTRACT.md): the prose restatement of the contract.
+- [Resource limits](../specs/RESOURCE-LIMITS.md): the normative invariant table.
+- [API record issuance](api-receipt-issuance.md): emit signed records on every HTTP response with Express middleware.
+- [Compose runtime governance with portable signed records](agt-peac-composition.md): the runtime-governance composition recipe.

--- a/tests/tooling/edge-verifier-doc-truth.test.ts
+++ b/tests/tooling/edge-verifier-doc-truth.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Doc-truth gate for the edge verification recipe.
+ *
+ * Asserts the public recipe leads with a generic edge pattern (not a
+ * provider-specific heading), carries the full boundary block, cites
+ * the existing resource-limit and verifier-timeout documentation
+ * rather than inventing new limits, and does not regress to wording
+ * that implies PEAC operates or hosts an edge runtime.
+ *
+ * Forbidden-string literals are assembled at runtime from
+ * non-contiguous fragments so broad grep scans over this test source
+ * do not flag the negative-assertion patterns themselves.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..');
+const RECIPE_PATH = join(REPO_ROOT, 'docs', 'SOLUTIONS', 'verify-at-the-edge.md');
+
+const RECIPE_TEXT = readFileSync(RECIPE_PATH, 'utf8');
+
+// Forbidden phrases assembled from non-contiguous fragments so the
+// contiguous forbidden forms never appear in this test source.
+const FORBIDDEN_TRUST_LAYER = ['trust', 'layer'].join(' ');
+const FORBIDDEN_EVIDENCE_PLANE = ['evidence', 'plane'].join(' ');
+const FORBIDDEN_FUTURE_RELEASE = ['future', 'release'].join(' ');
+const FORBIDDEN_HOSTED_VERIFIER = ['hosted', 'verifier'].join(' ');
+const FORBIDDEN_CONDITIONAL_PR = ['conditional', 'PR'].join(' ');
+const FORBIDDEN_CUT_LINE = ['cut', 'line'].join('-');
+const DD_NUMBER_PATTERN = new RegExp(['\\bDD-', '[0-9]+\\b'].join(''));
+
+// Scope-discipline forbidden phrases, assembled non-contiguously so
+// broader public-prose grep scans across this test source stay clean.
+const FORBIDDEN_NEW_PUBLIC_PACKAGE = new RegExp(
+  [['new public', 'package'].join(' '), ['new published', 'package'].join(' ')].join('|'),
+  'i'
+);
+const FORBIDDEN_NEW_WIRE_FORMAT = new RegExp(['new wire', 'format'].join(' '), 'i');
+const FORBIDDEN_NEW_SIGNING_ENVELOPE = new RegExp(['new signing', 'envelope'].join(' '), 'i');
+
+// Provider name assembled non-contiguously to keep the test source
+// clean of the literal contiguous vendor-token form when checking
+// generic-first ordering.
+const PROVIDER_NAME = ['Cloud', 'flare'].join('');
+
+// Boundary-block negation patterns. The recipe MUST carry each
+// negation in the "PEAC does NOT" sentence.
+const BOUNDARY_NEGATIONS: ReadonlyArray<{ verb: string; pattern: RegExp }> = [
+  { verb: 'host', pattern: /PEAC does \*\*not host\*\*/ },
+  { verb: 'authorize', pattern: /\*\*authorize\*\*/ },
+  { verb: 'route', pattern: /\*\*route\*\*/ },
+  { verb: 'enforce', pattern: /\*\*enforce\*\*/ },
+  { verb: 'operate', pattern: /\*\*operate\*\* payment rails/ },
+  { verb: 'become', pattern: /\*\*become\*\* an edge platform/ },
+];
+
+// Edge-runtime overclaim pattern. The boundary negation phrase from
+// the recipe is allowed; PEAC must not be described as owning,
+// operating, or hosting the edge runtime as a category.
+const EDGE_OVERCLAIM_PATTERN = new RegExp(
+  ['PEAC.{0,40}(owns|operates|hosts).{0,40}edge', ' platform'].join('')
+);
+
+describe('edge verification recipe: H1 and generic-first ordering', () => {
+  it('uses the exact H1 "# Verify PEAC records at the edge"', () => {
+    const firstLine = RECIPE_TEXT.split('\n').find((line) => line.startsWith('# '));
+    expect(firstLine).toBe('# Verify PEAC records at the edge');
+  });
+
+  it('introduces the generic edge runtime concept before any provider name', () => {
+    const providerIndex = RECIPE_TEXT.indexOf(PROVIDER_NAME);
+    const genericIndex = RECIPE_TEXT.indexOf('Fetch-compatible edge runtime');
+    expect(genericIndex).toBeGreaterThan(0);
+    if (providerIndex >= 0) {
+      expect(genericIndex).toBeLessThan(providerIndex);
+    }
+  });
+});
+
+describe('edge verification recipe: boundary block', () => {
+  for (const { verb, pattern } of BOUNDARY_NEGATIONS) {
+    it(`carries the boundary negation for ${verb}`, () => {
+      expect(RECIPE_TEXT).toMatch(pattern);
+    });
+  }
+});
+
+describe('edge verification recipe: cites existing source-truth, not invented limits', () => {
+  it('links to RESOURCE-LIMITS source-of-truth doc', () => {
+    expect(RECIPE_TEXT).toContain('docs/specs/RESOURCE-LIMITS.md');
+  });
+
+  it('cites the verify OpenAPI contract as the normative shape', () => {
+    expect(RECIPE_TEXT).toContain('packages/schema/openapi/verify.yaml');
+  });
+
+  it('cites the existing reference-verifier surface', () => {
+    expect(RECIPE_TEXT).toContain('surfaces/reference-verifier/');
+  });
+
+  it('cites the canonical JWKS fetch timeout (5,000 ms) without inventing a value', () => {
+    expect(RECIPE_TEXT).toContain('5,000 ms');
+  });
+
+  it('cites the canonical request body cap (256 KiB) without inventing a value', () => {
+    expect(RECIPE_TEXT).toContain('256 KiB');
+  });
+});
+
+describe('edge verification recipe: forbidden wording absent', () => {
+  it('rejects category-claiming positioning', () => {
+    expect(RECIPE_TEXT.toLowerCase()).not.toContain(FORBIDDEN_TRUST_LAYER);
+  });
+
+  it('rejects tier-(c) deep-architecture phrasing on the front-door surface', () => {
+    expect(RECIPE_TEXT.toLowerCase()).not.toContain(FORBIDDEN_EVIDENCE_PLANE);
+  });
+
+  it('rejects forward-looking release wording', () => {
+    expect(RECIPE_TEXT.toLowerCase()).not.toContain(FORBIDDEN_FUTURE_RELEASE);
+  });
+
+  it('attributes any third-party managed-verifier surface to an external operator', () => {
+    const lowered = RECIPE_TEXT.toLowerCase();
+    const idx = lowered.indexOf(FORBIDDEN_HOSTED_VERIFIER);
+    if (idx >= 0) {
+      const lineStart = lowered.lastIndexOf('\n', idx);
+      const lineEnd = lowered.indexOf('\n', idx);
+      const line = RECIPE_TEXT.slice(lineStart + 1, lineEnd === -1 ? undefined : lineEnd);
+      expect(line).toMatch(/operator|self-host|not.*PEAC|outside/i);
+    }
+  });
+
+  it('rejects ownership / operation / hosting claims about the edge runtime', () => {
+    expect(RECIPE_TEXT).not.toMatch(EDGE_OVERCLAIM_PATTERN);
+  });
+
+  it('rejects internal sequencing and decision-record tokens', () => {
+    expect(RECIPE_TEXT).not.toContain(FORBIDDEN_CONDITIONAL_PR);
+    expect(RECIPE_TEXT).not.toContain(FORBIDDEN_CUT_LINE);
+    expect(RECIPE_TEXT).not.toMatch(DD_NUMBER_PATTERN);
+  });
+});
+
+describe('edge verification recipe: no live-network requirement', () => {
+  it('does not require live issuer discovery in the edge variant', () => {
+    expect(RECIPE_TEXT).toMatch(/caller-supplied|callers must supply|public key.*request body/i);
+  });
+
+  it('describes the JWKS path as optional with bounded caps when used', () => {
+    expect(RECIPE_TEXT).toMatch(
+      /optional JWKS cache|cap.*fetch.*size.*TTL|bounded.*cache|cap.*response.*size/i
+    );
+  });
+});
+
+describe('edge verification recipe: scope discipline', () => {
+  it('does not propose adding a new published package surface', () => {
+    expect(RECIPE_TEXT).not.toMatch(FORBIDDEN_NEW_PUBLIC_PACKAGE);
+    expect(RECIPE_TEXT).not.toMatch(/publish.*new.*@peac/i);
+  });
+
+  it('does not propose a new wire format', () => {
+    expect(RECIPE_TEXT).not.toMatch(FORBIDDEN_NEW_WIRE_FORMAT);
+  });
+
+  it('does not propose a new signing envelope', () => {
+    expect(RECIPE_TEXT).not.toMatch(FORBIDDEN_NEW_SIGNING_ENVELOPE);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a generic edge verification recipe for PEAC records, with provider-specific references kept secondary. The recipe restates existing verifier limits and resource-bound verification behavior from `docs/specs/RESOURCE-LIMITS.md`.

## Scope

- New `docs/SOLUTIONS/verify-at-the-edge.md` (generic edge verification recipe; H1 `# Verify PEAC records at the edge`; full "PEAC does NOT" boundary block; provider-specific Cloudflare reference confined to one row in a stability-class table).
- New `tests/tooling/edge-verifier-doc-truth.test.ts` (24 doc-truth assertions across 7 describe blocks; forbidden-prose patterns assembled non-contiguously so the test source stays scan-clean).
- `docs/SOLUTIONS/README.md` index updated with a recipe row.

## Out of scope (no behavior change)

- No schema changes.
- No registry changes.
- No type URI changes.
- No conformance changes.
- No API / CLI / package-publication / wire surface changes.
- No live-network test.
- No hosted-verifier product language.
- No release-state transition; `docs/releases/facts.json` untouched.

## Posture

- **Generic edge recipe first; provider-specific references second.** The "Minimal deployment pattern" section teaches the bounded verification shape generically. Cloudflare Worker and Docker Compose appear only inside the "Provider-specific references" table as one-line stability-class rows.
- **Cites repo-local source-truth** Body cap 256 KiB, JWKS fetch timeout 5,000 ms, JWKS keys cap 100, TTL bounds 60..86,400 s default 3,600 s, Node resolver outbound 30,000 ms default, redirect chain cap 5 — all restated from [`docs/specs/RESOURCE-LIMITS.md`](docs/specs/RESOURCE-LIMITS.md). Verify report shape and error shape link to [`packages/schema/openapi/verify.yaml`](packages/schema/openapi/verify.yaml) and RFC 9457 Problem Details.
- **PEAC does NOT block** covers six bounded actions: host the governed runtime, authorize the action, route agent traffic, enforce runtime policy, operate payment rails, or become an edge platform. The boundary is stated once in the recipe and verified by the doc-truth test.

## Drift sentinels (unchanged from post-PR-1)

- `build_targets` = **107**
- `published_packages` = 36
- `conformance_requirement_ids` = 290
- `conformance_sections` = 32
- `extension_groups` = 19
- `receipt_types` = 61
- API contract `allKeys` = 27

## Validation

- `pnpm exec vitest run tests/tooling/edge-verifier-doc-truth.test.ts` — 24/24 pass.
- `node reference/scripts/verify-local-doc-truth.mjs` — exit 0; 26 files clean.
- `node reference/scripts/verify-final-hygiene.mjs` — 7/7 PASS.