### PR TITLE
docs/test: ERC-8126 + AP2 interop vectors and composition notes

### DIFF
--- a/docs/specs/AP2-COMPOSITION.md
+++ b/docs/specs/AP2-COMPOSITION.md
@@ -1,0 +1,100 @@
+# PEAC and AP2 Composition
+
+**Status:** Informative
+**Version:** 0.1
+**Applies to:** Operators who record verifiable interaction records
+that reference AP2 mandate artifacts (open-checkout mandates and
+related mandate kinds).
+
+---
+
+## Why this document exists
+
+AP2 (Agent Payments Protocol) is a specification for delegated
+payment mandates between principals and agents. AP2 issue
+[#265](https://github.com/google-agentic-commerce/AP2/issues/265)
+discusses a derivation rule for `open_mandate_hash`:
+
+```text
+open_mandate_hash = sha256_hex(JCS_RFC8785(unsigned open-checkout-mandate body))
+```
+
+(lowercase hexadecimal; the hash input is the claims object, not
+the JWS compact form). PEAC composes with AP2 by recording
+interaction-time observations that reference an existing
+mandate; PEAC does not extend AP2 or replace the mandate
+mechanism. AP2 normative authority lives outside this repository.
+
+This document records the composition pattern and points to the
+repository interop fixtures that exercise it.
+
+## Boundary
+
+- PEAC does not extend AP2 or introduce a parallel authorization
+  model.
+- PEAC does not mint mandates, sign mandates, or evaluate mandate
+  validity.
+- PEAC does not normatively compile AP2 mandate semantics into
+  `@peac/policy-kit` policy decisions.
+- PEAC's repository interop fixtures are intended as additional
+  interoperability artifacts, not a change to AP2.
+
+## Composition pattern
+
+The recommended composition has three layers:
+
+1. **Mandate issuance.** A principal and agent issue an unsigned
+   open-checkout-mandate body and an accompanying JWS over that
+   body, per AP2.
+2. **Reference capture.** A PEAC-emitting consumer records the
+   mandate by reference. The reference uses the
+   `open_mandate_hash` as defined in AP2 issue #265
+   (`sha256_hex(JCS_RFC8785(unsigned mandate body))`). PEAC does
+   not embed the mandate body itself.
+3. **Recording.** The consumer projects the reference into a
+   PEAC interaction record. The verifier can reconstruct the
+   reference deterministically from the same unsigned body and
+   the same derivation rule.
+
+PEAC records references to AP2 mandate artifacts; PEAC does not
+extend the AP2 mandate mechanism.
+
+## Verifier guidance
+
+A PEAC verifier that processes an AP2 mandate reference:
+
+- may surface the `open_mandate_hash`, the mandate type
+  identifier, and any other observation fields drawn from the
+  AP2 surface.
+- must not treat the presence of a reference as a substitute for
+  verifying the upstream JWS-signed mandate envelope itself.
+- must not re-derive the `open_mandate_hash` from a non-JCS
+  canonicalization or a non-SHA-256 digest function. The
+  derivation in AP2 issue #265 is the only one PEAC recognizes
+  for this composition pattern.
+
+## Repository interop fixtures
+
+This repository includes 3 positive and 2 negative interop
+fixtures for the `open_mandate_hash` derivation at
+[`specs/conformance/interop/ap2-open-mandate-hash/`](../../specs/conformance/interop/ap2-open-mandate-hash/README.md).
+Positive fixtures cover baseline, budget-bound, and expiry-bound
+mandate shapes. Negative fixtures cover the two most common
+composition failure modes: using a non-SHA-256 digest function on
+the canonical bytes, and using a non-JCS canonicalization rule on
+the input bytes.
+
+These fixtures are scenario-shaped and do not target the
+canonicalization edge cases already covered by the
+cross-implementation work in AP2 issue #265 (object-key-order,
+array-order, optional fields, currency-minor-unit, Unicode NFC
+vs NFD). They are intended as additional interoperability
+fixtures, not as a replacement for the vector set discussed in
+AP2 issue #265.
+
+## Related work
+
+- [AP2 issue #265: v0 conformance vectors for `open_mandate_hash`](https://github.com/google-agentic-commerce/AP2/issues/265)
+- [RFC 8785: JSON Canonicalization Scheme (JCS)](https://datatracker.ietf.org/doc/html/rfc8785)
+- [`specs/conformance/interop/ap2-open-mandate-hash/README.md`](../../specs/conformance/interop/ap2-open-mandate-hash/README.md)
+- [`scripts/verify-interop-vectors.mjs`](../../scripts/verify-interop-vectors.mjs)

--- a/docs/specs/ERC-8126-COMPOSITION.md
+++ b/docs/specs/ERC-8126-COMPOSITION.md
@@ -1,0 +1,99 @@
+# PEAC and ERC-8126 Composition
+
+**Status:** Informative
+**Version:** 0.1
+**Applies to:** Operators who record verifiable interaction records
+that reference ERC-8126 attestations posted to an ERC-8004
+Validation Registry.
+
+---
+
+## Why this document exists
+
+[ERC-8126](https://eips.ethereum.org/EIPS/eip-8126) is an Ethereum
+standards-process document describing a verification surface for
+on-chain agents. ERC-8126 references ERC-8004 and is intended to
+flow its verification outputs through ERC-8004's Validation
+Registry. PEAC composes with ERC-8126 by recording
+interaction-time observations that reference an existing
+Validation Registry attestation; PEAC does not standardize the
+attestation surface itself.
+
+This document records that composition pattern and points to the
+repository interop fixtures that exercise it.
+
+## Boundary
+
+- PEAC does not standardize ERC-8126 or ERC-8004.
+- PEAC does not host the Validation Registry, post attestations to
+  it, or calculate or assign ERC-8126 risk scores.
+- PEAC does not impose a verification-type enumeration on
+  ERC-8126; the verification-type acronyms (ETV, MCV, SCV, WAV,
+  WV, and the optional PDV and QCV) are defined by ERC-8126
+  itself.
+- PEAC does not require any particular attestation carrier. A
+  PEAC interaction record may reference an attestation regardless
+  of how that attestation was carried on-chain or off-chain.
+
+## Carrier label used by these fixtures
+
+These fixtures model three carrier examples: JWS compact
+serialization, EIP-712 typed data, and an on-chain reference.
+
+The repository interop fixtures cover these three carrier labels
+explicitly:
+
+- `jws`
+- `eip712`
+- `onchain`
+
+This fixture set does not include a COSE-Sign1 vector. This
+repository does not include a PEAC COSE carrier implementation.
+
+The repository fixtures are at
+[`specs/conformance/interop/erc8126-attestation-format/`](../../specs/conformance/interop/erc8126-attestation-format/README.md).
+These fixtures use `attestationFormat` as fixture metadata so a
+verifier can distinguish among carrier examples. ERC-8126 and
+ERC-8004 define their own registry semantics; this fixture field
+is not required by PEAC and is not defined by PEAC.
+
+## Composition pattern
+
+The recommended composition has three layers:
+
+1. **Attestation post.** An ERC-8126-aligned verifier produces a
+   verification result and posts an attestation to the
+   ERC-8004 Validation Registry. The attestation references the
+   chosen carrier.
+2. **Reference capture.** A PEAC-emitting consumer records the
+   attestation by reference: it stores an opaque
+   `attestation_ref` plus a carrier label (if known) and the
+   verification-type acronym (if known). PEAC does not embed the
+   carrier-specific payload itself.
+3. **Recording.** The consumer projects the reference into a
+   PEAC interaction record. The verifier reconstructs the
+   reference deterministically; no network call to the Validation
+   Registry is required at verification time.
+
+PEAC records references to ERC-8126-aligned attestation
+artifacts and does not standardize ERC-8126.
+
+## Verifier guidance
+
+A PEAC verifier that processes an ERC-8126 attestation reference:
+
+- may surface the `attestation_ref`, the verification-type
+  acronym, and the carrier label in its verification report.
+- must not treat the presence of a reference as a substitute for
+  upstream verification. A PEAC verifier that wishes to verify
+  the underlying attestation must do so through the relevant
+  carrier-specific path; PEAC does not embed that verification.
+- must not mint a verification-type acronym or invent a carrier
+  label not recognized by ERC-8126 or its registered extensions.
+
+## Related work
+
+- [ERC-8126 specification](https://eips.ethereum.org/EIPS/eip-8126)
+- [ERC-8004 specification](https://eips.ethereum.org/EIPS/eip-8004)
+- [`specs/conformance/interop/erc8126-attestation-format/README.md`](../../specs/conformance/interop/erc8126-attestation-format/README.md)
+- [`scripts/verify-interop-vectors.mjs`](../../scripts/verify-interop-vectors.mjs)

--- a/scripts/verify-interop-vectors.mjs
+++ b/scripts/verify-interop-vectors.mjs
@@ -1,0 +1,413 @@
+#!/usr/bin/env node
+
+/**
+ * Interop vector verifier.
+ *
+ * Walks specs/conformance/interop/<family>/{positive,negative}/ and
+ * deterministically verifies every vector against the family-specific
+ * derivation rules. Offline-only: no network, no subprocess, no
+ * dynamic import from fixture paths, no dependency on test runners.
+ *
+ * Families covered:
+ *
+ *   erc8126-attestation-format/
+ *     positive/  attestationFormat label is drawn from { jws, eip712, onchain }
+ *                + canonical-bytes SHA-256 digest matches expected
+ *     negative/  v04-unknown-format: attestationFormat present but not in label set
+ *                v05-missing-format: attestationFormat field absent
+ *
+ *   ap2-open-mandate-hash/
+ *     positive/  sha256_hex(JCS_RFC8785(input)) matches expected.open_mandate_hash
+ *     negative/  v04-non-sha256-digest:  candidate_open_mandate_hash_via_sha1 !=
+ *                                        sha256_hex(JCS_RFC8785(body))
+ *                v05-non-jcs-canonicalization: candidate_non_jcs_bytes_utf8 !=
+ *                                              JCS_RFC8785(body)
+ *
+ * Exit codes:
+ *   0  all vectors verified
+ *   1  one or more vectors failed verification
+ *   2  script error (missing fixtures, malformed JSON, missing utility, etc.)
+ */
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { basename, dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createHash } from 'node:crypto';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+
+const CRYPTO_DIST = join(ROOT, 'packages', 'crypto', 'dist', 'index.mjs');
+if (!existsSync(CRYPTO_DIST)) {
+  console.error(`SCRIPT ERROR: missing ${relative(ROOT, CRYPTO_DIST)}.`);
+  console.error(`  Build @peac/crypto first:  pnpm --filter @peac/crypto build`);
+  process.exit(2);
+}
+const { canonicalize, canonicalizeBytes } = await import(CRYPTO_DIST);
+const INTEROP_ROOT = join(ROOT, 'specs', 'conformance', 'interop');
+
+const ERC_FAMILY = 'erc8126-attestation-format';
+const AP2_FAMILY = 'ap2-open-mandate-hash';
+
+const RECOGNIZED_ATTESTATION_LABELS = new Set(['jws', 'eip712', 'onchain']);
+
+const ALLOWED_TOP_LEVEL_KEYS = new Set([
+  '$schema',
+  'vector_id',
+  'description',
+  'input',
+  'expected',
+  'expected_failure',
+]);
+
+const ALLOWED_FAILURE_KIND = new Set([
+  'validation_failure',
+  'canonicalization_failure',
+  'digest_failure',
+]);
+
+const ALLOWED_EXPECTED_FAILURE_KEYS = new Set(['kind', 'reason']);
+
+const VECTOR_ID_PATTERN = /^[a-z][a-z0-9-]*-v[0-9]{2}-[a-z0-9-]+$/;
+const SNAKE_CASE_PATTERN = /^[a-z][a-z0-9_]*$/;
+
+const EXPECTED_COUNTS = {
+  [ERC_FAMILY]: { positive: 3, negative: 2 },
+  [AP2_FAMILY]: { positive: 3, negative: 2 },
+};
+
+const EXPECTED_FAILURE_REASONS = {
+  [ERC_FAMILY]: {
+    'v04-unknown-format.json': 'unsupported_attestation_format',
+    'v05-missing-format.json': 'missing_attestation_format',
+  },
+  [AP2_FAMILY]: {
+    'v04-non-sha256-digest.json': 'non_sha256_digest',
+    'v05-non-jcs-canonicalization.json': 'non_jcs_canonicalization',
+  },
+};
+
+function readJson(path) {
+  const text = readFileSync(path, 'utf8');
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    throw new Error(`Invalid JSON at ${relative(ROOT, path)}: ${err.message}`);
+  }
+}
+
+function listJsonFiles(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch (err) {
+    throw new Error(`Cannot read ${relative(ROOT, dir)}: ${err.message}`);
+  }
+  return entries
+    .filter((name) => name.endsWith('.json'))
+    .map((name) => join(dir, name))
+    .filter((path) => statSync(path).isFile())
+    .sort();
+}
+
+function sha256Hex(input) {
+  const buf = typeof input === 'string' ? Buffer.from(input, 'utf8') : Buffer.from(input);
+  return createHash('sha256').update(buf).digest('hex');
+}
+
+function sha1Hex(input) {
+  const buf = typeof input === 'string' ? Buffer.from(input, 'utf8') : Buffer.from(input);
+  return createHash('sha1').update(buf).digest('hex');
+}
+
+function verifyVectorEnvelope(vector, path) {
+  const issues = [];
+  const rel = relative(ROOT, path);
+  if (typeof vector !== 'object' || vector === null) {
+    issues.push(`${rel}: vector is not an object`);
+    return issues;
+  }
+  // Mechanical enforcement of the allowed top-level key set.
+  const unknownKeys = Object.keys(vector).filter((k) => !ALLOWED_TOP_LEVEL_KEYS.has(k));
+  if (unknownKeys.length > 0) {
+    issues.push(
+      `${rel}: unexpected top-level key(s): ${unknownKeys.join(', ')} (allowed: ${[...ALLOWED_TOP_LEVEL_KEYS].join(', ')})`
+    );
+  }
+  if (typeof vector.$schema !== 'string') {
+    issues.push(`${rel}: missing $schema`);
+  }
+  if (typeof vector.vector_id !== 'string') {
+    issues.push(`${rel}: missing vector_id`);
+  } else if (!VECTOR_ID_PATTERN.test(vector.vector_id)) {
+    issues.push(`${rel}: vector_id ${vector.vector_id} does not match ${VECTOR_ID_PATTERN}`);
+  }
+  if (typeof vector.description !== 'string' || vector.description.length === 0) {
+    issues.push(`${rel}: missing or empty description`);
+  }
+  if (typeof vector.input !== 'object' || vector.input === null) {
+    issues.push(`${rel}: missing input object`);
+  }
+  const hasExpected = Object.prototype.hasOwnProperty.call(vector, 'expected');
+  const hasExpectedFailure = Object.prototype.hasOwnProperty.call(vector, 'expected_failure');
+  if (hasExpected === hasExpectedFailure) {
+    issues.push(
+      `${rel}: must declare exactly one of expected (positive) or expected_failure (negative)`
+    );
+  }
+  if (hasExpectedFailure) {
+    const f = vector.expected_failure;
+    if (typeof f !== 'object' || f === null) {
+      issues.push(`${rel}: expected_failure must be an object`);
+    } else {
+      const unknownFailureKeys = Object.keys(f).filter(
+        (k) => !ALLOWED_EXPECTED_FAILURE_KEYS.has(k)
+      );
+      if (unknownFailureKeys.length > 0) {
+        issues.push(
+          `${rel}: unexpected expected_failure key(s): ${unknownFailureKeys.join(', ')} (allowed: kind, reason)`
+        );
+      }
+      if (!ALLOWED_FAILURE_KIND.has(f.kind)) {
+        issues.push(
+          `${rel}: expected_failure.kind must be one of validation_failure / canonicalization_failure / digest_failure`
+        );
+      }
+      if (typeof f.reason !== 'string' || !SNAKE_CASE_PATTERN.test(f.reason)) {
+        issues.push(`${rel}: expected_failure.reason must be snake_case`);
+      }
+    }
+  }
+  return issues;
+}
+
+function verifyErc8126Positive(vector, path) {
+  const issues = [];
+  const rel = relative(ROOT, path);
+  const input = vector.input;
+  if (typeof input.attestationFormat !== 'string') {
+    issues.push(`${rel}: positive vector must declare attestationFormat`);
+  } else if (!RECOGNIZED_ATTESTATION_LABELS.has(input.attestationFormat)) {
+    issues.push(
+      `${rel}: positive vector attestationFormat ${input.attestationFormat} not in recognized open-label set { jws, eip712, onchain }`
+    );
+  }
+  const expected = vector.expected;
+  if (typeof expected.canonical_bytes_sha256_hex !== 'string') {
+    issues.push(`${rel}: positive vector must declare expected.canonical_bytes_sha256_hex`);
+    return issues;
+  }
+  const canonical = canonicalizeBytes(input);
+  if (
+    typeof expected.canonical_bytes_utf8_length === 'number' &&
+    canonical.length !== expected.canonical_bytes_utf8_length
+  ) {
+    issues.push(
+      `${rel}: canonical-bytes UTF-8 length ${canonical.length} != expected ${expected.canonical_bytes_utf8_length}`
+    );
+  }
+  const actual = sha256Hex(canonical);
+  if (actual !== expected.canonical_bytes_sha256_hex) {
+    issues.push(
+      `${rel}: canonical-bytes SHA-256 mismatch (expected ${expected.canonical_bytes_sha256_hex}, got ${actual})`
+    );
+  }
+  // Deterministic regeneration: canonicalize twice and assert byte-identical.
+  const canonical2 = canonicalizeBytes(input);
+  if (Buffer.compare(Buffer.from(canonical), Buffer.from(canonical2)) !== 0) {
+    issues.push(`${rel}: canonical-bytes regeneration is non-deterministic`);
+  }
+  return issues;
+}
+
+function verifyErc8126Negative(vector, path) {
+  const issues = [];
+  const rel = relative(ROOT, path);
+  const filename = basename(path);
+  const declaredReason = vector.expected_failure?.reason;
+  const expectedReason = EXPECTED_FAILURE_REASONS[ERC_FAMILY][filename];
+  if (!expectedReason) {
+    issues.push(`${rel}: unrecognized ERC-8126 negative vector filename`);
+    return issues;
+  }
+  if (declaredReason !== expectedReason) {
+    issues.push(`${rel}: expected_failure.reason ${declaredReason} != ${expectedReason}`);
+  }
+  const input = vector.input;
+  if (filename === 'v04-unknown-format.json') {
+    if (typeof input.attestationFormat !== 'string') {
+      issues.push(`${rel}: v04 must declare attestationFormat to exercise unsupported-format path`);
+    } else if (RECOGNIZED_ATTESTATION_LABELS.has(input.attestationFormat)) {
+      issues.push(
+        `${rel}: v04 attestationFormat ${input.attestationFormat} should not be in recognized open-label set`
+      );
+    }
+  } else if (filename === 'v05-missing-format.json') {
+    if (Object.prototype.hasOwnProperty.call(input, 'attestationFormat')) {
+      issues.push(`${rel}: v05 must omit attestationFormat to exercise missing-format path`);
+    }
+  }
+  return issues;
+}
+
+function verifyAp2Positive(vector, path) {
+  const issues = [];
+  const rel = relative(ROOT, path);
+  const input = vector.input;
+  const expected = vector.expected;
+  if (typeof expected.open_mandate_hash !== 'string') {
+    issues.push(`${rel}: positive vector must declare expected.open_mandate_hash`);
+    return issues;
+  }
+  const canonical = canonicalizeBytes(input);
+  if (
+    typeof expected.canonical_bytes_utf8_length === 'number' &&
+    canonical.length !== expected.canonical_bytes_utf8_length
+  ) {
+    issues.push(
+      `${rel}: canonical-bytes UTF-8 length ${canonical.length} != expected ${expected.canonical_bytes_utf8_length}`
+    );
+  }
+  const actual = sha256Hex(canonical);
+  if (actual !== expected.open_mandate_hash) {
+    issues.push(
+      `${rel}: open_mandate_hash mismatch (expected ${expected.open_mandate_hash}, got ${actual})`
+    );
+  }
+  const canonical2 = canonicalizeBytes(input);
+  if (Buffer.compare(Buffer.from(canonical), Buffer.from(canonical2)) !== 0) {
+    issues.push(`${rel}: canonical-bytes regeneration is non-deterministic`);
+  }
+  return issues;
+}
+
+function verifyAp2Negative(vector, path) {
+  const issues = [];
+  const rel = relative(ROOT, path);
+  const filename = basename(path);
+  const declaredReason = vector.expected_failure?.reason;
+  const expectedReason = EXPECTED_FAILURE_REASONS[AP2_FAMILY][filename];
+  if (!expectedReason) {
+    issues.push(`${rel}: unrecognized AP2 negative vector filename`);
+    return issues;
+  }
+  if (declaredReason !== expectedReason) {
+    issues.push(`${rel}: expected_failure.reason ${declaredReason} != ${expectedReason}`);
+  }
+  const input = vector.input;
+  if (typeof input.body !== 'object' || input.body === null) {
+    issues.push(`${rel}: AP2 negative vector must include input.body`);
+    return issues;
+  }
+  const jcsBytes = canonicalizeBytes(input.body);
+  const sha256 = sha256Hex(jcsBytes);
+  if (filename === 'v04-non-sha256-digest.json') {
+    const candidate = input.candidate_open_mandate_hash_via_sha1;
+    if (typeof candidate !== 'string') {
+      issues.push(`${rel}: v04 must declare candidate_open_mandate_hash_via_sha1`);
+      return issues;
+    }
+    if (candidate === sha256) {
+      issues.push(
+        `${rel}: candidate SHA-1 digest collides with SHA-256 derivation (vector is not negative)`
+      );
+    }
+    const expectedSha1 = sha1Hex(jcsBytes);
+    if (candidate !== expectedSha1) {
+      issues.push(
+        `${rel}: candidate_open_mandate_hash_via_sha1 ${candidate} != sha1_hex(JCS(body)) ${expectedSha1}`
+      );
+    }
+  } else if (filename === 'v05-non-jcs-canonicalization.json') {
+    const candidateBytes = input.candidate_non_jcs_bytes_utf8;
+    const candidateHash = input.candidate_open_mandate_hash_via_non_jcs;
+    if (typeof candidateBytes !== 'string') {
+      issues.push(`${rel}: v05 must declare candidate_non_jcs_bytes_utf8`);
+      return issues;
+    }
+    if (typeof candidateHash !== 'string') {
+      issues.push(`${rel}: v05 must declare candidate_open_mandate_hash_via_non_jcs`);
+      return issues;
+    }
+    const jcsString = canonicalize(input.body);
+    if (candidateBytes === jcsString) {
+      issues.push(
+        `${rel}: candidate non-JCS bytes equal JCS canonical bytes (vector is not negative)`
+      );
+    }
+    const candidateBytesHash = sha256Hex(candidateBytes);
+    if (candidateHash !== candidateBytesHash) {
+      issues.push(
+        `${rel}: candidate_open_mandate_hash_via_non_jcs ${candidateHash} != sha256_hex(candidate_non_jcs_bytes_utf8) ${candidateBytesHash}`
+      );
+    }
+    if (candidateHash === sha256) {
+      issues.push(
+        `${rel}: candidate non-JCS digest collides with SHA-256(JCS(body)) (vector is not negative)`
+      );
+    }
+  }
+  return issues;
+}
+
+function verifyFamily(family, positiveFn, negativeFn) {
+  const familyDir = join(INTEROP_ROOT, family);
+  const positiveDir = join(familyDir, 'positive');
+  const negativeDir = join(familyDir, 'negative');
+  const positives = listJsonFiles(positiveDir);
+  const negatives = listJsonFiles(negativeDir);
+  const expected = EXPECTED_COUNTS[family];
+  const issues = [];
+  if (positives.length !== expected.positive) {
+    issues.push(
+      `${family}: expected ${expected.positive} positive vectors, got ${positives.length}`
+    );
+  }
+  if (negatives.length !== expected.negative) {
+    issues.push(
+      `${family}: expected ${expected.negative} negative vectors, got ${negatives.length}`
+    );
+  }
+  for (const path of positives) {
+    const vector = readJson(path);
+    issues.push(...verifyVectorEnvelope(vector, path));
+    if (vector.expected) {
+      issues.push(...positiveFn(vector, path));
+    }
+  }
+  for (const path of negatives) {
+    const vector = readJson(path);
+    issues.push(...verifyVectorEnvelope(vector, path));
+    if (vector.expected_failure) {
+      issues.push(...negativeFn(vector, path));
+    }
+  }
+  return { positives: positives.length, negatives: negatives.length, issues };
+}
+
+function main() {
+  const ercResult = verifyFamily(ERC_FAMILY, verifyErc8126Positive, verifyErc8126Negative);
+  const ap2Result = verifyFamily(AP2_FAMILY, verifyAp2Positive, verifyAp2Negative);
+  const allIssues = [...ercResult.issues, ...ap2Result.issues];
+  const total =
+    ercResult.positives + ercResult.negatives + ap2Result.positives + ap2Result.negatives;
+  console.log(`Interop vector verifier:`);
+  console.log(`  ${ERC_FAMILY}: ${ercResult.positives} positive, ${ercResult.negatives} negative`);
+  console.log(`  ${AP2_FAMILY}: ${ap2Result.positives} positive, ${ap2Result.negatives} negative`);
+  console.log(`  Total: ${total} vectors across 2 interop families`);
+  if (allIssues.length > 0) {
+    console.error(`\nFAIL: ${allIssues.length} issue(s):`);
+    for (const issue of allIssues) {
+      console.error(`  - ${issue}`);
+    }
+    process.exit(1);
+  }
+  console.log(`\nPASS: all interop vectors verified`);
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(`SCRIPT ERROR: ${err.message}`);
+  process.exit(2);
+}

--- a/specs/conformance/interop/ap2-open-mandate-hash/README.md
+++ b/specs/conformance/interop/ap2-open-mandate-hash/README.md
@@ -1,0 +1,60 @@
+# AP2 `open_mandate_hash` interop vectors
+
+This directory holds repository interop fixtures that exercise the `open_mandate_hash` derivation discussed on `google-agentic-commerce/AP2#265`. The derivation referenced by that issue is:
+
+```text
+open_mandate_hash = sha256_hex(JCS_RFC8785(unsigned open-checkout-mandate body))
+```
+
+(lowercase hexadecimal; the hash input is the claims object, not the JWS compact form). These fixtures complement the cross-implementation work already present in that thread; they do not extend AP2 or replace the AP2 mandate mechanism.
+
+## Layout
+
+```text
+ap2-open-mandate-hash/
+  README.md
+  positive/
+    v01-open-mandate-hash-baseline.json
+    v02-open-mandate-hash-with-budget.json
+    v03-open-mandate-hash-with-expiry.json
+  negative/
+    v04-non-sha256-digest.json
+    v05-non-jcs-canonicalization.json
+```
+
+Positive vectors (3) declare a synthetic but plausible unsigned open-checkout-mandate body and pair it with the expected `open_mandate_hash` value, computed as `sha256_hex(JCS_RFC8785(input))`. These bodies are intentionally minimal and do not claim to be normative AP2 mandate shapes; they exist so the repository interop verifier can verify byte-deterministic regeneration of the digest under the derivation rule.
+
+Negative vectors (2) exercise the two most common composition failure modes: using a non-SHA-256 digest function on the canonical bytes, and using a non-JCS canonicalization rule for the input bytes. Each negative vector declares `expected_failure.kind` and `expected_failure.reason` as fixture-scoped descriptive strings. These strings are not stable PEAC error codes, not a normative error class, and not part of any public PEAC API.
+
+## Mandate-body shape used by the fixtures
+
+All positive fixtures share a baseline shape:
+
+| Field             | Type    | Notes                                                              |
+| ----------------- | ------- | ------------------------------------------------------------------ |
+| `mandate_type`    | string  | Always `open_checkout_mandate` for these fixtures.                 |
+| `mandate_version` | string  | Synthetic version label (`0.1.0`) used for fixture identification. |
+| `principal`       | string  | Opaque principal identifier (DID-shaped string).                   |
+| `agent`           | string  | Opaque agent identifier (DID-shaped string).                       |
+| `currency`        | string  | ISO 4217 alphabetic code.                                          |
+| `amount_minor`    | integer | Authorized base amount in minor units.                             |
+| `items`           | array   | Mandate line items (empty for these baseline fixtures).            |
+| `issued_at`       | string  | RFC 3339 UTC timestamp.                                            |
+| `budget`          | object  | Present only on `v02-open-mandate-hash-with-budget`.               |
+| `expires_at`      | string  | Present only on `v03-open-mandate-hash-with-expiry`.               |
+
+The vectors deliberately do not target the canonicalization edge cases already covered by the cross-implementation work in `AP2#265` (object-key-order, array-order, optional fields, currency-minor-unit, Unicode NFC vs NFD). PEAC-side coverage is scenario-shaped: baseline, budget-bound, expiry-bound, plus the two negative composition-failure cases.
+
+## Verification
+
+The repository verifier at `scripts/verify-interop-vectors.mjs` walks this directory and asserts:
+
+- Each fixture matches the required envelope described by `specs/conformance/schemas/interop-vector.json`.
+- Each positive fixture's input, when JCS-canonicalized and SHA-256 digested, yields lowercase hex bytes matching `expected.open_mandate_hash`.
+- Each positive fixture's canonical bytes regenerate byte-for-byte across runs.
+- Each negative fixture exercises its declared failure mode (non-SHA-256 digest function on the canonical bytes, or non-JCS canonicalization on the input bytes).
+- Exactly 3 positive vectors and 2 negative vectors are present in this directory.
+
+## Boundary
+
+These fixtures do not extend AP2 or replace the AP2 mandate mechanism. PEAC can record signed interaction records that reference AP2 mandate artifacts; it does not introduce a parallel authorization model. AP2 normative authority for the mandate mechanism lives outside this repository.

--- a/specs/conformance/interop/ap2-open-mandate-hash/negative/v04-non-sha256-digest.json
+++ b/specs/conformance/interop/ap2-open-mandate-hash/negative/v04-non-sha256-digest.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../../../schemas/interop-vector.json",
+  "vector_id": "ap2-open-mandate-hash-v04-non-sha256-digest",
+  "description": "Composition failure: a candidate implementation derived the digest with SHA-1 over the JCS canonical bytes instead of SHA-256. The repository interop verifier confirms that this candidate digest does not equal the SHA-256 derivation defined in AP2 issue #265.",
+  "input": {
+    "body": {
+      "mandate_type": "open_checkout_mandate",
+      "mandate_version": "0.1.0",
+      "principal": "did:web:ap2.example/users/user-001",
+      "agent": "did:web:ap2.example/agents/agent-001",
+      "currency": "USD",
+      "amount_minor": 0,
+      "items": [],
+      "issued_at": "2026-05-23T00:00:00Z"
+    },
+    "candidate_open_mandate_hash_via_sha1": "46c6074b18eddd23921ab4c2cbf6d6305ea9a293"
+  },
+  "expected_failure": {
+    "kind": "digest_failure",
+    "reason": "non_sha256_digest"
+  }
+}

--- a/specs/conformance/interop/ap2-open-mandate-hash/negative/v05-non-jcs-canonicalization.json
+++ b/specs/conformance/interop/ap2-open-mandate-hash/negative/v05-non-jcs-canonicalization.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../../../schemas/interop-vector.json",
+  "vector_id": "ap2-open-mandate-hash-v05-non-jcs-canonicalization",
+  "description": "Composition failure: a candidate implementation serialized the unsigned mandate body with JSON.stringify in source-order instead of the RFC 8785 JCS canonical order. The repository interop verifier confirms that the candidate byte sequence does not equal the JCS canonical bytes defined in AP2 issue #265.",
+  "input": {
+    "body": {
+      "mandate_type": "open_checkout_mandate",
+      "mandate_version": "0.1.0",
+      "principal": "did:web:ap2.example/users/user-001",
+      "agent": "did:web:ap2.example/agents/agent-001",
+      "currency": "USD",
+      "amount_minor": 0,
+      "items": [],
+      "issued_at": "2026-05-23T00:00:00Z"
+    },
+    "candidate_non_jcs_bytes_utf8": "{\"issued_at\":\"2026-05-23T00:00:00Z\",\"items\":[],\"amount_minor\":0,\"currency\":\"USD\",\"agent\":\"did:web:ap2.example/agents/agent-001\",\"principal\":\"did:web:ap2.example/users/user-001\",\"mandate_version\":\"0.1.0\",\"mandate_type\":\"open_checkout_mandate\"}",
+    "candidate_open_mandate_hash_via_non_jcs": "d17e94eaeb3e614b75cca7f9e73a08e09d07269473a56f7bd821968a9a4e7047"
+  },
+  "expected_failure": {
+    "kind": "canonicalization_failure",
+    "reason": "non_jcs_canonicalization"
+  }
+}

--- a/specs/conformance/interop/ap2-open-mandate-hash/positive/v01-open-mandate-hash-baseline.json
+++ b/specs/conformance/interop/ap2-open-mandate-hash/positive/v01-open-mandate-hash-baseline.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../../../schemas/interop-vector.json",
+  "vector_id": "ap2-open-mandate-hash-v01-open-mandate-hash-baseline",
+  "description": "Baseline unsigned open-checkout-mandate body with empty items list and zero authorized amount.",
+  "input": {
+    "mandate_type": "open_checkout_mandate",
+    "mandate_version": "0.1.0",
+    "principal": "did:web:ap2.example/users/user-001",
+    "agent": "did:web:ap2.example/agents/agent-001",
+    "currency": "USD",
+    "amount_minor": 0,
+    "items": [],
+    "issued_at": "2026-05-23T00:00:00Z"
+  },
+  "expected": {
+    "canonical_bytes_utf8_length": 242,
+    "open_mandate_hash": "d1a24ae8a67d4dc30358245e8230b6f0588bc4ddd611ae4bbf2a131afc74f42c"
+  }
+}

--- a/specs/conformance/interop/ap2-open-mandate-hash/positive/v02-open-mandate-hash-with-budget.json
+++ b/specs/conformance/interop/ap2-open-mandate-hash/positive/v02-open-mandate-hash-with-budget.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../../../schemas/interop-vector.json",
+  "vector_id": "ap2-open-mandate-hash-v02-open-mandate-hash-with-budget",
+  "description": "Unsigned open-checkout-mandate body with a budget object capping authorized spend at the mandate-interval level.",
+  "input": {
+    "mandate_type": "open_checkout_mandate",
+    "mandate_version": "0.1.0",
+    "principal": "did:web:ap2.example/users/user-001",
+    "agent": "did:web:ap2.example/agents/agent-001",
+    "currency": "USD",
+    "amount_minor": 25000,
+    "items": [],
+    "budget": {
+      "currency": "USD",
+      "amount_minor": 25000,
+      "interval": "per_mandate"
+    },
+    "issued_at": "2026-05-23T00:00:00Z"
+  },
+  "expected": {
+    "canonical_bytes_utf8_length": 320,
+    "open_mandate_hash": "ab362e76f926ce22c5ad8ae5c0eba3829bdbb7a27cc0f577e47d881f75308224"
+  }
+}

--- a/specs/conformance/interop/ap2-open-mandate-hash/positive/v03-open-mandate-hash-with-expiry.json
+++ b/specs/conformance/interop/ap2-open-mandate-hash/positive/v03-open-mandate-hash-with-expiry.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../schemas/interop-vector.json",
+  "vector_id": "ap2-open-mandate-hash-v03-open-mandate-hash-with-expiry",
+  "description": "Unsigned open-checkout-mandate body with an absolute expiry timestamp at the mandate level.",
+  "input": {
+    "mandate_type": "open_checkout_mandate",
+    "mandate_version": "0.1.0",
+    "principal": "did:web:ap2.example/users/user-001",
+    "agent": "did:web:ap2.example/agents/agent-001",
+    "currency": "USD",
+    "amount_minor": 0,
+    "items": [],
+    "expires_at": "2026-12-31T23:59:59Z",
+    "issued_at": "2026-05-23T00:00:00Z"
+  },
+  "expected": {
+    "canonical_bytes_utf8_length": 278,
+    "open_mandate_hash": "483a3952ef63af0ef06176dc69e57f5a08afdc791d9cf696775612248bcb6b80"
+  }
+}

--- a/specs/conformance/interop/erc8126-attestation-format/README.md
+++ b/specs/conformance/interop/erc8126-attestation-format/README.md
@@ -1,0 +1,57 @@
+# ERC-8126 attestation-format interop vectors
+
+This directory holds repository interop fixtures that use an illustrative open carrier label (`attestationFormat`) on Validation Registry attestation posts built by ERC-8126 / ERC-8004-aligned systems. The fixtures are not normative ERC-8126 conformance vectors and they do not stand in for a registry-shipped attestation format. They exist so that PEAC-side tooling can reason about how PEAC composes with an ERC-8126 attestation surface that carries an open attestation-carrier label.
+
+## Layout
+
+```text
+erc8126-attestation-format/
+  README.md
+  positive/
+    v01-jws-attestation.json
+    v02-eip712-attestation.json
+    v03-onchain-attestation.json
+  negative/
+    v04-unknown-format.json
+    v05-missing-format.json
+```
+
+Positive vectors (3) declare an `attestationFormat` value drawn from the illustrative open label set and pair it with an opaque `attestation_ref` that points to a carrier-specific payload (not embedded in the fixture). Each positive vector also declares its expected canonical-bytes SHA-256 digest under `expected.canonical_bytes_sha256_hex`, computed as `sha256_hex(JCS_RFC8785(input))`. This makes byte-deterministic verification possible without invoking any external service.
+
+Negative vectors (2) exercise unsupported and missing carrier metadata. Each negative vector declares `expected_failure.kind` and `expected_failure.reason` as fixture-scoped descriptive strings. These strings are not stable PEAC error codes, not a normative error class, and not part of any public PEAC API. They exist solely to make the repository interop verifier deterministic.
+
+## Carrier-label set covered
+
+- `jws` (positive)
+- `eip712` (positive)
+- `onchain` (positive)
+- unrecognized vendor-prefixed label (negative)
+- absent label (negative)
+
+A COSE-Sign1 carrier is discussed in the companion composition note at `docs/specs/ERC-8126-COMPOSITION.md` as a possible additive label in the same open set. This fixture set does not include a COSE-Sign1 vector. This repository does not include a PEAC COSE carrier implementation.
+
+## Field shape
+
+All positive and negative inputs share a baseline attestation-post shape:
+
+| Field               | Type    | Notes                                                                                                                                                                         |
+| ------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent_id`          | string  | Opaque ERC-8004 agent identifier; not validated by these fixtures.                                                                                                            |
+| `verification_type` | string  | One of the ERC-8126 verification-type acronyms (ETV, MCV, SCV, WAV, WV, plus optional PDV / QCV). Fixtures do not pin the exact enumeration; the spec is the source of truth. |
+| `risk_score`        | integer | Integer 0-100; informational only for these fixtures.                                                                                                                         |
+| `attestationFormat` | string  | Carrier label used by these fixtures. Carries the open carrier label (or is absent on `v05-missing-format`).                                                                  |
+| `attestation_ref`   | string  | Opaque reference to the carrier-specific payload. The carrier payload itself is not embedded in the fixture.                                                                  |
+| `observed_at`       | string  | RFC 3339 UTC timestamp.                                                                                                                                                       |
+
+## Verification
+
+The repository verifier at `scripts/verify-interop-vectors.mjs` walks this directory and asserts:
+
+- Each fixture matches the required envelope described by `specs/conformance/schemas/interop-vector.json`.
+- Each positive fixture's input, when JCS-canonicalized and SHA-256 digested, yields lowercase hex bytes matching `expected.canonical_bytes_sha256_hex`.
+- Each negative fixture exercises its declared `expected_failure.reason` against the family's fixture-scoped validation rule (`attestationFormat` value must be present and drawn from the recognized open-label set defined in this README).
+- Exactly 3 positive vectors and 2 negative vectors are present in this directory.
+
+## Boundary
+
+These fixtures do not standardize ERC-8126. PEAC records references to ERC-8126-aligned attestation artifacts. The `attestationFormat` field is repository fixture metadata; it is not required by PEAC and is not defined by PEAC. ERC-8126 and ERC-8004 define their own registry semantics.

--- a/specs/conformance/interop/erc8126-attestation-format/negative/v04-unknown-format.json
+++ b/specs/conformance/interop/erc8126-attestation-format/negative/v04-unknown-format.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/interop-vector.json",
+  "vector_id": "erc8126-attestation-format-v04-unknown-format",
+  "description": "Validation Registry attestation post whose attestationFormat label is not drawn from the recognized open-label set; the repository interop verifier rejects it.",
+  "input": {
+    "agent_id": "did:web:erc8126.example/agents/agent-004",
+    "verification_type": "SCV",
+    "risk_score": 41,
+    "attestationFormat": "vendor-x-proprietary-format",
+    "attestation_ref": "urn:peac:interop:erc8126:unknown-attestation:0004",
+    "observed_at": "2026-05-23T00:00:00Z"
+  },
+  "expected_failure": {
+    "kind": "validation_failure",
+    "reason": "unsupported_attestation_format"
+  }
+}

--- a/specs/conformance/interop/erc8126-attestation-format/negative/v05-missing-format.json
+++ b/specs/conformance/interop/erc8126-attestation-format/negative/v05-missing-format.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../schemas/interop-vector.json",
+  "vector_id": "erc8126-attestation-format-v05-missing-format",
+  "description": "Validation Registry attestation post that omits the attestationFormat field entirely; the repository interop verifier rejects it.",
+  "input": {
+    "agent_id": "did:web:erc8126.example/agents/agent-005",
+    "verification_type": "WV",
+    "risk_score": 12,
+    "attestation_ref": "urn:peac:interop:erc8126:missing-format-attestation:0005",
+    "observed_at": "2026-05-23T00:00:00Z"
+  },
+  "expected_failure": {
+    "kind": "validation_failure",
+    "reason": "missing_attestation_format"
+  }
+}

--- a/specs/conformance/interop/erc8126-attestation-format/positive/v01-jws-attestation.json
+++ b/specs/conformance/interop/erc8126-attestation-format/positive/v01-jws-attestation.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/interop-vector.json",
+  "vector_id": "erc8126-attestation-format-v01-jws-attestation",
+  "description": "Validation Registry attestation reference carrying the illustrative fixture carrier label `jws`.",
+  "input": {
+    "agent_id": "did:web:erc8126.example/agents/agent-001",
+    "verification_type": "ETV",
+    "risk_score": 18,
+    "attestationFormat": "jws",
+    "attestation_ref": "urn:peac:interop:erc8126:jws-attestation:0001",
+    "observed_at": "2026-05-23T00:00:00Z"
+  },
+  "expected": {
+    "canonical_bytes_utf8_length": 226,
+    "canonical_bytes_sha256_hex": "5c9518545f8a0129d2237439cce67629e24419a648a926ad63e21a2ecf055d67"
+  }
+}

--- a/specs/conformance/interop/erc8126-attestation-format/positive/v02-eip712-attestation.json
+++ b/specs/conformance/interop/erc8126-attestation-format/positive/v02-eip712-attestation.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/interop-vector.json",
+  "vector_id": "erc8126-attestation-format-v02-eip712-attestation",
+  "description": "Validation Registry attestation reference carrying the illustrative fixture carrier label `eip712`.",
+  "input": {
+    "agent_id": "did:web:erc8126.example/agents/agent-002",
+    "verification_type": "MCV",
+    "risk_score": 32,
+    "attestationFormat": "eip712",
+    "attestation_ref": "urn:peac:interop:erc8126:eip712-attestation:0002",
+    "observed_at": "2026-05-23T00:00:00Z"
+  },
+  "expected": {
+    "canonical_bytes_utf8_length": 232,
+    "canonical_bytes_sha256_hex": "a18b9de864a3018db3665e16039bfae2fdf504a8f03564ed9a41c17cea87fab6"
+  }
+}

--- a/specs/conformance/interop/erc8126-attestation-format/positive/v03-onchain-attestation.json
+++ b/specs/conformance/interop/erc8126-attestation-format/positive/v03-onchain-attestation.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/interop-vector.json",
+  "vector_id": "erc8126-attestation-format-v03-onchain-attestation",
+  "description": "Validation Registry attestation reference carrying the illustrative fixture carrier label `onchain`.",
+  "input": {
+    "agent_id": "did:web:erc8126.example/agents/agent-003",
+    "verification_type": "WAV",
+    "risk_score": 7,
+    "attestationFormat": "onchain",
+    "attestation_ref": "urn:peac:interop:erc8126:onchain-attestation:0003",
+    "observed_at": "2026-05-23T00:00:00Z"
+  },
+  "expected": {
+    "canonical_bytes_utf8_length": 233,
+    "canonical_bytes_sha256_hex": "a58287adf296a1dc7a9092eceb4f66c49e6aa752699833647161154fcbcfd5d5"
+  }
+}

--- a/specs/conformance/schemas/interop-vector.json
+++ b/specs/conformance/schemas/interop-vector.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.peacprotocol.org/schemas/conformance/interop-vector.schema.json",
+  "title": "PEAC Interop Vector",
+  "description": "Shape of a single interop fixture under specs/conformance/interop/<family>/{positive,negative}/. Interop vectors are repository interoperability fixtures, not normative conformance corpus entries. Each negative vector declares its expected failure as fixture-scoped descriptive strings; these strings are not stable PEAC error codes.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["$schema", "description", "vector_id", "input"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Relative or absolute reference to this schema document."
+    },
+    "vector_id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*-v[0-9]{2}-[a-z0-9-]+$",
+      "description": "Kebab-case identifier prefixed with family slug and v<NN>- ordinal, for example erc8126-attestation-format-v01-jws-attestation or ap2-open-mandate-hash-v04-non-sha256-digest."
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Single-line human-readable summary of what the vector exercises."
+    },
+    "input": {
+      "type": "object",
+      "description": "Vector payload. Shape is family-specific and described in the family README."
+    },
+    "expected": {
+      "type": "object",
+      "description": "Present on positive vectors only. Family-specific. Typical fields: canonical_bytes_sha256_hex (lowercase hex SHA-256 of the JCS canonical bytes of input), open_mandate_hash, attestation_carrier."
+    },
+    "expected_failure": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "reason"],
+      "description": "Present on negative vectors only. The kind and reason strings are fixture-scoped descriptive labels; they are not stable PEAC error codes and must not be relied on as a public API.",
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["validation_failure", "canonicalization_failure", "digest_failure"],
+          "description": "Coarse classification of the failure surface."
+        },
+        "reason": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "description": "Snake-case descriptive label for the specific failure. Fixture-scoped; not stable; not a PEAC error code."
+        }
+      }
+    }
+  },
+  "oneOf": [
+    {
+      "required": ["expected"],
+      "not": { "required": ["expected_failure"] }
+    },
+    {
+      "required": ["expected_failure"],
+      "not": { "required": ["expected"] }
+    }
+  ]
+}

--- a/tests/conformance/interop-ap2.spec.ts
+++ b/tests/conformance/interop-ap2.spec.ts
@@ -1,0 +1,188 @@
+/**
+ * AP2 open_mandate_hash interop vector conformance tests.
+ *
+ * Repository interop fixtures under specs/conformance/interop/ap2-open-mandate-hash/
+ * are validated for envelope shape, deterministic JCS canonical-bytes
+ * regeneration, SHA-256 derivation matching the AP2 #265 rule, and
+ * declared composition-failure modes on negative vectors.
+ * Negative-vector reason strings are fixture-scoped and not stable PEAC
+ * error codes.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { canonicalize, canonicalizeBytes } from '@peac/crypto';
+
+const FAMILY_DIR = join(
+  __dirname,
+  '..',
+  '..',
+  'specs',
+  'conformance',
+  'interop',
+  'ap2-open-mandate-hash'
+);
+
+interface PositiveVector {
+  $schema: string;
+  vector_id: string;
+  description: string;
+  input: Record<string, unknown>;
+  expected: {
+    canonical_bytes_utf8_length?: number;
+    open_mandate_hash: string;
+  };
+}
+
+interface NegativeV04 {
+  $schema: string;
+  vector_id: string;
+  description: string;
+  input: {
+    body: Record<string, unknown>;
+    candidate_open_mandate_hash_via_sha1: string;
+  };
+  expected_failure: { kind: 'digest_failure'; reason: 'non_sha256_digest' };
+}
+
+interface NegativeV05 {
+  $schema: string;
+  vector_id: string;
+  description: string;
+  input: {
+    body: Record<string, unknown>;
+    candidate_non_jcs_bytes_utf8: string;
+    candidate_open_mandate_hash_via_non_jcs: string;
+  };
+  expected_failure: { kind: 'canonicalization_failure'; reason: 'non_jcs_canonicalization' };
+}
+
+function readVector<T>(rel: string): T {
+  return JSON.parse(readFileSync(join(FAMILY_DIR, rel), 'utf8')) as T;
+}
+
+function listFixtures(subdir: string): string[] {
+  return readdirSync(join(FAMILY_DIR, subdir))
+    .filter((name) => name.endsWith('.json'))
+    .sort();
+}
+
+function sha256Hex(input: Uint8Array | string): string {
+  const buf = typeof input === 'string' ? Buffer.from(input, 'utf8') : Buffer.from(input);
+  return createHash('sha256').update(buf).digest('hex');
+}
+
+function sha1Hex(input: Uint8Array | string): string {
+  const buf = typeof input === 'string' ? Buffer.from(input, 'utf8') : Buffer.from(input);
+  return createHash('sha1').update(buf).digest('hex');
+}
+
+describe('AP2 open_mandate_hash interop vectors', () => {
+  it('contains exactly 3 positive and 2 negative vectors', () => {
+    const positives = listFixtures('positive');
+    const negatives = listFixtures('negative');
+    expect(positives).toHaveLength(3);
+    expect(negatives).toHaveLength(2);
+  });
+
+  describe('positive vectors', () => {
+    for (const filename of listFixtures('positive')) {
+      describe(filename, () => {
+        const vector = readVector<PositiveVector>(join('positive', filename));
+
+        it('declares envelope fields', () => {
+          expect(vector.$schema).toBeTypeOf('string');
+          expect(vector.vector_id).toBeTypeOf('string');
+          expect(vector.description.length).toBeGreaterThan(0);
+          expect(vector.input).toBeTypeOf('object');
+          expect(vector.expected.open_mandate_hash).toMatch(/^[0-9a-f]{64}$/);
+          expect(vector).not.toHaveProperty('expected_failure');
+        });
+
+        it('open_mandate_hash matches sha256_hex(JCS(input))', () => {
+          const bytes = canonicalizeBytes(vector.input);
+          const actual = sha256Hex(bytes);
+          expect(actual).toBe(vector.expected.open_mandate_hash);
+          if (typeof vector.expected.canonical_bytes_utf8_length === 'number') {
+            expect(bytes.length).toBe(vector.expected.canonical_bytes_utf8_length);
+          }
+        });
+
+        it('canonical-bytes regeneration is deterministic', () => {
+          const a = canonicalize(vector.input);
+          const b = canonicalize(vector.input);
+          expect(a).toBe(b);
+        });
+      });
+    }
+  });
+
+  describe('negative vectors', () => {
+    it('declares envelope fields and stable-error-namespace absence on every negative', () => {
+      for (const filename of listFixtures('negative')) {
+        const vector = readVector<{
+          $schema: string;
+          vector_id: string;
+          description: string;
+          input: Record<string, unknown>;
+          expected_failure: { kind: string; reason: string };
+        }>(join('negative', filename));
+        expect(vector.$schema).toBeTypeOf('string');
+        expect(vector.vector_id).toBeTypeOf('string');
+        expect(vector.description.length).toBeGreaterThan(0);
+        expect(vector.expected_failure.reason).toMatch(/^[a-z][a-z0-9_]*$/);
+        expect(['validation_failure', 'canonicalization_failure', 'digest_failure']).toContain(
+          vector.expected_failure.kind
+        );
+        expect(vector).not.toHaveProperty('expected');
+        expect(vector.expected_failure).not.toHaveProperty('error_code');
+        expect(vector.expected_failure).not.toHaveProperty('error_class');
+        expect(vector.expected_failure).not.toHaveProperty('error_namespace');
+        expect(vector).not.toHaveProperty('error_code');
+        expect(vector).not.toHaveProperty('error_class');
+        expect(vector).not.toHaveProperty('error_namespace');
+      }
+    });
+
+    describe('v04-non-sha256-digest.json', () => {
+      const vector = readVector<NegativeV04>(join('negative', 'v04-non-sha256-digest.json'));
+
+      it('declares the expected fixture-scoped reason', () => {
+        expect(vector.expected_failure.kind).toBe('digest_failure');
+        expect(vector.expected_failure.reason).toBe('non_sha256_digest');
+      });
+
+      it('candidate digest equals sha1_hex(JCS(body)) and not sha256_hex(JCS(body))', () => {
+        const bytes = canonicalizeBytes(vector.input.body);
+        const sha256 = sha256Hex(bytes);
+        const sha1 = sha1Hex(bytes);
+        expect(vector.input.candidate_open_mandate_hash_via_sha1).toBe(sha1);
+        expect(vector.input.candidate_open_mandate_hash_via_sha1).not.toBe(sha256);
+      });
+    });
+
+    describe('v05-non-jcs-canonicalization.json', () => {
+      const vector = readVector<NegativeV05>(join('negative', 'v05-non-jcs-canonicalization.json'));
+
+      it('declares the expected fixture-scoped reason', () => {
+        expect(vector.expected_failure.kind).toBe('canonicalization_failure');
+        expect(vector.expected_failure.reason).toBe('non_jcs_canonicalization');
+      });
+
+      it('candidate bytes do not equal JCS canonical bytes', () => {
+        const jcs = canonicalize(vector.input.body);
+        expect(vector.input.candidate_non_jcs_bytes_utf8).not.toBe(jcs);
+      });
+
+      it('candidate digest equals sha256_hex(candidate_bytes) and not sha256_hex(JCS(body))', () => {
+        const candidateBytesHash = sha256Hex(vector.input.candidate_non_jcs_bytes_utf8);
+        const jcsBytes = canonicalizeBytes(vector.input.body);
+        const jcsHash = sha256Hex(jcsBytes);
+        expect(vector.input.candidate_open_mandate_hash_via_non_jcs).toBe(candidateBytesHash);
+        expect(vector.input.candidate_open_mandate_hash_via_non_jcs).not.toBe(jcsHash);
+      });
+    });
+  });
+});

--- a/tests/conformance/interop-erc8126.spec.ts
+++ b/tests/conformance/interop-erc8126.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * ERC-8126 attestation-format interop vector conformance tests.
+ *
+ * Repository interop fixtures under specs/conformance/interop/erc8126-attestation-format/
+ * are validated for envelope shape, deterministic JCS canonical-bytes
+ * regeneration, recognized open-label set membership, and declared
+ * expected_failure shape on negative vectors. Negative-vector reason
+ * strings are fixture-scoped and not stable PEAC error codes.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { canonicalize, canonicalizeBytes } from '@peac/crypto';
+
+const FAMILY_DIR = join(
+  __dirname,
+  '..',
+  '..',
+  'specs',
+  'conformance',
+  'interop',
+  'erc8126-attestation-format'
+);
+
+const RECOGNIZED_LABELS = new Set(['jws', 'eip712', 'onchain']);
+
+interface PositiveVector {
+  $schema: string;
+  vector_id: string;
+  description: string;
+  input: Record<string, unknown> & { attestationFormat?: string };
+  expected: {
+    canonical_bytes_utf8_length?: number;
+    canonical_bytes_sha256_hex: string;
+  };
+}
+
+interface NegativeVector {
+  $schema: string;
+  vector_id: string;
+  description: string;
+  input: Record<string, unknown>;
+  expected_failure: {
+    kind: 'validation_failure' | 'canonicalization_failure' | 'digest_failure';
+    reason: string;
+  };
+}
+
+function readVector<T>(rel: string): T {
+  return JSON.parse(readFileSync(join(FAMILY_DIR, rel), 'utf8')) as T;
+}
+
+function listFixtures(subdir: string): string[] {
+  return readdirSync(join(FAMILY_DIR, subdir))
+    .filter((name) => name.endsWith('.json'))
+    .sort();
+}
+
+function sha256Hex(input: Uint8Array | string): string {
+  const buf = typeof input === 'string' ? Buffer.from(input, 'utf8') : Buffer.from(input);
+  return createHash('sha256').update(buf).digest('hex');
+}
+
+describe('ERC-8126 attestation-format interop vectors', () => {
+  it('contains exactly 3 positive and 2 negative vectors', () => {
+    const positives = listFixtures('positive');
+    const negatives = listFixtures('negative');
+    expect(positives).toHaveLength(3);
+    expect(negatives).toHaveLength(2);
+  });
+
+  describe('positive vectors', () => {
+    const positives = listFixtures('positive');
+    for (const filename of positives) {
+      describe(filename, () => {
+        const vector = readVector<PositiveVector>(join('positive', filename));
+
+        it('declares envelope fields', () => {
+          expect(vector.$schema).toBeTypeOf('string');
+          expect(vector.vector_id).toBeTypeOf('string');
+          expect(vector.description.length).toBeGreaterThan(0);
+          expect(vector.input).toBeTypeOf('object');
+          expect(vector.expected).toBeTypeOf('object');
+          expect(vector).not.toHaveProperty('expected_failure');
+        });
+
+        it('declares attestationFormat in the recognized open-label set', () => {
+          expect(typeof vector.input.attestationFormat).toBe('string');
+          expect(RECOGNIZED_LABELS.has(vector.input.attestationFormat!)).toBe(true);
+        });
+
+        it('canonical-bytes SHA-256 matches expected', () => {
+          const bytes = canonicalizeBytes(vector.input);
+          const actual = sha256Hex(bytes);
+          expect(actual).toBe(vector.expected.canonical_bytes_sha256_hex);
+          if (typeof vector.expected.canonical_bytes_utf8_length === 'number') {
+            expect(bytes.length).toBe(vector.expected.canonical_bytes_utf8_length);
+          }
+        });
+
+        it('canonical-bytes regeneration is deterministic', () => {
+          const a = canonicalize(vector.input);
+          const b = canonicalize(vector.input);
+          expect(a).toBe(b);
+        });
+      });
+    }
+  });
+
+  describe('negative vectors', () => {
+    const expectedReasons: Record<string, string> = {
+      'v04-unknown-format.json': 'unsupported_attestation_format',
+      'v05-missing-format.json': 'missing_attestation_format',
+    };
+
+    for (const filename of listFixtures('negative')) {
+      describe(filename, () => {
+        const vector = readVector<NegativeVector>(join('negative', filename));
+
+        it('declares envelope fields', () => {
+          expect(vector.$schema).toBeTypeOf('string');
+          expect(vector.vector_id).toBeTypeOf('string');
+          expect(vector.description.length).toBeGreaterThan(0);
+          expect(vector.input).toBeTypeOf('object');
+          expect(vector).not.toHaveProperty('expected');
+        });
+
+        it('declares expected_failure.kind and expected_failure.reason', () => {
+          expect(['validation_failure', 'canonicalization_failure', 'digest_failure']).toContain(
+            vector.expected_failure.kind
+          );
+          expect(vector.expected_failure.reason).toMatch(/^[a-z][a-z0-9_]*$/);
+        });
+
+        it('declares the expected fixture-scoped reason', () => {
+          expect(vector.expected_failure.reason).toBe(expectedReasons[filename]);
+        });
+
+        it('does not declare a stable PEAC error code or error class', () => {
+          expect(vector.expected_failure).not.toHaveProperty('error_code');
+          expect(vector.expected_failure).not.toHaveProperty('error_class');
+          expect(vector.expected_failure).not.toHaveProperty('error_namespace');
+          expect(vector).not.toHaveProperty('error_code');
+          expect(vector).not.toHaveProperty('error_class');
+          expect(vector).not.toHaveProperty('error_namespace');
+        });
+
+        it('exercises the declared failure mode', () => {
+          if (filename === 'v04-unknown-format.json') {
+            const attestationFormat = (vector.input as { attestationFormat?: string })
+              .attestationFormat;
+            expect(typeof attestationFormat).toBe('string');
+            expect(RECOGNIZED_LABELS.has(attestationFormat!)).toBe(false);
+          } else if (filename === 'v05-missing-format.json') {
+            expect(vector.input).not.toHaveProperty('attestationFormat');
+          }
+        });
+      });
+    }
+  });
+});

--- a/tests/tooling/erc8126-ap2-composition-doc-truth.test.ts
+++ b/tests/tooling/erc8126-ap2-composition-doc-truth.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Doc-truth tests for the ERC-8126 and AP2 composition spec notes and
+ * their associated interop fixture corpus.
+ *
+ * Asserts:
+ *  - Composition spec docs exist and declare required sections
+ *  - Non-claims are stated explicitly
+ *  - COSE is excluded from the ERC-8126 vector corpus
+ *  - The vector counts are exactly 3 positive + 2 negative per family
+ *  - 2 interop families total
+ *  - Every negative vector declares expected_failure.kind + expected_failure.reason
+ *  - No stable error namespace fields leak into the vector corpus
+ *  - The interop vector schema exists and forbids stable error fields
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join as pathJoin, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = pathJoin(__dirname, '..', '..');
+
+const ERC_SPEC = pathJoin(ROOT, 'docs/specs/ERC-8126-COMPOSITION.md');
+const AP2_SPEC = pathJoin(ROOT, 'docs/specs/AP2-COMPOSITION.md');
+const SCHEMA = pathJoin(ROOT, 'specs/conformance/schemas/interop-vector.json');
+const INTEROP_ROOT = pathJoin(ROOT, 'specs/conformance/interop');
+const ERC_FAMILY_DIR = pathJoin(INTEROP_ROOT, 'erc8126-attestation-format');
+const AP2_FAMILY_DIR = pathJoin(INTEROP_ROOT, 'ap2-open-mandate-hash');
+const VERIFIER = pathJoin(ROOT, 'scripts/verify-interop-vectors.mjs');
+
+function readText(p: string): string {
+  return readFileSync(p, 'utf8');
+}
+
+/** Collapse intra-paragraph whitespace so substring assertions tolerate hard-wrapped Markdown. */
+function normalize(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+function readJson(p: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(p, 'utf8'));
+}
+
+function listJson(dir: string): string[] {
+  return readdirSync(dir)
+    .filter((name) => name.endsWith('.json'))
+    .sort();
+}
+
+describe('ERC-8126 composition spec doc-truth', () => {
+  it('exists at the expected path', () => {
+    expect(existsSync(ERC_SPEC), `Expected file at ${ERC_SPEC}`).toBe(true);
+  });
+
+  it('declares the required headings', () => {
+    const text = readText(ERC_SPEC);
+    const required = [
+      '# PEAC and ERC-8126 Composition',
+      '**Status:** Informative',
+      '## Why this document exists',
+      '## Boundary',
+      '## Carrier label used by these fixtures',
+      '## Composition pattern',
+      '## Verifier guidance',
+      '## Related work',
+    ];
+    const missing = required.filter((heading) => !text.includes(heading));
+    expect(missing, `Missing headings:\n${missing.join('\n')}`).toEqual([]);
+  });
+
+  it('declares explicit non-claims', () => {
+    const text = normalize(readText(ERC_SPEC));
+    expect(text).toContain('PEAC does not standardize ERC-8126');
+    expect(text).toContain('PEAC does not host the Validation Registry');
+    expect(text).toContain('PEAC records references to ERC-8126-aligned attestation');
+  });
+
+  it('records the COSE scope note in durable wording', () => {
+    const text = normalize(readText(ERC_SPEC));
+    expect(text).toContain('This fixture set does not include a COSE-Sign1 vector');
+    expect(text).toContain('This repository does not include a PEAC COSE carrier implementation');
+  });
+
+  it('points to the repository interop fixtures and verifier', () => {
+    const text = readText(ERC_SPEC);
+    expect(text).toContain('specs/conformance/interop/erc8126-attestation-format/');
+    expect(text).toContain('scripts/verify-interop-vectors.mjs');
+  });
+});
+
+describe('AP2 composition spec doc-truth', () => {
+  it('exists at the expected path', () => {
+    expect(existsSync(AP2_SPEC), `Expected file at ${AP2_SPEC}`).toBe(true);
+  });
+
+  it('declares the required headings', () => {
+    const text = readText(AP2_SPEC);
+    const required = [
+      '# PEAC and AP2 Composition',
+      '**Status:** Informative',
+      '## Why this document exists',
+      '## Boundary',
+      '## Composition pattern',
+      '## Verifier guidance',
+      '## Repository interop fixtures',
+      '## Related work',
+    ];
+    const missing = required.filter((heading) => !text.includes(heading));
+    expect(missing, `Missing headings:\n${missing.join('\n')}`).toEqual([]);
+  });
+
+  it('declares explicit non-claims', () => {
+    const text = normalize(readText(AP2_SPEC));
+    expect(text).toContain('PEAC does not extend AP2');
+    expect(text).toContain('PEAC does not mint mandates');
+    expect(text).toContain('PEAC records references to AP2 mandate artifacts');
+  });
+
+  it('points to the repository interop fixtures and verifier and AP2 #265', () => {
+    const text = readText(AP2_SPEC);
+    expect(text).toContain('specs/conformance/interop/ap2-open-mandate-hash/');
+    expect(text).toContain('scripts/verify-interop-vectors.mjs');
+    expect(text).toContain('google-agentic-commerce/AP2/issues/265');
+  });
+});
+
+describe('Interop vector schema doc-truth', () => {
+  it('exists at the expected path', () => {
+    expect(existsSync(SCHEMA), `Expected schema at ${SCHEMA}`).toBe(true);
+  });
+
+  it('uses the documented PEAC schema $id namespace', () => {
+    const schema = readJson(SCHEMA);
+    expect(schema.$id).toBe(
+      'https://www.peacprotocol.org/schemas/conformance/interop-vector.schema.json'
+    );
+  });
+
+  it('enumerates only fixture-scoped expected_failure.kind values', () => {
+    const schema = readJson(SCHEMA) as {
+      properties: { expected_failure: { properties: { kind: { enum: string[] } } } };
+    };
+    const enumValues = schema.properties.expected_failure.properties.kind.enum;
+    expect(enumValues.sort()).toEqual(
+      ['canonicalization_failure', 'digest_failure', 'validation_failure'].sort()
+    );
+  });
+});
+
+describe('Interop fixture corpus doc-truth', () => {
+  it('contains exactly 2 interop families (no extras)', () => {
+    const families = readdirSync(INTEROP_ROOT)
+      .filter((name) => !name.startsWith('.'))
+      .sort();
+    expect(families).toEqual(['ap2-open-mandate-hash', 'erc8126-attestation-format']);
+  });
+
+  it('ERC-8126 family contains 3 positive + 2 negative vectors only', () => {
+    expect(listJson(pathJoin(ERC_FAMILY_DIR, 'positive'))).toHaveLength(3);
+    expect(listJson(pathJoin(ERC_FAMILY_DIR, 'negative'))).toHaveLength(2);
+  });
+
+  it('AP2 family contains 3 positive + 2 negative vectors only', () => {
+    expect(listJson(pathJoin(AP2_FAMILY_DIR, 'positive'))).toHaveLength(3);
+    expect(listJson(pathJoin(AP2_FAMILY_DIR, 'negative'))).toHaveLength(2);
+  });
+
+  it('exactly 10 interop vectors across both families', () => {
+    const erc =
+      listJson(pathJoin(ERC_FAMILY_DIR, 'positive')).length +
+      listJson(pathJoin(ERC_FAMILY_DIR, 'negative')).length;
+    const ap2 =
+      listJson(pathJoin(AP2_FAMILY_DIR, 'positive')).length +
+      listJson(pathJoin(AP2_FAMILY_DIR, 'negative')).length;
+    expect(erc + ap2).toBe(10);
+  });
+
+  it('ERC-8126 family does not contain a COSE vector', () => {
+    const allFiles = [
+      ...listJson(pathJoin(ERC_FAMILY_DIR, 'positive')),
+      ...listJson(pathJoin(ERC_FAMILY_DIR, 'negative')),
+    ];
+    for (const filename of allFiles) {
+      expect(filename.toLowerCase()).not.toContain('cose');
+    }
+    const allInputs = allFiles.map((filename) => {
+      const v = readJson(
+        pathJoin(
+          ERC_FAMILY_DIR,
+          filename.startsWith('v0') && /^v0[123]/.test(filename) ? 'positive' : 'negative',
+          filename
+        )
+      );
+      return (v.input as { attestationFormat?: string }).attestationFormat ?? '';
+    });
+    for (const label of allInputs) {
+      expect(label.toLowerCase()).not.toBe('cose');
+    }
+  });
+
+  it('every negative vector across both families declares expected_failure.kind + reason', () => {
+    const negatives = [
+      ...listJson(pathJoin(ERC_FAMILY_DIR, 'negative')).map((n) =>
+        pathJoin(ERC_FAMILY_DIR, 'negative', n)
+      ),
+      ...listJson(pathJoin(AP2_FAMILY_DIR, 'negative')).map((n) =>
+        pathJoin(AP2_FAMILY_DIR, 'negative', n)
+      ),
+    ];
+    expect(negatives).toHaveLength(4);
+    for (const p of negatives) {
+      const v = readJson(p) as {
+        expected_failure?: { kind?: string; reason?: string };
+      };
+      expect(v.expected_failure, `${p} missing expected_failure`).toBeTypeOf('object');
+      expect(typeof v.expected_failure!.kind).toBe('string');
+      expect(typeof v.expected_failure!.reason).toBe('string');
+      expect(v.expected_failure!.reason).toMatch(/^[a-z][a-z0-9_]*$/);
+    }
+  });
+
+  it('no vector declares a stable PEAC error code, error class, or error namespace', () => {
+    const allPaths = [
+      ...listJson(pathJoin(ERC_FAMILY_DIR, 'positive')).map((n) =>
+        pathJoin(ERC_FAMILY_DIR, 'positive', n)
+      ),
+      ...listJson(pathJoin(ERC_FAMILY_DIR, 'negative')).map((n) =>
+        pathJoin(ERC_FAMILY_DIR, 'negative', n)
+      ),
+      ...listJson(pathJoin(AP2_FAMILY_DIR, 'positive')).map((n) =>
+        pathJoin(AP2_FAMILY_DIR, 'positive', n)
+      ),
+      ...listJson(pathJoin(AP2_FAMILY_DIR, 'negative')).map((n) =>
+        pathJoin(AP2_FAMILY_DIR, 'negative', n)
+      ),
+    ];
+    expect(allPaths).toHaveLength(10);
+    for (const p of allPaths) {
+      const text = readText(p);
+      expect(text).not.toMatch(/"error_code"/);
+      expect(text).not.toMatch(/"error_class"/);
+      expect(text).not.toMatch(/"error_namespace"/);
+      expect(text).not.toMatch(/"peac_error"/);
+    }
+  });
+
+  it('every vector has only allowed top-level keys', () => {
+    const allowedTopLevel = new Set([
+      '$schema',
+      'vector_id',
+      'description',
+      'input',
+      'expected',
+      'expected_failure',
+    ]);
+    const allPaths = [
+      ...listJson(pathJoin(ERC_FAMILY_DIR, 'positive')).map((n) =>
+        pathJoin(ERC_FAMILY_DIR, 'positive', n)
+      ),
+      ...listJson(pathJoin(ERC_FAMILY_DIR, 'negative')).map((n) =>
+        pathJoin(ERC_FAMILY_DIR, 'negative', n)
+      ),
+      ...listJson(pathJoin(AP2_FAMILY_DIR, 'positive')).map((n) =>
+        pathJoin(AP2_FAMILY_DIR, 'positive', n)
+      ),
+      ...listJson(pathJoin(AP2_FAMILY_DIR, 'negative')).map((n) =>
+        pathJoin(AP2_FAMILY_DIR, 'negative', n)
+      ),
+    ];
+    for (const p of allPaths) {
+      const v = readJson(p);
+      const unknown = Object.keys(v).filter((k) => !allowedTopLevel.has(k));
+      expect(unknown, `${p}: unexpected top-level keys: ${unknown.join(', ')}`).toEqual([]);
+    }
+  });
+
+  it('every negative vector restricts expected_failure to kind + reason', () => {
+    const allowedFailureKeys = new Set(['kind', 'reason']);
+    const allNegatives = [
+      ...listJson(pathJoin(ERC_FAMILY_DIR, 'negative')).map((n) =>
+        pathJoin(ERC_FAMILY_DIR, 'negative', n)
+      ),
+      ...listJson(pathJoin(AP2_FAMILY_DIR, 'negative')).map((n) =>
+        pathJoin(AP2_FAMILY_DIR, 'negative', n)
+      ),
+    ];
+    for (const p of allNegatives) {
+      const v = readJson(p) as { expected_failure?: Record<string, unknown> };
+      expect(v.expected_failure, `${p}: missing expected_failure`).toBeTypeOf('object');
+      const unknown = Object.keys(v.expected_failure!).filter((k) => !allowedFailureKeys.has(k));
+      expect(unknown, `${p}: unexpected expected_failure keys: ${unknown.join(', ')}`).toEqual([]);
+    }
+  });
+
+  it('verifier script exists at the expected path', () => {
+    expect(existsSync(VERIFIER), `Expected verifier at ${VERIFIER}`).toBe(true);
+  });
+});


### PR DESCRIPTION
Adds 10 interop vectors under `specs/conformance/interop/` and two informative composition notes for ERC-8126 attestation references and AP2 `open_mandate_hash` references.

No public API change. No wire format change. No package surface change. No new extension namespace. No new receipt types. No new conformance requirement IDs. No new conformance sections. No new parity corpus families.
