### PR TITLE
chore(release): stamp REPO_SURFACE_STATUS updated for v0.14.4

### DIFF
--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable surface classification for PEAC Protocol workspace. CI fails if any workspace member is missing. See docs/PACKAGE_STATUS.md for human-readable view.",
   "version": "0.13.0",
-  "updated": "2026-05-17",
+  "updated": "2026-05-19",
   "states": {
     "default": "Current recommended path. Actively maintained, Wire 0.2 native.",
     "supported": "Actively maintained, published, production-ready. May not be on default quickstart path.",

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -2,7 +2,7 @@
 
 Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scripts/generate-surface-status.mjs`.
 
-**Version:** 0.13.0 | **Updated:** 2026-05-17
+**Version:** 0.13.0 | **Updated:** 2026-05-19
 
 ## Layer 1
 


### PR DESCRIPTION
## Summary

Bumps `REPO_SURFACE_STATUS.updated` to publish UTC day after v0.14.4 promote-latest completion. Closes the post-promote YELLOW from the inline closeout step.

## Scope

Two-file stamp PR only:

- `REPO_SURFACE_STATUS.json` — `updated: "2026-05-17"` → `"2026-05-19"`
- `docs/SURFACE_STATUS.md` — regenerated to match (`Generated from REPO_SURFACE_STATUS.json` line)

## Validation

```
pnpm verify:release-closeout --version 0.14.4 --stage promote --strict
# expect: 7 GREEN / 0 YELLOW / 0 RED
```

## Compatibility

No schema, wire, public API, or package-publication change. Pure release-state metadata.
