### PR TITLE
fix(plugin-pack): refresh current MCP server pins

### DIFF
--- a/surfaces/plugin-pack/claude-code/.mcp.json
+++ b/surfaces/plugin-pack/claude-code/.mcp.json
@@ -4,7 +4,7 @@
     "peac": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@peac/mcp-server@0.12.14"],
+      "args": ["-y", "@peac/mcp-server@0.14.5"],
       "env": {}
     }
   }

--- a/surfaces/plugin-pack/codex/codex-config.pinned.json
+++ b/surfaces/plugin-pack/codex/codex-config.pinned.json
@@ -3,7 +3,7 @@
   "mcpServers": {
     "peac": {
       "command": "npx",
-      "args": ["-y", "@peac/mcp-server@0.12.14"],
+      "args": ["-y", "@peac/mcp-server@0.14.5"],
       "env": {}
     }
   }

--- a/surfaces/plugin-pack/cursor/mcp.json
+++ b/surfaces/plugin-pack/cursor/mcp.json
@@ -3,7 +3,7 @@
   "mcpServers": {
     "peac": {
       "command": "npx",
-      "args": ["-y", "@peac/mcp-server@0.12.14"],
+      "args": ["-y", "@peac/mcp-server@0.14.5"],
       "env": {}
     }
   }

--- a/surfaces/plugin-pack/vscode/mcp.json
+++ b/surfaces/plugin-pack/vscode/mcp.json
@@ -4,7 +4,7 @@
     "peac": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@peac/mcp-server@0.12.14"],
+      "args": ["-y", "@peac/mcp-server@0.14.5"],
       "env": {}
     }
   }


### PR DESCRIPTION
## What changed

Updated active plugin-pack templates to pin the current `@peac/mcp-server` version.

## Why

Keeps copy-paste MCP setup configs aligned with the current package version.

## What did not change

- No protocol semantics
- No runtime behavior
- No package exports
- No conformance fixtures

## Validation

- `python3 -m json.tool` on each updated file
- `pnpm exec prettier --check surfaces/plugin-pack/**/*.json`
- `git diff --check`
