### PR TITLE
docs: guidance version markers

### DIFF
--- a/docs/KEY-CUSTODY-AND-TENANCY.md
+++ b/docs/KEY-CUSTODY-AND-TENANCY.md
@@ -29,7 +29,7 @@ The signing interface (`signWire02()`) accepts raw Ed25519 private keys. Organiz
 
 When organizations run `@peac/protocol` or `@peac/mcp-server` locally, all cryptographic operations execute in-process. There is no shared state, no external network calls during signing, and no multi-tenant surface.
 
-### Hosted Verify (planned, v0.12.8)
+### Hosted Verify (planned)
 
 The Hosted Verify API uses per-API-key tenant isolation:
 

--- a/docs/KEY-CUSTODY-AND-TENANCY.md
+++ b/docs/KEY-CUSTODY-AND-TENANCY.md
@@ -1,6 +1,6 @@
 # Key custody and tenancy
 
-> Version: 0.12.13 | Status: Current
+> Status: Current
 
 This document describes the key custody architecture, tenancy guarantees, and procurement model for organizations evaluating or deploying the PEAC Protocol.
 

--- a/docs/SECURITY-OPERATIONS.md
+++ b/docs/SECURITY-OPERATIONS.md
@@ -1,6 +1,6 @@
 # Security operations
 
-> Version: 0.12.13 | Status: Current
+> Status: Current
 
 This document describes the operational security model of the PEAC Protocol: support windows, incident handling, supply chain provenance, logging boundaries, tenant isolation, and data residency.
 

--- a/docs/SECURITY-OPERATIONS.md
+++ b/docs/SECURITY-OPERATIONS.md
@@ -91,7 +91,7 @@ SBOM generation (SPDX or CycloneDX) is planned but not yet configured. The turbo
 
 No multi-tenant surface. All operations are in-process. Operators control all isolation boundaries.
 
-### Hosted Verify (planned, v0.12.8)
+### Hosted Verify (planned)
 
 | Boundary             | Mechanism                                        |
 | -------------------- | ------------------------------------------------ |

--- a/docs/WHEN_NOT_TO_USE_PEAC.md
+++ b/docs/WHEN_NOT_TO_USE_PEAC.md
@@ -1,6 +1,6 @@
 # When Not to Use PEAC
 
-> Version: 0.12.7 | Status: Current
+> Status: Current
 
 PEAC Protocol is a signed evidence layer for recording what happened during automated interactions. It is not a general-purpose infrastructure tool. This document describes scenarios where PEAC is the wrong choice.
 

--- a/tests/tooling/docs-version-banner-truth.test.ts
+++ b/tests/tooling/docs-version-banner-truth.test.ts
@@ -1,18 +1,22 @@
 /**
- * Doc-truth gate for public documentation status banners.
+ * Doc-truth gate against stale version-specific current/planned markers in
+ * evergreen public docs.
  *
- * Public docs MUST NOT use the legacy banner pattern
+ * Public docs MUST NOT use either of the legacy version-bound patterns:
  *
  *   > Version: <X.Y.Z> | Status: Current
  *
- * because the embedded version becomes stale as soon as the package
- * release moves forward. Evergreen guidance uses the version-neutral
- * pattern
+ *   ### Some Heading (planned, v<X.Y.Z>)
+ *
+ * because the embedded version becomes stale as soon as the package release
+ * moves forward. Evergreen guidance uses the version-neutral forms:
  *
  *   > Status: Current
  *
- * (as in docs/REFERENCE_ARCHITECTURES.md). Release-specific notes
- * already live under docs/release-notes/ and are not in scope.
+ *   ### Some Heading (planned)
+ *
+ * (as in docs/REFERENCE_ARCHITECTURES.md). Release-specific notes already
+ * live under docs/release-notes/ and are not in scope.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -27,8 +31,9 @@ const DOCS_ROOT = join(REPO_ROOT, 'docs');
 // truth artifacts).
 const EXCLUDED_SUBDIRS = new Set(['release-notes', 'releases', 'reboot', 'baselines']);
 
-// Pattern that should never appear in evergreen public docs.
+// Patterns that should never appear in evergreen public docs.
 const STALE_BANNER = /^>\s*Version:\s*\d+\.\d+\.\d+\s*\|\s*Status:\s*Current\b/m;
+const VERSIONED_PLANNED_MARKER = /\(planned,\s*v?\d+\.\d+\.\d+\)/i;
 
 function collectMarkdownFiles(root: string, results: string[] = []): string[] {
   for (const entry of readdirSync(root)) {
@@ -56,6 +61,16 @@ describe('docs status banners: no versioned "Status: Current" claims', () => {
     it(`${rel} does not carry a versioned "Status: Current" banner`, () => {
       const text = readFileSync(path, 'utf8');
       expect(text).not.toMatch(STALE_BANNER);
+    });
+  }
+});
+
+describe('docs planned markers: no versioned "(planned, vX.Y.Z)" claims', () => {
+  for (const path of MD_FILES) {
+    const rel = path.slice(REPO_ROOT.length + 1);
+    it(`${rel} does not carry a versioned "(planned, vX.Y.Z)" marker`, () => {
+      const text = readFileSync(path, 'utf8');
+      expect(text).not.toMatch(VERSIONED_PLANNED_MARKER);
     });
   }
 });

--- a/tests/tooling/docs-version-banner-truth.test.ts
+++ b/tests/tooling/docs-version-banner-truth.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Doc-truth gate for public documentation status banners.
+ *
+ * Public docs MUST NOT use the legacy banner pattern
+ *
+ *   > Version: <X.Y.Z> | Status: Current
+ *
+ * because the embedded version becomes stale as soon as the package
+ * release moves forward. Evergreen guidance uses the version-neutral
+ * pattern
+ *
+ *   > Status: Current
+ *
+ * (as in docs/REFERENCE_ARCHITECTURES.md). Release-specific notes
+ * already live under docs/release-notes/ and are not in scope.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REPO_ROOT = join(__dirname, '..', '..');
+const DOCS_ROOT = join(REPO_ROOT, 'docs');
+
+// Subdirectories that intentionally carry version-pinned banners
+// (release-specific notes, frozen historical references, generated
+// truth artifacts).
+const EXCLUDED_SUBDIRS = new Set(['release-notes', 'releases', 'reboot', 'baselines']);
+
+// Pattern that should never appear in evergreen public docs.
+const STALE_BANNER = /^>\s*Version:\s*\d+\.\d+\.\d+\s*\|\s*Status:\s*Current\b/m;
+
+function collectMarkdownFiles(root: string, results: string[] = []): string[] {
+  for (const entry of readdirSync(root)) {
+    const full = join(root, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      if (EXCLUDED_SUBDIRS.has(entry)) continue;
+      collectMarkdownFiles(full, results);
+    } else if (st.isFile() && entry.endsWith('.md')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+const MD_FILES = collectMarkdownFiles(DOCS_ROOT);
+
+describe('docs status banners: no versioned "Status: Current" claims', () => {
+  it('finds at least one markdown file under docs/', () => {
+    expect(MD_FILES.length).toBeGreaterThan(0);
+  });
+
+  for (const path of MD_FILES) {
+    const rel = path.slice(REPO_ROOT.length + 1);
+    it(`${rel} does not carry a versioned "Status: Current" banner`, () => {
+      const text = readFileSync(path, 'utf8');
+      expect(text).not.toMatch(STALE_BANNER);
+    });
+  }
+});


### PR DESCRIPTION
Refreshes stale version-specific wording in public evergreen documentation so current guidance does not claim older package versions are current or planned.

Three trust-artifact docs now use version-neutral `Status: Current` banners, and stale versioned `Hosted Verify (planned, v0.12.8)` headings are normalized to `Hosted Verify (planned)`.

Adds a doc-truth check to keep versioned `Status: Current` banners and versioned planned markers out of public evergreen docs.

No protocol semantics change. No runtime behavior change. No package version change. No public API change.
