### PR TITLE
docs: readme sync 0.14.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,18 @@ verified outside the system that produced them.
 PEAC is useful when a system does work and another party later needs to
 verify what happened without trusting that system's logs.
 
-| Event              | Example record                                                                                                     |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------ |
-| API call           | request, response, usage, access decision, policy-visible outcome                                                  |
-| MCP tool run       | tool input/output reference, tool result, issuer, timestamp, signature                                             |
-| Agent action       | action invoked, delegated, approved, denied, cancelled, or timed out                                               |
-| Gateway decision   | access, routing, export, or boundary decision reported by a gateway                                                |
-| Payment event      | payment request, authorization, settlement observation, mandate, dispute context                                   |
-| Provisioning event | catalog, provider link, account, credential, budget, subscription, domain, deployment, or resource lifecycle event |
+| Event              | Familiar surfaces                                                                                     | Example record                                                                                                     |
+| ------------------ | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| API call           | Stripe-style APIs, Cloudflare Workers, Vercel functions, internal HTTP services                       | request, response, usage, access decision, policy-visible outcome                                                  |
+| MCP tool run       | MCP servers, Smithery-listed tools, internal MCP servers                                              | tool input/output reference, tool result, issuer, timestamp, signature                                             |
+| Agent action       | A2A handoffs, agent-framework steps, Microsoft AGT-style runtime events                               | action invoked, delegated, approved, denied, cancelled, or timed out                                               |
+| Gateway decision   | Cloudflare, Portkey, Kong, API gateways, AI gateways                                                  | access, routing, export, or boundary decision reported by a gateway                                                |
+| Payment event      | x402, paymentauth / MPP, ACP, AP2-style commerce flows                                                | payment request, authorization, settlement observation, mandate, dispute context                                   |
+| Provisioning event | Stripe Projects-style provider setup, Vercel deployments, GitHub Actions, Terraform-managed resources | catalog, provider link, account, credential, budget, subscription, domain, deployment, or resource lifecycle event |
+
+These are orientation examples, not partnership claims or exclusive
+integration targets. PEAC records what those systems report; it does not
+replace them.
 
 PEAC does not make those decisions. It records what another system
 reported, binds it to an issuer and time, and makes it portable for
@@ -63,7 +67,7 @@ workflows.
    facts + policy/context + result + time + issuer + signature
 
 3. A counterparty verifies the record
-   locally with issuer keys, or through a self-hosted verifier
+   locally, in CI, or through a self-hosted verifier using issuer keys
 
 4. The record travels
    audit review, dispute review, compliance workflow, incident report,
@@ -146,6 +150,11 @@ PEAC does not replace those systems. It gives them a portable records
 layer: what was reported, by whom, when, under which context, and with
 which verifiable signature.
 
+If you work around MCP, A2A, x402, paymentauth / MPP, ACP, AP2-style
+commerce, UCP-style commerce, runtime governance, OpenTelemetry, or
+internal platform workflows, PEAC is the signed-record layer beside
+those systems, not a replacement for them.
+
 ## Why PEAC
 
 Modern systems often need proof that travels beyond the system that
@@ -180,6 +189,9 @@ Practical recipes under [`docs/SOLUTIONS/`](docs/SOLUTIONS/):
 
 - [API record issuance](docs/SOLUTIONS/api-receipt-issuance.md)
 - [MCP tool-call records](docs/SOLUTIONS/mcp-tool-call-receipts.md)
+- [Agent action records](docs/SOLUTIONS/verify-agent-action.md)
+- [Gateway export records](docs/SOLUTIONS/verify-gateway-export.md)
+- [Commerce mandate records](docs/SOLUTIONS/verify-commerce-mandate.md)
 - [Commerce evidence bundle](docs/SOLUTIONS/commerce-evidence-bundle.md)
 - [Cloudflare x402 + PEAC](docs/SOLUTIONS/cloudflare-x402-peac.md)
 - [Runtime evidence export](docs/SOLUTIONS/runtime-evidence-export.md)

--- a/README.md
+++ b/README.md
@@ -1,79 +1,178 @@
 # PEAC Protocol
 
+**Portable signed records for automated interactions.**
+
+PEAC is an open protocol for issuing and verifying signed interaction
+records across APIs, MCP tools, agent workflows, gateway decisions,
+payment-adjacent flows, provisioning events, runtimes, and audit systems.
+
+When local logs are not enough, PEAC gives teams records that can be
+verified outside the system that produced them.
+
 **Govern locally. Prove across boundaries.**
-
-When logs are not enough, PEAC gives teams portable signed records that can be verified outside the system that produced them.
-
-Portable signed records for API, MCP, agent, and cross-runtime interactions.
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-brightgreen.svg)](LICENSE)
 [![Latest Release](https://img.shields.io/github/v/release/peacprotocol/peac?color=brightgreen)](https://github.com/peacprotocol/peac/releases)
 [![npm downloads](https://img.shields.io/npm/dm/@peac/protocol?style=flat&color=brightgreen)](https://www.npmjs.com/package/@peac/protocol)
 [![CI Status](https://img.shields.io/github/actions/workflow/status/peacprotocol/peac/ci.yml?branch=main&label=CI&color=brightgreen)](https://github.com/peacprotocol/peac/actions/workflows/ci.yml)
 
-## What you can do with PEAC
+## What PEAC records
 
-| If you...                                        | PEAC helps you...                                                                                                                                           | Start here                                                                        |
-| ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| Run an API or HTTP service                       | issue signed interaction records with responses so clients can verify what happened later                                                                   | [API Provider Quickstart](docs/guides/quickstart-api-provider.md)                 |
-| Run metered APIs or agent-consumed services      | issue records for usage, access decisions, responses, and policy-visible outcomes that may need to be verified after the request                            | [API Provider Quickstart](docs/guides/quickstart-api-provider.md)                 |
-| Run an MCP server                                | attach signed records to tool calls and expose verification tools for operators                                                                             | [MCP Integration Kit](integrator-kits/mcp/README.md) or `npx -y @peac/mcp-server` |
-| Build agentic commerce or payment flows          | record evidence around x402, paymentauth / MPP, ACP, UCP commerce flows, AP2-style payment flows, settlement observations, and disputes                     | [Commerce evidence bundle](docs/SOLUTIONS/commerce-evidence-bundle.md)            |
-| Need to verify a record                          | verify a PEAC receipt offline with the issuer's public key                                                                                                  | [Agent Operator Quickstart](docs/guides/quickstart-agent-operator.md)             |
-| Operate managed runtimes or agent control planes | record runtime-governance observations without making PEAC the control plane                                                                                | [`@peac/adapter-runtime-governance`](packages/adapters/runtime-governance/)       |
-| Need audit evidence beside observability         | produce portable records that can be referenced alongside logs, traces, OpenTelemetry, SIEMs, and audit repositories without replacing them                 | [Where PEAC fits](docs/WHERE-IT-FITS.md)                                          |
-| Run agent-to-agent workflows                     | record handoff events across agent-card discovery, task lifecycle, and human-review boundaries                                                              | [A2A Handoff Records](docs/specs/A2A-HANDOFF-RECORDS.md)                          |
-| Need command-execution records                   | record unsigned observations with `peac observe command` or signed command-execution records with `peac record command`                                     | [CLI Carrier Profile](docs/specs/CLI-CARRIER-PROFILE.md)                          |
-| Need lifecycle records from another system       | issue records for caller-reported evaluation, approval, experiment, and workflow events                                                                     | [Lifecycle Observation Profile](docs/specs/LIFECYCLE-OBSERVATION-PROFILE.md)      |
-| Need provisioning lifecycle records              | record reported catalog, provider-link, account, resource, credential, payment-authorization, budget, subscription, domain, and deployment lifecycle events | [Provisioning Lifecycle Records](docs/SOLUTIONS/verify-agent-provisioning.md)     |
+PEAC is useful when a system does work and another party later needs to
+verify what happened without trusting that system's logs.
+
+| Event              | Example record                                                                                                     |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| API call           | request, response, usage, access decision, policy-visible outcome                                                  |
+| MCP tool run       | tool input/output reference, tool result, issuer, timestamp, signature                                             |
+| Agent action       | action invoked, delegated, approved, denied, cancelled, or timed out                                               |
+| Gateway decision   | access, routing, export, or boundary decision reported by a gateway                                                |
+| Payment event      | payment request, authorization, settlement observation, mandate, dispute context                                   |
+| Provisioning event | catalog, provider link, account, credential, budget, subscription, domain, deployment, or resource lifecycle event |
+
+PEAC does not make those decisions. It records what another system
+reported, binds it to an issuer and time, and makes it portable for
+verification.
+
+## What a PEAC record preserves
+
+A PEAC record is signed evidence about an interaction.
+
+| Field             | Meaning                                                                                              |
+| ----------------- | ---------------------------------------------------------------------------------------------------- |
+| Facts             | what the producing system reported happened                                                          |
+| Policy or context | the terms, policy, protocol, or configuration context that applied                                   |
+| Result            | allowed, denied, completed, failed, observed, settled, disputed, or another profile-specific outcome |
+| Time              | when the interaction was recorded                                                                    |
+| Issuer            | which service, runtime, gateway, or agent system issued the record                                   |
+| Signature         | a verifiable signature over the record                                                               |
+
+A counterparty can verify the record locally with the issuer's public key
+or through a self-hosted verifier. Records can also be exported into
+portable bundles for audit, review, dispute, compliance, or incident
+workflows.
+
+## How it works
+
+```text
+1. A system performs work
+   API call, MCP tool run, agent action, gateway decision,
+   payment event, provisioning event, runtime observation, or audit event
+
+2. The system issues a signed PEAC record
+   facts + policy/context + result + time + issuer + signature
+
+3. A counterparty verifies the record
+   locally with issuer keys, or through a self-hosted verifier
+
+4. The record travels
+   audit review, dispute review, compliance workflow, incident report,
+   exported bundle, or another system boundary
+```
+
+PEAC records what another system reported. It does not decide whether an
+action was allowed, authenticate the actor, settle payment, operate the
+runtime, or replace logs and traces.
+
+Full loop: [`docs/HOW-IT-WORKS.md`](docs/HOW-IT-WORKS.md). Artifact
+vocabulary (record, receipt, bundle, report):
+[`docs/ARTIFACTS.md`](docs/ARTIFACTS.md). Where PEAC sits next to other
+systems: [`docs/WHERE-IT-FITS.md`](docs/WHERE-IT-FITS.md). Protocol
+scope: [`docs/WHAT-PEAC-STANDARDIZES.md`](docs/WHAT-PEAC-STANDARDIZES.md).
+
+## Choose your path
+
+| If you...                                       | PEAC helps you...                                                                                                                   | Start here                                                                        |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Run an API or metered service                   | issue signed records for requests, responses, usage, and policy-visible outcomes                                                    | [API Provider Quickstart](docs/guides/quickstart-api-provider.md)                 |
+| Build MCP tools or agent workflows              | attach records to tool runs, command execution, handoffs, lifecycle events, and agent actions                                       | [MCP Integration Kit](integrator-kits/mcp/README.md) or `npx -y @peac/mcp-server` |
+| Build payment, gateway, or commerce flows       | preserve signed evidence around access, payment, settlement, mandate, gateway, and dispute events without becoming the payment rail | [Commerce evidence bundle](docs/SOLUTIONS/commerce-evidence-bundle.md)            |
+| Track provisioning or resource lifecycle events | record catalog, provider-link, account, credential, budget, subscription, domain, deployment, and resource events                   | [Provisioning lifecycle records](docs/SOLUTIONS/verify-agent-provisioning.md)     |
+| Need audit or review evidence                   | export portable records and bundles that can be referenced beside logs, traces, SIEMs, reports, and audit repositories              | [Where PEAC fits](docs/WHERE-IT-FITS.md)                                          |
+| Need to verify a record                         | verify a signed PEAC record with the issuer's public key or a self-hosted verifier                                                  | [Agent Operator Quickstart](docs/guides/quickstart-agent-operator.md)             |
 
 Full path-by-role tree: [`docs/START_HERE.md`](docs/START_HERE.md).
 
-## Verify a PEAC receipt in 60 seconds
+## Quickstart: verify one record
 
 ```bash
-pnpm add @peac/protocol @peac/crypto
+npm install @peac/protocol @peac/crypto
 ```
 
 ```typescript
 import { verifyLocal } from '@peac/protocol';
 
-const receipt = response.headers.get('PEAC-Receipt');
-const result = await verifyLocal(receipt, publicKey, {
+const recordJws = response.headers.get('PEAC-Receipt');
+
+if (!recordJws) {
+  throw new Error('Missing PEAC-Receipt header');
+}
+
+const result = await verifyLocal(recordJws, publicKey, {
   issuer: 'https://api.example.com',
 });
 
-if (result.valid) {
-  console.log(result.claims.iss, result.claims.kind, result.claims.type);
+if (!result.valid) {
+  throw new Error(result.reason ?? 'PEAC record verification failed');
 }
+
+console.log(result.claims.iss, result.claims.kind, result.claims.type);
 ```
 
-Node 24 tested, Node 22+ compatible. Go middleware and examples supported (Go 1.26+). Python via API-first examples and OpenAPI-driven flows.
+This quickstart shows the developer path for one record. Operational
+latency and throughput baselines are tracked separately in
+[`docs/SLO.md`](docs/SLO.md).
 
-## How it works
-
-```text
-1. Publish terms at /.well-known/peac.txt
-2. Return PEAC-Receipt with a signed interaction record
-3. Verify offline with the issuer's public key
-```
-
-Full loop: [`docs/HOW-IT-WORKS.md`](docs/HOW-IT-WORKS.md). Artifact vocabulary (record, receipt, bundle, report): [`docs/ARTIFACTS.md`](docs/ARTIFACTS.md). Where PEAC sits next to other systems: [`docs/WHERE-IT-FITS.md`](docs/WHERE-IT-FITS.md). Protocol scope: [`docs/WHAT-PEAC-STANDARDIZES.md`](docs/WHAT-PEAC-STANDARDIZES.md).
+Node 24 tested, Node 22+ compatible. Go middleware and examples
+supported (Go 1.26+). Python via API-first examples and OpenAPI-driven
+flows.
 
 ## Where PEAC fits
 
-PEAC is useful when an action crosses a system, organization, protocol, agent, or settlement boundary and the local log is not enough.
+PEAC is useful when an action crosses a system, organization, protocol,
+agent, gateway, payment, provisioning, or audit boundary and the local
+log is not enough.
 
-| Surface                                 | What PEAC adds                                                                                                                           |
-| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| Metered APIs and HTTP services          | signed records for requests, responses, usage, and policy-visible outcomes                                                               |
-| MCP tools and agent runtimes            | records for tool calls, command execution, handoffs, and runtime observations                                                            |
-| Agentic commerce and automated payments | evidence around x402, paymentauth / MPP, ACP, UCP commerce flows, AP2-style payment flows, settlement observations, and disputes         |
-| Runtime governance and managed agents   | portable observations from Microsoft Agent Governance Toolkit, Claude Managed Agents, custom harnesses, and other runtime control planes |
-| Observability and audit systems         | verifiable records that complement logs, traces, OpenTelemetry, SIEMs, and audit repositories                                            |
-| Cross-protocol workflows                | a records layer beside A2A, MCP, x402, paymentauth / MPP, ACP, UCP / AP2, OpenTelemetry, SLSA, in-toto, and DID-based identity systems   |
+| Surface                         | What PEAC adds                                                                                                 |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| APIs and HTTP services          | signed records for requests, responses, usage, and policy-visible outcomes                                     |
+| MCP tools and agent workflows   | records for tool runs, command execution, handoffs, lifecycle events, and agent actions                        |
+| Gateway and commerce systems    | records for access, payment, settlement, mandate, gateway, export, and dispute events                          |
+| Provisioning systems            | records for provider links, accounts, credentials, budgets, subscriptions, domains, deployments, and resources |
+| Runtime and evaluation systems  | portable observations from local runtime, policy, evaluation, and control systems                              |
+| Observability and audit systems | verifiable records that complement logs, traces, SIEMs, reports, bundles, and audit repositories               |
 
-PEAC does not replace those systems. It gives them a portable records layer: what was reported, by whom, when, under which protocol context, and with which verifiable signature.
+PEAC does not replace those systems. It gives them a portable records
+layer: what was reported, by whom, when, under which context, and with
+which verifiable signature.
+
+## Why PEAC
+
+Modern systems often need proof that travels beyond the system that
+produced the log.
+
+- Logs are local. PEAC records are portable and independently verifiable.
+- Traces correlate execution. PEAC records preserve signed claims across
+  organizational boundaries.
+- Auth, policy, runtime, and payment systems decide whether actions may
+  happen. PEAC records what another system reported happened.
+
+## For reviewers and operators
+
+PEAC is designed to be reviewed as protocol infrastructure, not as a
+hosted control plane.
+
+| Need                                      | Read                                                           |
+| ----------------------------------------- | -------------------------------------------------------------- |
+| Supported versions and disclosure process | [`SECURITY.md`](SECURITY.md)                                   |
+| Measured local verification baselines     | [`docs/SLO.md`](docs/SLO.md)                                   |
+| Stability classes and archived surfaces   | [`docs/STABILITY-CONTRACT.md`](docs/STABILITY-CONTRACT.md)     |
+| Compatibility and deprecation status      | [`docs/COMPATIBILITY_MATRIX.md`](docs/COMPATIBILITY_MATRIX.md) |
+| External standards references             | [`docs/STANDARDS_LEDGER.md`](docs/STANDARDS_LEDGER.md)         |
+| Release-line invariant snapshots          | [`docs/baselines/`](docs/baselines/)                           |
+
+The reference verifier is self-hostable. Verification can also be
+performed locally when the record and issuer public key are available.
 
 ## Use cases
 
@@ -87,17 +186,9 @@ Practical recipes under [`docs/SOLUTIONS/`](docs/SOLUTIONS/):
 - [Provisioning lifecycle verification](docs/SOLUTIONS/verify-agent-provisioning.md)
 - [Regulatory audit trail](docs/SOLUTIONS/regulatory-audit-trail.md)
 
-## Why PEAC
-
-Modern systems often need proof that travels beyond the system that produced the log.
-
-- Logs are local. PEAC records are portable and independently verifiable.
-- Traces correlate execution. PEAC records preserve signed claims across organizational boundaries.
-- Auth, policy, runtime, and payment systems decide whether actions may happen. PEAC records what another system reported happened.
-
 ## Try it in 5 minutes
 
-- Verify a receipt locally with `verifyLocal()` or `pnpm dlx @peac/cli verify`.
+- Verify a record locally with `verifyLocal()` or `pnpm dlx @peac/cli verify`.
 - Start the MCP server: `npx -y @peac/mcp-server`.
 - Run the minimal example: `pnpm --filter @peac/example-minimal demo`.
 - Run the provisioning lifecycle example:
@@ -109,22 +200,17 @@ Modern systems often need proof that travels beyond the system that produced the
 
 ## Implementations and surfaces
 
-- **TypeScript core** — issuance, verification, CLI, middleware (this repo).
-- **Go SDK** — [`sdks/go/`](sdks/go/) with production HTTP middleware.
-- **MCP tools** — [`packages/mcp-server/`](packages/mcp-server/) evidence tools.
-- **Editor and plugin-pack surfaces** — Cursor, Codex, Claude Code, VS Code, Continue, Windsurf, OpenCode under [`surfaces/plugin-pack/`](surfaces/plugin-pack/); canonical [Smithery config](packages/mcp-server/smithery.yaml).
-- **Express middleware** — [`packages/middleware-express/`](packages/middleware-express/).
-- **Commerce and agentic-payment mappings** — x402 v1/v2, paymentauth / MPP, ACP delegated payment, and UCP commerce envelopes and AP2-style payment-flow records under [`packages/adapters/x402/`](packages/adapters/x402/), [`packages/mappings/paymentauth/`](packages/mappings/paymentauth/), [`packages/mappings/acp/`](packages/mappings/acp/), and [`packages/mappings/ucp/`](packages/mappings/ucp/).
-- **Runtime governance and managed agents** — [`packages/adapters/runtime-governance/`](packages/adapters/runtime-governance/) records observations from Microsoft Agent Governance Toolkit, Claude Managed Agents, and custom runtime control planes.
-- **Observability and audit linkage** — PEAC records can be referenced from traces, reports, bundles, and audit repositories without replacing OpenTelemetry, SIEMs, or log pipelines.
-- **A2A handoff records** — [`docs/specs/A2A-HANDOFF-RECORDS.md`](docs/specs/A2A-HANDOFF-RECORDS.md) and [`integrator-kits/a2a/`](integrator-kits/a2a/).
-- **CLI execution records** — `peac observe command`, `peac record command`, and [`docs/specs/CLI-CARRIER-PROFILE.md`](docs/specs/CLI-CARRIER-PROFILE.md).
-- **Lifecycle observation records** — `peac emit lifecycle` and [`docs/specs/LIFECYCLE-OBSERVATION-PROFILE.md`](docs/specs/LIFECYCLE-OBSERVATION-PROFILE.md).
-- **Provisioning lifecycle records** — [`examples/provisioning-lifecycle/`](examples/provisioning-lifecycle/), [`examples/agent-provisioning-demo/`](examples/agent-provisioning-demo/), and [`docs/SOLUTIONS/verify-agent-provisioning.md`](docs/SOLUTIONS/verify-agent-provisioning.md).
-- **Supply-chain and provenance mappings** — [`packages/mappings/intoto/`](packages/mappings/intoto/) and [`packages/mappings/slsa/`](packages/mappings/slsa/) for records that sit beside existing provenance systems.
-- **Reference verifier (self-hostable)** — [`apps/api/`](apps/api/) with deployment recipes under [`surfaces/reference-verifier/`](surfaces/reference-verifier/).
+| Surface                                              | Where                                                                                    |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| TypeScript issuance and verification                 | [`@peac/protocol`](packages/protocol/)                                                   |
+| CLI and local tools                                  | [`@peac/cli`](packages/cli/)                                                             |
+| MCP server                                           | [`@peac/mcp-server`](packages/mcp-server/)                                               |
+| HTTP middleware and Go support                       | [`packages/middleware-express/`](packages/middleware-express/), [`sdks/go/`](sdks/go/)   |
+| Commerce, runtime, provenance, and protocol mappings | [`packages/mappings/`](packages/mappings/), [`packages/adapters/`](packages/adapters/)   |
+| Self-hostable reference verifier                     | [`apps/api/`](apps/api/), [`surfaces/reference-verifier/`](surfaces/reference-verifier/) |
+| Examples and recipes                                 | [`examples/`](examples/), [`docs/SOLUTIONS/`](docs/SOLUTIONS/)                           |
 
-Long tail (A2A, gRPC, DID, managed agents, and more): [`docs/README_LONG.md`](docs/README_LONG.md).
+Extended package catalog: [`docs/README_LONG.md`](docs/README_LONG.md).
 
 ## Artifacts
 
@@ -150,13 +236,18 @@ Other commands: `peac observe command`, `peac record command`, `peac emit lifecy
 
 ## Protocol boundary
 
-PEAC is a records layer, not a runtime control plane. It records what another system attested and makes that record portable, signed, and verifiable across boundaries.
+PEAC is a records layer, not a runtime control plane. It records what
+another system attested and makes that record portable, signed, and
+verifiable across boundaries.
 
-PEAC does not authorize actions, validate credentials, process payments, settle transactions, operate agents, host workflows, manage vaults, assign trust scores, or replace observability systems. Full boundary: [`docs/WHERE-IT-FITS.md`](docs/WHERE-IT-FITS.md).
+PEAC does not authorize actions, validate credentials, process payments,
+settle transactions, operate agents, host workflows, manage vaults,
+assign trust scores, or replace observability systems. Full boundary:
+[`docs/WHERE-IT-FITS.md`](docs/WHERE-IT-FITS.md).
 
 ## Security
 
-- JWS signature verification required before trusting any receipt claim.
+- JWS signature verification is required before trusting any record claim.
 - Key discovery via `/.well-known/peac-issuer.json` JWKS with SSRF guards.
 - Kernel constraints enforced at issuance and verification (fail-closed).
 - No silent network fallback for offline verification.
@@ -166,7 +257,16 @@ See [`SECURITY.md`](SECURITY.md), [`docs/TRUST-ARTIFACTS.md`](docs/TRUST-ARTIFAC
 
 ## Privacy-aware verification
 
-PEAC ships privacy-aware defaults and deployment guidance. Interaction evidence is hash-by-default on the receipt side (`docs/specs/PRIVACY-PROFILE.md`); the verifier separates immutable signed evidence from mutable derived metadata so retention, deletion, and rights-handling act on the right layer. Operator-facing guidance for privacy-sensitive and regulated environments (data classification, retention and deletion, deployment roles, data-subject rights, and a DPIA starter) lives in [`docs/privacy/`](docs/privacy/README.md). PEAC supports privacy-aware verification; it does not replace operator legal review, lawful-basis decisions, or controller obligations.
+PEAC ships privacy-aware defaults and deployment guidance. Interaction
+evidence is hash-by-default on the record side
+(`docs/specs/PRIVACY-PROFILE.md`); the verifier separates immutable
+signed evidence from mutable derived metadata so retention, deletion,
+and rights-handling act on the right layer. Operator-facing guidance
+for privacy-sensitive and regulated environments (data classification,
+retention and deletion, deployment roles, data-subject rights, and a
+DPIA starter) lives in [`docs/privacy/`](docs/privacy/README.md). PEAC
+supports privacy-aware verification; it does not replace operator legal
+review, lawful-basis decisions, or controller obligations.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary

Sharpens the root README for first-time developers, operators, OSS reviewers,
and enterprise security reviewers.

The update keeps PEAC records-first, leads with what PEAC records and what a
record preserves, shortens the role selector, clarifies the verification
path, moves long-tail ecosystem detail behind deeper docs, and surfaces
security, SLO, stability, compatibility, and standards references earlier.

## Scope

- clearer opening explanation
- new "What PEAC records" section with concrete event examples
- new "What a PEAC record preserves" section with field semantics
- fuller "How it works" lifecycle from work to portable record
- shorter path-by-role table
- records-first verification quickstart with `npm install`
- category-first "Where PEAC fits" section
- reviewer/operator documentation table
- collapsed implementation-surface inventory
- records-first wording cleanup

## Invariants

No code change.
No wire-format change.
No schema change.
No public API change.
No package metadata change.
No runtime behavior change.

Frozen identifiers preserved: `PEAC-Receipt`, `receipt_jws`, `receipt_ref`,
`receipt_url`, `peac-receipt/0.1`, `peac-bundle/0.1`.

## Validation

- `pnpm format:check`
- `node reference/scripts/verify-private-wording-local.mjs`
- `bash scripts/ci/forbid-strings.sh`
- `node reference/scripts/verify-local-doc-truth.mjs`
- `node reference/scripts/verify-final-hygiene.mjs`
- `pnpm verify:release`
