### PR TITLE
chore(release): stamp v0.14.5 dist_tag latest

### DIFF
--- a/docs/releases/current.json
+++ b/docs/releases/current.json
@@ -2,7 +2,7 @@
   "description": "PEAC release manifest: CI-enforceable source of truth for release state",
   "version": "0.14.5",
   "wire_format_version": "0.2",
-  "dist_tag": "next",
+  "dist_tag": "latest",
   "registries_version": "0.6.0",
   "errors_version": "0.14.5"
 }

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -3,7 +3,7 @@
   "schema_version": "1.0.0",
   "version": "0.14.5",
   "wire_format_version": "0.2",
-  "dist_tag": "next",
+  "dist_tag": "latest",
   "release_date": "2026-05-21",
   "metrics": {
     "tests": 10838,


### PR DESCRIPTION
## Summary

Post-promote release-state stamp. Flips `dist_tag` in
`docs/releases/facts.json` and `docs/releases/current.json` from
`next` to `latest` after promote-latest dispatched successfully and
all 36 packages now resolve to `0.14.5` on npm `latest`.

## Scope

- `docs/releases/facts.json`: `dist_tag` next -> latest
- `docs/releases/current.json`: `dist_tag` next -> latest

## Invariants

No code change. No wire-format change. No schema change.
No conformance-ID change. No package set change.
