### PR TITLE
docs(composition,mcp): document MCP registry and SEP alignment

### DIFF
--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -4,19 +4,19 @@ Current as of the repository state after the v0.14.3 profile additions.
 
 ## Wire Format Support
 
-| Surface                    | Wire 0.2 (`interaction-record+jwt`)                                 | Wire 0.1 (`peac-receipt/0.1`)                                        | Status                                                         |
-| -------------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------- |
-| `@peac/protocol` (TS/Node) | Full: `issue()` + `verifyLocal()`                                   | Legacy verify only (`verifyLocalWire01()`, not exported from barrel) | **default**                                                    |
-| `@peac/crypto` (TS/Node)   | Full: dual-stack sign/verify/decode                                 | Decode and verify only                                               | **default**                                                    |
-| `@peac/schema` (TS/Node)   | Full: `Wire02ClaimsSchema`, extension groups, type enforcement      | Legacy `ReceiptClaimsSchema`                                         | **default**                                                    |
-| `@peac/cli`                | Full                                                                | -                                                                    | **default**                                                    |
-| `@peac/mcp-server`         | Full (5 tools)                                                      | -                                                                    | **default**                                                    |
-| `@peac/middleware-express` | Full                                                                | -                                                                    | **default**                                                    |
-| Go SDK (`sdks/go/`)        | Full: `Issue()` + `VerifyLocal()` + JCS (22 cross-language vectors) | Legacy verify only                                                   | **supported** (core issue/verify); middleware **experimental** |
-| Python                     | API-first via reference verifier (httpx examples, `>=3.12`)         | -                                                                    | **examples only**                                              |
-| .NET                       | Offline verifier example (`examples/dotnet-quickstart/`, net10.0)   | -                                                                    | **examples only** (not a PEAC .NET SDK; no NuGet package)      |
-| `@peac/core`               | -                                                                   | Full (Wire 0.9 locked)                                               | **archived** (at v0.13.0)                                      |
-| `@peac/sdk`                | -                                                                   | Full (Wire 0.1)                                                      | **archived** (use `@peac/protocol`)                            |
+| Surface                    | Wire 0.2 (`interaction-record+jwt`)                                                | Wire 0.1 (`peac-receipt/0.1`)                                        | Status                                                         |
+| -------------------------- | ---------------------------------------------------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `@peac/protocol` (TS/Node) | Full: `issue()` + `verifyLocal()`                                                  | Legacy verify only (`verifyLocalWire01()`, not exported from barrel) | **default**                                                    |
+| `@peac/crypto` (TS/Node)   | Full: dual-stack sign/verify/decode                                                | Decode and verify only                                               | **default**                                                    |
+| `@peac/schema` (TS/Node)   | Full: `Wire02ClaimsSchema`, extension groups, type enforcement                     | Legacy `ReceiptClaimsSchema`                                         | **default**                                                    |
+| `@peac/cli`                | Full                                                                               | -                                                                    | **default**                                                    |
+| `@peac/mcp-server`         | Full (5 tools); composition guide: [MCP composition](SOLUTIONS/mcp-composition.md) | -                                                                    | **default**                                                    |
+| `@peac/middleware-express` | Full                                                                               | -                                                                    | **default**                                                    |
+| Go SDK (`sdks/go/`)        | Full: `Issue()` + `VerifyLocal()` + JCS (22 cross-language vectors)                | Legacy verify only                                                   | **supported** (core issue/verify); middleware **experimental** |
+| Python                     | API-first via reference verifier (httpx examples, `>=3.12`)                        | -                                                                    | **examples only**                                              |
+| .NET                       | Offline verifier example (`examples/dotnet-quickstart/`, net10.0)                  | -                                                                    | **examples only** (not a PEAC .NET SDK; no NuGet package)      |
+| `@peac/core`               | -                                                                                  | Full (Wire 0.9 locked)                                               | **archived** (at v0.13.0)                                      |
+| `@peac/sdk`                | -                                                                                  | Full (Wire 0.1)                                                      | **archived** (use `@peac/protocol`)                            |
 
 ## Runtime Environments
 

--- a/docs/SOLUTIONS/mcp-composition.md
+++ b/docs/SOLUTIONS/mcp-composition.md
@@ -1,0 +1,88 @@
+# MCP composition with PEAC records
+
+> **Outcome:** Your team runs Model Context Protocol (MCP) servers, clients, or tool integrations. You want a portable signed record of what each MCP interaction reported, verifiable by any downstream party with the issuer's public key, without depending on the MCP runtime that produced it.
+>
+> **Audience:** MCP server / client operator, MCP-tool integrator, or auditor reviewing MCP-mediated work.
+>
+> **Time:** Reading time only. This is a composition guide; no code changes are required.
+
+## What this shows
+
+How the PEAC records layer composes with the Model Context Protocol. MCP defines the runtime contract between agents and tools. PEAC produces portable signed records of what an MCP server, client, or tool integration attested during that contract. The two layers are independent: MCP evolves on its own schedule; PEAC records what an MCP participant reported and stays verifiable beyond the runtime that produced it.
+
+This document is a composition guide. It does not change wire format, signing envelope, public API, schema, or registry. The companion code recipe is [MCP tool-call records](mcp-tool-call-receipts.md), which shows the attachment carriers and the `_meta` keys.
+
+## How PEAC composes with MCP
+
+PEAC's MCP composition surface is shaped by three repo-local artifacts that ship today and one stable extension namespace:
+
+- the existing `@peac/mcp-server` package (built-in MCP evidence tools);
+- the existing `@peac/mappings-mcp` package (`_meta` carrier mapping per the Evidence Carrier Contract);
+- the existing recipe [`docs/SOLUTIONS/mcp-tool-call-receipts.md`](mcp-tool-call-receipts.md);
+- the `org.peacprotocol/mcp-tool-call` example type URI used by that recipe (an integrator-emitted custom type URI, not a registered PEAC profile).
+
+The composition is record-only. PEAC reads what the MCP server or client reported, signs an interaction record, and stops there. The MCP runtime keeps owning transport, registry, auth, conformance, and process management.
+
+## MCP auth observations and `iss`
+
+SEP-2468 recommends including an Issuer (`iss`) parameter in MCP authentication responses. The proposal merged on 2026-05-17 into the canonical MCP specification repository (modelcontextprotocol/specification PR 2468). The recommendation aligns with the PEAC Wire 0.2 envelope: every Wire 0.2 interaction record already carries a canonical `iss` claim as a required field.
+
+Composition: an MCP server that emits SEP-2468-shaped auth responses can be observed by an integrator and re-attested by a separate PEAC interaction record. The MCP server keeps owning the authentication decision. PEAC carries a portable signed record of what the MCP server reported. The `iss` value in the PEAC record is the operator's canonical issuer URL, not necessarily the same URL the MCP server emitted in its auth response; the two carry independent identities.
+
+## MCP conformance discipline
+
+SEP-2484 requires conformance tests for Standards Track SEPs before they reach Final status. The proposal merged on 2026-05-17 into the canonical MCP specification repository (modelcontextprotocol/specification PR 2484). The PEAC repository has its own conformance discipline under [`specs/conformance/`](../../specs/conformance/) with 290 requirement IDs across 32 sections plus 11 parity-corpus families.
+
+The two conformance regimes are complementary, not coupled. PEAC's conformance scope is what PEAC's record layer must accept and reject; the MCP SEP conformance scope is what an MCP runtime must implement. A PEAC record that observes an MCP interaction does not require the upstream MCP server to be SEP-2484 conformant, and the upstream MCP server does not require the PEAC record layer to be present.
+
+## MCP schema evolution
+
+SEP-2106 aligns MCP tool `inputSchema` and `outputSchema` with JSON Schema 2020-12. The proposal merged on 2026-05-18 into the canonical MCP specification repository (modelcontextprotocol/specification PR 2106).
+
+This evolves the MCP runtime contract; it does not change the PEAC record layer. PEAC records the MCP interaction the integrator observed at the time of recording. A record produced before the SEP-2106 alignment is still verifiable after the alignment; a record produced after is still verifiable using the same Wire 0.2 envelope. PEAC does not validate MCP tool inputs or outputs against any MCP-defined schema; it preserves the integrator-reported observation.
+
+## Deprecated MCP surfaces
+
+SEP-2577 deprecates the MCP server features Roots, Sampling, and Logging. The proposal merged on 2026-05-15 into the canonical MCP specification repository (modelcontextprotocol/specification PR 2577). The deprecation introduces no wire-level break during the deprecation period; clients that already integrate against those surfaces continue to interoperate while the deprecation runs.
+
+PEAC records what the MCP server attested. A PEAC record emitted before SEP-2577 that references one of those surfaces stays verifiable; a forward record simply will not reference them. PEAC has no migration burden tied to MCP feature deprecation.
+
+## Resumable tasks and partial results
+
+MCP runtimes increasingly support long-running tasks and partial-result emission. When an integrator observes a task resumption or a partial-result step, PEAC composes via the existing `org.peacprotocol/lifecycle-observation` extension namespace and its `lifecycle-workflow-transition` event kind (shipped in v0.14.1). The record carries the observed transition; the MCP runtime keeps owning task scheduling, retry, and partial-result delivery. See [Record evaluation-platform events](eval-platform-records.md) for the lifecycle-observation issuance pattern.
+
+## Stdio process lifetime
+
+PEAC's MCP composition is observational: PEAC records what an MCP server reported during its lifetime. PEAC does not start, stop, monitor, restart, or supervise MCP server processes. Stdio transport, restart policy, and timeout handling are the operator's responsibility. The PEAC record carries observation timestamps that the operator supplied; PEAC does not back-fill or correct MCP server lifetime claims.
+
+## Error-code boundaries
+
+PEAC has its own stable error namespace, used by the PEAC reference verifier and the PEAC schema validators. MCP defines its own server-side error codes for tool invocation, transport, and auth. The two namespaces are independent; PEAC does not mirror MCP error code values and MCP does not mirror PEAC error code values. When an integrator observes an MCP error, the integrator can include the MCP-reported error string and code as opaque values inside the recorded extension body, but the PEAC envelope itself uses only the canonical PEAC error namespace.
+
+## What PEAC does not do
+
+- PEAC does not host an MCP registry.
+- PEAC does not route MCP requests.
+- PEAC does not implement MCP transport.
+- PEAC does not evaluate MCP tool safety.
+- PEAC does not score MCP servers.
+- PEAC does not validate MCP server identity.
+- PEAC does not enforce MCP auth policy.
+- PEAC does not manage MCP server processes.
+
+## Watch items
+
+The Model Context Protocol working group is actively discussing several proposals that may affect this composition surface. PEAC will not preemptively record their semantics until each lands. Track upstream:
+
+- specification feature-lifecycle and deprecation policy (SEP-2596, open at time of writing);
+- progressive tool disclosure (SEP-2636, open at time of writing);
+- event-driven tool invocation (SEP-2495, open at time of writing).
+
+When any of these moves to merged status upstream, this composition document will receive a targeted update; no PEAC wire, schema, or registry change is expected as a result of upstream MCP evolution.
+
+## Where to go from here
+
+- [MCP tool-call records](mcp-tool-call-receipts.md) — the canonical code recipe for attaching a signed record to an MCP tool-call response.
+- [Compatibility matrix — MCP rows](../COMPATIBILITY_MATRIX.md) — current MCP surface inventory.
+- [Wire 0.2 spec](../specs/WIRE-0.2.md) — the `interaction-record+jwt` envelope.
+- [Evidence Carrier Contract](../specs/EVIDENCE-CARRIER-CONTRACT.md) — MCP `_meta` carrier shape.

--- a/docs/SOLUTIONS/mcp-composition.md
+++ b/docs/SOLUTIONS/mcp-composition.md
@@ -8,18 +8,18 @@
 
 ## What this shows
 
-How the PEAC records layer composes with the Model Context Protocol. MCP defines the runtime contract between agents and tools. PEAC produces portable signed records of what an MCP server, client, or tool integration attested during that contract. The two layers are independent: MCP evolves on its own schedule; PEAC records what an MCP participant reported and stays verifiable beyond the runtime that produced it.
+How the PEAC records layer composes with the Model Context Protocol. MCP defines the runtime contract between agents and tools. PEAC produces portable signed records of what an MCP server, client, or tool integration reported during that contract. The two layers are independent: MCP evolves on its own schedule; PEAC records what an MCP participant reported and stays verifiable beyond the runtime that produced it.
 
 This document is a composition guide. It does not change wire format, signing envelope, public API, schema, or registry. The companion code recipe is [MCP tool-call records](mcp-tool-call-receipts.md), which shows the attachment carriers and the `_meta` keys.
 
 ## How PEAC composes with MCP
 
-PEAC's MCP composition surface is shaped by three repo-local artifacts that ship today and one stable extension namespace:
+PEAC's MCP composition surface is shaped by three repo-local artifacts and one example type URI used by the existing recipe:
 
 - the existing `@peac/mcp-server` package (built-in MCP evidence tools);
 - the existing `@peac/mappings-mcp` package (`_meta` carrier mapping per the Evidence Carrier Contract);
 - the existing recipe [`docs/SOLUTIONS/mcp-tool-call-receipts.md`](mcp-tool-call-receipts.md);
-- the `org.peacprotocol/mcp-tool-call` example type URI used by that recipe (an integrator-emitted custom type URI, not a registered PEAC profile).
+- the `org.peacprotocol/mcp-tool-call` example type URI used by that recipe. It is an integrator-emitted custom type URI, not a registered PEAC extension group, registered receipt type, or PEAC profile.
 
 The composition is record-only. PEAC reads what the MCP server or client reported, signs an interaction record, and stops there. The MCP runtime keeps owning transport, registry, auth, conformance, and process management.
 
@@ -27,7 +27,9 @@ The composition is record-only. PEAC reads what the MCP server or client reporte
 
 SEP-2468 recommends including an Issuer (`iss`) parameter in MCP authentication responses. The proposal merged on 2026-05-17 into the canonical MCP specification repository (modelcontextprotocol/specification PR 2468). The recommendation aligns with the PEAC Wire 0.2 envelope: every Wire 0.2 interaction record already carries a canonical `iss` claim as a required field.
 
-Composition: an MCP server that emits SEP-2468-shaped auth responses can be observed by an integrator and re-attested by a separate PEAC interaction record. The MCP server keeps owning the authentication decision. PEAC carries a portable signed record of what the MCP server reported. The `iss` value in the PEAC record is the operator's canonical issuer URL, not necessarily the same URL the MCP server emitted in its auth response; the two carry independent identities.
+Composition: an MCP server that emits SEP-2468-shaped auth responses can be observed by an integrator and recorded by a separate PEAC interaction record. The MCP server keeps owning the authentication decision. PEAC carries a portable signed record of what the MCP server reported. The `iss` value in the PEAC record is the operator's canonical issuer URL, not necessarily the same URL the MCP server emitted in its auth response; the two carry independent identities.
+
+PEAC verifies the PEAC record issuer and signature; it does not authenticate the MCP server, replace MCP auth, or enforce MCP authorization policy. The PEAC verification step confirms that the PEAC record itself is structurally valid and signed by the issuer the record claims; it makes no statement about whether the upstream MCP server's auth decision was correct, complete, or compliant with any MCP-defined policy.
 
 ## MCP conformance discipline
 
@@ -45,7 +47,7 @@ This evolves the MCP runtime contract; it does not change the PEAC record layer.
 
 SEP-2577 deprecates the MCP server features Roots, Sampling, and Logging. The proposal merged on 2026-05-15 into the canonical MCP specification repository (modelcontextprotocol/specification PR 2577). The deprecation introduces no wire-level break during the deprecation period; clients that already integrate against those surfaces continue to interoperate while the deprecation runs.
 
-PEAC records what the MCP server attested. A PEAC record emitted before SEP-2577 that references one of those surfaces stays verifiable; a forward record simply will not reference them. PEAC has no migration burden tied to MCP feature deprecation.
+PEAC records what the MCP server reported. A PEAC record emitted before SEP-2577 that references one of those surfaces stays verifiable; a forward record simply will not reference them. PEAC has no migration burden tied to MCP feature deprecation.
 
 ## Resumable tasks and partial results
 

--- a/docs/SOLUTIONS/mcp-tool-call-receipts.md
+++ b/docs/SOLUTIONS/mcp-tool-call-receipts.md
@@ -119,6 +119,7 @@ The MCP server and mapping test suites cover the `_meta` carrier path; `examples
 
 ## Where to go from here
 
+- [MCP composition with PEAC records](mcp-composition.md) — composition guide covering MCP auth observations, conformance discipline, schema evolution, deprecated MCP surfaces, and the PEAC-vs-MCP boundary.
 - [MCP Integration Kit](../../integrator-kits/mcp/README.md) — full MCP setup guide.
 - [`packages/mcp-server/`](../../packages/mcp-server/) — server reference (5 evidence tools).
 - [`packages/mappings/mcp/`](../../packages/mappings/mcp/) — `_meta` carrier mapping reference.

--- a/tests/tooling/mcp-composition-doc-truth.test.ts
+++ b/tests/tooling/mcp-composition-doc-truth.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Doc-truth gate for the v0.14.4 MCP composition guide.
+ *
+ * Asserts:
+ *
+ *   - docs/SOLUTIONS/mcp-composition.md exists with the canonical H1.
+ *   - The four merged SEPs cited by the guide (2468, 2484, 2577, 2106)
+ *     appear by exact number.
+ *   - SEP-2202 is not described as merged or accepted (it was closed
+ *     without merging).
+ *   - The "PEAC does NOT" boundary block carries all eight required
+ *     negation lines.
+ *   - The guide does not regress to deep-architecture or
+ *     control-surface category framings (assembled from non-contiguous
+ *     fragments below) and does not imply PEAC orchestrates the
+ *     upstream MCP runtime, enforces its auth policy, scores its
+ *     servers, or hosts its registry.
+ *   - docs/COMPATIBILITY_MATRIX.md references the new composition doc
+ *     on the MCP row.
+ *   - docs/SOLUTIONS/mcp-tool-call-receipts.md cross-links to the new
+ *     composition doc.
+ *
+ * Forbidden-string literals are assembled at runtime from
+ * non-contiguous fragments so broad public-prose grep scans over this
+ * test source do not flag the negative-assertion patterns themselves.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..');
+const COMPOSITION_PATH = join(REPO_ROOT, 'docs', 'SOLUTIONS', 'mcp-composition.md');
+const TOOL_CALL_RECIPE_PATH = join(REPO_ROOT, 'docs', 'SOLUTIONS', 'mcp-tool-call-receipts.md');
+const COMPAT_MATRIX_PATH = join(REPO_ROOT, 'docs', 'COMPATIBILITY_MATRIX.md');
+
+const COMPOSITION_TEXT = readFileSync(COMPOSITION_PATH, 'utf8');
+const TOOL_CALL_RECIPE_TEXT = readFileSync(TOOL_CALL_RECIPE_PATH, 'utf8');
+const COMPAT_MATRIX_TEXT = readFileSync(COMPAT_MATRIX_PATH, 'utf8');
+
+// Forbidden phrases assembled from non-contiguous fragments so the
+// contiguous forbidden forms never appear in this test source.
+const FORBIDDEN_TRUST_LAYER = ['trust', 'layer'].join(' ');
+const FORBIDDEN_GOVERNANCE_LAYER = ['governance', 'layer'].join(' ');
+const FORBIDDEN_CONTROL_PLANE = ['control', 'plane'].join(' ');
+const FORBIDDEN_ENFORCES_MCP_AUTH = ['enforces MCP', 'auth'].join(' ');
+const FORBIDDEN_SCORES_MCP_SERVERS = ['scores MCP', 'servers'].join(' ');
+const FORBIDDEN_HOSTS_MCP_REGISTRY = ['hosts an MCP', 'registry'].join(' ');
+const FORBIDDEN_ORCHESTRATES = 'orchestrates';
+const FORBIDDEN_FUTURE_RELEASE = ['future', 'release'].join(' ');
+const FORBIDDEN_CONDITIONAL_PR = ['conditional', 'PR'].join(' ');
+const FORBIDDEN_CUT_LINE = ['cut', 'line'].join('-');
+// DD-NNN pattern assembled non-contiguously per v0.14.4 PR 3
+// carry-forward learning #6.
+const DD_NUMBER_PATTERN = new RegExp(['\\bD', 'D-', '[0-9]+\\b'].join(''));
+
+describe('mcp-composition guide: file exists with canonical H1', () => {
+  it('exists at docs/SOLUTIONS/mcp-composition.md', () => {
+    expect(existsSync(COMPOSITION_PATH)).toBe(true);
+  });
+
+  it('uses the canonical H1 "MCP composition with PEAC records"', () => {
+    const firstLine = COMPOSITION_TEXT.split('\n').find((line) => line.startsWith('# '));
+    expect(firstLine).toBe('# MCP composition with PEAC records');
+  });
+});
+
+describe('mcp-composition guide: SEP citations by exact number', () => {
+  for (const sep of ['2468', '2484', '2577', '2106'] as const) {
+    it(`cites merged SEP-${sep} by exact number`, () => {
+      expect(COMPOSITION_TEXT).toContain(`SEP-${sep}`);
+    });
+  }
+
+  it('does not describe SEP-2202 as merged or accepted', () => {
+    // SEP-2202 was closed without merging. The guide should NOT cite
+    // it as an accepted / merged feature. If it appears at all, it
+    // must be in a "closed without merging" context.
+    if (COMPOSITION_TEXT.includes('SEP-2202')) {
+      const idx = COMPOSITION_TEXT.indexOf('SEP-2202');
+      const window = COMPOSITION_TEXT.slice(Math.max(0, idx - 80), idx + 200);
+      expect(window).toMatch(/closed without|not merged|not accepted|did not merge/i);
+    }
+    // Either way, SEP-2202 must not appear in a positive-merge context.
+    expect(COMPOSITION_TEXT).not.toMatch(/SEP-2202 (is|was) merged/);
+  });
+});
+
+describe('mcp-composition guide: boundary block', () => {
+  const REQUIRED_BOUNDARIES: ReadonlyArray<string> = [
+    'PEAC does not host an MCP registry.',
+    'PEAC does not route MCP requests.',
+    'PEAC does not implement MCP transport.',
+    'PEAC does not evaluate MCP tool safety.',
+    'PEAC does not score MCP servers.',
+    'PEAC does not validate MCP server identity.',
+    'PEAC does not enforce MCP auth policy.',
+    'PEAC does not manage MCP server processes.',
+  ];
+
+  for (const line of REQUIRED_BOUNDARIES) {
+    it(`carries the boundary line "${line}"`, () => {
+      expect(COMPOSITION_TEXT).toContain(line);
+    });
+  }
+});
+
+describe('mcp-composition guide: forbidden category-claim wording absent', () => {
+  it('rejects deep-architecture category framing #1', () => {
+    expect(COMPOSITION_TEXT.toLowerCase()).not.toContain(FORBIDDEN_TRUST_LAYER);
+  });
+
+  it('rejects deep-architecture category framing #2', () => {
+    expect(COMPOSITION_TEXT.toLowerCase()).not.toContain(FORBIDDEN_GOVERNANCE_LAYER);
+  });
+
+  it('rejects deep-architecture category framing #3', () => {
+    expect(COMPOSITION_TEXT.toLowerCase()).not.toContain(FORBIDDEN_CONTROL_PLANE);
+  });
+
+  it('does not say "PEAC orchestrates"', () => {
+    // PEAC is the records layer; the upstream MCP runtime is the
+    // orchestrator. Reject any prose claiming PEAC orchestrates.
+    expect(COMPOSITION_TEXT.toLowerCase()).not.toMatch(
+      new RegExp(`peac ${FORBIDDEN_ORCHESTRATES}`)
+    );
+  });
+
+  it('does not assert that PEAC enforces MCP auth in a positive claim', () => {
+    // The boundary block "PEAC does not enforce MCP auth policy" is
+    // allowed and required. No positive "PEAC enforces MCP auth"
+    // claim may appear anywhere else.
+    expect(COMPOSITION_TEXT).not.toMatch(/PEAC\s+enforces\s+MCP\s+auth/i);
+    expect(COMPOSITION_TEXT.toLowerCase()).not.toContain(FORBIDDEN_ENFORCES_MCP_AUTH);
+  });
+
+  it('does not assert that PEAC scores MCP servers in a positive claim', () => {
+    expect(COMPOSITION_TEXT).not.toMatch(/PEAC\s+scores\s+MCP\s+servers/i);
+    expect(COMPOSITION_TEXT.toLowerCase()).not.toContain(FORBIDDEN_SCORES_MCP_SERVERS);
+  });
+
+  it('does not assert that PEAC hosts an MCP registry in a positive claim', () => {
+    expect(COMPOSITION_TEXT).not.toMatch(/PEAC\s+hosts\s+an\s+MCP\s+registry/i);
+    expect(COMPOSITION_TEXT.toLowerCase()).not.toContain(FORBIDDEN_HOSTS_MCP_REGISTRY);
+  });
+});
+
+describe('mcp-composition guide: forbidden internal-process tokens', () => {
+  it('rejects forward-looking release wording', () => {
+    expect(COMPOSITION_TEXT.toLowerCase()).not.toContain(FORBIDDEN_FUTURE_RELEASE);
+  });
+
+  it('rejects internal sequencing / decision-record tokens', () => {
+    expect(COMPOSITION_TEXT).not.toContain(FORBIDDEN_CONDITIONAL_PR);
+    expect(COMPOSITION_TEXT).not.toContain(FORBIDDEN_CUT_LINE);
+    expect(COMPOSITION_TEXT).not.toMatch(DD_NUMBER_PATTERN);
+  });
+});
+
+describe('mcp-composition guide: scope discipline', () => {
+  it('does not propose a new wire format', () => {
+    expect(COMPOSITION_TEXT).not.toMatch(/new wire format/i);
+  });
+
+  it('does not propose a new signing envelope', () => {
+    expect(COMPOSITION_TEXT).not.toMatch(/new signing envelope/i);
+  });
+
+  it('does not propose adding a new public package surface', () => {
+    expect(COMPOSITION_TEXT).not.toMatch(/new public package/i);
+    expect(COMPOSITION_TEXT).not.toMatch(/new published package/i);
+  });
+
+  it('does not propose an MCP SDK dependency upgrade', () => {
+    expect(COMPOSITION_TEXT).not.toMatch(/upgrade.*@modelcontextprotocol\/sdk/i);
+    expect(COMPOSITION_TEXT).not.toMatch(/MCP SDK upgrade/i);
+  });
+});
+
+describe('compatibility matrix: cross-links the MCP composition guide', () => {
+  it('cites docs/SOLUTIONS/mcp-composition.md from the MCP server row', () => {
+    expect(COMPAT_MATRIX_TEXT).toContain('SOLUTIONS/mcp-composition.md');
+  });
+});
+
+describe('mcp-tool-call recipe: cross-links the MCP composition guide', () => {
+  it('cross-links mcp-composition.md from the existing recipe', () => {
+    expect(TOOL_CALL_RECIPE_TEXT).toContain('mcp-composition.md');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a composition guide that documents how PEAC records compose with the Model Context Protocol (MCP). The PEAC records layer is independent of the MCP runtime; MCP evolves on its own schedule, and PEAC records what an MCP participant reported so the record stays verifiable beyond the runtime that produced it.

- New `docs/SOLUTIONS/mcp-composition.md` covering MCP auth observations and the `iss` claim, MCP conformance discipline, MCP tool schema evolution, deprecated MCP surfaces, resumable tasks and partial results, stdio process lifetime, and error-code boundaries.
- Cross-link from the existing `docs/SOLUTIONS/mcp-tool-call-receipts.md` recipe to the new composition guide.
- Conservative `docs/COMPATIBILITY_MATRIX.md` MCP row refinement that cites the composition guide.
- New `tests/tooling/mcp-composition-doc-truth.test.ts` (30 assertions).

## Scope

Docs/test only.

No `packages/mcp-server/` change, no `packages/mappings/mcp/` change, no MCP SDK dependency upgrade, no schema, no registry, no type URI, no conformance ID, no public API, no CLI surface, no release-facts change, no package-publication change, and no wire/signing change.

## Behavior

The guide cites four MCP SEPs by exact number that have merged upstream into the canonical MCP specification repository: SEP-2468 (Issuer parameter in MCP auth responses), SEP-2484 (conformance tests for Standards Track SEPs before Final), SEP-2577 (deprecation of Roots / Sampling / Logging), and SEP-2106 (tool input/output schemas aligned with JSON Schema 2020-12). SEP-2202 is intentionally not cited as merged: it was closed without merging.

The guide includes an eight-line "What PEAC does not do" block: PEAC does not host an MCP registry, route MCP requests, implement MCP transport, evaluate MCP tool safety, score MCP servers, validate MCP server identity, enforce MCP auth policy, or manage MCP server processes.

## Validation

- `pnpm exec vitest run tests/tooling/mcp-composition-doc-truth.test.ts`
- `pnpm exec vitest run tests/tooling/`
- `node reference/scripts/verify-local-doc-truth.mjs`
- `node reference/scripts/verify-final-hygiene.mjs`
- `bash scripts/ci/forbid-strings.sh`
- `PEAC_FAST=1 bash scripts/guard.sh`
- `pnpm verify:release`
- `pnpm exec turbo run build --dry=json | jq '.tasks | length'`

Expected:
- `tests/tooling/mcp-composition-doc-truth.test.ts` passes 30 of 30.
- `build_targets` remains 107.
- `docs/releases/facts.json` is untouched.

## Compatibility

No public protocol or package surface change. The compatibility-matrix MCP row now cites the new composition guide; no other matrix rows change. The companion code recipe `docs/SOLUTIONS/mcp-tool-call-receipts.md` gains one cross-link to the composition guide and is otherwise unchanged.
