### PR TITLE
chore(release): stamp v0.14.4 latest promotion

### DIFF
--- a/docs/releases/current.json
+++ b/docs/releases/current.json
@@ -2,7 +2,7 @@
   "description": "PEAC release manifest: CI-enforceable source of truth for release state",
   "version": "0.14.4",
   "wire_format_version": "0.2",
-  "dist_tag": "next",
+  "dist_tag": "latest",
   "registries_version": "0.6.0",
   "errors_version": "0.14.4"
 }

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -3,7 +3,7 @@
   "schema_version": "1.0.0",
   "version": "0.14.4",
   "wire_format_version": "0.2",
-  "dist_tag": "next",
+  "dist_tag": "latest",
   "release_date": "2026-05-19",
   "metrics": {
     "tests": 10838,


### PR DESCRIPTION
## Summary

Flips release-state metadata `dist_tag: next` → `latest` after npm `latest` promotion completed for v0.14.4.

## Scope

Two-file stamp PR only:

- `docs/releases/facts.json` — `dist_tag: "next"` → `"latest"`
- `docs/releases/current.json` — `dist_tag: "next"` → `"latest"`

## Validation

```
npm view @peac/protocol dist-tags
# { latest: '0.14.4', next: '0.14.4' }
```

All 36 published packages already at `latest: 0.14.4` on npm.

## Compatibility

No schema, wire, public API, or package-publication change. Pure release-state metadata.
