### PR TITLE
release: stamp v0.15.0 publish state

### DIFF
--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable surface classification for PEAC Protocol workspace. CI fails if any workspace member is missing. See docs/PACKAGE_STATUS.md for human-readable view.",
   "version": "0.13.0",
-  "updated": "2026-05-22",
+  "updated": "2026-06-01",
   "states": {
     "default": "Current recommended path. Actively maintained, Wire 0.2 native.",
     "supported": "Actively maintained, published, production-ready. May not be on default quickstart path.",

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -2,7 +2,7 @@
 
 Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scripts/generate-surface-status.mjs`.
 
-**Version:** 0.13.0 | **Updated:** 2026-05-22
+**Version:** 0.13.0 | **Updated:** 2026-06-01
 
 ## Layer 1
 

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -4,7 +4,7 @@
   "version": "0.15.0",
   "wire_format_version": "0.2",
   "dist_tag": "latest",
-  "release_date": "2026-05-22",
+  "release_date": "2026-06-01",
   "metrics": {
     "tests": 10838,
     "test_files": 445,


### PR DESCRIPTION
## Summary

Stamps post-publish release-state metadata for v0.15.0. `publish.yml` succeeded
and v0.15.0 is published to the `next` dist-tag; `latest` remains `0.14.5`.

## Scope

- Sets `docs/releases/facts.json` `release_date` to the publish date (2026-06-01).
- Updates `REPO_SURFACE_STATUS.json` `updated` and regenerates `docs/SURFACE_STATUS.md`.
- Metadata only: no package versions, CHANGELOG, specs, source, or wording change.

## State

- npm: `next: 0.15.0`, `latest: 0.14.5`.
- Promotion to `latest`, the post-promote `dist_tag` stamp, and finalizing the
  GitHub Release as non-prerelease remain pending.

## Validation

- `release:stamp:check:publish 2026-06-01`, `check-version-sync`, `verify-release`
  (25/0/1), `forbid-strings`, `guard`, `format:check`, `git diff --check`: pass.
