### PR TITLE
docs(mappings): TAP package

### DIFF
--- a/packages/mappings/tap/package.json
+++ b/packages/mappings/tap/package.json
@@ -2,7 +2,7 @@
   "name": "@peac/mappings-tap",
   "version": "0.14.5",
   "private": true,
-  "description": "Visa Trusted Agent Protocol mapping to PEAC control evidence",
+  "description": "Visa Trusted Agent Protocol mapping to PEAC interaction evidence",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## What changed

Aligned the TAP mapping package description with PEAC's records/evidence terminology.

## Why

PEAC records and carries verifiable evidence. It should not describe its mapping surfaces as "control" surfaces.

## What did not change

- No runtime code
- No protocol semantics
- No package versions
- No published package surface
- No public scanner or gate changes

## Validation

- `pnpm exec prettier --check packages/mappings/tap/package.json`
- `git diff --check`
- `pnpm typecheck:core`
- `bash scripts/ci/forbid-strings.sh`
- Pre-push Tier-1 gate (guard fast mode + format check + changed-package build + test) passed.
