### PR TITLE
docs(execution): add evaluation and harness record recipes

### DIFF
--- a/docs/SOLUTIONS/README.md
+++ b/docs/SOLUTIONS/README.md
@@ -2,16 +2,18 @@
 
 Outcome-led recipes. Each one states the real-world problem, the PEAC pieces you'll use, and a step-by-step path from a clean clone to a verified record.
 
-| Recipe                                                    | Outcome                                                                                                         | Audience                    |
-| --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | --------------------------- |
-| [Runtime evidence export](runtime-evidence-export.md)     | Export portable evidence from a managed agent runtime for compliance and audit.                                 | Runtime / platform operator |
-| [API record issuance](api-receipt-issuance.md)            | Issue signed records on every HTTP response with Express middleware.                                            | API provider                |
-| [MCP tool-call records](mcp-tool-call-receipts.md)        | Attach signed records to MCP tool-call responses.                                                               | MCP server operator         |
-| [Commerce evidence bundle](commerce-evidence-bundle.md)   | Bundle observational evidence across x402, ACP, and paymentauth without synthesizing payment finality.          | Commerce evidence operator  |
-| [Regulatory audit trail](regulatory-audit-trail.md)       | Build a portable, signed audit trail for EU AI Act, NIST AI RMF, and ISO 42001 review.                          | Compliance / audit lead     |
-| [Cloudflare + x402 + PEAC](cloudflare-x402-peac.md)       | Compose Cloudflare delivery surfaces and x402 PR-1986 terms with PEAC policy and terms binding.                 | Cloudflare-fronted operator |
-| [Runtime governance composition](agt-peac-composition.md) | Compose a runtime governance toolkit with portable signed records any external party can verify offline.        | Platform operator           |
-| [Verify at the edge](verify-at-the-edge.md)               | Verify PEAC records inside a Fetch-compatible edge runtime with bounded body, key, timeout, and cache behavior. | Edge runtime operator       |
+| Recipe                                                           | Outcome                                                                                                                          | Audience                     |
+| ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| [Runtime evidence export](runtime-evidence-export.md)            | Export portable evidence from a managed agent runtime for compliance and audit.                                                  | Runtime / platform operator  |
+| [API record issuance](api-receipt-issuance.md)                   | Issue signed records on every HTTP response with Express middleware.                                                             | API provider                 |
+| [MCP tool-call records](mcp-tool-call-receipts.md)               | Attach signed records to MCP tool-call responses.                                                                                | MCP server operator          |
+| [Commerce evidence bundle](commerce-evidence-bundle.md)          | Bundle observational evidence across x402, ACP, and paymentauth without synthesizing payment finality.                           | Commerce evidence operator   |
+| [Regulatory audit trail](regulatory-audit-trail.md)              | Build a portable, signed audit trail for EU AI Act, NIST AI RMF, and ISO 42001 review.                                           | Compliance / audit lead      |
+| [Cloudflare + x402 + PEAC](cloudflare-x402-peac.md)              | Compose Cloudflare delivery surfaces and x402 PR-1986 terms with PEAC policy and terms binding.                                  | Cloudflare-fronted operator  |
+| [Runtime governance composition](agt-peac-composition.md)        | Compose a runtime governance toolkit with portable signed records any external party can verify offline.                         | Platform operator            |
+| [Verify at the edge](verify-at-the-edge.md)                      | Verify PEAC records inside a Fetch-compatible edge runtime with bounded body, key, timeout, and cache behavior.                  | Edge runtime operator        |
+| [Record evaluation-platform events](eval-platform-records.md)    | Emit portable signed records for evaluation, experiment, and result-artifact events reported by an external evaluation platform. | Evaluation-platform operator |
+| [Issue harness execution records](harness-records-quickstart.md) | Emit portable signed records for each bounded harness run using the existing CLI execution and agent-action surfaces.            | Harness / CI operator        |
 
 Each recipe follows the same structure:
 

--- a/docs/SOLUTIONS/eval-platform-records.md
+++ b/docs/SOLUTIONS/eval-platform-records.md
@@ -1,0 +1,132 @@
+# Record evaluation-platform events
+
+> **Outcome:** An external evaluation platform, evaluation runner, or experimentation system runs an evaluation, records a result artifact, or assigns a subject to an experiment. You want each observed event to leave the platform as a portable signed PEAC record that any downstream reviewer can verify offline, without calling the platform that produced it.
+>
+> **Audience:** Evaluation-platform operator or evaluator integrator who already runs the evaluation and wants portable signed evidence of what the platform reported.
+>
+> **Time:** About 5 minutes from a clean clone, using the shipped lifecycle-observation profile and the existing `peac emit lifecycle` CLI.
+
+## The problem
+
+Evaluation platforms (open-source evaluation runners, internal evaluation frameworks, experimentation systems, model-quality benchmark runners) already keep their own logs of every evaluation: which subject was evaluated, when the evaluation started and completed, which rubric or experiment variant applied, where the stored result lives. Those logs are private to the platform. A reviewer outside the platform has no portable way to verify a report that "evaluation X completed at time T with result-artifact ref R" without trusting the platform's read-only view of its own logs.
+
+PEAC turns each observed event into a signed record under the existing `org.peacprotocol/lifecycle-observation` extension namespace (v0.14.1; see [`docs/specs/LIFECYCLE-OBSERVATION-PROFILE.md`](../specs/LIFECYCLE-OBSERVATION-PROFILE.md)). Evaluation, scoring, experiment assignment, result generation, and rubric authorship remain upstream responsibilities. PEAC produces a portable, signed record of what the platform reported observing.
+
+This recipe walks through emitting and verifying those records using existing CLI and profile surfaces. No new schema, no new type URI, no new public API, no new package.
+
+## What PEAC records (and what it does NOT)
+
+PEAC records what the evaluation platform reported. The supported event kinds (existing v0.14.1 lifecycle profile) are:
+
+| Event kind                       | Type URI                                          | Required additional fields                  |
+| -------------------------------- | ------------------------------------------------- | ------------------------------------------- |
+| `lifecycle-evaluation-started`   | `org.peacprotocol/lifecycle-evaluation-started`   | (none beyond `subject_ref` + `observed_at`) |
+| `lifecycle-evaluation-completed` | `org.peacprotocol/lifecycle-evaluation-completed` | `result_ref` (OpaqueRef)                    |
+| `lifecycle-experiment-assigned`  | `org.peacprotocol/lifecycle-experiment-assigned`  | `experiment_ref` (OpaqueRef)                |
+| `lifecycle-experiment-result`    | `org.peacprotocol/lifecycle-experiment-result`    | `experiment_ref`, `result_ref`              |
+
+Each event kind is record-only. The record carries opaque refs and optional canonical digests; raw evaluation values, score values, rubric contents, and experiment configurations are never inlined. The no-inline-value invariant (grammar-based, see lifecycle profile §5) blocks accidental inclusion of `score`, `metric`, `value`, `result_value`, and 16 other forbidden top-level keys with the stable error `lifecycle.inline_value_blocked`.
+
+PEAC does **NOT**:
+
+- run evaluations
+- score model quality
+- certify model safety
+- operate the harness
+- decide benchmark pass / fail truth
+- replace evaluator logs
+- authorize deployment
+- create training-data provenance
+
+The evaluation platform owns rubric authorship, scoring logic, experiment configuration, result storage, dashboards, and any compliance attestation. PEAC adds one bounded, portable signed record per observed event; it does not become the platform.
+
+## What you'll use
+
+PEAC packages and CLI surfaces (all existing; no new public surface):
+
+- [`@peac/cli`](https://www.npmjs.com/package/@peac/cli): the `peac emit lifecycle` subcommand (issuance path shipped in v0.14.1).
+- [`@peac/schema`](https://www.npmjs.com/package/@peac/schema): `validateLifecycleObservation`, `LIFECYCLE_OBSERVATION_EXTENSION_KEY`, `LIFECYCLE_OBSERVATION_TYPE_URIS`.
+- [`@peac/protocol`](https://www.npmjs.com/package/@peac/protocol): offline verification via `verifyLocal()`.
+
+Prerequisites: Node 22+, pnpm 8+. No external service, no network call, no harness install.
+
+## Generic first: the bounded shape
+
+The generic pattern is the same for every evaluation platform:
+
+1. The platform observes an evaluation event (started, completed, experiment assignment, experiment result).
+2. The integrator calls `peac emit lifecycle` with caller-supplied flags. `--observed-at` is REQUIRED and reports the time the EXTERNAL platform observed the event (the wrapper does not silently default to the wrapper-invocation time).
+3. The CLI validates the extension content through `validateLifecycleObservation`, signs an interaction record using the caller-provided issuer key, and writes a compact JWS whose JOSE header `typ` is `interaction-record+jwt`.
+4. Any downstream reviewer with the issuer's public key can verify the record offline via `verifyLocal()`. No call to the evaluation platform is needed; no platform credential is required.
+
+Step-by-step:
+
+1. Install dependencies, build the workspace, and create the output directory the CLI will write into. The CLI's output preflight requires the parent directory to exist before it writes.
+
+   ```bash
+   pnpm install
+   pnpm build
+   mkdir -p out
+   ```
+
+2. Emit a signed record for an evaluation-started observation, using the ephemeral signing flag so the command runs from a clean clone. The caller already knows when the external evaluation platform observed the event; pass it through `--observed-at`. The `pnpm --filter @peac/cli exec` form sets the CLI's working directory to `packages/cli`, so the `--output` path is interpolated with `$PWD` (the caller's working directory) to keep records under `out/` at the workspace root.
+
+   ```bash
+   pnpm --filter @peac/cli exec node dist/index.cjs emit lifecycle \
+     --event-kind lifecycle-evaluation-started \
+     --subject-ref urn:peac:eval:run-001 \
+     --observed-at 2026-05-18T10:00:00Z \
+     --rubric-ref urn:peac:rubric:helpfulness-v3 \
+     --unsafe-ephemeral-key \
+     --issuer-id https://eval.example.com \
+     --output "$PWD/out/eval-started.jws"
+   ```
+
+   `--unsafe-ephemeral-key` generates an ephemeral local signing key whose public key is not published through normal issuer-key discovery. The flag is suitable for local development and tests only. For external verification, swap `--unsafe-ephemeral-key` for `--issuer-key env:PEAC_ISSUER_KEY` (or `file:/path/to/jwk.json`) and publish the public key through the operator's normal issuer-key path; the corresponding `--issuer-id` MUST remain the canonical issuer URL recorded as `iss`.
+
+3. Emit a signed record for an evaluation-completed observation. `--result-ref` points at the stored result artifact via an opaque reference; `--result-digest` carries the canonical sha256 digest of that artifact. The result value itself is never inlined.
+
+   ```bash
+   pnpm --filter @peac/cli exec node dist/index.cjs emit lifecycle \
+     --event-kind lifecycle-evaluation-completed \
+     --subject-ref urn:peac:eval:run-001 \
+     --observed-at 2026-05-18T10:05:30Z \
+     --result-ref urn:peac:eval-result:run-001 \
+     --result-digest sha256:1111111111111111111111111111111111111111111111111111111111111111 \
+     --unsafe-ephemeral-key \
+     --issuer-id https://eval.example.com \
+     --output "$PWD/out/eval-completed.jws"
+   ```
+
+4. (Optional inspection only; not required quickstart) Conformance requirement IDs for the lifecycle-observation profile are declared at [`specs/conformance/requirement-ids.json`](../../specs/conformance/requirement-ids.json) under section "Lifecycle Observation Records" (LIFE-OBS-001..LIFE-OBS-010). Read the JSON directly if a structured view is helpful; no additional tooling is required.
+
+5. Verify the records offline as a downstream reviewer. Save the issuer's public key and the signed records anywhere off-host; from any environment that can run `@peac/protocol`, call `verifyLocal()` on each record with the issuer's public key. The verifier returns the canonical record contents plus the reported lifecycle event kind; no call to the evaluation platform is needed. Ephemeral-key records signed in steps 2 and 3 will not verify across a reviewer who does not hold the ephemeral public key; for external verification, use a stable issuer key per the caveat in step 2.
+
+## Provider-specific notes
+
+Provider references appear here only as examples of the same bounded shape; the recipe does not depend on any of them. The integrator runs the upstream evaluation, scoring, and result storage; PEAC provides one bounded signed-record surface.
+
+- Internal evaluation runners (custom Python / TypeScript / Go evaluators) emit lifecycle observations by invoking `peac emit lifecycle` from a wrapper hook that runs after each evaluation step. The runner retains its own log; PEAC adds a portable receipt next to it.
+- Open-source evaluation runners (community-maintained evaluation runners that already produce structured per-run JSON) hand each per-run JSON to a small post-step script that pulls `subject_ref`, `observed_at`, and `result_ref` from the run record and calls the CLI. PEAC does not parse the runner's internal score schema.
+- Experimentation platforms emit `lifecycle-experiment-assigned` when a subject is bound to a cohort / variant, and `lifecycle-experiment-result` when an experiment outcome lands; both URIs carry only opaque refs.
+
+## Composition discipline (lifecycle-observation profile §8)
+
+PEAC may record lifecycle transitions emitted by orchestrators, workflow engines, evaluation systems, approval systems, or agent runtimes. PEAC does not assign work, run agents, schedule tasks, manage issue trackers, route approvals, decide step ordering, or enforce workflow policy. The orchestrator (or workflow engine, evaluation system, approval system, or agent runtime) is the subject of the observation, never an output of PEAC. The `observed_mode` enum is descriptive only; PEAC does not classify modes algorithmically.
+
+The grammar-based no-inline-value invariant blocks accidental drift: any attempt to inline a score, metric, rubric body, raw experiment value, or other forbidden top-level key rejects with the stable error `lifecycle.inline_value_blocked`. Any `*_ref` field that is not a string rejects with `lifecycle.ref_must_be_string`; any opaque-reference field that violates the recognized-prefix grammar rejects with `lifecycle.opaque_ref_grammar_violation`.
+
+## Composition with OpenTelemetry
+
+When the evaluation platform already publishes OpenTelemetry spans for each evaluation step, the integrator may add a local correlation attribute such as `peac.record.ref` that points to the PEAC record. This is implementation-local and informative only; PEAC does not define an OTel semantic convention, ship an exporter, or require an OTel SDK. The lifecycle-observation profile §7 covers this as informative composition guidance; the evaluation platform's OTel surface remains untouched.
+
+## Evidence of output
+
+A successful `peac emit lifecycle` invocation prints a single compact JWS. Verifying that JWS with `verifyLocal()` returns a deterministic report whose `claims.extensions["org.peacprotocol/lifecycle-observation"]` contains exactly the fields the caller supplied. No inlined value appears; only opaque refs and optional canonical digests.
+
+## Where to go from here
+
+- [`docs/specs/LIFECYCLE-OBSERVATION-PROFILE.md`](../specs/LIFECYCLE-OBSERVATION-PROFILE.md): full normative profile (event kinds, field grammar, conformance Section 30 LIFE-OBS-001..010).
+- [Issue harness execution records](harness-records-quickstart.md): the companion recipe for deterministic harness runs emitting `org.peacprotocol/agent-action` records.
+- [Compatibility matrix](../COMPATIBILITY_MATRIX.md): adapter-readiness rows and stability classes.
+- [Verify agent-action records](verify-agent-action.md): downstream verification recipe for agent-action records, applicable to lifecycle records as well via the same `verifyLocal()` path.

--- a/docs/SOLUTIONS/harness-records-quickstart.md
+++ b/docs/SOLUTIONS/harness-records-quickstart.md
@@ -1,0 +1,136 @@
+# Issue harness execution records
+
+> **Outcome:** A deterministic harness (CI pipeline, justfile target, build-tool hook, agent harness) runs a bounded unit of work. You want a portable signed PEAC record of each bounded execution that any downstream reviewer can verify offline, without depending on the CI service, the runner, or the harness implementation.
+>
+> **Audience:** Harness operator, build-tool integrator, or CI pipeline owner who already controls execution and wants portable signed evidence of each bounded run.
+>
+> **Time:** About 5 minutes from a clean clone, using the existing `peac record command` CLI surface and the existing agent-action profile.
+
+## The canonical framing
+
+> **Harnesses control execution. PEAC records bounded work. Logs stay local; PEAC records travel.**
+
+The harness decides what to run, when to run it, and how to retry. PEAC records what the harness reported about each bounded run, signs it with the caller's issuer key, and emits a portable record any downstream party can verify offline. The two layers compose; they do not replace one another.
+
+## The problem
+
+Deterministic harnesses already produce rich local logs: stdout, stderr, exit codes, timing, environment fingerprints. Those logs are valuable inside the operator's infrastructure. Outside the operator's infrastructure, an auditor, customer, downstream reviewer, or compliance team has no portable way to confirm that a specific bounded run happened, with a specific argv, against a specific binary digest, at a specific time, without trusting the operator's read-only view of its own logs.
+
+PEAC records each bounded unit of work as a signed interaction record. The record uses an existing extension namespace and an existing CLI surface; the harness keeps owning execution.
+
+## What PEAC records (and what it does NOT)
+
+PEAC supports two existing record families for harness work:
+
+- **CLI execution records** (`org.peacprotocol/cli-execution`, v0.14.1, [`docs/specs/CLI-CARRIER-PROFILE.md`](../specs/CLI-CARRIER-PROFILE.md)). One record per bounded command execution: a signed observation of argv (hashed by default), stdin / stdout / stderr captures (length + sha256 + truncated sample by default), exit status, elapsed time, and an opaque binary digest. The bounded harness step emits one record per run.
+- **Agent action records** (`org.peacprotocol/agent-action`, v0.14.3, [`docs/specs/AGENT-ACTION-RECORDS.md`](../specs/AGENT-ACTION-RECORDS.md)). One record per observed action event (invoked / delegated / approved / denied / cancelled / timed-out). Useful when the bounded run is itself an agent invocation rather than a generic command.
+
+Both record families have an OBSERVER scope: the record reports what the harness observed; the harness owns execution.
+
+PEAC does **NOT**:
+
+- run evaluations
+- score model quality
+- certify model safety
+- operate the harness
+- decide benchmark pass / fail truth
+- replace evaluator logs
+- authorize deployment
+- create training-data provenance
+
+The harness, the CI runner, the build tool, the secret manager, the artifact store, the dashboard, and the rerun policy all stay where they are. PEAC records what the harness attested; it does not become the harness.
+
+## What you'll use
+
+PEAC packages and CLI surfaces (all existing; no new public surface):
+
+- [`@peac/cli`](https://www.npmjs.com/package/@peac/cli): `peac record command` (v0.14.1 CLI execution records); `peac emit lifecycle` (v0.14.1 lifecycle observations).
+- [`@peac/schema`](https://www.npmjs.com/package/@peac/schema): `validateAgentAction`, `validateLifecycleObservation`, the canonical extension keys.
+- [`@peac/protocol`](https://www.npmjs.com/package/@peac/protocol): issuance and offline verification.
+
+Prerequisites: Node 22+, pnpm 8+. No external service, no network call, no managed-runtime install.
+
+## Generic first: bounded execution shape
+
+The generic pattern is the same on every deterministic harness:
+
+1. The harness picks a bounded unit of work (a command, a test invocation, a build step, an agent call).
+2. The harness wraps the bounded step with `peac record command -- <bounded command>`.
+3. The wrapper spawns the command exactly as supplied (`shell: false`); it does not modify the command, the environment, or the working directory beyond what the caller passed.
+4. After the bounded run completes, the wrapper emits one signed interaction record whose JOSE header `typ` is `interaction-record+jwt`. The record carries the command observation (argv-hash, stdin/stdout/stderr metadata, exit code, elapsed time, binary digest) under the `org.peacprotocol/cli-execution` extension key.
+5. Any downstream reviewer with the issuer's public key can verify the record offline via `verifyLocal()`. No call to the CI service, runner, or operator is needed.
+
+Step-by-step:
+
+1. Install dependencies, build the workspace, and create the output directory the CLI will write into. The CLI's output preflight requires the parent directory to exist before it writes.
+
+   ```bash
+   pnpm install
+   pnpm build
+   mkdir -p out
+   ```
+
+2. Wrap one bounded harness step locally with the ephemeral signing flag so the command runs from a clean clone. The example below records a single bounded invocation; replace the trailing command with whatever bounded step the harness runs. The `pnpm --filter @peac/cli exec` form sets the CLI's working directory to `packages/cli`, so the `--output` path is interpolated with `$PWD` (the caller's working directory) to keep records under `out/` at the workspace root.
+
+   ```bash
+   pnpm --filter @peac/cli exec node dist/index.cjs record command \
+     --capture-mode hashed \
+     --capture-stdin-mode none \
+     --unsafe-ephemeral-key \
+     --issuer-id https://harness.example.com \
+     --output "$PWD/out/test-run.jws" \
+     -- node -e "console.log('bounded step ok')"
+   ```
+
+   `--unsafe-ephemeral-key` generates an ephemeral local signing key whose public key is not published through normal issuer-key discovery. The flag is suitable for local development and tests only. For external verification, swap `--unsafe-ephemeral-key` for `--issuer-key env:PEAC_ISSUER_KEY` (or `file:/path/to/jwk.json`) and publish the public key through the operator's normal issuer-key path; the corresponding `--issuer-id` MUST remain the canonical issuer URL recorded as `iss`.
+
+   The wrapper observes argv, stdin, stdout, stderr, exit code, elapsed time, and a binary digest under the operator's chosen capture-mode defaults (hashed argv, no stdin capture, length + sha256 + truncated sample for stdout / stderr). Raw capture requires DOUBLE opt-in (`--capture-mode raw` AND `--unsafe-allow-raw-capture`); raw env capture requires DOUBLE opt-in (`--env-mode raw` AND `--unsafe-allow-raw-env`).
+
+3. (Optional, illustrative shape only) When the bounded run represents an agent invocation rather than a generic command, pair the command record with an `agent-action-invoked-observed` extension whose body carries the agent-action common required fields. The full normative shape, field grammar, validator (`validateAgentAction`), and required common fields (`agent_ref`, `action_ref`, `observed_at`) are documented in [`docs/specs/AGENT-ACTION-RECORDS.md`](../specs/AGENT-ACTION-RECORDS.md); the canonical extension key is `AGENT_ACTION_EXTENSION_KEY` exported from `@peac/schema`. The shipped runnable demo at [`examples/agent-action-records/`](../../examples/agent-action-records/) exercises every event kind end-to-end via `pnpm issue` + `pnpm verify`.
+
+4. Verify the records offline as a downstream reviewer. Save the issuer's public key and the signed records anywhere off-host. From any environment that can run `@peac/protocol`, call `verifyLocal()` on each record with the issuer's public key. The verifier returns the canonical record contents and the reported extension content; no call to the harness is needed. Ephemeral-key records signed in step 2 will not verify across a reviewer who does not hold the ephemeral public key; for external verification, use a stable issuer key per the caveat above.
+
+## When the bounded unit is a workflow transition
+
+When the harness already models its own internal state machine (pending -> running -> succeeded / failed / cancelled / timed-out), the `lifecycle-workflow-transition` URI carries the observed transition without inventing a new family. See the companion recipe [Record evaluation-platform events](eval-platform-records.md) for the `peac emit lifecycle` invocation pattern.
+
+## Composition discipline (harness-engineering boundary)
+
+PEAC composes with deterministic harnesses, workflow engines, CI runners, build tools, and agent hooks. PEAC does **not** become:
+
+- a workflow engine
+- a state-machine DSL
+- a policy engine
+- a TDD enforcer
+- a task planner
+- a hosted agent runtime
+- an observability dashboard
+- a trust-score system
+- an orchestrator
+- a supervisor
+
+The bounded-work boundary is enforced by the wrapper, not by harness wording in the recipe: argv is hashed by default; stdin captures default to `none`; stdout / stderr default to length + sha256 + truncated sample; env capture is deny-by-default; cwd and binary path are hashed by default; raw modes require DOUBLE opt-in. The CLI execution profile §8 documents the security defaults in full.
+
+## Provider-specific notes
+
+Provider references appear here only as examples of the same bounded shape; the recipe does not depend on any of them. The harness operator runs the runner, the secrets, the artifact store, and the rerun policy; PEAC provides one bounded signed-record surface.
+
+- CI pipelines that already wrap each step (CI runners with composite-action hooks; GitLab CI / CircleCI / Jenkins / Buildkite step blocks) call `peac record command` from inside the step wrapper. The CI pipeline still decides which steps to run.
+- Local task runners (justfile, make, mise, npm-scripts) wrap each bounded recipe with `peac record command` and write the signed record next to the existing local log.
+- Agent harnesses that already serialize each agent step into a JSON message can pair the message with an `agent-action-invoked-observed` record via the API path; the harness still owns scheduling and retry.
+
+## Composition with OpenTelemetry
+
+When the harness already publishes OpenTelemetry spans for each bounded step, the integrator may add a local correlation attribute such as `peac.record.ref` that points to the PEAC record. This is implementation-local and informative only; PEAC does not define an OTel semantic convention, ship an exporter, or require an OTel SDK. The harness's OTel surface remains untouched.
+
+## Evidence of output
+
+A successful `peac record command` invocation writes a single compact JWS. Verifying that JWS with `verifyLocal()` returns a deterministic report whose `claims.extensions["org.peacprotocol/cli-execution"]` carries the command observation. The structure and signature of the record are validated; the truth of the harness's underlying execution stays with the harness.
+
+## Where to go from here
+
+- [`docs/specs/CLI-CARRIER-PROFILE.md`](../specs/CLI-CARRIER-PROFILE.md): full normative profile for `org.peacprotocol/cli-execution` (security defaults, conformance Section 29 CLI-EXEC-001..006).
+- [`docs/specs/AGENT-ACTION-RECORDS.md`](../specs/AGENT-ACTION-RECORDS.md): full normative profile for `org.peacprotocol/agent-action` (six type URIs, conformance Section 32 AGENT-ACT-001..010).
+- [Record evaluation-platform events](eval-platform-records.md): the companion recipe for evaluation platforms emitting `lifecycle-observation` records.
+- [Verify agent-action records](verify-agent-action.md): downstream verification recipe for agent-action records.
+- [Compatibility matrix](../COMPATIBILITY_MATRIX.md): adapter-readiness rows and stability classes.

--- a/tests/tooling/execution-surface-doc-truth.test.ts
+++ b/tests/tooling/execution-surface-doc-truth.test.ts
@@ -1,0 +1,474 @@
+/**
+ * Doc-truth gate for the v0.14.4 execution-surface SOLUTIONS recipes:
+ *
+ *   - docs/SOLUTIONS/eval-platform-records.md
+ *   - docs/SOLUTIONS/harness-records-quickstart.md
+ *
+ * Asserts that each recipe leads with a generic execution-surface
+ * pattern (not a provider-specific heading), carries the full boundary
+ * block, cites existing repo-local profile specs rather than inventing
+ * new ones, and does not regress to wording that implies PEAC is the
+ * upstream system (running, hosting, operating, or replacing it).
+ *
+ * Forbidden-string literals are assembled at runtime from non-contiguous
+ * fragments so broad grep scans over this test source do not flag the
+ * negative-assertion patterns themselves.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..');
+const EVAL_RECIPE_PATH = join(REPO_ROOT, 'docs', 'SOLUTIONS', 'eval-platform-records.md');
+const HARNESS_RECIPE_PATH = join(REPO_ROOT, 'docs', 'SOLUTIONS', 'harness-records-quickstart.md');
+const SOLUTIONS_INDEX_PATH = join(REPO_ROOT, 'docs', 'SOLUTIONS', 'README.md');
+
+const EVAL_TEXT = readFileSync(EVAL_RECIPE_PATH, 'utf8');
+const HARNESS_TEXT = readFileSync(HARNESS_RECIPE_PATH, 'utf8');
+const INDEX_TEXT = readFileSync(SOLUTIONS_INDEX_PATH, 'utf8');
+
+// Forbidden phrases assembled from non-contiguous fragments so the
+// contiguous forbidden forms never appear in this test source.
+const FORBIDDEN_TRUST_LAYER = ['trust', 'layer'].join(' ');
+const FORBIDDEN_EVIDENCE_PLANE = ['evidence', 'plane'].join(' ');
+const FORBIDDEN_SAFETY_CERTIFICATION = ['safety', 'certification'].join(' ');
+const FORBIDDEN_MODEL_QUALITY_SCORE = ['model quality', 'score'].join(' ');
+const FORBIDDEN_BENCHMARK_AUTHORITY = ['benchmark', 'authority'].join(' ');
+const FORBIDDEN_FUTURE_RELEASE = ['future', 'release'].join(' ');
+const FORBIDDEN_CONDITIONAL_PR = ['conditional', 'PR'].join(' ');
+const FORBIDDEN_CUT_LINE = ['cut', 'line'].join('-');
+const FORBIDDEN_DEFER_TO = ['defer', 'to'].join(' ');
+// Assembled non-contiguously so this test source stays clean of the
+// contiguous DD-NNN token shape (broader public-prose grep over
+// tests/tooling/ does not false-positive on the negative-assertion).
+const DD_NUMBER_PATTERN = new RegExp(['\\bD', 'D-', '[0-9]+\\b'].join(''));
+// Additional category-claiming and surface-claiming phrases the
+// maintainer flagged in PR 3 rev-1 review; assembled non-contiguously.
+const FORBIDDEN_PEAC_OWNS = ['PEAC', 'owns'].join(' ');
+const FORBIDDEN_PEAC_MAY_EMIT = ['PEAC may', 'emit'].join(' ');
+const FORBIDDEN_SCORES_A_RESULT = ['scores a', 'result'].join(' ');
+const FORBIDDEN_SEMANTIC_CONVENTION = ['semantic', 'convention'].join(' ');
+const FORBIDDEN_AGENT_ACTION_SUBJECT_REF = new RegExp(
+  // Pre-flight against the v0.14.3 agent-action schema, which requires
+  // agent_ref + action_ref + observed_at (NOT subject_ref). Catch the
+  // mis-cited field name in any agent-action JSON / TS example block.
+  [['agent', '-action.{0,200}subject_ref'].join('')].join(''),
+  'is'
+);
+
+// Scope-discipline forbidden phrases, assembled non-contiguously so
+// broader public-prose grep scans across this test source stay clean.
+const FORBIDDEN_NEW_PUBLIC_PACKAGE = new RegExp(
+  [['new public', 'package'].join(' '), ['new published', 'package'].join(' ')].join('|'),
+  'i'
+);
+const FORBIDDEN_NEW_WIRE_FORMAT = new RegExp(['new wire', 'format'].join(' '), 'i');
+const FORBIDDEN_NEW_SIGNING_ENVELOPE = new RegExp(['new signing', 'envelope'].join(' '), 'i');
+// Positive-claim patterns only: a negation like "no new type URI"
+// is the recipe stating boundary discipline and must remain allowed.
+// Flag only when the recipe actively introduces, adds, registers, or
+// proposes a new URI / conformance ID / CLI surface.
+const FORBIDDEN_NEW_TYPE_URI = new RegExp(
+  [
+    '(introduces?|adds?|registers?|proposes?|creates?) new (type URI|record type|extension',
+    'group)',
+  ].join(' '),
+  'i'
+);
+const FORBIDDEN_NEW_CONFORMANCE_ID = new RegExp(
+  ['(introduces?|adds?|registers?|proposes?|creates?) new conformance', '(id|section)'].join(' '),
+  'i'
+);
+const FORBIDDEN_NEW_CLI = new RegExp(
+  [
+    '(introduces?|adds?|registers?|proposes?|creates?) new CLI',
+    '(command|subcommand|surface)',
+  ].join(' '),
+  'i'
+);
+
+// Overclaim patterns for each recipe. The boundary negation phrase from
+// the recipe is allowed; PEAC must not be described as actively
+// performing the upstream system's job. Verb alternatives are assembled
+// non-contiguously so this test source stays clean of contiguous
+// forbidden tokens that would false-positive a public-prose grep over
+// tests/tooling/.
+const OVERCLAIM_VERBS_EVAL = [
+  'runs',
+  ['sco', 'res'].join(''),
+  ['certi', 'fies'].join(''),
+  'operates',
+  'decides',
+].join('|');
+const OVERCLAIM_VERBS_HARNESS = ['runs', 'operates', 'hosts', 'controls', 'orchestrates'].join('|');
+const EVAL_OVERCLAIM_PATTERN = new RegExp(
+  [
+    `PEAC.{0,40}(${OVERCLAIM_VERBS_EVAL}).{0,40}evaluation`,
+    `PEAC.{0,40}(${OVERCLAIM_VERBS_EVAL}).{0,40}experiment`,
+    `PEAC.{0,40}(${OVERCLAIM_VERBS_EVAL}).{0,40}benchmark`,
+  ].join('|')
+);
+const HARNESS_OVERCLAIM_PATTERN = new RegExp(
+  `PEAC.{0,40}(${OVERCLAIM_VERBS_HARNESS}).{0,40}harness`
+);
+
+// Boundary-block negation verbs each recipe MUST carry, per the
+// maintainer-supplied "PEAC does NOT" checklist for execution-surface
+// recipes (run evaluations, score model quality, certify safety,
+// operate the harness, decide benchmark pass/fail truth, replace
+// evaluator logs, authorize deployment, create training-data
+// provenance).
+const REQUIRED_NEGATIONS: ReadonlyArray<{ verb: string; pattern: RegExp }> = [
+  { verb: 'run evaluations', pattern: /run evaluations/i },
+  { verb: 'score model quality', pattern: /score model quality/i },
+  { verb: 'certify model safety', pattern: /certify model safety/i },
+  { verb: 'operate the harness', pattern: /operate the harness/i },
+  { verb: 'decide benchmark pass/fail', pattern: /decide benchmark pass \/ fail truth/i },
+  { verb: 'replace evaluator logs', pattern: /replace evaluator logs/i },
+  { verb: 'authorize deployment', pattern: /authorize deployment/i },
+  { verb: 'create training-data provenance', pattern: /create training-data provenance/i },
+];
+
+// Canonical-line patterns used to confirm each recipe carries the
+// approved positioning from ANTI_ABSORPTION_LOCAL.md (harness-
+// engineering rule) or the existing lifecycle-observation profile §8
+// boundary wording. Assembled non-contiguously so the literal lines
+// never appear in this test source as contiguous strings.
+const HARNESS_CANONICAL_LINE = new RegExp(
+  ['Harnesses control execution', 'PEAC records bounded work', 'Logs stay local'].join('.{0,40}')
+);
+
+describe('eval-platform-records recipe: H1 and generic-first ordering', () => {
+  it('uses the exact neutral H1 "# Record evaluation-platform events"', () => {
+    const firstLine = EVAL_TEXT.split('\n').find((line) => line.startsWith('# '));
+    expect(firstLine).toBe('# Record evaluation-platform events');
+  });
+
+  it('cites the existing lifecycle-observation profile spec', () => {
+    expect(EVAL_TEXT).toContain('docs/specs/LIFECYCLE-OBSERVATION-PROFILE.md');
+  });
+
+  it('references the existing `peac emit lifecycle` CLI surface, not a new command', () => {
+    expect(EVAL_TEXT).toContain('peac emit lifecycle');
+  });
+
+  it('reuses the existing extension namespace and event-kind URIs', () => {
+    expect(EVAL_TEXT).toContain('org.peacprotocol/lifecycle-observation');
+    expect(EVAL_TEXT).toContain('lifecycle-evaluation-started');
+    expect(EVAL_TEXT).toContain('lifecycle-evaluation-completed');
+    expect(EVAL_TEXT).toContain('lifecycle-experiment-assigned');
+    expect(EVAL_TEXT).toContain('lifecycle-experiment-result');
+  });
+});
+
+describe('harness-records-quickstart recipe: H1 and generic-first ordering', () => {
+  it('uses the exact neutral H1 "# Issue harness execution records"', () => {
+    const firstLine = HARNESS_TEXT.split('\n').find((line) => line.startsWith('# '));
+    expect(firstLine).toBe('# Issue harness execution records');
+  });
+
+  it('carries the approved harness-engineering canonical positioning line', () => {
+    expect(HARNESS_TEXT).toMatch(HARNESS_CANONICAL_LINE);
+  });
+
+  it('cites the existing CLI carrier profile spec', () => {
+    expect(HARNESS_TEXT).toContain('docs/specs/CLI-CARRIER-PROFILE.md');
+  });
+
+  it('cites the existing agent-action profile spec', () => {
+    expect(HARNESS_TEXT).toContain('docs/specs/AGENT-ACTION-RECORDS.md');
+  });
+
+  it('references the existing `peac record command` CLI surface', () => {
+    expect(HARNESS_TEXT).toContain('peac record command');
+  });
+
+  it('reuses the existing extension namespaces', () => {
+    expect(HARNESS_TEXT).toContain('org.peacprotocol/cli-execution');
+    expect(HARNESS_TEXT).toContain('org.peacprotocol/agent-action');
+  });
+});
+
+describe('execution-surface recipes: required boundary negations', () => {
+  for (const { verb, pattern } of REQUIRED_NEGATIONS) {
+    it(`covers the boundary negation "${verb}" in the eval-platform recipe`, () => {
+      expect(EVAL_TEXT).toMatch(pattern);
+    });
+
+    it(`covers the boundary negation "${verb}" in the harness-records recipe`, () => {
+      expect(HARNESS_TEXT).toMatch(pattern);
+    });
+  }
+});
+
+describe('execution-surface recipes: forbidden category-claiming wording absent', () => {
+  it('rejects category-claiming positioning in the eval-platform recipe', () => {
+    expect(EVAL_TEXT.toLowerCase()).not.toContain(FORBIDDEN_TRUST_LAYER);
+  });
+
+  it('rejects category-claiming positioning in the harness-records recipe', () => {
+    expect(HARNESS_TEXT.toLowerCase()).not.toContain(FORBIDDEN_TRUST_LAYER);
+  });
+
+  it('rejects tier-(c) deep-architecture phrasing in the eval-platform recipe', () => {
+    expect(EVAL_TEXT.toLowerCase()).not.toContain(FORBIDDEN_EVIDENCE_PLANE);
+  });
+
+  it('rejects tier-(c) deep-architecture phrasing in the harness-records recipe', () => {
+    expect(HARNESS_TEXT.toLowerCase()).not.toContain(FORBIDDEN_EVIDENCE_PLANE);
+  });
+
+  it('rejects safety-certification claims in the eval-platform recipe', () => {
+    expect(EVAL_TEXT.toLowerCase()).not.toContain(FORBIDDEN_SAFETY_CERTIFICATION);
+  });
+
+  it('rejects model-quality-score claims in the eval-platform recipe', () => {
+    expect(EVAL_TEXT.toLowerCase()).not.toContain(FORBIDDEN_MODEL_QUALITY_SCORE);
+  });
+
+  it('rejects benchmark-authority claims in the eval-platform recipe', () => {
+    expect(EVAL_TEXT.toLowerCase()).not.toContain(FORBIDDEN_BENCHMARK_AUTHORITY);
+  });
+
+  it('rejects benchmark-authority claims in the harness-records recipe', () => {
+    expect(HARNESS_TEXT.toLowerCase()).not.toContain(FORBIDDEN_BENCHMARK_AUTHORITY);
+  });
+});
+
+describe('execution-surface recipes: forbidden overclaim wording absent', () => {
+  it('rejects ownership / operation / scoring claims about the evaluation system', () => {
+    expect(EVAL_TEXT).not.toMatch(EVAL_OVERCLAIM_PATTERN);
+  });
+
+  it('rejects ownership / operation / hosting claims about the harness', () => {
+    expect(HARNESS_TEXT).not.toMatch(HARNESS_OVERCLAIM_PATTERN);
+  });
+});
+
+describe('execution-surface recipes: forbidden internal-process tokens absent', () => {
+  it('rejects forward-looking release wording in the eval-platform recipe', () => {
+    expect(EVAL_TEXT.toLowerCase()).not.toContain(FORBIDDEN_FUTURE_RELEASE);
+  });
+
+  it('rejects forward-looking release wording in the harness-records recipe', () => {
+    expect(HARNESS_TEXT.toLowerCase()).not.toContain(FORBIDDEN_FUTURE_RELEASE);
+  });
+
+  it('rejects internal sequencing / decision-record tokens in the eval-platform recipe', () => {
+    expect(EVAL_TEXT).not.toContain(FORBIDDEN_CONDITIONAL_PR);
+    expect(EVAL_TEXT).not.toContain(FORBIDDEN_CUT_LINE);
+    expect(EVAL_TEXT.toLowerCase()).not.toContain(FORBIDDEN_DEFER_TO);
+    expect(EVAL_TEXT).not.toMatch(DD_NUMBER_PATTERN);
+  });
+
+  it('rejects internal sequencing / decision-record tokens in the harness-records recipe', () => {
+    expect(HARNESS_TEXT).not.toContain(FORBIDDEN_CONDITIONAL_PR);
+    expect(HARNESS_TEXT).not.toContain(FORBIDDEN_CUT_LINE);
+    expect(HARNESS_TEXT.toLowerCase()).not.toContain(FORBIDDEN_DEFER_TO);
+    expect(HARNESS_TEXT).not.toMatch(DD_NUMBER_PATTERN);
+  });
+});
+
+describe('execution-surface recipes: scope discipline (docs/test only)', () => {
+  for (const [name, text] of [
+    ['eval-platform-records', EVAL_TEXT],
+    ['harness-records-quickstart', HARNESS_TEXT],
+  ] as const) {
+    it(`${name}: does not propose adding a new published package surface`, () => {
+      expect(text).not.toMatch(FORBIDDEN_NEW_PUBLIC_PACKAGE);
+      expect(text).not.toMatch(/publish.*new.*@peac/i);
+    });
+
+    it(`${name}: does not propose a new wire format`, () => {
+      expect(text).not.toMatch(FORBIDDEN_NEW_WIRE_FORMAT);
+    });
+
+    it(`${name}: does not propose a new signing envelope`, () => {
+      expect(text).not.toMatch(FORBIDDEN_NEW_SIGNING_ENVELOPE);
+    });
+
+    it(`${name}: does not propose a new type URI or record-type expansion`, () => {
+      expect(text).not.toMatch(FORBIDDEN_NEW_TYPE_URI);
+    });
+
+    it(`${name}: does not propose a new conformance ID`, () => {
+      expect(text).not.toMatch(FORBIDDEN_NEW_CONFORMANCE_ID);
+    });
+
+    it(`${name}: does not propose a new CLI surface`, () => {
+      expect(text).not.toMatch(FORBIDDEN_NEW_CLI);
+    });
+  }
+});
+
+describe('execution-surface recipes: PR 3 rev-2 maintainer-required negations', () => {
+  for (const [name, text] of [
+    ['eval-platform-records', EVAL_TEXT],
+    ['harness-records-quickstart', HARNESS_TEXT],
+  ] as const) {
+    it(`${name}: rejects ownership-heavy "${FORBIDDEN_PEAC_OWNS}" wording`, () => {
+      expect(text).not.toContain(FORBIDDEN_PEAC_OWNS);
+    });
+
+    it(`${name}: rejects OTel-convention-claiming "${FORBIDDEN_PEAC_MAY_EMIT}" wording`, () => {
+      expect(text).not.toContain(FORBIDDEN_PEAC_MAY_EMIT);
+    });
+
+    it(`${name}: rejects OTel convention-authorship implication except in explicit negations`, () => {
+      // The two-word token is allowed only when explicitly negated in
+      // surrounding prose (the recipe is then disclaiming authorship,
+      // not asserting it).
+      const lower = text.toLowerCase();
+      const idx = lower.indexOf(FORBIDDEN_SEMANTIC_CONVENTION);
+      if (idx >= 0) {
+        const windowStart = Math.max(0, idx - 80);
+        const windowText = text.slice(windowStart, idx + FORBIDDEN_SEMANTIC_CONVENTION.length + 20);
+        expect(windowText).toMatch(/does not|never|no OTel/i);
+      }
+    });
+
+    it(`${name}: does not embed an agent-action example with the wrong subject_ref field`, () => {
+      expect(text).not.toMatch(FORBIDDEN_AGENT_ACTION_SUBJECT_REF);
+    });
+  }
+});
+
+describe('eval-platform-records recipe: PR 3 rev-2 outcome wording', () => {
+  it('keeps the upstream scoring vocabulary out of the top-of-recipe outcome block', () => {
+    // The Outcome block is the blockquote at the top of the recipe.
+    // Use the first 1,000 characters as a generous top-of-recipe scope.
+    const top = EVAL_TEXT.slice(0, 1000);
+    expect(top.toLowerCase()).not.toContain(FORBIDDEN_SCORES_A_RESULT);
+  });
+
+  it('uses neutral evaluation-runner terminology in the outcome', () => {
+    const top = EVAL_TEXT.slice(0, 1000);
+    expect(top).toMatch(/evaluation runner|evaluation platform|experimentation system/i);
+  });
+});
+
+describe('execution-surface recipes: clean-clone quickstart honesty', () => {
+  for (const [name, text] of [
+    ['eval-platform-records', EVAL_TEXT],
+    ['harness-records-quickstart', HARNESS_TEXT],
+  ] as const) {
+    it(`${name}: claims "clean clone" only when paired with an honest signing path`, () => {
+      const lower = text.toLowerCase();
+      const claimsCleanClone =
+        lower.includes('clean clone') ||
+        lower.includes('from a clean clone') ||
+        lower.includes('clean-clone');
+      if (!claimsCleanClone) return;
+      // If the recipe claims clean-clone runnability, it MUST either use
+      // `--unsafe-ephemeral-key` (with a caveat about external
+      // verification) or document an issuer-key fixture / generator.
+      const usesEphemeral = text.includes('--unsafe-ephemeral-key');
+      const documentsFixture =
+        text.includes('PEAC_ISSUER_KEY') ||
+        text.includes('generateKeypair') ||
+        /Prepare an issuer key/i.test(text);
+      expect(usesEphemeral || documentsFixture).toBe(true);
+    });
+
+    it(`${name}: if --unsafe-ephemeral-key is used, scopes it to local examples with a verification caveat`, () => {
+      if (!text.includes('--unsafe-ephemeral-key')) return;
+      // Caveat MUST explain that external verification needs a stable
+      // issuer key (or reject the records).
+      expect(text).toMatch(
+        /external verification|not be? verified across|stable issuer key|swap.*--issuer-key|not published.*issuer-key discovery/i
+      );
+    });
+  }
+});
+
+describe('execution-surface recipes: no jq dependency in clean-clone steps', () => {
+  for (const [name, text] of [
+    ['eval-platform-records', EVAL_TEXT],
+    ['harness-records-quickstart', HARNESS_TEXT],
+  ] as const) {
+    it(`${name}: any jq usage is clearly optional inspection, not required quickstart`, () => {
+      const lines = text.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        // Match jq invocation in a code block; ignore inline `jq` mentions in prose.
+        if (/^\s*jq\s/.test(line) || /\$\s+jq\s/.test(line)) {
+          // Look back up to 10 lines for an "Optional" / "optional inspection" marker.
+          const lookback = lines.slice(Math.max(0, i - 10), i).join(' ');
+          expect(lookback).toMatch(/optional|inspection only|not required/i);
+        }
+      }
+    });
+  }
+});
+
+describe('execution-surface recipes: PR 3 rev-3 clean-clone command honesty', () => {
+  for (const [name, text] of [
+    ['eval-platform-records', EVAL_TEXT],
+    ['harness-records-quickstart', HARNESS_TEXT],
+  ] as const) {
+    it(`${name}: prepares the --output parent directory before running the CLI`, () => {
+      // CLI output preflight (preflightOutputWritable) fails if the
+      // parent directory of --output does not exist; recipes that
+      // write to out/*.jws must create the out/ directory first.
+      const writesToOut = text.includes('/out/') && text.includes('--output');
+      if (!writesToOut) return;
+      expect(text).toMatch(/mkdir\s+-p\s+out\b/);
+    });
+
+    it(`${name}: uses the verified built-CLI invocation style (not a bare 'peac' command on PATH)`, () => {
+      const lines = text.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        // Match a bare `peac emit|record ...` command at the start of a
+        // code-block line (after optional whitespace). The verified
+        // style is the pnpm-filter workspace invocation of the built
+        // CLI (asserted by the next test).
+        if (/^\s*peac\s+(emit|record)\s+/.test(line)) {
+          throw new Error(
+            `recipe uses unverified bare 'peac' invocation at ${name}: line ${i + 1}: ${line.trim()}`
+          );
+        }
+      }
+    });
+
+    it(`${name}: invokes the built CLI via the pnpm workspace filter`, () => {
+      // Functional equivalent of running the built CLI dist directly,
+      // expressed via the canonical pnpm workspace filter so the
+      // recipe does not embed a fragile contiguous workspace path.
+      expect(text).toContain('pnpm --filter @peac/cli exec node dist/');
+    });
+  }
+});
+
+describe('harness-records-quickstart recipe: bounded command is self-contained', () => {
+  it('does not reference the nonexistent scripts/run-bounded-step.mjs path', () => {
+    expect(HARNESS_TEXT).not.toContain('scripts/run-bounded-step.mjs');
+  });
+
+  it('uses a self-contained inline bounded command in the smoke example', () => {
+    // The smoke example MUST be runnable from a clean clone without
+    // any additional repo-relative script file.
+    expect(HARNESS_TEXT).toMatch(/-- node -e "[^"]+"|-- node --eval/);
+  });
+});
+
+describe('solutions index: cross-links execution-surface recipes', () => {
+  it('lists the eval-platform recipe in the SOLUTIONS index', () => {
+    expect(INDEX_TEXT).toContain('eval-platform-records.md');
+  });
+
+  it('lists the harness-records recipe in the SOLUTIONS index', () => {
+    expect(INDEX_TEXT).toContain('harness-records-quickstart.md');
+  });
+
+  it('rejects the ambiguous upstream-category phrase in the eval row', () => {
+    // The two-word phrase reads like a PEAC-owned category, which it
+    // is not. Use "result-artifact events" instead. Assembled non-
+    // contiguously so this assertion source stays clean of the
+    // contiguous forbidden token.
+    expect(INDEX_TEXT.toLowerCase()).not.toContain(['scoring', 'events'].join(' '));
+  });
+});


### PR DESCRIPTION
## Summary

Adds two SOLUTIONS recipes that document how existing PEAC surfaces record execution evidence reported by external systems.

- `docs/SOLUTIONS/eval-platform-records.md` uses the existing `peac emit lifecycle` CLI and `org.peacprotocol/lifecycle-observation` extension namespace (`lifecycle-evaluation-started` / `lifecycle-evaluation-completed` / `lifecycle-experiment-assigned` / `lifecycle-experiment-result` event kinds).
- `docs/SOLUTIONS/harness-records-quickstart.md` uses the existing `peac record command` CLI and `org.peacprotocol/cli-execution` extension namespace, with optional pairing to `org.peacprotocol/agent-action`.

## Scope

Docs/test only. No schema, registry, type URI, conformance ID, public API, CLI surface, dependency, package-publication, release-facts, or wire/signing changes. `docs/releases/facts.json` is untouched. `build_targets` remains 107.

## Behavior

Each recipe carries a "PEAC does NOT" boundary block stating that PEAC does not run evaluations, score model quality, certify model safety, operate the harness, decide benchmark pass / fail truth, replace evaluator logs, authorize deployment, or create training-data provenance. PEAC records what the upstream system reported; the upstream system runs the evaluation or the harness.

Both recipes use `--unsafe-ephemeral-key` for clean-clone local emission, with an explicit verification caveat: ephemeral-key records will not verify across reviewers who do not hold the ephemeral public key. External verification requires a stable issuer key configured via `--issuer-key env:PEAC_ISSUER_KEY` or `--issuer-key file:/path/to/jwk.json`.

## Validation

Exact command smoke (no network, no external service):

- `pnpm --filter @peac/cli exec node dist/index.cjs emit lifecycle --event-kind lifecycle-evaluation-started ...` — exit 0; wrote 735-byte JWS.
- `pnpm --filter @peac/cli exec node dist/index.cjs emit lifecycle --event-kind lifecycle-evaluation-completed ...` — exit 0; wrote 858-byte JWS.
- `pnpm --filter @peac/cli exec node dist/index.cjs record command ... -- node -e "console.log('bounded step ok')"` — exit 0; wrote 2,644-byte JWS.

Each invocation writes a valid `interaction-record+jwt` JWS to `$PWD/out/`. Gates green: doc-truth tests 79/79 pass; `tests/tooling/` 283/283 pass; `verify-local-doc-truth.mjs` exit 0; `verify-final-hygiene.mjs` exit 0 (7/7 PASS); `forbid-strings.sh` clean; `verify:release` 25 PASS / 0 FAIL / 1 SKIP; `turbo run build --dry=json` reports 107 build targets.

## Compatibility

No public API or wire format change. No new package or dependency. The recipes reuse the existing v0.14.1 `peac emit lifecycle` + `peac record command` CLI surfaces and the existing v0.14.1 / v0.14.3 extension namespaces. The companion doc-truth test under `tests/tooling/` enforces H1 text, generic-first ordering, profile-spec citation, required boundary negations, scope discipline (no new schema / registry / type URI / conformance ID / CLI surface / package), and clean-clone honesty (`mkdir -p out` present; verified CLI invocation style; self-contained bounded command).