### PR TITLE
docs/test: interop fixture

### DIFF
--- a/scripts/verify-interop-vectors.mjs
+++ b/scripts/verify-interop-vectors.mjs
@@ -189,7 +189,7 @@ function verifyErc8126Positive(vector, path) {
     issues.push(`${rel}: positive vector must declare attestationFormat`);
   } else if (!RECOGNIZED_ATTESTATION_LABELS.has(input.attestationFormat)) {
     issues.push(
-      `${rel}: positive vector attestationFormat ${input.attestationFormat} not in recognized open-label set { jws, eip712, onchain }`
+      `${rel}: positive vector attestationFormat ${input.attestationFormat} not in fixture label set { jws, eip712, onchain }`
     );
   }
   const expected = vector.expected;
@@ -239,7 +239,7 @@ function verifyErc8126Negative(vector, path) {
       issues.push(`${rel}: v04 must declare attestationFormat to exercise unsupported-format path`);
     } else if (RECOGNIZED_ATTESTATION_LABELS.has(input.attestationFormat)) {
       issues.push(
-        `${rel}: v04 attestationFormat ${input.attestationFormat} should not be in recognized open-label set`
+        `${rel}: v04 attestationFormat ${input.attestationFormat} should not be in fixture label set`
       );
     }
   } else if (filename === 'v05-missing-format.json') {

--- a/specs/conformance/interop/ap2-open-mandate-hash/README.md
+++ b/specs/conformance/interop/ap2-open-mandate-hash/README.md
@@ -6,7 +6,7 @@ This directory holds repository interop fixtures that exercise the `open_mandate
 open_mandate_hash = sha256_hex(JCS_RFC8785(unsigned open-checkout-mandate body))
 ```
 
-(lowercase hexadecimal; the hash input is the claims object, not the JWS compact form). These fixtures complement the cross-implementation work already present in that thread; they do not extend AP2 or replace the AP2 mandate mechanism.
+(lowercase hexadecimal; the hash input is the unsigned mandate body / claims object, not the JWS compact form). These fixtures complement the cross-implementation vector work already present in that issue; they do not extend AP2 or replace the AP2 mandate mechanism.
 
 ## Layout
 
@@ -43,7 +43,7 @@ All positive fixtures share a baseline shape:
 | `budget`          | object  | Present only on `v02-open-mandate-hash-with-budget`.               |
 | `expires_at`      | string  | Present only on `v03-open-mandate-hash-with-expiry`.               |
 
-The vectors deliberately do not target the canonicalization edge cases already covered by the cross-implementation work in `AP2#265` (object-key-order, array-order, optional fields, currency-minor-unit, Unicode NFC vs NFD). PEAC-side coverage is scenario-shaped: baseline, budget-bound, expiry-bound, plus the two negative composition-failure cases.
+The vectors deliberately do not target the canonicalization edge cases already covered by the cross-implementation vector work in `AP2#265` (object-key-order, array-order, optional fields, currency-minor-unit, Unicode NFC vs NFD). These repository fixtures are scenario-shaped: baseline, budget-bound, expiry-bound, plus the two negative composition-failure cases.
 
 ## Verification
 

--- a/specs/conformance/interop/erc8126-attestation-format/README.md
+++ b/specs/conformance/interop/erc8126-attestation-format/README.md
@@ -1,6 +1,8 @@
 # ERC-8126 attestation-format interop vectors
 
-This directory holds repository interop fixtures that use an illustrative open carrier label (`attestationFormat`) on Validation Registry attestation posts built by ERC-8126 / ERC-8004-aligned systems. The fixtures are not normative ERC-8126 conformance vectors and they do not stand in for a registry-shipped attestation format. They exist so that PEAC-side tooling can reason about how PEAC composes with an ERC-8126 attestation surface that carries an open attestation-carrier label.
+This directory contains repository interop fixtures that use an illustrative fixture carrier label (`attestationFormat`) for PEAC-side references to ERC-8126 / ERC-8004 Validation Registry attestation surfaces.
+
+The fixtures are not normative ERC-8126 conformance vectors and do not stand in for a registry-shipped attestation format. They exist so PEAC-side tooling can exercise deterministic handling of attestation references that include carrier metadata.
 
 ## Layout
 
@@ -16,7 +18,7 @@ erc8126-attestation-format/
     v05-missing-format.json
 ```
 
-Positive vectors (3) declare an `attestationFormat` value drawn from the illustrative open label set and pair it with an opaque `attestation_ref` that points to a carrier-specific payload (not embedded in the fixture). Each positive vector also declares its expected canonical-bytes SHA-256 digest under `expected.canonical_bytes_sha256_hex`, computed as `sha256_hex(JCS_RFC8785(input))`. This makes byte-deterministic verification possible without invoking any external service.
+Positive vectors (3) declare an `attestationFormat` value drawn from the illustrative fixture label set and pair it with an opaque `attestation_ref` that points to a carrier-specific payload (not embedded in the fixture). Each positive vector also declares its expected canonical-bytes SHA-256 digest under `expected.canonical_bytes_sha256_hex`, computed as `sha256_hex(JCS_RFC8785(input))`. This makes byte-deterministic verification possible without invoking any external service.
 
 Negative vectors (2) exercise unsupported and missing carrier metadata. Each negative vector declares `expected_failure.kind` and `expected_failure.reason` as fixture-scoped descriptive strings. These strings are not stable PEAC error codes, not a normative error class, and not part of any public PEAC API. They exist solely to make the repository interop verifier deterministic.
 
@@ -25,23 +27,23 @@ Negative vectors (2) exercise unsupported and missing carrier metadata. Each neg
 - `jws` (positive)
 - `eip712` (positive)
 - `onchain` (positive)
-- unrecognized vendor-prefixed label (negative)
+- unsupported carrier label (negative)
 - absent label (negative)
 
-A COSE-Sign1 carrier is discussed in the companion composition note at `docs/specs/ERC-8126-COMPOSITION.md` as a possible additive label in the same open set. This fixture set does not include a COSE-Sign1 vector. This repository does not include a PEAC COSE carrier implementation.
+The companion composition note at `docs/specs/ERC-8126-COMPOSITION.md` mentions COSE-Sign1 as an adjacent carrier class. This fixture set intentionally does not include a COSE-Sign1 vector. This repository does not include a PEAC COSE carrier implementation.
 
 ## Field shape
 
-All positive and negative inputs share a baseline attestation-post shape:
+All positive and negative inputs share a baseline attestation-reference shape:
 
-| Field               | Type    | Notes                                                                                                                                                                         |
-| ------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `agent_id`          | string  | Opaque ERC-8004 agent identifier; not validated by these fixtures.                                                                                                            |
-| `verification_type` | string  | One of the ERC-8126 verification-type acronyms (ETV, MCV, SCV, WAV, WV, plus optional PDV / QCV). Fixtures do not pin the exact enumeration; the spec is the source of truth. |
-| `risk_score`        | integer | Integer 0-100; informational only for these fixtures.                                                                                                                         |
-| `attestationFormat` | string  | Carrier label used by these fixtures. Carries the open carrier label (or is absent on `v05-missing-format`).                                                                  |
-| `attestation_ref`   | string  | Opaque reference to the carrier-specific payload. The carrier payload itself is not embedded in the fixture.                                                                  |
-| `observed_at`       | string  | RFC 3339 UTC timestamp.                                                                                                                                                       |
+| Field               | Type    | Notes                                                                                                                                                           |
+| ------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent_id`          | string  | Opaque ERC-8004 agent identifier; not validated by these fixtures.                                                                                              |
+| `verification_type` | string  | Acronym drawn from ERC-8126 verification terminology. These fixtures use representative ERC-8126 terms; the ERC-8126 specification remains the source of truth. |
+| `risk_score`        | integer | Integer 0-100; informational only for these fixtures.                                                                                                           |
+| `attestationFormat` | string  | Fixture carrier label used by this fixture set (or absent on `v05-missing-format`).                                                                             |
+| `attestation_ref`   | string  | Opaque reference to the carrier-specific payload. The carrier payload itself is not embedded in the fixture.                                                    |
+| `observed_at`       | string  | RFC 3339 UTC timestamp.                                                                                                                                         |
 
 ## Verification
 
@@ -49,7 +51,7 @@ The repository verifier at `scripts/verify-interop-vectors.mjs` walks this direc
 
 - Each fixture matches the required envelope described by `specs/conformance/schemas/interop-vector.json`.
 - Each positive fixture's input, when JCS-canonicalized and SHA-256 digested, yields lowercase hex bytes matching `expected.canonical_bytes_sha256_hex`.
-- Each negative fixture exercises its declared `expected_failure.reason` against the family's fixture-scoped validation rule (`attestationFormat` value must be present and drawn from the recognized open-label set defined in this README).
+- Each negative fixture exercises its declared `expected_failure.reason` against the family's fixture-scoped validation rule (`attestationFormat` value must be present and drawn from the recognized fixture label set defined in this README).
 - Exactly 3 positive vectors and 2 negative vectors are present in this directory.
 
 ## Boundary

--- a/specs/conformance/interop/erc8126-attestation-format/negative/v04-unknown-format.json
+++ b/specs/conformance/interop/erc8126-attestation-format/negative/v04-unknown-format.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/interop-vector.json",
   "vector_id": "erc8126-attestation-format-v04-unknown-format",
-  "description": "Validation Registry attestation post whose attestationFormat label is not drawn from the recognized open-label set; the repository interop verifier rejects it.",
+  "description": "Validation Registry attestation reference carrying an unsupported fixture carrier label; the repository interop verifier rejects it.",
   "input": {
     "agent_id": "did:web:erc8126.example/agents/agent-004",
     "verification_type": "SCV",

--- a/specs/conformance/interop/erc8126-attestation-format/negative/v05-missing-format.json
+++ b/specs/conformance/interop/erc8126-attestation-format/negative/v05-missing-format.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../schemas/interop-vector.json",
   "vector_id": "erc8126-attestation-format-v05-missing-format",
-  "description": "Validation Registry attestation post that omits the attestationFormat field entirely; the repository interop verifier rejects it.",
+  "description": "Validation Registry attestation reference that omits the fixture carrier label; the repository interop verifier rejects it.",
   "input": {
     "agent_id": "did:web:erc8126.example/agents/agent-005",
     "verification_type": "WV",

--- a/tests/conformance/interop-erc8126.spec.ts
+++ b/tests/conformance/interop-erc8126.spec.ts
@@ -3,7 +3,7 @@
  *
  * Repository interop fixtures under specs/conformance/interop/erc8126-attestation-format/
  * are validated for envelope shape, deterministic JCS canonical-bytes
- * regeneration, recognized open-label set membership, and declared
+ * regeneration, fixture label set membership, and declared
  * expected_failure shape on negative vectors. Negative-vector reason
  * strings are fixture-scoped and not stable PEAC error codes.
  */
@@ -86,7 +86,7 @@ describe('ERC-8126 attestation-format interop vectors', () => {
           expect(vector).not.toHaveProperty('expected_failure');
         });
 
-        it('declares attestationFormat in the recognized open-label set', () => {
+        it('declares attestationFormat in the fixture label set', () => {
           expect(typeof vector.input.attestationFormat).toBe('string');
           expect(RECOGNIZED_LABELS.has(vector.input.attestationFormat!)).toBe(true);
         });


### PR DESCRIPTION
Tightens ERC-8126 and AP2 interop fixture wording to keep carrier-label and mandate-hash language explicitly repository-scoped and fixture-centered.

No vector input changes. No expected hash changes. No verifier behavior change. No protocol semantics change. Canonical-byte SHA-256 expectations are unaffected because the changed vector descriptions live outside `input`.
