### PR TITLE
docs(composition): document AGT EvidenceAnchor proposal

### DIFF
--- a/docs/SOLUTIONS/agt-peac-composition.md
+++ b/docs/SOLUTIONS/agt-peac-composition.md
@@ -111,6 +111,14 @@ PEAC reads what the runtime reported, records it under the canonical `org.peacpr
 - [Verify commerce-mandate records](verify-commerce-mandate.md): commerce-mandate observations alongside runtime decisions.
 - [Compatibility matrix — `@peac/adapter-runtime-governance` row](../COMPATIBILITY_MATRIX.md): record families, fixture-only stability class, and the runtime-governance mapper note.
 
-## Footnote on an upstream anchoring proposal
+## PEAC records and the AGT EvidenceAnchor proposal (informational)
 
-Microsoft AGT PR #2244 is an upstream proposal for a pluggable external anchoring slot. This recipe does not cover it. If the upstream project merges the proposal or publishes stable documentation for it, PEAC should document the relationship separately while preserving the same runtime boundary.
+The upstream proposal `microsoft/agent-governance-toolkit#2244` (AGT PR #2244) merged on 2026-05-18 as an EvidenceAnchor design document. The current upstream artifact is proposal documentation; no Python abstract base class, CLI flag, `anchors[]` schema emission, or plugin package is shipped in AGT today. EvidenceAnchor is currently an AGT proposal, not an implemented dependency surface.
+
+The existing PEAC and AGT composition remains record-only:
+
+> **AGT runs the runtime. PEAC records what AGT reported.**
+
+If AGT implements the proposed SPI, PEAC records can be referenced as portable signed artifacts by an anchor backend without changing PEAC wire format or AGT runtime behavior. The relevant composition point is deterministic canonical bytes: the AGT proposal describes RFC 8785 JCS + SHA-256 action references, while PEAC records use deterministic canonicalization for signed verification artifacts. That shared canonicalization contract is the narrow composition point: a PEAC record can remain a portable signed artifact that an anchor backend could reference once the upstream interface is implemented.
+
+No implementation lands in PEAC with this section. PEAC adds no AGT runtime dependency. PEAC adds no SPI shim. PEAC does not become an anchor backend, and AGT does not become a PEAC consumer. The relationship described above is conditional on upstream implementation; until then the existing record-only boundary stands unchanged.

--- a/tests/tooling/agt-peac-composition-doc-truth.test.ts
+++ b/tests/tooling/agt-peac-composition-doc-truth.test.ts
@@ -40,8 +40,9 @@ function extractSection(text: string, heading: string): string {
 
 const SECTION_TEXT = extractSection(DOC_TEXT, SECTION_HEADING);
 
-// Forbidden phrasings assembled from fragments. The phrasings describe
-// overclaims the doc must never make about the PEAC and AGT relationship.
+// Disallowed relationship phrasings are assembled from fragments so this
+// guard can catch accidental overclaims without presenting them as supported
+// documentation.
 const FORBIDDEN_MICROSOFT_PARTNERSHIP = ['Microsoft', 'partnership'].join(' ');
 const FORBIDDEN_AGT_ADOPTED_PEAC = ['AGT', 'adopted', 'PEAC'].join(' ');
 const FORBIDDEN_PEAC_ADOPTS_AGT = ['PEAC', 'adopts', 'AGT'].join(' ');

--- a/tests/tooling/agt-peac-composition-doc-truth.test.ts
+++ b/tests/tooling/agt-peac-composition-doc-truth.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Doc-truth gate for the AGT EvidenceAnchor composition section in
+ * docs/SOLUTIONS/agt-peac-composition.md.
+ *
+ * Keeps the new informational section anchored to:
+ *
+ *   1. The upstream proposal cited by exact number
+ *      (microsoft/agent-governance-toolkit#2244).
+ *   2. The proposal-only framing (no claim of an implemented SPI,
+ *      backend, or partnership).
+ *   3. The record-only PEAC / AGT composition line.
+ *   4. The shared determinism contract (RFC 8785 JCS + SHA-256).
+ *
+ * Relationship-boundary checks are scoped to the new section so that
+ * pre-existing runtime-descriptive prose elsewhere in the doc is not
+ * over-constrained. Disallowed phrases are assembled from fragments so the
+ * test can guard against accidental overclaims without presenting those
+ * phrases as supported documentation.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..');
+const DOC_PATH = join(REPO_ROOT, 'docs', 'SOLUTIONS', 'agt-peac-composition.md');
+const DOC_TEXT = readFileSync(DOC_PATH, 'utf8');
+
+const SECTION_HEADING = '## PEAC records and the AGT EvidenceAnchor proposal (informational)';
+
+function extractSection(text: string, heading: string): string {
+  const idx = text.indexOf(heading);
+  if (idx === -1) return '';
+  const rest = text.slice(idx + heading.length);
+  const nextHeadingIdx = rest.search(/\n##\s/);
+  return nextHeadingIdx === -1 ? rest : rest.slice(0, nextHeadingIdx);
+}
+
+const SECTION_TEXT = extractSection(DOC_TEXT, SECTION_HEADING);
+
+// Forbidden phrasings assembled from fragments. The phrasings describe
+// overclaims the doc must never make about the PEAC and AGT relationship.
+const FORBIDDEN_MICROSOFT_PARTNERSHIP = ['Microsoft', 'partnership'].join(' ');
+const FORBIDDEN_AGT_ADOPTED_PEAC = ['AGT', 'adopted', 'PEAC'].join(' ');
+const FORBIDDEN_PEAC_ADOPTS_AGT = ['PEAC', 'adopts', 'AGT'].join(' ');
+const FORBIDDEN_PEAC_PLUGS_INTO_AGT = ['PEAC', 'plugs', 'into', 'AGT'].join(' ');
+const FORBIDDEN_AGT_RECOMMENDS_PEAC = ['AGT', 'recommends', 'PEAC'].join(' ');
+const FORBIDDEN_GOVERNANCE_LAYER = ['governance', 'layer'].join(' ');
+const FORBIDDEN_TRUST_LAYER = ['trust', 'layer'].join(' ');
+const FORBIDDEN_CONTROL_PLANE = ['control', 'plane'].join(' ');
+const FORBIDDEN_PEAC_ENFORCES_AGT_POLICY = ['PEAC', 'enforces', 'AGT', 'policy'].join(' ');
+const FORBIDDEN_EVIDENCEANCHOR_IMPLEMENTATION = ['EvidenceAnchor', 'implementation'].join(' ');
+const FORBIDDEN_WORKING_PLUGIN = ['working', 'plugin'].join(' ');
+const FORBIDDEN_PYTHON_WRAPPER = ['Python', 'wrapper'].join(' ');
+
+describe('agt-peac-composition.md: AGT EvidenceAnchor section exists', () => {
+  it('contains the expected section heading', () => {
+    expect(DOC_TEXT).toContain(SECTION_HEADING);
+  });
+
+  it('extracts a non-empty section body', () => {
+    expect(SECTION_TEXT.length).toBeGreaterThan(0);
+  });
+});
+
+describe('agt-peac-composition.md: upstream and contract citations', () => {
+  it('cites the upstream proposal by exact number', () => {
+    expect(DOC_TEXT).toContain('microsoft/agent-governance-toolkit#2244');
+  });
+
+  it('introduces the proposal name', () => {
+    expect(DOC_TEXT).toContain('EvidenceAnchor');
+  });
+
+  it('uses the word "proposal" alongside EvidenceAnchor', () => {
+    expect(SECTION_TEXT.toLowerCase()).toContain('proposal');
+  });
+
+  it('cites the RFC 8785 canonicalization scheme', () => {
+    expect(DOC_TEXT).toContain('RFC 8785');
+  });
+
+  it('cites SHA-256 as the digest function', () => {
+    expect(DOC_TEXT).toContain('SHA-256');
+  });
+});
+
+describe('agt-peac-composition.md: canonical record-only boundary', () => {
+  it('preserves the boundary line "AGT runs the runtime. PEAC records what AGT reported."', () => {
+    expect(DOC_TEXT).toContain('AGT runs the runtime. PEAC records what AGT reported.');
+  });
+
+  it('states explicitly that no implementation lands with this section', () => {
+    expect(SECTION_TEXT).toContain('No implementation');
+  });
+});
+
+describe('agt-peac-composition.md: new section does not overclaim the relationship', () => {
+  const cases: ReadonlyArray<readonly [string, string]> = [
+    ['partnership overclaim #1', FORBIDDEN_MICROSOFT_PARTNERSHIP],
+    ['relationship overclaim #1', FORBIDDEN_AGT_ADOPTED_PEAC],
+    ['relationship overclaim #2', FORBIDDEN_PEAC_ADOPTS_AGT],
+    ['relationship overclaim #3', FORBIDDEN_PEAC_PLUGS_INTO_AGT],
+    ['relationship overclaim #4', FORBIDDEN_AGT_RECOMMENDS_PEAC],
+    ['category framing #1', FORBIDDEN_GOVERNANCE_LAYER],
+    ['category framing #2', FORBIDDEN_TRUST_LAYER],
+    ['category framing #3', FORBIDDEN_CONTROL_PLANE],
+    ['policy overclaim #1', FORBIDDEN_PEAC_ENFORCES_AGT_POLICY],
+    ['implementation overclaim #1', FORBIDDEN_EVIDENCEANCHOR_IMPLEMENTATION],
+    ['implementation overclaim #2', FORBIDDEN_WORKING_PLUGIN],
+    ['implementation overclaim #3', FORBIDDEN_PYTHON_WRAPPER],
+  ];
+
+  for (const [label, phrase] of cases) {
+    it(`new section does not contain ${label}`, () => {
+      expect(SECTION_TEXT.toLowerCase()).not.toContain(phrase.toLowerCase());
+    });
+  }
+});


### PR DESCRIPTION
Adds an informational section to `docs/SOLUTIONS/agt-peac-composition.md` describing how PEAC signed interaction records could compose with the AGT EvidenceAnchor proposal if AGT implements the proposed SPI.

The section cites `microsoft/agent-governance-toolkit#2244` by exact number, records that the current upstream artifact is a proposal, and explains the shared RFC 8785 JCS + SHA-256 determinism contract without adding an AGT runtime dependency.

A doc-truth test keeps the section anchored to the upstream proposal number, the proposal-only boundary, and the record-only PEAC/AGT composition line.

No implementation. No new package. No AGT runtime dependency. No SPI shim. No wire format change. No schema change. No registry change. No protocol semantics change. No public API change.
