### PR TITLE
docs: readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,14 @@ scope: [`docs/WHAT-PEAC-STANDARDIZES.md`](docs/WHAT-PEAC-STANDARDIZES.md).
 
 ## Choose your path
 
-| If you...                                       | PEAC helps you...                                                                                                                   | Start here                                                                        |
-| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| Run an API or metered service                   | issue signed records for requests, responses, usage, and policy-visible outcomes                                                    | [API Provider Quickstart](docs/guides/quickstart-api-provider.md)                 |
-| Build MCP tools or agent workflows              | attach records to tool runs, command execution, handoffs, lifecycle events, and agent actions                                       | [MCP Integration Kit](integrator-kits/mcp/README.md) or `npx -y @peac/mcp-server` |
-| Build payment, gateway, or commerce flows       | preserve signed evidence around access, payment, settlement, mandate, gateway, and dispute events without becoming the payment rail | [Commerce evidence bundle](docs/SOLUTIONS/commerce-evidence-bundle.md)            |
-| Track provisioning or resource lifecycle events | record catalog, provider-link, account, credential, budget, subscription, domain, deployment, and resource events                   | [Provisioning lifecycle records](docs/SOLUTIONS/verify-agent-provisioning.md)     |
-| Need audit or review evidence                   | export portable records and bundles that can be referenced beside logs, traces, SIEMs, reports, and audit repositories              | [Where PEAC fits](docs/WHERE-IT-FITS.md)                                          |
-| Need to verify a record                         | verify a signed PEAC record with the issuer's public key or a self-hosted verifier                                                  | [Agent Operator Quickstart](docs/guides/quickstart-agent-operator.md)             |
+| If you...                                       | PEAC helps you...                                                                                                                      | Start here                                                                        |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Run an API or metered service                   | issue signed records for requests, responses, usage, and policy-visible outcomes                                                       | [API Provider Quickstart](docs/guides/quickstart-api-provider.md)                 |
+| Build MCP tools or agent workflows              | attach records to tool runs, command execution, handoffs, lifecycle events, and agent actions                                          | [MCP Integration Kit](integrator-kits/mcp/README.md) or `npx -y @peac/mcp-server` |
+| Build payment, gateway, or commerce flows       | preserve signed evidence around access, payment, settlement, mandate, gateway, and dispute events without operating the payment system | [Commerce evidence bundle](docs/SOLUTIONS/commerce-evidence-bundle.md)            |
+| Track provisioning or resource lifecycle events | record catalog, provider-link, account, credential, budget, subscription, domain, deployment, and resource events                      | [Provisioning lifecycle records](docs/SOLUTIONS/verify-agent-provisioning.md)     |
+| Need audit or review evidence                   | export portable records and bundles that can be referenced beside logs, traces, SIEMs, reports, and audit repositories                 | [Where PEAC fits](docs/WHERE-IT-FITS.md)                                          |
+| Need to verify a record                         | verify a signed PEAC record with the issuer's public key or a self-hosted verifier                                                     | [Agent Operator Quickstart](docs/guides/quickstart-agent-operator.md)             |
 
 Full path-by-role tree: [`docs/START_HERE.md`](docs/START_HERE.md).
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,11 @@
 
 **Portable signed records for automated interactions.**
 
-PEAC is an open protocol for issuing and verifying signed interaction
-records across APIs, MCP tools, agent workflows, gateway decisions,
-payment-adjacent flows, provisioning events, runtimes, and audit systems.
+When logs are not enough, PEAC gives teams records another party can verify outside the system that produced them.
 
-When local logs are not enough, PEAC gives teams records that can be
-verified outside the system that produced them.
+PEAC records what APIs, MCP tools, agent workflows, gateways, payment-adjacent flows, provisioning systems, runtimes, and audit systems report. It does not run those systems or make their decisions.
 
-**Govern locally. Prove across boundaries.**
+**Record locally. Verify across boundaries.**
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-brightgreen.svg)](LICENSE)
 [![Latest Release](https://img.shields.io/github/v/release/peacprotocol/peac?color=brightgreen)](https://github.com/peacprotocol/peac/releases)

--- a/docs/README_LONG.md
+++ b/docs/README_LONG.md
@@ -1,6 +1,6 @@
 # PEAC Protocol Developer Guide
 
-> **Deep reference for package authors and integrators.** If you are new to PEAC, start at [`docs/START_HERE.md`](START_HERE.md) for the role-based job selector, then see [`docs/HOW-IT-WORKS.md`](HOW-IT-WORKS.md), [`docs/ARTIFACTS.md`](ARTIFACTS.md), [`docs/WHERE-IT-FITS.md`](WHERE-IT-FITS.md), and [`docs/WHAT-PEAC-STANDARDIZES.md`](WHAT-PEAC-STANDARDIZES.md) for the operator mental model. Outcome-led recipes under [`docs/SOLUTIONS/`](SOLUTIONS/). This document is a full package catalog and protocol-surface tour for contributors who need the long-tail detail.
+> **Deep reference for package authors and integrators.** New to PEAC? Start with [`docs/START_HERE.md`](START_HERE.md), then read [`docs/HOW-IT-WORKS.md`](HOW-IT-WORKS.md), [`docs/ARTIFACTS.md`](ARTIFACTS.md), [`docs/WHERE-IT-FITS.md`](WHERE-IT-FITS.md), and [`docs/WHAT-PEAC-STANDARDIZES.md`](WHAT-PEAC-STANDARDIZES.md) for the protocol overview. Outcome-led recipes live under [`docs/SOLUTIONS/`](SOLUTIONS/). This document is the long-form package catalog and protocol-surface guide for contributors.
 
 Integration examples, package catalog, protocol surfaces, and repo navigation. For a concise overview, see the [main README](../README.md).
 
@@ -8,7 +8,7 @@ Integration examples, package catalog, protocol surfaces, and repo navigation. F
 
 ## Getting oriented
 
-PEAC is a kernel-first monorepo. Dependencies flow down only; higher layers never import from lower layers.
+PEAC is a kernel-first monorepo. Dependencies point toward lower-numbered layers only; lower-numbered layers must never import higher-numbered layers.
 
 ```text
 Layer 0: @peac/kernel         -- zero-dependency constants and registries
@@ -48,7 +48,7 @@ PEAC records evidence from commerce protocols without executing payments. `payme
 | --------------------------------------------- | ---------------------------- | -------------------------------------------------- |
 | paymentauth / MPP (Machine Payments Protocol) | `@peac/mappings-paymentauth` | HTTP 402 challenges, receipts, carrier coexistence |
 | ACP                                           | `@peac/mappings-acp`         | Session lifecycle, payment observations            |
-| Stripe SPT                                    | `@peac/rails-stripe`         | Delegation grants, PI observations                 |
+| Stripe SPT                                    | `@peac/rails-stripe`         | Delegation records and payment-intent observations |
 | x402                                          | `@peac/adapter-x402`         | Offer/receipt verification, v1/v2 read             |
 | UCP                                           | `@peac/mappings-ucp`         | Order-vs-payment separation                        |
 
@@ -76,7 +76,7 @@ v0.14.1 adds three record surfaces for agent and operator workflows:
 
 These are record/export surfaces. The CLI wrapper may spawn a caller-supplied child process to produce an observation; PEAC does not choose the command, schedule it, supervise it as a long-running process, authorize it, or orchestrate workflows. PEAC does not approve the action, score the runtime, or vouch for the truth of caller-reported lifecycle events.
 
-### Settlement fields
+### Payment evidence fields
 
 Add payment evidence via the commerce extension:
 
@@ -160,7 +160,7 @@ See [packages/middleware-core/README.md](../packages/middleware-core/README.md) 
 
 ### x402 integration
 
-PEAC works as the receipts and verification layer for [x402](https://x402.org) payment flows. x402 handles the payment; PEAC records verifiable evidence of the payment flow.
+PEAC can carry signed records for [x402](https://x402.org) payment flows. x402 handles payment. PEAC records verifiable evidence reported around the payment flow.
 
 1. Client requests a protected resource
 2. Server returns `402 Payment Required` with x402 payment details
@@ -168,7 +168,7 @@ PEAC works as the receipts and verification layer for [x402](https://x402.org) p
 4. Server issues a signed `PEAC-Receipt` header carrying payment evidence
 5. Client verifies the receipt offline
 
-**Package:** `@peac/rails-x402` (payment rail) and `@peac/adapter-x402` (evidence carrier).
+**Package:** `@peac/rails-x402` (x402-specific evidence mapping) and `@peac/adapter-x402` (record carrier).
 
 See [examples/x402-node-server](../examples/x402-node-server) for a working implementation.
 
@@ -361,6 +361,8 @@ peac policy generate peac-policy.yaml --out dist --well-known
 
 ## Package catalog
 
+> Package catalog note: this section includes both published packages and workspace-only surfaces. Install only packages listed in the active publish manifest or marked available in [`docs/PACKAGE_STATUS.md`](PACKAGE_STATUS.md). Workspace-only surfaces are documented for contributors and integrators, not as installable public packages.
+
 **Core:**
 
 | Package          | Description                                  |
@@ -383,12 +385,12 @@ peac policy generate peac-policy.yaml --out dist --well-known
 
 **Rails:**
 
-| Package                | Description           |
-| ---------------------- | --------------------- |
-| `@peac/rails-x402`     | x402 payment rail     |
-| `@peac/rails-stripe`   | Stripe payment rail   |
-| `@peac/rails-razorpay` | Razorpay payment rail |
-| `@peac/rails-card`     | Card billing bridge   |
+| Package                | Description                   |
+| ---------------------- | ----------------------------- |
+| `@peac/rails-x402`     | x402 evidence mapping         |
+| `@peac/rails-stripe`   | Stripe evidence mapping       |
+| `@peac/rails-razorpay` | Razorpay evidence mapping     |
+| `@peac/rails-card`     | Card billing evidence mapping |
 
 **Adapters:**
 
@@ -420,7 +422,7 @@ peac policy generate peac-policy.yaml --out dist --well-known
 
 **Infrastructure:** `@peac/contracts`, `@peac/http-signatures`, `@peac/jwks-cache`, `@peac/net-node`, `@peac/adapter-core`, `@peac/privacy`, `@peac/telemetry`, `@peac/telemetry-otel`, `@peac/transport-grpc`, `@peac/capture-core`, `@peac/capture-node`, `@peac/attribution`, `@peac/audit`, `@peac/policy-kit`.
 
-**Publication status:** Package rows include both packages on npm `latest` and workspace-only surfaces. The active publish set is defined by [`scripts/publish-manifest.json`](../scripts/publish-manifest.json); per-package status is summarized in [`docs/PACKAGE_STATUS.md`](PACKAGE_STATUS.md). See [npm](https://www.npmjs.com/search?q=%40peac) and [Releases](https://github.com/peacprotocol/peac/releases). Install only packages present in the active publish manifest.
+**Publication status:** The active publish set is defined by [`scripts/publish-manifest.json`](../scripts/publish-manifest.json). Per-package status is summarized in [`docs/PACKAGE_STATUS.md`](PACKAGE_STATUS.md). Install only packages present in the active publish manifest.
 
 ---
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -1,10 +1,10 @@
 # Start Here
 
-**Govern locally. Prove across boundaries.**
+**Record locally. Verify across boundaries.**
 
-When logs aren't enough, PEAC gives you portable signed records anyone can verify offline.
+When logs are not enough, PEAC gives you portable signed records another party can verify offline.
 
-Portable signed records for agent, API, MCP, and cross-runtime interactions.
+PEAC helps API, MCP, agent, gateway, payment-adjacent, provisioning, runtime, and audit systems export records that travel beyond local logs.
 
 Pick the path that matches what you are building.
 
@@ -41,9 +41,9 @@ You have a receipt (JWS string) and want to verify it offline with a public key.
 
 Key packages: `@peac/protocol`, `@peac/crypto`.
 
-## I want to prove my runtime decisions
+## I need runtime decision records
 
-You run a managed agent runtime (or an adjacent governance system) and want to export signed records of its observations, decisions, or transitions so other parties can verify them offline.
+You run a managed agent runtime, policy system, or adjacent control surface and want to export signed records of what it reported, decided, or observed so other parties can verify those records offline.
 
 1. Review the [runtime-governance adapter](../packages/adapters/runtime-governance/) and its conformance fixtures.
 2. Outcome-led recipe: [`docs/SOLUTIONS/runtime-evidence-export.md`](SOLUTIONS/runtime-evidence-export.md)
@@ -97,13 +97,13 @@ You want verifiable evidence from commerce and payment flows across x402, paymen
 
 Key packages: `@peac/mappings-paymentauth`, `@peac/mappings-acp`, `@peac/rails-stripe`, `@peac/adapter-x402`, `@peac/mappings-ucp`.
 
-### Audit, dispute, and governance evidence
+### Audit, dispute, and regulatory evidence
 
-You need signed evidence for audit, dispute review, or regulatory alignment. Evidence that survives organizational boundaries, not just local logs.
+You need signed records for audit, dispute review, or regulatory alignment — records that survive organizational boundaries, not just local logs.
 
 1. Start with the [API Provider Quickstart](guides/quickstart-api-provider.md) to understand issuance
 2. See [Evidence Bundles](specs/EVIDENCE-CARRIER-CONTRACT.md) for offline verification bundles
-3. Review [Governance Mappings](governance/) for NIST AI RMF, EU AI Act, OWASP ASI alignment
+3. Review [regulatory and assurance mappings](governance/) for NIST AI RMF, EU AI Act, and OWASP ASI alignment
 4. Outcome-led recipe: [`docs/SOLUTIONS/regulatory-audit-trail.md`](SOLUTIONS/regulatory-audit-trail.md)
 
 Key packages: `@peac/protocol`, `@peac/audit`.
@@ -154,7 +154,7 @@ Layer 4: @peac/mappings-*   (MCP, A2A, x402, and more)
 Layer 5: @peac/mcp-server   (MCP server)
 ```
 
-Dependencies flow down only. Start at the highest layer you need.
+Dependencies point toward lower-numbered layers only; lower layers never import higher-numbered layers. Start at the highest layer you need.
 
 ## Reference
 

--- a/tsconfig.examples.json
+++ b/tsconfig.examples.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": ["examples/**/*", "docs/examples/**/*"],
-  "exclude": ["node_modules", "**/node_modules/**"]
-}

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "include": ["scripts/**/*", "tests/golden/**/*", "tests/performance/**/*", "tests/bench/**/*"]
-}


### PR DESCRIPTION
## What changed

Aligned public documentation and repo surface around records-first wording:

- Replaced the old governance-oriented tagline with `Record locally. Verify across boundaries.`
- Tightened README and Start Here opening copy.
- Reworded runtime, audit, and payment-adjacent language around records and verification.
- Corrected the developer guide layer-dependency sentence.
- Reworded payment-adjacent developer-guide sections around evidence records rather than payment infrastructure.
- Added a package-catalog note distinguishing published packages from workspace-only surfaces.
- Removed two unused root TypeScript config files.

## Why

PEAC is a records layer. It records what another system reported and makes those records portable and verifiable. Public entry points should not imply that PEAC governs, controls, operates, or settles those systems.

## What did not change

- No runtime code
- No protocol semantics
- No package versions
- No published package surface
- No workspace census or classification docs
- No guard or scanner changes in the public repo

## Validation

- `pnpm exec prettier --check README.md docs/START_HERE.md docs/README_LONG.md`
- `git diff --check`
- retired-phrase grep
- `bash scripts/check-planning-leak.sh README.md docs/START_HERE.md docs/README_LONG.md`
- `node scripts/verify-release.mjs`
- `node scripts/generate-surface-status.mjs --check`
- `pnpm typecheck:core`
- `pnpm build`
- `pnpm test`
- `env PEAC_FAST=1 bash scripts/guard.sh`
- `bash scripts/ci/forbid-strings.sh`
- `~/.peac-private/local-gates/audit-public-diff.sh origin/main`
