### PR TITLE
docs: align verification and security documentation with v0.14.4

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-Last reviewed: 2026-04-19
+Last reviewed: 2026-05-21
 
 This is the canonical security policy for the PEAC Protocol. It describes
 how to report a vulnerability, which versions receive security fixes, what
@@ -35,12 +35,14 @@ kept in the loop and the disclosure calendar is coordinated.
 
 ## Supported versions
 
-| Line                             | Status                            | Wire format                         | Security-fix window            |
-| -------------------------------- | --------------------------------- | ----------------------------------- | ------------------------------ |
-| `v0.12.x`                        | Active                            | Wire 0.2 (`interaction-record+jwt`) | Through the `v0.13.x` line     |
-| `v0.11.x`                        | Maintenance (security fixes only) | Wire 0.1 (`peac-receipt/0.1`)       | 6 months after `v0.13.0` ships |
-| `v0.10.x` and earlier            | End of life                       | Wire 0.1 and earlier                | No further updates             |
-| `peac.receipt/0.9` archival path | Historical verify-only            | `peac.receipt/0.9`                  | Archived at `v0.13.0`          |
+| Line                             | Status                                     | Wire format                         | Security-fix window                           |
+| -------------------------------- | ------------------------------------------ | ----------------------------------- | --------------------------------------------- |
+| `v0.14.x`                        | Active (current)                           | Wire 0.2 (`interaction-record+jwt`) | Through the next minor line                   |
+| `v0.13.x`                        | Maintenance (security fixes only)          | Wire 0.2 (`interaction-record+jwt`) | 6 months after the next minor line ships      |
+| `v0.12.x`                        | Maintenance (critical security fixes only) | Wire 0.2 (`interaction-record+jwt`) | Through 2026-11-03 (6 months after `v0.14.0`) |
+| `v0.11.x`                        | Maintenance (security fixes only)          | Wire 0.1 (`peac-receipt/0.1`)       | Through 2026-10-25 (6 months after `v0.13.0`) |
+| `v0.10.x` and earlier            | End of life                                | Wire 0.1 and earlier                | No further updates                            |
+| `peac.receipt/0.9` archival path | Historical verify-only                     | `peac.receipt/0.9`                  | Archived at `v0.13.0`                         |
 
 See [Compatibility matrix](docs/COMPATIBILITY_MATRIX.md) for full runtime
 and wire-format compatibility, and [Security operations](docs/SECURITY-OPERATIONS.md)
@@ -97,9 +99,11 @@ scan is clean; the scan is the authoritative check.
   pull requests, pushes to main, and weekly.
 - Dependency review blocks CRITICAL advisories and denies GPL-3.0 /
   AGPL-3.0 introductions.
-- External security review cadence: scope and artifact list are planned
-  for a future release; execution is coordinated with an independent
-  reviewer.
+- Independent third-party security review has not been completed for this
+  release. Current review coverage includes CodeQL, dependency review,
+  provenance attestations, audit gating, threat-model coverage, and release
+  verification. Any completed third-party review will be listed here with
+  scope and date.
 
 ## Trust artifacts
 
@@ -119,29 +123,26 @@ Full trust documentation is organized in
 - [HTTP transport security](docs/security/HTTP-TRANSPORT-SECURITY.md).
 - [OWASP ASI mapping](docs/security/OWASP-ASI-MAPPING.md).
 
-## Future carrier security controls (pre-doctrine)
+## Carrier security controls
 
-Future execution-surface carriers (CLI execution evidence; observational
-lifecycle records) are not shipped. Their security contract is
-pre-declared so that future implementation MUST honor the rules on day
-one:
+Execution, lifecycle, and provisioning carrier surfaces are shipped and
+covered by their profile specifications:
 
-- No raw secret capture by default; redaction or hashing defaults for
-  `argv`, `stdin`, `stdout`, `stderr`.
-- Hash-only default for stream captures unless a documented
-  `capture_policy` enables raw capture.
-- Environment-variable allowlist plus value hashing; no blanket
-  environment dump.
-- Explicit `argv_mode` for shell-string invocations; no hidden shell
-  expansion.
-- Bounded byte ceilings on command capture; truncation or hashing
-  replaces silent drops.
-- Lifecycle records observational-only; no implied PEAC decision, trust
-  score, policy enforcement, or payment finality.
+- [CLI carrier profile](docs/specs/CLI-CARRIER-PROFILE.md)
+- [Lifecycle observation profile](docs/specs/LIFECYCLE-OBSERVATION-PROFILE.md)
+- [Provisioning lifecycle profile](docs/specs/PROVISIONING-LIFECYCLE-PROFILE.md)
 
-Each rule above becomes a named threat ID with a concrete test file when
-the corresponding surface is implemented. Details in
-[Threat model: future carrier surfaces](docs/THREAT_MODEL.md#future-carrier-surfaces-pre-doctrine).
+The carrier security posture is:
+
+- no raw secret capture by default;
+- redaction or hashing defaults for `argv`, `stdin`, `stdout`, and `stderr`;
+- hash-only default for stream captures unless an explicit capture policy enables raw capture;
+- environment-variable allowlists plus value hashing, not blanket environment dumps;
+- explicit `argv_mode` for shell-string invocations;
+- bounded byte ceilings on command capture, with truncation or hashing instead of silent drops;
+- lifecycle records are observational only and do not imply PEAC decisions, trust scores, policy enforcement, or payment finality.
+
+Each rule is covered by the shipped profile specs and threat-model coverage.
 
 ## Contacts
 

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -124,6 +124,8 @@ Informational and regression-oriented. Operator-facing service-level objectives 
 | ------------------------- | ---------------- | ------------------------ | ------------------------------------------------------------------------------------------------ |
 | `@peac/core`              | v0.10.0          | v0.13.0 (archived)       | Use `@peac/kernel` plus `@peac/schema` plus `@peac/crypto` plus `@peac/protocol`.                |
 | `@peac/sdk`               | v0.12.7          | v0.13.0 (archived)       | Use `@peac/protocol` directly.                                                                   |
+| `@peac/disc`              | v0.12.14         | v0.13.0 (archived)       | Use `@peac/policy-kit` for peac.txt policy-document loading.                                     |
+| `@peac/pref`              | v0.12.14         | v0.13.0 (archived)       | Use `@peac/mappings-content-signals` for AIPREF / robots.txt / tdmrep parsing.                   |
 | API `/verify` endpoint    | v0.12.7          | post-Sunset (2026-11-01) | Use `/v1/verify`. Legacy `/verify` delegates in-process; carries RFC 9745 / RFC 8594 / RFC 8288. |
 | `apps/bridge`             | v0.12.7          | v0.13.0                  | Use `@peac/protocol` or `/api/v1/verify`.                                                        |
 | Wire 0.1 default teaching | v0.12.7          | Immediate                | All defaults now Wire 0.2.                                                                       |

--- a/docs/SLO.md
+++ b/docs/SLO.md
@@ -10,43 +10,49 @@
 
 ## Baseline metadata
 
-| Field                      | Value                                                                                           |
-| -------------------------- | ----------------------------------------------------------------------------------------------- |
-| `baseline_commit`          | `release-prep` (final value stamped on the v0.12.12 release-prep commit)                        |
-| `baseline_date`            | `release-prep` (final value stamped on the v0.12.12 release-prep commit)                        |
-| `baseline_machine_profile` | See [Benchmark methodology](BENCHMARK-METHODOLOGY.md)                                           |
-| Capture method             | `pnpm test --filter @peac/protocol tests/perf/wire02-slo.test.ts` with `PEAC_BENCH_JSON=<path>` |
+| Field                      | Value                                                                       |
+| -------------------------- | --------------------------------------------------------------------------- |
+| `baseline_commit`          | `0c6d2047`                                                                  |
+| `baseline_date`            | `2026-05-21`                                                                |
+| `baseline_machine_profile` | See [Benchmark methodology](BENCHMARK-METHODOLOGY.md)                       |
+| Capture method             | `PEAC_BENCH_JSON=<path> pnpm exec vitest run tests/perf/wire02-slo.test.ts` |
 
-All rows below carry `baseline_commit: release-prep` until the release-prep
-commit replaces the placeholders with captured numbers. The captured numbers
-are the measurement against the `baseline_commit` on the documented machine
-profile; real-world performance varies with hardware, network, workload, and
-receipt size.
+The local protocol operations table below carries captured values for
+`issue()` and `verifyLocal()` measured against the `baseline_commit` on
+the documented machine profile. The reference verifier and MCP
+round-trip tables remain unmeasured this cycle; those rows are outside
+the current measured baseline and require dedicated benchmarks.
+Real-world performance varies with hardware, network, workload, and
+record size.
 
-## Local protocol operations (`@peac/protocol` v0.12.12)
+## Local protocol operations (`@peac/protocol` v0.14.4)
 
-| Operation                               | Median (p50)   | p95            | p99            | Notes                        |
-| --------------------------------------- | -------------- | -------------- | -------------- | ---------------------------- |
-| `issue()` (Ed25519, ~1 KB record)       | `release-prep` | `release-prep` | `release-prep` | Loopback; Ed25519 only       |
-| `verifyLocal()` (Ed25519, ~1 KB record) | `release-prep` | `release-prep` | `release-prep` | Local validation; no network |
+| Operation                               | Median (p50) | p95    | p99    | Notes                                                                                                                    |
+| --------------------------------------- | ------------ | ------ | ------ | ------------------------------------------------------------------------------------------------------------------------ |
+| `issue()` (Ed25519, ~1 KB record)       | 0.4 ms       | 0.5 ms | 0.6 ms | Loopback; Ed25519 only. Measured via `issueWire02()`, which `issue()` delegates to directly without measurable overhead. |
+| `verifyLocal()` (Ed25519, ~1 KB record) | 1.5 ms       | 1.7 ms | 1.9 ms | Local validation; no network.                                                                                            |
 
 The existing SLO gate in [tests/perf/wire02-slo.test.ts](../tests/perf/wire02-slo.test.ts)
 asserts `verifyLocal` p95 MUST be ≤ 10 ms. That gate runs in CI on every PR.
 
 ## Reference verifier (`apps/api` `/v1/verify`)
 
-| Operation                                                     | Median (p50)   | p95            | p99            | Notes                                        |
-| ------------------------------------------------------------- | -------------- | -------------- | -------------- | -------------------------------------------- |
-| `/v1/verify` (Ed25519, ~1 KB record)                          | `release-prep` | `release-prep` | `release-prep` | Loopback; no JWKS resolution                 |
-| `/v1/verify` with JWKS resolution (single issuer, warm cache) | `release-prep` | `release-prep` | `release-prep` | Measured after first request; JWKS cache hot |
+| Operation                                                     | Median (p50)            | p95                     | p99                     | Notes                                        |
+| ------------------------------------------------------------- | ----------------------- | ----------------------- | ----------------------- | -------------------------------------------- |
+| `/v1/verify` (Ed25519, ~1 KB record)                          | Not measured this cycle | Not measured this cycle | Not measured this cycle | Loopback; no JWKS resolution                 |
+| `/v1/verify` with JWKS resolution (single issuer, warm cache) | Not measured this cycle | Not measured this cycle | Not measured this cycle | Measured after first request; JWKS cache hot |
+
+> Reference verifier rows are outside the current measured baseline and require dedicated benchmarks against the same machine profile.
 
 ## MCP tool-call round-trip with record issuance
 
-| Operation                                                                 | Median (p50)   | p95            | p99            | Notes                 |
-| ------------------------------------------------------------------------- | -------------- | -------------- | -------------- | --------------------- |
-| MCP `tools/call` round-trip emitting `_meta.org.peacprotocol/receipt_jws` | `release-prep` | `release-prep` | `release-prep` | Local stdio transport |
+| Operation                                                                 | Median (p50)            | p95                     | p99                     | Notes                 |
+| ------------------------------------------------------------------------- | ----------------------- | ----------------------- | ----------------------- | --------------------- |
+| MCP `tools/call` round-trip emitting `_meta.org.peacprotocol/receipt_jws` | Not measured this cycle | Not measured this cycle | Not measured this cycle | Local stdio transport |
 
-## Receipt size classes used in the table
+> MCP round-trip row is outside the current measured baseline and requires a dedicated benchmark against the same machine profile.
+
+## Record size classes used in the table
 
 - Class A: ~1 KB record (typical agent observation; used in the rows above).
 - Class B: ~8 KB record (commerce evidence with attached upstream artifact).
@@ -64,35 +70,20 @@ The published numbers reflect Class A unless a row explicitly states otherwise.
   [Hosted Verify contract](HOSTED_VERIFY_CONTRACT.md).
 - Baseline numbers describe loopback measurement on the documented machine
   profile. Production performance varies with hardware, network, workload,
-  and receipt size.
-- SLO numbers are not available for future execution-surface carriers (CLI
-  execution evidence; observational lifecycle records). Those carriers
-  enter the SLO document at v0.14.1; see the forward-looking subsection
-  below.
+  and record size.
+- Carrier-specific capture overhead is not measured this cycle. The local
+  signing and verification cost for records emitted by those carriers is
+  represented by the `issue()` and `verifyLocal()` rows above.
 
 ## Regression policy
 
 - `verifyLocal()` p95 is gated by the existing CI benchmark regression
   check in [tests/perf/wire02-slo.test.ts](../tests/perf/wire02-slo.test.ts).
-- `issue()` baseline is published here and becomes a regression-gate
-  candidate alongside the broader mutation-testing baseline work tracked
-  for a future release.
-- Reference verifier `/v1/verify` baseline is published here. Regression
-  gating is scheduled to evolve alongside the existing Go middleware
-  benchmark discipline.
-
-## Future execution-surface carriers (pre-doctrine)
-
-This subsection is forward-looking. It documents the expected SLO
-commitments for future public carriers that have not yet shipped. These
-rules apply when, and only when, the corresponding carriers land.
-
-- CLI execution-evidence carrier: SLO rows publish at v0.14.1 against the
-  same machine profile. Until v0.14.1 ships, no CLI execution-evidence
-  SLO is claimed.
-- Observational lifecycle-record carrier: SLO rows publish at v0.14.1.
-  Lifecycle records are observational-only; SLO measures record-emission
-  time on the PEAC side, not the upstream producing system.
+- `issue()` baseline is published here. It is not a blocking regression
+  gate until a dedicated gate is added and documented.
+- Reference verifier `/v1/verify` baseline is not published in this cycle.
+  It enters regression policy only after a measured baseline is captured
+  against the documented machine profile.
 
 ## Related documents
 

--- a/docs/SLO.md
+++ b/docs/SLO.md
@@ -27,10 +27,10 @@ record size.
 
 ## Local protocol operations (`@peac/protocol` v0.14.4)
 
-| Operation                               | Median (p50) | p95    | p99    | Notes                                                                                                                    |
-| --------------------------------------- | ------------ | ------ | ------ | ------------------------------------------------------------------------------------------------------------------------ |
-| `issue()` (Ed25519, ~1 KB record)       | 0.4 ms       | 0.5 ms | 0.6 ms | Loopback; Ed25519 only. Measured via `issueWire02()`, which `issue()` delegates to directly without measurable overhead. |
-| `verifyLocal()` (Ed25519, ~1 KB record) | 1.5 ms       | 1.7 ms | 1.9 ms | Local validation; no network.                                                                                            |
+| Operation                               | Median (p50) | p95    | p99    | Notes                                                                   |
+| --------------------------------------- | ------------ | ------ | ------ | ----------------------------------------------------------------------- |
+| `issue()` (Ed25519, ~1 KB record)       | 0.4 ms       | 0.5 ms | 0.6 ms | Measured on the Wire 0.2 issuance path used by `issue()`; Ed25519 only. |
+| `verifyLocal()` (Ed25519, ~1 KB record) | 1.5 ms       | 1.7 ms | 1.9 ms | Local validation; no network.                                           |
 
 The existing SLO gate in [tests/perf/wire02-slo.test.ts](../tests/perf/wire02-slo.test.ts)
 asserts `verifyLocal` p95 MUST be ≤ 10 ms. That gate runs in CI on every PR.

--- a/docs/SOLUTIONS/runtime-evidence-export.md
+++ b/docs/SOLUTIONS/runtime-evidence-export.md
@@ -1,6 +1,6 @@
 # Runtime evidence export
 
-> **Outcome:** Your managed agent runtime (Microsoft Agent Governance Toolkit, Claude Managed Agents, OpenAI ACP-backed runtime, or a custom harness) emits decisions. You want those decisions to leave the runtime as portable signed records that an auditor, a counterparty, or another team can verify offline.
+> **Outcome:** A managed agent runtime or custom harness emits governance decisions. You want those decisions to leave the runtime as portable signed records that an auditor, a counterparty, or another team can verify offline.
 >
 > **Audience:** Runtime / platform operator.
 >
@@ -19,7 +19,7 @@ PEAC packages:
 - `@peac/protocol` — issuance and offline verification.
 - `@peac/crypto` — Ed25519 signing.
 - `@peac/adapter-runtime-governance` — generic runtime-governance observation mapper.
-- `@peac/adapter-managed-agents` — runtime-specific mappings (Claude Managed Agents event families, and similar shapes for other managed runtimes).
+- `@peac/adapter-managed-agents` — runtime-specific mappings for managed-runtime event families.
 
 Optional adjacent systems: any runtime that already produces a structured decision event. This recipe uses the shipped conformance fixtures, so no external runtime is required to run it.
 
@@ -124,8 +124,8 @@ The conformance vectors used in the step-by-step are under [`specs/conformance/r
 
 ## Where to go from here
 
-- [`docs/compatibility/COMPATIBILITY_MATRIX.md`](../COMPATIBILITY_MATRIX.md) — Adapter Readiness row for `@peac/adapter-runtime-governance` and `@peac/adapter-managed-agents`.
+- [`docs/COMPATIBILITY_MATRIX.md`](../COMPATIBILITY_MATRIX.md) — Adapter Readiness row for `@peac/adapter-runtime-governance` and `@peac/adapter-managed-agents`.
 - [`docs/profiles/`](../profiles/) — runtime-governance profile doc.
 - [`docs/WHERE-IT-FITS.md`](../WHERE-IT-FITS.md) — PEAC vs runtime governance boundary.
 - [`docs/WHAT-PEAC-STANDARDIZES.md`](../WHAT-PEAC-STANDARDIZES.md) — what the protocol defines and what it stops at.
-- **Future carrier surfaces:** planned releases extend PEAC to carry CLI execution evidence and observational lifecycle records (eval, approval, experiment, or workflow event exports emitted by other systems) as additional carrier surfaces. The protocol boundary does not change.
+- **Related carrier surfaces:** PEAC also supports CLI execution records and observational lifecycle records as shipped carrier surfaces. These records preserve bounded work emitted by other systems; the protocol boundary does not change.

--- a/docs/STABILITY-CONTRACT.md
+++ b/docs/STABILITY-CONTRACT.md
@@ -7,12 +7,13 @@ expectations to concrete, reviewable entries.
 
 ## Classifications
 
-| Classification  | Commitment                                                                                                                    |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `stable`        | Public commitment. Breaking changes at a declared major-version boundary. Wire constants in this class are frozen until v1.0. |
-| `experimental`  | Public but explicitly subject to change. Breaking changes may land in any release with a CHANGELOG note. Flagged in source.   |
-| `deprecated`    | Public and supported within its declared window; scheduled for removal at a named release.                                    |
-| `internal-only` | Not part of the public surface. Not documented on README, `docs/START_HERE.md`, examples, listings, or marketing prose.       |
+| Classification  | Commitment                                                                                                                                                                              |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `stable`        | Public commitment. Breaking changes at a declared major-version boundary. Wire constants in this class are frozen until v1.0.                                                           |
+| `experimental`  | Public but explicitly subject to change. Breaking changes may land in any release with a CHANGELOG note. Flagged in source.                                                             |
+| `deprecated`    | Public and supported within its declared window; scheduled for removal at a named release.                                                                                              |
+| `archived`      | Historical surface removed from the active workspace. Source is preserved under `archive/`; historical npm versions may remain installable, but new integrations MUST NOT depend on it. |
+| `internal-only` | Not part of the public surface. Not documented on README, `docs/START_HERE.md`, examples, listings, or marketing prose.                                                                 |
 
 These classifications describe behavioral stability, not package-level
 maintenance (security and correctness fixes apply to every active line per
@@ -33,36 +34,37 @@ maintenance (security and correctness fixes apply to every active line per
 
 ## Public TypeScript APIs
 
-| Surface (package)                                                                           | Classification  | Notes                                                                                                                      |
-| ------------------------------------------------------------------------------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| [`@peac/protocol`](../packages/protocol) `issue()`                                          | `stable`        | Wire 0.2 issuance entry point                                                                                              |
-| [`@peac/protocol`](../packages/protocol) `verifyLocal()`                                    | `stable`        | Offline verification                                                                                                       |
-| [`@peac/protocol`](../packages/protocol) `verify()`                                         | `stable`        | Verification with optional hosted report assembly                                                                          |
-| `@peac/protocol` discovery / JWKS resolver helpers                                          | `internal-only` | Use via `verifyLocal()` / `verify()`; see [protocol-behavior](specs/PROTOCOL-BEHAVIOR.md)                                  |
-| [`@peac/crypto`](../packages/crypto) Ed25519 sign / verify                                  | `stable`        | RFC 8032 primitives                                                                                                        |
-| [`@peac/crypto`](../packages/crypto) JCS                                                    | `stable`        | RFC 8785 serialization                                                                                                     |
-| [`@peac/schema`](../packages/schema) record + extension-group exports                       | `stable`        | Zod v4 schemas                                                                                                             |
-| [`@peac/kernel`](../packages/kernel) type URIs and constants                                | `stable`        | Some constants relocate in a later release with a compat barrel; announced via [deprecation policy](DEPRECATION_POLICY.md) |
-| `@peac/control` high-level APIs                                                             | `stable`        | Compose `@peac/protocol` with higher-level flows                                                                           |
-| `@peac/middleware-core`, `@peac/middleware-express`                                         | `stable`        | HTTP middleware                                                                                                            |
-| `@peac/disc` issuer-config resolution                                                       | `stable`        | `/.well-known/peac-issuer.json` → `jwks_uri`                                                                               |
-| `@peac/jwks-cache`                                                                          | `stable`        | Bounded LRU JWKS cache with kid-reuse detection                                                                            |
-| `@peac/audit` bundle exports                                                                | `stable`        | Offline dispute-bundle composition                                                                                         |
-| [`@peac/adapter-core`](../packages/adapters/core) `assertExplicitFinality`                  | `stable`        | Commerce mapper-boundary guard                                                                                             |
-| `@peac/mappings-{mcp,a2a,acp,paymentauth,ucp,content-signals,intoto,slsa}`                  | `stable`        | Observation mappers                                                                                                        |
-| `@peac/adapter-{x402,openclaw,eat,did,managed-agents,runtime-governance,openai-compatible}` | `stable`        | Layer 4 adapters                                                                                                           |
-| `@peac/rails-x402`, `@peac/rails-card`, `@peac/rails-razorpay`, `@peac/rails-stripe`        | `stable`        | Commerce rails                                                                                                             |
-| `@peac/http-signatures`                                                                     | `stable`        | RFC 9421 helpers                                                                                                           |
-| `@peac/net-node` SSRF-safe fetch                                                            | `stable`        | Used by resolver paths; see [security considerations](specs/SECURITY-CONSIDERATIONS.md)                                    |
-| `@peac/transport-grpc`                                                                      | `stable`        | A2A gRPC carrier                                                                                                           |
-| `@peac/policy-kit`                                                                          | `stable`        | Policy authoring helpers (non-enforcement)                                                                                 |
-| `@peac/capture-core`, `@peac/capture-node`                                                  | `stable`        | Local capture utilities                                                                                                    |
-| `@peac/telemetry`, `@peac/telemetry-otel`                                                   | `stable`        | OpenTelemetry signals (opt-in)                                                                                             |
-| `@peac/contracts`                                                                           | `stable`        | Machine-readable contract exports                                                                                          |
-| `@peac/pay402`, `@peac/pref`, `@peac/attribution`, `@peac/receipts`                         | `stable`        | Supporting packages on Layer 4                                                                                             |
-| `@peac/worker-core`                                                                         | `stable`        | Worker-oriented helpers                                                                                                    |
-| `@peac/core`                                                                                | `archived`      | Archived at v0.13.0; source under `archive/0.9.0-0.9.14/packages-core/`; historical npm `<=0.9.14` remains installable     |
-| `@peac/sdk`                                                                                 | `archived`      | Archived; historical npm `<=0.10.2` remains installable                                                                    |
+| Surface (package)                                                                           | Classification  | Notes                                                                                                                                                                                                    |
+| ------------------------------------------------------------------------------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`@peac/protocol`](../packages/protocol) `issue()`                                          | `stable`        | Wire 0.2 issuance entry point                                                                                                                                                                            |
+| [`@peac/protocol`](../packages/protocol) `verifyLocal()`                                    | `stable`        | Offline verification                                                                                                                                                                                     |
+| [`@peac/protocol`](../packages/protocol) `verify()`                                         | `stable`        | Verification with optional hosted report assembly                                                                                                                                                        |
+| `@peac/protocol` discovery / JWKS resolver helpers                                          | `internal-only` | Use only through documented verification flows; do not import resolver helpers directly. See [protocol-behavior](specs/PROTOCOL-BEHAVIOR.md).                                                            |
+| [`@peac/crypto`](../packages/crypto) Ed25519 sign / verify                                  | `stable`        | RFC 8032 primitives                                                                                                                                                                                      |
+| [`@peac/crypto`](../packages/crypto) JCS                                                    | `stable`        | RFC 8785 serialization                                                                                                                                                                                   |
+| [`@peac/schema`](../packages/schema) record + extension-group exports                       | `stable`        | Zod v4 schemas                                                                                                                                                                                           |
+| [`@peac/kernel`](../packages/kernel) type URIs and constants                                | `stable`        | Some constants relocate in a later release with a compat barrel; announced via [deprecation policy](DEPRECATION_POLICY.md)                                                                               |
+| `@peac/control` high-level APIs                                                             | `stable`        | Compose `@peac/protocol` with higher-level flows                                                                                                                                                         |
+| `@peac/middleware-core`, `@peac/middleware-express`                                         | `stable`        | HTTP middleware                                                                                                                                                                                          |
+| `@peac/disc`                                                                                | `archived`      | Archived at v0.13.0; source under `archive/discovery/`; historical npm remains installable. Use `@peac/policy-kit` for peac.txt policy-document loading.                                                 |
+| `@peac/jwks-cache`                                                                          | `stable`        | Bounded LRU JWKS cache with kid-reuse detection                                                                                                                                                          |
+| `@peac/audit` bundle exports                                                                | `stable`        | Offline dispute-bundle composition                                                                                                                                                                       |
+| [`@peac/adapter-core`](../packages/adapters/core) `assertExplicitFinality`                  | `stable`        | Commerce mapper-boundary guard                                                                                                                                                                           |
+| `@peac/mappings-{mcp,a2a,acp,paymentauth,ucp,content-signals,intoto,slsa}`                  | `stable`        | Observation mappers                                                                                                                                                                                      |
+| `@peac/adapter-{x402,openclaw,eat,did,managed-agents,runtime-governance,openai-compatible}` | `stable`        | Layer 4 adapters                                                                                                                                                                                         |
+| `@peac/rails-x402`, `@peac/rails-card`, `@peac/rails-razorpay`, `@peac/rails-stripe`        | `stable`        | Commerce rails                                                                                                                                                                                           |
+| `@peac/http-signatures`                                                                     | `stable`        | RFC 9421 helpers                                                                                                                                                                                         |
+| `@peac/net-node` SSRF-safe fetch                                                            | `stable`        | Used by resolver paths; see [security considerations](specs/SECURITY-CONSIDERATIONS.md)                                                                                                                  |
+| `@peac/transport-grpc`                                                                      | `stable`        | A2A gRPC carrier                                                                                                                                                                                         |
+| `@peac/policy-kit`                                                                          | `stable`        | Policy authoring helpers (non-enforcement)                                                                                                                                                               |
+| `@peac/capture-core`, `@peac/capture-node`                                                  | `stable`        | Local capture utilities                                                                                                                                                                                  |
+| `@peac/telemetry`, `@peac/telemetry-otel`                                                   | `stable`        | OpenTelemetry signals (opt-in)                                                                                                                                                                           |
+| `@peac/contracts`                                                                           | `stable`        | Machine-readable contract exports                                                                                                                                                                        |
+| `@peac/pay402`, `@peac/attribution`, `@peac/receipts`                                       | `stable`        | Supporting packages on Layer 4                                                                                                                                                                           |
+| `@peac/pref`                                                                                | `archived`      | Archived at v0.13.0 (deprecated facade since v0.12.14); source under `archive/pref/`; historical npm remains installable. Use `@peac/mappings-content-signals` for AIPREF / robots.txt / tdmrep parsing. |
+| `@peac/worker-core`                                                                         | `stable`        | Worker-oriented helpers                                                                                                                                                                                  |
+| `@peac/core`                                                                                | `archived`      | Archived at v0.13.0; source under `archive/0.9.0-0.9.14/packages-core/`; historical npm `<=0.9.14` remains installable                                                                                   |
+| `@peac/sdk`                                                                                 | `archived`      | Archived; historical npm `<=0.10.2` remains installable                                                                                                                                                  |
 
 Consumers: import only from the package's documented public entry points.
 Subpath imports into internal modules are not a stable surface even when
@@ -191,7 +193,7 @@ Path: [`surfaces/plugin-pack/`](../surfaces/plugin-pack/).
 | `ProofMethodSchema` (compat alias)                        | v0.12.2          | v0.13.0                  | **Removed in v0.13.0.** Transport-binding values (`http-message-signature`, `dpop`, `mtls`, `jwk-thumbprint`) inlined on `AgentProofSchema.method`.                                                                                |
 | A2A v0.3.0 compatibility path                             | v0.12.3          | v0.13.0                  | **Removed in v0.13.0.** Agent Cards carrying only a top-level `url`, kebab-case TaskState strings, and the `/.well-known/agent.json` legacy discovery path are no longer accepted. A2A v1.0.0 `supportedInterfaces[]` is required. |
 | Legacy `POST /verify` endpoint (in favor of `/v1/verify`) | v0.12.x          | post-Sunset (2026-11-01) | Removed from active OpenAPI teaching at v0.13.0. Runtime alias preserved, delegating in-process to `/v1/verify`, until the advertised Sunset date.                                                                                 |
-| `packages/sdk-js/` workspace stub                         | v0.12.x          | v0.13.0                  | Scheduled                                                                                                                                                                                                                          |
+| `packages/sdk-js/` workspace stub                         | v0.12.x          | v0.13.0                  | **Removed in v0.13.0.** Historical source preserved under `archive/sdk-js/`; new integrations use `@peac/protocol` directly.                                                                                                       |
 | `peac.receipt/0.9` archival format                        | Legacy frozen    | v0.13.0 (quarantine)     | Quarantined to historical contexts; wire stays frozen                                                                                                                                                                              |
 | `@peac/core` archival verify-only path                    | Legacy frozen    | v0.13.0                  | **Archived in v0.13.0** to `archive/0.9.0-0.9.14/packages-core/`; historical npm `<=0.9.14` remains installable.                                                                                                                   |
 
@@ -202,16 +204,16 @@ All status transitions are tracked in
 policy live in [Security operations](SECURITY-OPERATIONS.md) and
 [Deprecation policy](DEPRECATION_POLICY.md).
 
-## Forthcoming surfaces (pre-doctrine)
+## Unshipped experimental surfaces
 
-The following surfaces are not yet shipped. They enter the stability
-contract only when the corresponding code lands. Classifications here are
-forward-looking and binding for the future public code, not for any
-current behavior.
+The following surfaces are not shipped in the current release. They are
+listed only to make the stability boundary explicit. They do not describe
+current behavior and are not a commitment to ship without a separate
+release decision.
 
 | Surface                                               | Status      | Target                                                             |
 | ----------------------------------------------------- | ----------- | ------------------------------------------------------------------ |
-| COSE/CBOR codec flag (`PEAC_EXPERIMENTAL_CODEC=cose`) | Not shipped | `experimental` once shipped; gated by an explicit roadmap decision |
+| COSE/CBOR codec flag (`PEAC_EXPERIMENTAL_CODEC=cose`) | Not shipped | `experimental` once shipped; gated by an explicit release decision |
 
 No public COSE/CBOR codec ships in this release. Security and semantic
 constraints for future codec surfaces are documented when public code
@@ -231,7 +233,7 @@ a public-API commitment.
 | `PEAC_INTERNAL_SHADOW_RESOLVER=1` (env)                                      | `apps/api` shadow-mode diagnostic foundation  | Activates lazy loading of the workspace-private resolver composition layer used by the shadow-mode pointer-fetch parity foundation. v0.13.2 ships only the foundation (boundary, normalization, sink, executor, no-network smoke); no live route integration, no internal endpoint, no public surface change.                                                                                                                                                                                                                                                                                                                    |
 | `PEAC_INTERNAL_SHADOW_BUFFER_SIZE=<n>` (env)                                 | `apps/api` shadow-mismatch-sink ring buffer   | Overrides the default in-memory mismatch sink capacity. Clamped to `[64, 16384]`; default 1024.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `PEAC_INTERNAL_LEGACY_PATH=1` (env) or `_internal.legacyPath: true` (option) | `@peac/protocol.{issue, verifyLocal, verify}` | For `issue()` and `verifyLocal()`: routes the protocol entry points through the previous direct-canonical admission path (rollback) instead of the bounded validation path (default). For `verifyReceipt()` (Wire 0.1 verifier): no behavioral effect; the bounded validation path is keyed on Wire 0.2 claim shapes. Both flag values produce byte-equivalent public outputs across the covered runtime matrix. Version-specific operator runbook in [`docs/diagnostics/ROLLBACK-v0.14.0.md`](diagnostics/ROLLBACK-v0.14.0.md); release-neutral runbook in [`docs/diagnostics/ROLLBACK-PATH.md`](diagnostics/ROLLBACK-PATH.md). |
-| `PEAC_EXPERIMENTAL_CODEC=<name>` (env, future)                               | `@peac/protocol.{issue, verifyLocal, verify}` | Selects a non-default record codec. v0.13.x ships `jws-jwt` only. Future codecs (e.g., `cose-sign1`) are experimental per the Forthcoming surfaces table.                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `PEAC_EXPERIMENTAL_CODEC=<name>` (env, reserved)                             | `@peac/protocol.{issue, verifyLocal, verify}` | Selects a non-default record codec. v0.13.x ships `jws-jwt` only. Additional codecs, if released, are experimental unless this contract assigns a stronger classification.                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 
 Allowed locations for these identifiers in tracked source:
 
@@ -270,13 +272,13 @@ Either way, the public-call boundary returns the real-path value
 immediately. Shadow scheduling uses a macrotask boundary
 (`setTimeout(..., 0)`) so the shadow function does not run before the
 caller's awaited promise continuation. Pure-CPU validators are
-themselves bounded by the receipt-content invariants in
+themselves bounded by the record-content invariants in
 [Resource limits](specs/RESOURCE-LIMITS.md), so the practical
 resource bound holds even without runtime cancellation.
 
-A future internal release may wire `AbortSignal` plumbing into
-specific validator entry points if a hard cancellation guarantee
-becomes desirable.
+Hard cancellation is not part of the current stability commitment. Any
+cancellation guarantee for validator entry points requires an explicit
+release decision, documented semantics, and tests.
 
 ## Related documents
 

--- a/docs/STABILITY-CONTRACT.md
+++ b/docs/STABILITY-CONTRACT.md
@@ -216,8 +216,8 @@ release decision.
 | COSE/CBOR codec flag (`PEAC_EXPERIMENTAL_CODEC=cose`) | Not shipped | `experimental` once shipped; gated by an explicit release decision |
 
 No public COSE/CBOR codec ships in this release. Security and semantic
-constraints for future codec surfaces are documented when public code
-lands.
+constraints for additional codec surfaces are documented with any
+released public code.
 
 ## Internal-only flags
 

--- a/docs/TRUST-ARTIFACTS.md
+++ b/docs/TRUST-ARTIFACTS.md
@@ -12,7 +12,7 @@ the documentation can link here.
 - [Benchmark methodology](BENCHMARK-METHODOLOGY.md): machine profile,
   fixture set, measurement protocol, and reproduction commands.
 - [Stability contract](STABILITY-CONTRACT.md): every public surface
-  classified `stable`, `experimental`, `deprecated`, or `internal-only`.
+  classified `stable`, `experimental`, `deprecated`, `archived`, or `internal-only`.
 - [Threat model](THREAT_MODEL.md): consolidated threat catalog with
   per-threat test-coverage links.
 
@@ -121,10 +121,15 @@ PEAC supports privacy-aware verification and GDPR-aligned
 deployments. PEAC does not replace operator legal review, lawful-basis
 decisions, or controller obligations.
 
-## Forward-looking
+## Carrier surfaces
 
-- Execution-surface carriers (CLI execution evidence; observational
-  lifecycle records) are scheduled for v0.14.1; their pre-doctrine
-  security controls are declared in the
-  [Threat model forward-looking subsection](THREAT_MODEL.md#future-carrier-surfaces-pre-doctrine)
-  and [Stability contract forthcoming subsection](STABILITY-CONTRACT.md#forthcoming-surfaces-pre-doctrine).
+Execution-surface carriers shipped in v0.14.1 and provisioning lifecycle
+carriers shipped in v0.14.2 are classified `stable` in
+[Stability contract](STABILITY-CONTRACT.md) and have CLI surfaces under
+`@peac/cli` (`peac observe command`, `peac record command`, `peac emit lifecycle`).
+The earlier forward-looking security controls described for these
+carriers are now superseded by their shipped specs:
+
+- [`docs/specs/CLI-CARRIER-PROFILE.md`](specs/CLI-CARRIER-PROFILE.md)
+- [`docs/specs/LIFECYCLE-OBSERVATION-PROFILE.md`](specs/LIFECYCLE-OBSERVATION-PROFILE.md)
+- [`docs/specs/PROVISIONING-LIFECYCLE-PROFILE.md`](specs/PROVISIONING-LIFECYCLE-PROFILE.md)

--- a/docs/compatibility/commerce-protocol-coverage.md
+++ b/docs/compatibility/commerce-protocol-coverage.md
@@ -34,8 +34,9 @@ overclaim. PEAC keeps them separate.
 
 ## Mapper-boundary finality-synthesis rule
 
-Across all three protocols, PEAC enforces a single rule at the mapper
-boundary in code (`@peac/adapter-core` `assertExplicitFinality`):
+Across all three protocols, the mapper boundary in code
+(`@peac/adapter-core` `assertExplicitFinality`) refuses payloads that
+would synthesize finality the upstream did not claim:
 
 > Commerce mappings preserve raw upstream artifacts and MUST NOT synthesize
 > payment finality from non-payment artifacts or lifecycle states alone.

--- a/docs/specs/DISPUTE.md
+++ b/docs/specs/DISPUTE.md
@@ -451,7 +451,7 @@ Valid characters: `0123456789ABCDEFGHJKMNPQRSTVWXYZ`
 
 ### A.3 Case Sensitivity
 
-PEAC enforces UPPERCASE as the canonical form:
+Canonical form requires UPPERCASE; non-canonical input is rejected by the verifier:
 
 - Generators MUST produce uppercase
 - Validators MAY normalize lowercase but SHOULD warn

--- a/docs/specs/RESOURCE-LIMITS.md
+++ b/docs/specs/RESOURCE-LIMITS.md
@@ -10,16 +10,16 @@
 
 Resource limits exist for three reasons: predictable verification cost,
 predictable wire size, and explicit denial-of-service surface area.
-Limits are deliberately small. Tightening a limit is a roadmap decision;
-loosening one is a stability-contract change.
+Limits are deliberately small. Tightening a limit requires a documented
+release decision; loosening one is a stability-contract change.
 
 ## Invariant table
 
 The reference values below ship at v0.13.0. Each row points at the
-authoritative constant; if a future release tightens the value, the
-constant is the single source of truth and this row is updated.
+authoritative constant. When a release changes a value, the constant is
+the single source of truth and this row is updated.
 
-### Receipt-content invariants (kernel)
+### Record-content invariants (kernel)
 
 | Invariant                      | Value   | Constant                                                                                                                 | Test                                                                                                                     |
 | ------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
@@ -229,9 +229,10 @@ NOT skip any layer's cap.
   PEAC-managed app-level header-byte budget; header-size rejection is
   left to the runtime / parser / deployment layer (Node's HTTP server
   exposes `maxHeaderSize`; current Node documentation lists the
-  default at 16 KiB, but deployment hosts may differ). A request body
-  is the sized payload that PEAC enforces, capped at 256 KiB by
-  `MAX_BODY_SIZE` in [`apps/api/src/verify-v1.ts`](../../apps/api/src/verify-v1.ts).
+  default at 16 KiB, but deployment hosts may differ). The request body
+  is the payload bounded by the reference verifier. Requests above
+  256 KiB are rejected by `MAX_BODY_SIZE` in
+  [`apps/api/src/verify-v1.ts`](../../apps/api/src/verify-v1.ts).
 
 ## CLI capture limits
 
@@ -266,7 +267,7 @@ The full CLI subcommand contract is specified in
 
 ## Tightening process
 
-A future release MAY tighten any limit in this document. Tightening is
+A release MAY tighten any limit in this document. Tightening is
 a stability-contract change; the new value MUST be:
 
 1. Recorded in this document with the new value and the constant path.
@@ -274,8 +275,8 @@ a stability-contract change; the new value MUST be:
 3. Guarded by a test that asserts the new ceiling.
 4. Captured in [`CHANGELOG.md`](../../CHANGELOG.md) under "Changed".
 
-A future release MUST NOT loosen any limit in this document without an
-explicit roadmap decision recorded in
+A release MUST NOT loosen any limit in this document without an explicit
+release decision recorded in
 [`docs/STABILITY-CONTRACT.md`](../STABILITY-CONTRACT.md). Loosening is
 a stability classification flip and follows the same lifecycle as a
 public-API breaking change.

--- a/llms.txt
+++ b/llms.txt
@@ -31,7 +31,7 @@ PEAC Protocol provides cryptographically signed, offline-verifiable interaction 
 - UCP Mapping: `@peac/mappings-ucp` for Universal Commerce Protocol evidence
 - x402 Adapter: `@peac/adapter-x402` for payment-required HTTP evidence
 - Content Signals: `@peac/mappings-content-signals` for robots.txt, Content-Usage (AIPREF), and tdmrep.json signal parsing
-- OpenAI Adapter: `@peac/adapter-openai-compatible` for hash-first inference receipts from any OpenAI-compatible provider
+- OpenAI Adapter: `@peac/adapter-openai-compatible` for hash-first inference records from any OpenAI-compatible provider
 - HTTP: `PEAC-Receipt` response header carries compact JWS for any HTTP API
 - Evidence Carrier Contract: universal carry interface across MCP, A2A, Agentic Commerce Protocol (ACP), UCP, x402, and HTTP
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,31 +1,31 @@
 # PEAC Protocol
 
 > Open standard for verifiable interaction records across agent, tool, API, and cross-runtime systems. Portable signed records anyone can verify offline.
-> Last reviewed: 2026-04-18
+> Last reviewed: 2026-05-21
 
 ## What is PEAC
 
-PEAC Protocol provides cryptographically signed, offline-verifiable receipts that record what happened during automated interactions. Each receipt is a compact JWS (JSON Web Signature) using Ed25519 signatures that can be verified offline given the issuer's public key (or a pinned JWKS). PEAC does not orchestrate protocols or enforce behavior; it provides neutral evidence of what terms applied and what happened.
+PEAC Protocol provides cryptographically signed, offline-verifiable interaction records for automated interactions. The current signed wire artifact is a compact JWS using Ed25519 signatures and can be verified offline with the issuer's public key or a pinned JWKS. PEAC does not orchestrate protocols or enforce behavior; it provides neutral evidence of what terms applied and what happened.
 
 ## Quick Start
 
-- Install the MCP server: `npm install -g @peac/mcp-server`
-- Verify a receipt: start the MCP server, then call `peac_verify` with a JWS and public key
-- Issue a receipt: use `@peac/protocol` with `issue()` and an Ed25519 signing key
+- Install the MCP server: `npx -y @peac/mcp-server`
+- Verify a record: start the MCP server, then call `peac_verify` with a JWS and public key
+- Issue a record: use `@peac/protocol` with `issue()` and an Ed25519 signing key
 - GitHub: https://github.com/peacprotocol/peac
 - Website: https://www.peacprotocol.org
 
 ## Key Packages
 
 - `@peac/kernel`: Normative constants, error codes, and type definitions (Layer 0)
-- `@peac/schema`: Zod validation schemas for receipts and evidence (Layer 1)
+- `@peac/schema`: Zod validation schemas for interaction records, legacy receipt surfaces, and evidence extensions (Layer 1)
 - `@peac/crypto`: Ed25519 signing and verification (Layer 2)
 - `@peac/protocol`: High-level issue and verify API (Layer 3)
-- `@peac/mcp-server`: MCP server with 5 tools for receipt operations (Layer 5)
+- `@peac/mcp-server`: MCP server with 5 tools for record verification and issuance (Layer 5)
 
 ## Agent Integration
 
-- MCP Server: 5-tool MCP server for Claude Desktop, Cursor, VS Code Copilot, and any MCP client
+- MCP Server: 5-tool MCP server for any MCP-compatible client
 - A2A Mapping: `@peac/mappings-a2a` for Google Agent-to-Agent protocol evidence
 - ACP Mapping: `@peac/mappings-acp` for Agentic Commerce Protocol (ACP) evidence
 - UCP Mapping: `@peac/mappings-ucp` for Universal Commerce Protocol evidence


### PR DESCRIPTION
## Summary

Aligns PEAC's public verification, security, stability, compatibility, and
machine-readable documentation with the v0.14.4 release state.

This update removes stale forward-looking language, clarifies supported
versions, records measured local SLO baselines, updates deprecated and archived
package status, and tightens wording around PEAC's protocol boundary.

## Scope

- updates measured local `@peac/protocol` SLO rows
- marks unmeasured verifier and MCP rows explicitly
- updates supported-version and disclosure-policy language
- clarifies deprecated and archived package status
- refreshes `llms.txt` install and records-first wording
- removes wording that could imply PEAC controls, governs, or enforces runtime behavior
- aligns carrier-profile references with shipped CLI, lifecycle, and provisioning records

## Invariants

No wire-format change.
No signing-envelope change.
No schema change.
No public API change.
No CLI behavior change.
No new package.
No runtime behavior change.

## Validation

- `node reference/scripts/verify-local-doc-truth.mjs`
- `node reference/scripts/verify-final-hygiene.mjs`
- `node reference/scripts/verify-private-wording-local.mjs`
- `bash scripts/ci/forbid-strings.sh`
- `pnpm format:check`
- `pnpm verify:release`
