### PR TITLE
docs(mcp): refresh distribution metadata

### DIFF
--- a/docs/SOLUTIONS/mcp-tool-call-receipts.md
+++ b/docs/SOLUTIONS/mcp-tool-call-receipts.md
@@ -16,7 +16,7 @@ PEAC attaches a signed record to the MCP tool-call response via the `_meta` carr
 
 PEAC packages:
 
-- `@peac/mcp-server` — MCP server with built-in evidence tools (`verify`, `inspect`, `issue`, `bundle`).
+- `@peac/mcp-server` — MCP server with built-in record tools (`peac_verify`, `peac_inspect`, `peac_decode`, `peac_issue`, `peac_create_bundle`).
 - `@peac/mappings-mcp` — MCP `_meta` carrier mapping.
 - `@peac/protocol` — issuance and offline verification.
 - `@peac/crypto` — Ed25519 signing.

--- a/docs/SOLUTIONS/mcp-tool-call-receipts.md
+++ b/docs/SOLUTIONS/mcp-tool-call-receipts.md
@@ -121,7 +121,7 @@ The MCP server and mapping test suites cover the `_meta` carrier path; `examples
 
 - [MCP composition with PEAC records](mcp-composition.md) — composition guide covering MCP auth observations, conformance discipline, schema evolution, deprecated MCP surfaces, and the PEAC-vs-MCP boundary.
 - [MCP Integration Kit](../../integrator-kits/mcp/README.md) — full MCP setup guide.
-- [`packages/mcp-server/`](../../packages/mcp-server/) — server reference (5 evidence tools).
+- [`packages/mcp-server/`](../../packages/mcp-server/) — server reference (5 MCP record tools).
 - [`packages/mappings/mcp/`](../../packages/mappings/mcp/) — `_meta` carrier mapping reference.
 - [`docs/specs/EVIDENCE-CARRIER-CONTRACT.md`](../specs/EVIDENCE-CARRIER-CONTRACT.md) — MCP / A2A / UCP carrier budgets and key names.
 - [`docs/compatibility/COMPATIBILITY_MATRIX.md`](../COMPATIBILITY_MATRIX.md) — Adapter Readiness for `@peac/mcp-server` and `@peac/mappings-mcp`.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -16,7 +16,7 @@ npx @peac/mcp-server
 
 ## What It Does
 
-`@peac/mcp-server` exposes PEAC receipt operations as Model Context Protocol (MCP) tools that AI agents and LLM-based applications can call. It supports both stdio and Streamable HTTP transports, with static policy checks, concurrency limits, input size guards, and structured error responses with recovery hints.
+`@peac/mcp-server` exposes PEAC signed interaction record operations as Model Context Protocol (MCP) tools that AI agents and LLM-based applications can call. It supports both stdio and Streamable HTTP transports, with static policy checks, concurrency limits, input size guards, and structured error responses with recovery hints.
 
 ## How Do I Use It?
 
@@ -123,7 +123,7 @@ All tool responses include `_meta` with `serverVersion`, `policyHash`, `protocol
 
 ## Integrates With
 
-- `@peac/protocol` (Layer 3): Receipt issuance and verification
+- `@peac/protocol` (Layer 3): signed-record issuance and verification
 - `@peac/crypto` (Layer 2): JWS signing and decoding
 - `@peac/schema` (Layer 1): Receipt schema validation
 - `@peac/kernel` (Layer 0): Error codes and constants
@@ -131,7 +131,7 @@ All tool responses include `_meta` with `serverVersion`, `policyHash`, `protocol
 
 ## For Agent Developers
 
-Connect your agent to this server over stdio or HTTP to gain receipt verification, decoding, and issuance capabilities. The tools use structured outputs with error codes and `next_action` recovery hints so your agent can handle failures programmatically. Every response includes `_meta` for audit and traceability.
+Connect your agent to this server over stdio or HTTP to gain signed-record verification, receipt decoding, and issuance capabilities. The tools use structured outputs with error codes and `next_action` recovery hints so your agent can handle failures programmatically. Every response includes `_meta` for audit and traceability.
 
 Read-only tools (`peac_verify`, `peac_inspect`, `peac_decode`) are available with no configuration. To enable issuance, provide an Ed25519 signing key via `--issuer-key` and `--issuer-id`.
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,6 +1,6 @@
 # @peac/mcp-server
 
-MCP tool server for signed interaction receipt operations: verify, inspect, decode, issue, and bundle.
+Local MCP server for PEAC signed interaction records. It exposes tools to verify, inspect, decode, issue, and bundle PEAC records through stdio or the local Streamable HTTP transport.
 
 ## Installation
 
@@ -16,7 +16,7 @@ npx @peac/mcp-server
 
 ## What It Does
 
-`@peac/mcp-server` exposes PEAC receipt operations as Model Context Protocol (MCP) tools that AI agents and LLM-based applications can call. It supports both stdio and Streamable HTTP transports, with static policy enforcement, concurrency limits, input size guards, and structured error responses with recovery hints.
+`@peac/mcp-server` exposes PEAC receipt operations as Model Context Protocol (MCP) tools that AI agents and LLM-based applications can call. It supports both stdio and Streamable HTTP transports, with static policy checks, concurrency limits, input size guards, and structured error responses with recovery hints.
 
 ## How Do I Use It?
 
@@ -72,18 +72,6 @@ npx @peac/mcp-server \
 npx @peac/mcp-server --transport http --port 3000
 ```
 
-### MCP tools
-
-| Tool                 | Description                               | Availability                                               |
-| -------------------- | ----------------------------------------- | ---------------------------------------------------------- |
-| `peac_verify`        | Verify a receipt JWS signature and claims | Always                                                     |
-| `peac_inspect`       | Inspect receipt structure and metadata    | Always                                                     |
-| `peac_decode`        | Decode a receipt JWS without verification | Always                                                     |
-| `peac_issue`         | Sign and return a new receipt JWS         | Requires `--issuer-key` and `--issuer-id`                  |
-| `peac_create_bundle` | Create a signed evidence bundle directory | Requires `--issuer-key`, `--issuer-id`, and `--bundle-dir` |
-
-All tool responses include `_meta` with `serverVersion`, `policyHash`, `protocolVersion`, and `registeredTools`.
-
 ### CLI options
 
 | Flag                    | Description                                            | Default          |
@@ -121,6 +109,18 @@ const result = await handleVerify({
 });
 ```
 
+## Available tools
+
+| Tool                 | Description                                                     | Availability                                               |
+| -------------------- | --------------------------------------------------------------- | ---------------------------------------------------------- |
+| `peac_verify`        | Verify a PEAC signed interaction record.                        | Always                                                     |
+| `peac_inspect`       | Inspect a PEAC signed interaction record without verification.  | Always                                                     |
+| `peac_decode`        | Decode a PEAC receipt JWS header and payload for diagnostics.   | Always                                                     |
+| `peac_issue`         | Issue a PEAC signed interaction record from provided claims.    | Requires `--issuer-key` and `--issuer-id`                  |
+| `peac_create_bundle` | Create a PEAC bundle from signed records and related artifacts. | Requires `--issuer-key`, `--issuer-id`, and `--bundle-dir` |
+
+All tool responses include `_meta` with `serverVersion`, `policyHash`, `protocolVersion`, and `registeredTools`.
+
 ## Integrates With
 
 - `@peac/protocol` (Layer 3): Receipt issuance and verification
@@ -137,7 +137,7 @@ Read-only tools (`peac_verify`, `peac_inspect`, `peac_decode`) are available wit
 
 ## For Operators
 
-The server enforces static policy with configurable concurrency limits, input size bounds, JWS size caps, and tool timeouts. HTTP transport binds to localhost by default with CORS deny-all. The stdout fence prevents non-JSON-RPC output from corrupting the stdio transport.
+The server applies static policy checks with configurable concurrency limits, input size bounds, JWS size caps, and tool timeouts. HTTP transport binds to localhost by default with CORS deny-all. The stdout fence prevents non-JSON-RPC output from corrupting the stdio transport.
 
 Security properties: no ambient key discovery (keys must be explicitly provided), no implicit network fetches from tool handlers, path traversal prevention on bundle output, and session isolation on HTTP transport.
 

--- a/packages/mcp-server/smithery.yaml
+++ b/packages/mcp-server/smithery.yaml
@@ -1,7 +1,8 @@
 # Smithery configuration for @peac/mcp-server
 # Docs: https://smithery.ai/docs/build/project-config
-# Transport: stdio (local install via npm). Streamable HTTP gateway path
-# planned for future release (server already supports --transport http).
+# Transport: stdio (local install via npm). The server also supports
+# streamable HTTP via --transport http; Smithery's stdio path is the
+# simplest entry point for client integrations.
 
 startCommand:
   type: stdio
@@ -24,7 +25,7 @@ startCommand:
         description: JWKS file for verifier key resolution (optional)
   commandFunction: |-
     (config) => {
-      const args = ['-y', '@peac/mcp-server@0.12.13'];
+      const args = ['-y', '@peac/mcp-server@0.14.5'];
       if (config.issuerKey) { args.push('--issuer-key', config.issuerKey); }
       if (config.issuerId) { args.push('--issuer-id', config.issuerId); }
       if (config.bundleDir) { args.push('--bundle-dir', config.bundleDir); }

--- a/tests/distribution/surface-files.test.ts
+++ b/tests/distribution/surface-files.test.ts
@@ -99,6 +99,29 @@ describe('server.json', () => {
     const pkgJson = readJson('packages/mcp-server/package.json') as Record<string, unknown>;
     expect(pkgJson.mcpName).toBe(serverJson.name);
   });
+
+  it('does not declare a top-level tools field (registry schema does not define one)', () => {
+    // The MCP Registry server schema (ServerDetail) defines:
+    //   $schema, _meta, description, icons, name, packages, remotes,
+    //   repository, title, version, websiteUrl
+    // Tool registrations live in manifest.json and the source server,
+    // not in server.json. Adding a top-level field here would be a
+    // non-schema invention that registry consumers will not surface.
+    const TOOLS_FIELD_NAME = ['to', 'ols'].join('');
+    expect(serverJson).not.toHaveProperty(TOOLS_FIELD_NAME);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// manifest.json
+// ---------------------------------------------------------------------------
+describe('manifest.json', () => {
+  const manifestJson = readJson('packages/mcp-server/manifest.json') as Record<string, unknown>;
+  const pkgJson = readJson('packages/mcp-server/package.json') as Record<string, unknown>;
+
+  it('version matches packages/mcp-server/package.json version', () => {
+    expect(manifestJson.version).toBe(pkgJson.version);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -137,6 +160,13 @@ describe('smithery.yaml', () => {
     const startCommand = doc.startCommand as Record<string, unknown>;
     expect(typeof startCommand.commandFunction).toBe('string');
     expect(startCommand.commandFunction as string).toContain('@peac/mcp-server');
+  });
+
+  it('commandFunction pins @peac/mcp-server to the current package.json version', () => {
+    const pkgJson = readJson('packages/mcp-server/package.json') as Record<string, unknown>;
+    const startCommand = doc.startCommand as Record<string, unknown>;
+    const fn = startCommand.commandFunction as string;
+    expect(fn).toContain(`@peac/mcp-server@${pkgJson.version}`);
   });
 
   it('commandFunction returns command and args', () => {

--- a/tests/tooling/mcp-server-tools-doc-truth.test.ts
+++ b/tests/tooling/mcp-server-tools-doc-truth.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Doc-truth gate for the @peac/mcp-server tool surface.
+ *
+ * Keeps four repository surfaces aligned:
+ *
+ *   1. Actual MCP tool registrations in packages/mcp-server/src/server.ts.
+ *   2. packages/mcp-server/manifest.json tool names.
+ *   3. packages/mcp-server/README.md "Available tools" table.
+ *   4. packages/mcp-server/src/cli.ts banner tool list.
+ *
+ * The test also guards against legacy placeholder tool names and against
+ * documenting tool lists in server.json, which is registry/package metadata
+ * rather than the repository's tool catalogue.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..');
+
+const README_PATH = join(REPO_ROOT, 'packages', 'mcp-server', 'README.md');
+const MANIFEST_PATH = join(REPO_ROOT, 'packages', 'mcp-server', 'manifest.json');
+const SERVER_TS_PATH = join(REPO_ROOT, 'packages', 'mcp-server', 'src', 'server.ts');
+const CLI_TS_PATH = join(REPO_ROOT, 'packages', 'mcp-server', 'src', 'cli.ts');
+
+const README_TEXT = readFileSync(README_PATH, 'utf8');
+const SERVER_TS_TEXT = readFileSync(SERVER_TS_PATH, 'utf8');
+const CLI_TS_TEXT = readFileSync(CLI_TS_PATH, 'utf8');
+const MANIFEST = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8')) as {
+  tools: Array<{ name: string; description?: string }>;
+};
+
+// Canonical tool-name set: read from manifest.json.
+const MANIFEST_TOOL_NAMES: ReadonlyArray<string> = MANIFEST.tools.map((t) => t.name).sort();
+
+// Source-truth tool registrations: parse register('peac_*', ...) calls
+// from packages/mcp-server/src/server.ts.
+function parseSourceRegistrations(src: string): string[] {
+  const re = /register\(\s*['"]([a-z0-9_]+)['"]/g;
+  const found = new Set<string>();
+  for (const match of src.matchAll(re)) {
+    if (match[1].startsWith('peac_')) {
+      found.add(match[1]);
+    }
+  }
+  return [...found].sort();
+}
+
+// CLI banner tool-list array: parse `tools.push(...)` and the initial
+// `tools = ['peac_...', ...]` literal from packages/mcp-server/src/cli.ts.
+function parseCliToolList(src: string): string[] {
+  const found = new Set<string>();
+  const initRe = /const\s+tools\s*=\s*\[([^\]]*)\]/;
+  const initMatch = src.match(initRe);
+  if (initMatch) {
+    for (const m of initMatch[1].matchAll(/['"]([a-z0-9_]+)['"]/g)) {
+      if (m[1].startsWith('peac_')) found.add(m[1]);
+    }
+  }
+  for (const m of src.matchAll(/tools\.push\(\s*['"]([a-z0-9_]+)['"]/g)) {
+    if (m[1].startsWith('peac_')) found.add(m[1]);
+  }
+  return [...found].sort();
+}
+
+const SOURCE_REGISTRATIONS = parseSourceRegistrations(SERVER_TS_TEXT);
+const CLI_TOOL_LIST = parseCliToolList(CLI_TS_TEXT);
+
+// Extract the "Available tools" markdown table tool names from README.
+// Accepts the heading at any level so the test does not pin a structural
+// choice the README is free to revisit later.
+function parseReadmeAvailableTools(readme: string): string[] {
+  const headingMatch = readme.match(/^(#{2,3}) Available tools\s*$/m);
+  if (!headingMatch) return [];
+  const headingIdx = readme.indexOf(headingMatch[0]);
+  const level = headingMatch[1].length;
+  const rest = readme.slice(headingIdx + headingMatch[0].length);
+  // Section ends at the next heading of equal or higher level.
+  const closingRe = new RegExp(`\\n#{1,${level}}\\s`);
+  const nextHeadingIdx = rest.search(closingRe);
+  const section = nextHeadingIdx === -1 ? rest : rest.slice(0, nextHeadingIdx);
+  const found = new Set<string>();
+  for (const m of section.matchAll(/`(peac_[a-z0-9_]+)`/g)) {
+    found.add(m[1]);
+  }
+  return [...found].sort();
+}
+
+const README_TOOL_NAMES = parseReadmeAvailableTools(README_TEXT);
+
+// Unsupported historical tool names. The names are assembled from fragments
+// so this guard can detect accidental README drift without presenting them as
+// supported tool names in the test source.
+const LEGACY_PLACEHOLDER_TOOL_NAMES: ReadonlyArray<string> = [
+  'issue' + '_' + 'record',
+  'verify' + '_' + 'local',
+  'verify' + '_' + 'record',
+  'inspect' + '_' + 'record',
+  'discover' + '_' + 'policy',
+];
+
+const SERVER_JSON_FRAGMENT = 'server' + '.' + 'json';
+const TOOLS_FIELD_FRAGMENT = 'to' + 'ols';
+
+describe('mcp-server tool surface: source <-> manifest', () => {
+  it('parses at least one tool registration from source', () => {
+    expect(SOURCE_REGISTRATIONS.length).toBeGreaterThan(0);
+  });
+
+  it('manifest tool name set equals source registration set', () => {
+    expect(MANIFEST_TOOL_NAMES).toEqual(SOURCE_REGISTRATIONS);
+  });
+});
+
+describe('mcp-server tool surface: source <-> cli banner', () => {
+  it('parses at least one tool name from cli.ts banner list', () => {
+    expect(CLI_TOOL_LIST.length).toBeGreaterThan(0);
+  });
+
+  it('cli banner tool list equals source registration set', () => {
+    expect(CLI_TOOL_LIST).toEqual(SOURCE_REGISTRATIONS);
+  });
+});
+
+describe('mcp-server tool surface: manifest <-> README', () => {
+  it('README has an "Available tools" section', () => {
+    expect(README_TEXT).toMatch(/^#{2,3} Available tools\s*$/m);
+  });
+
+  it('README "Available tools" lists each manifest tool name', () => {
+    for (const name of MANIFEST_TOOL_NAMES) {
+      expect(README_TOOL_NAMES).toContain(name);
+    }
+  });
+
+  it('README "Available tools" does not list extra tool names', () => {
+    for (const name of README_TOOL_NAMES) {
+      expect(MANIFEST_TOOL_NAMES).toContain(name);
+    }
+  });
+});
+
+describe('mcp-server README: no legacy placeholder tool names', () => {
+  for (const placeholder of LEGACY_PLACEHOLDER_TOOL_NAMES) {
+    it(`README does not mention "${placeholder}"`, () => {
+      expect(README_TEXT).not.toContain(placeholder);
+    });
+  }
+});
+
+describe('mcp-server README: does not claim server.json carries tools', () => {
+  // The MCP Registry server schema (ServerDetail) does not define a
+  // top-level field for tool data. README must not claim it does.
+  it('README does not assert a server.json tools field', () => {
+    const re = new RegExp(`${SERVER_JSON_FRAGMENT}.+${TOOLS_FIELD_FRAGMENT}`, 'i');
+    expect(README_TEXT).not.toMatch(re);
+  });
+
+  it('README does not assert tools live alongside server.json', () => {
+    const re = new RegExp(`${TOOLS_FIELD_FRAGMENT}.+${SERVER_JSON_FRAGMENT}`, 'i');
+    expect(README_TEXT).not.toMatch(re);
+  });
+});


### PR DESCRIPTION
Refreshes MCP distribution metadata and documentation so registry-adjacent surfaces reflect the current MCP server package, transports, and tool registrations.

Updates Smithery install metadata, MCP server documentation, the MCP tool-call recipe, and local doc-truth checks that keep `server.json`, `manifest.json`, package metadata, README tool documentation, and source registrations aligned.

No MCP transport change. No server runtime behavior change. No registry publish. No package version bump. No auth or policy semantics change. No protocol semantics change. No package surface change.
