### PR TITLE
chore(go-middleware): bring chi adapter to parity with echo, gin, nethttp

### DIFF
--- a/sdks/go/middleware/chi/README.md
+++ b/sdks/go/middleware/chi/README.md
@@ -1,0 +1,82 @@
+# @peac/middleware-chi (Go)
+
+PEAC receipt verification middleware for the Chi router
+(`github.com/go-chi/chi/v5`).
+
+## Install
+
+```bash
+go get github.com/peacprotocol/peac/sdks/go/middleware/chi
+```
+
+This is a separate Go module from the core `sdks/go/middleware` package so
+consumers who do not use Chi do not pay for a Chi transitive in their
+dependency graph. The adapter itself carries no Chi dependency; it
+exposes the stdlib-compatible `func(http.Handler) http.Handler` that
+Chi's `r.Use(...)` accepts natively.
+
+## Usage
+
+```go
+import (
+    "github.com/go-chi/chi/v5"
+    peacchi "github.com/peacprotocol/peac/sdks/go/middleware/chi"
+)
+
+func main() {
+    r := chi.NewRouter()
+    r.Use(peacchi.Verifier(peacchi.Config{
+        Issuer:   "https://publisher.example",
+        Audience: "https://agent.example",
+    }))
+
+    r.Get("/protected", protected)
+
+    http.ListenAndServe(":8080", r)
+}
+
+func protected(w http.ResponseWriter, r *http.Request) {
+    claims := peacchi.GetClaims(r)
+    _ = claims // use claims.Subject, claims.Purpose, etc.
+    w.WriteHeader(200)
+}
+```
+
+## Parity with echo, gin, and nethttp adapters
+
+| Aspect                                      | Contract                                                                                                              |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `type Config = middleware.Config`           | identical across all adapters                                                                                         |
+| `DefaultConfig()`                           | identical hardened defaults (panic recovery on, 1 MiB body cap, `TrustProxyHeaders` off)                              |
+| `Verifier(cfg Config)`                      | returns `func(http.Handler) http.Handler`; identical verifier semantics                                               |
+| Header behavior                             | `PEAC-Receipt` precedence; rail-x402 `PAYMENT-RESPONSE` / `X-PAYMENT-RESPONSE` honored; case-insensitive header names |
+| Timeout / body limit / trust-proxy defaults | identical across all adapters                                                                                         |
+| Error / status mapping                      | 401 / 400 / 503 taxonomy matches echo, gin, and nethttp exactly                                                       |
+
+The parity contract is enforced by a shared request-corpus test harness
+under `sdks/go/middleware/paritytest/` that runs the same requests
+against every adapter and asserts identical responses. The chi adapter
+is used as the reference adapter in that harness, so per-adapter tests
+under this module assert the localized invariants (Config alias,
+DefaultConfig match, required 401, optional pass-through) that the
+parity harness composes against.
+
+## Reading verified claims inside a Chi handler
+
+```go
+r.Get("/receipt-info", func(w http.ResponseWriter, r *http.Request) {
+    claims := peacchi.GetClaims(r)
+    if claims == nil {
+        http.Error(w, "no claims", http.StatusUnauthorized)
+        return
+    }
+    json.NewEncoder(w).Encode(claims)
+})
+```
+
+## Related documents
+
+- [Hosted Verify contract](../../../../docs/HOSTED_VERIFY_CONTRACT.md)
+- [Threat model](../../../../docs/THREAT_MODEL.md)
+- [Stability contract](../../../../docs/STABILITY-CONTRACT.md)
+- [Compatibility matrix for Go middleware](../../../../docs/compatibility/go-middleware.md)

--- a/sdks/go/middleware/chi/README.md
+++ b/sdks/go/middleware/chi/README.md
@@ -15,10 +15,17 @@ dependency graph. The adapter itself carries no Chi dependency; it
 exposes the stdlib-compatible `func(http.Handler) http.Handler` that
 Chi's `r.Use(...)` accepts natively.
 
+Applications that do not already depend on Chi should also add
+`github.com/go-chi/chi/v5`; the PEAC adapter module intentionally does
+not depend on Chi directly.
+
 ## Usage
 
 ```go
 import (
+    "encoding/json"
+    "net/http"
+
     "github.com/go-chi/chi/v5"
     peacchi "github.com/peacprotocol/peac/sdks/go/middleware/chi"
 )

--- a/sdks/go/middleware/chi/chi_test.go
+++ b/sdks/go/middleware/chi/chi_test.go
@@ -1,0 +1,83 @@
+package chi_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	coremw "github.com/peacprotocol/peac/sdks/go/middleware"
+	peacchi "github.com/peacprotocol/peac/sdks/go/middleware/chi"
+)
+
+// TestConfigIsAlias asserts that peacchi.Config is an alias for the
+// core middleware Config, not a new named type. This is the
+// foundational invariant the parity harness relies on when it uses
+// chi as the reference adapter.
+func TestConfigIsAlias(t *testing.T) {
+	var adapterCfg peacchi.Config
+	var coreCfg coremw.Config
+	if reflect.TypeOf(adapterCfg) != reflect.TypeOf(coreCfg) {
+		t.Fatalf("peacchi.Config is not a type alias for coremw.Config")
+	}
+}
+
+// TestDefaultConfigMatchesCore asserts adapter DefaultConfig returns
+// the same struct as the core DefaultConfig. The parity harness asserts
+// this across all stdlib-shaped adapters; this per-adapter test gives a
+// localized failure if chi drifts from the core defaults.
+func TestDefaultConfigMatchesCore(t *testing.T) {
+	if !reflect.DeepEqual(peacchi.DefaultConfig(), coremw.DefaultConfig()) {
+		t.Fatalf("peacchi.DefaultConfig() diverges from coremw.DefaultConfig()")
+	}
+}
+
+// TestVerifierRequired401 confirms that the stdlib middleware returned
+// by Verifier rejects requests without a PEAC-Receipt header when
+// Optional is false. Mirrors the parity-corpus required-401 scenario.
+func TestVerifierRequired401(t *testing.T) {
+	cfg := peacchi.DefaultConfig()
+	cfg.Issuer = "https://publisher.example"
+	cfg.Audience = "https://agent.example"
+
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("downstream handler was reached when receipt was missing")
+	})
+
+	h := peacchi.Verifier(cfg)(downstream)
+	req := httptest.NewRequest("GET", "/protected", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestVerifierOptionalPassesThrough confirms Optional=true lets
+// receipt-less requests through to the downstream handler. Mirrors
+// the parity-corpus optional-passthrough scenario.
+func TestVerifierOptionalPassesThrough(t *testing.T) {
+	cfg := peacchi.DefaultConfig()
+	cfg.Issuer = "https://publisher.example"
+	cfg.Audience = "https://agent.example"
+	cfg.Optional = true
+
+	reached := false
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	h := peacchi.Verifier(cfg)(downstream)
+	req := httptest.NewRequest("GET", "/protected", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if !reached {
+		t.Fatalf("optional middleware did not reach downstream handler")
+	}
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rr.Code)
+	}
+}


### PR DESCRIPTION
## Summary

Adds the two adapter-parity artifacts the other Go middleware adapters already ship: a per-adapter test file and a per-adapter README.

- `sdks/go/middleware/chi/chi_test.go` covers the four localized invariants the parity harness depends on when it uses chi as the reference adapter (`Config` is an alias, `DefaultConfig` matches core defaults, required verifier returns 401 on missing receipt, optional verifier passes through). Scenario shape mirrors `echo_test.go` and `nethttp_test.go`.
- `sdks/go/middleware/chi/README.md` mirrors the install / usage / parity-table / claims-access / related-documents shape of `echo/README.md` and `nethttp/README.md`.

## Scope

Go middleware adapter only. No new types, no new exports, no API change, no public protocol change, no dependency change. The chi adapter's exported surface and behavior are unchanged.

## Behavior

The shared parity harness under `sdks/go/middleware/paritytest/` continues to assert byte-identical responses across chi, echo, and nethttp; the per-adapter tests added here give a localized failure if chi drifts independently of the harness.

## Validation

```
cd sdks/go/middleware/chi && go test -v ./...
  → PASS: TestConfigIsAlias (0.00s)
  → PASS: TestDefaultConfigMatchesCore (0.00s)
  → PASS: TestVerifierRequired401 (0.00s)
  → PASS: TestVerifierOptionalPassesThrough (0.00s)
  → ok  github.com/peacprotocol/peac/sdks/go/middleware/chi  0.615s

# Sibling adapter parity (no regression):
cd sdks/go/middleware/paritytest && GOWORK=off go test .  → ok  0.533s
cd sdks/go/middleware/echo && GOWORK=off go test .         → ok  0.544s
cd sdks/go/middleware/nethttp && GOWORK=off go test .      → ok  0.538s
cd sdks/go && GOWORK=off go test ./...                     → all packages ok
```

Local repo gates: `verify-local-doc-truth.mjs` exit 0; `verify-final-hygiene.mjs` exit 0; `forbid-strings.sh` clean; `guard.sh` exit 0; `verify:release` 25 PASS / 0 FAIL / 1 SKIP; `turbo run build --dry=json` reports 107 build targets.

## Compatibility

No public API or wire format change. No new exports. No new dependencies (the chi adapter is a thin re-export of the stdlib-shaped core middleware; neither the adapter nor the test imports `github.com/go-chi/chi/v5`). `docs/releases/facts.json` is untouched. `build_targets` remains 107.