### PR TITLE
chore(release): stamp REPO_SURFACE_STATUS updated for v0.14.5

### DIFF
--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable surface classification for PEAC Protocol workspace. CI fails if any workspace member is missing. See docs/PACKAGE_STATUS.md for human-readable view.",
   "version": "0.13.0",
-  "updated": "2026-05-19",
+  "updated": "2026-05-22",
   "states": {
     "default": "Current recommended path. Actively maintained, Wire 0.2 native.",
     "supported": "Actively maintained, published, production-ready. May not be on default quickstart path.",

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -2,7 +2,7 @@
 
 Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scripts/generate-surface-status.mjs`.
 
-**Version:** 0.13.0 | **Updated:** 2026-05-19
+**Version:** 0.13.0 | **Updated:** 2026-05-22
 
 ## Layer 1
 

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -4,7 +4,7 @@
   "version": "0.14.5",
   "wire_format_version": "0.2",
   "dist_tag": "latest",
-  "release_date": "2026-05-21",
+  "release_date": "2026-05-22",
   "metrics": {
     "tests": 10838,
     "test_files": 445,


### PR DESCRIPTION
## Summary

Post-publish release-state stamp. Bumps `release_date` and
`REPO_SURFACE_STATUS.updated` from the release-prep UTC date to the
actual publish UTC date, and regenerates `docs/SURFACE_STATUS.md`
from the updated surface-status source.

## Scope

- `docs/releases/facts.json`: `release_date` 2026-05-21 -> 2026-05-22
- `REPO_SURFACE_STATUS.json`: `updated` 2026-05-19 -> 2026-05-22
- `docs/SURFACE_STATUS.md`: regenerated to match

## Invariants

No code change. No wire-format change. No schema change.
No conformance-ID change. No package set change.
