### PR TITLE
build: split release closeout stages

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -343,6 +343,9 @@ Stage meanings:
   (non-draft, non-prerelease) GitHub Release.
 - `mode1`: single-step `latest` with a finalized GitHub Release.
 
+When running `--stage promote` inline before the post-promote stamp PR has
+merged, pass `--allow-stamp-pending`; after the stamp PR lands, omit it.
+
 `REPO_SURFACE_STATUS.json` freshness is an independent staleness check, not
 part of the release-state stage split. It can report YELLOW after a release
 while every release-state row is GREEN, and `--strict` still fails on a

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -309,6 +309,49 @@ pnpm release:stamp:check:promote latest
 Merge the micro-PR. After this, all truth surfaces agree with the live npm
 registry state.
 
+### 11. Reconcile release-state truth
+
+After the npm and GitHub Release steps complete, reconcile every
+release-state surface (npm dist-tags, the git tag, the GitHub Release, and
+the tracked release-state JSON) with `scripts/verify-release-closeout.mjs`.
+The reconciler runs in stages because Mode 2 finalizes the GitHub Release
+after promotion, not before:
+
+```bash
+# Mode 2, mid-soak (after publish.yml, before promote): next channel.
+node scripts/verify-release-closeout.mjs --version X.Y.Z --stage publish
+
+# Mode 2, after promote-latest.yml succeeds, before finalizing the Release.
+node scripts/verify-release-closeout.mjs --version X.Y.Z --stage promote
+
+# Mode 2, after the GitHub Release is finalized (non-draft, non-prerelease).
+node scripts/verify-release-closeout.mjs --version X.Y.Z --stage final
+
+# Mode 1, single-step to latest with a finalized Release.
+node scripts/verify-release-closeout.mjs --version X.Y.Z --stage mode1
+```
+
+Stage meanings:
+
+- `publish`: audits the `next` dist-tag (latest is pre-promotion). The
+  GitHub Release may still be a draft or prerelease during Mode 2 soak.
+- `promote`: audits the `latest` dist-tag. GitHub Release finalization is
+  tolerated but not required at this stage, because Mode 2 finalizes the
+  Release after promotion. A still-draft or prerelease Release reports
+  GREEN here; finalization is asserted at `final`.
+- `final`: audits the `latest` dist-tag and requires a finalized
+  (non-draft, non-prerelease) GitHub Release.
+- `mode1`: single-step `latest` with a finalized GitHub Release.
+
+`REPO_SURFACE_STATUS.json` freshness is an independent staleness check, not
+part of the release-state stage split. It can report YELLOW after a release
+while every release-state row is GREEN, and `--strict` still fails on a
+YELLOW row. Pass `--max-updated-age-hours <n>` to widen the window or `0` to
+skip it, and `--skip-remote` to check local artifacts only when offline.
+
+Run the reconciler's own tests with `pnpm verify:release-closeout:test` (a
+standalone Node test, not part of the Vitest suite).
+
 ## Conventions
 
 - **Examples stay at `0.0.0`**: Examples are type-check only, not published. The version scripts enforce this invariant.

--- a/scripts/verify-release-closeout.mjs
+++ b/scripts/verify-release-closeout.mjs
@@ -13,25 +13,39 @@
  *   3. Git tag `v<version>` exists and points at a commit reachable from
  *      origin/main.
  *   4. A GitHub Release exists at the tag with the expected draft /
- *      prerelease state for the declared stage:
- *        --stage=publish   -> draft or prerelease is expected.
- *        --stage=promote   -> non-draft, non-prerelease.
- *        --stage=mode1     -> non-draft, non-prerelease (single-step latest).
+ *      prerelease state for the declared stage. Mode 2 finalizes the
+ *      GitHub Release AFTER promotion, so the release-state stages are
+ *      split:
+ *        --stage=publish   -> draft or prerelease expected (mid-soak).
+ *        --stage=promote   -> latest-channel npm state is audited;
+ *                             GitHub Release finalization is tolerated but
+ *                             not required. A still-draft / prerelease
+ *                             Release is GREEN (finalize at --stage=final);
+ *                             an already-finalized Release is YELLOW. The
+ *                             promote stage is never RED on release-
+ *                             finalization state.
+ *        --stage=final     -> latest-channel npm state plus a finalized
+ *                             (non-draft, non-prerelease) GitHub Release.
+ *        --stage=mode1     -> single-step latest plus a finalized Release.
  *   5. `docs/releases/facts.json` has release_date set and dist_tag
  *      aligned with the current stage.
  *   6. `docs/releases/current.json` has version equal to the given version.
- *   7. `REPO_SURFACE_STATUS.json` updated within the last 24 hours (best
- *      effort; set --max-updated-age-hours to override; pass 0 to skip).
+ *   7. `REPO_SURFACE_STATUS.json` updated within the last 24 hours. This is
+ *      an independent staleness gate (best effort; set
+ *      --max-updated-age-hours to override; pass 0 to skip) and is not
+ *      affected by the stage split: it can be YELLOW after a release while
+ *      every release-state row is GREEN, and --strict still fails on it.
  *
  * The reconciler reads npm state via `npm view` and GitHub Release state
  * via `gh release view`. Network failures are reported; offline runs can
  * pass --skip-remote to verify local artifacts only.
  *
  * Usage:
- *   node scripts/verify-release-closeout.mjs --version 0.12.13 --stage promote
- *   node scripts/verify-release-closeout.mjs --version 0.12.13 --stage publish
- *   node scripts/verify-release-closeout.mjs --version 0.12.13 --stage mode1
- *   node scripts/verify-release-closeout.mjs --version 0.12.13 --skip-remote
+ *   node scripts/verify-release-closeout.mjs --version 0.15.0 --stage promote
+ *   node scripts/verify-release-closeout.mjs --version 0.15.0 --stage final
+ *   node scripts/verify-release-closeout.mjs --version 0.15.0 --stage publish
+ *   node scripts/verify-release-closeout.mjs --version 0.15.0 --stage mode1
+ *   node scripts/verify-release-closeout.mjs --version 0.15.0 --skip-remote
  *
  * Exit codes:
  *   0  All rows GREEN.
@@ -47,67 +61,7 @@ import { execFileSync } from 'node:child_process';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
 
-const args = process.argv.slice(2);
-let version = null;
-let stage = null;
-let skipRemote = false;
-let strict = false;
-let jsonOutput = false;
-let allowStampPending = false;
-let maxUpdatedAgeHours = 24;
-const targetedPackages = [];
-
-for (let i = 0; i < args.length; i++) {
-  const a = args[i];
-  // Accept a standalone "--" sentinel so invocations like
-  // `pnpm run verify:release-closeout -- --version 0.12.13 --stage promote`
-  // pass through cleanly; pnpm forwards the sentinel as a literal arg.
-  if (a === '--') continue;
-  if (a === '--version' && args[i + 1]) {
-    version = args[i + 1];
-    i += 1;
-  } else if (a === '--stage' && args[i + 1]) {
-    stage = args[i + 1];
-    i += 1;
-  } else if (a === '--package' && args[i + 1]) {
-    targetedPackages.push(args[i + 1]);
-    i += 1;
-  } else if (a === '--max-updated-age-hours' && args[i + 1]) {
-    maxUpdatedAgeHours = Number(args[i + 1]);
-    i += 1;
-  } else if (a === '--skip-remote') {
-    skipRemote = true;
-  } else if (a === '--strict') {
-    strict = true;
-  } else if (a === '--json') {
-    jsonOutput = true;
-  } else if (a === '--allow-stamp-pending') {
-    allowStampPending = true;
-  } else {
-    process.stderr.write(`unknown argument: ${a}\n`);
-    process.exit(2);
-  }
-}
-
-if (!version) {
-  process.stderr.write(
-    'usage: verify-release-closeout.mjs --version <X.Y.Z> --stage <publish|promote|mode1> [--skip-remote] [--strict] [--json]\n'
-  );
-  process.exit(2);
-}
-
-if (!stage || !['publish', 'promote', 'mode1'].includes(stage)) {
-  process.stderr.write(
-    'error: --stage must be one of publish, promote, mode1\n'
-  );
-  process.exit(2);
-}
-
-const rows = [];
-
-function row(name, status, detail) {
-  rows.push({ name, status, detail });
-}
+const VALID_STAGES = ['publish', 'promote', 'final', 'mode1'];
 
 function loadJson(path) {
   try {
@@ -129,244 +83,370 @@ function run(cmd, cmdArgs, opts = {}) {
   }
 }
 
-// 1 & 2. npm dist-tag reconciliation.
-const manifestPath = resolve(REPO_ROOT, 'scripts/publish-manifest.json');
-const manifest = loadJson(manifestPath);
-const packages =
-  targetedPackages.length > 0
-    ? targetedPackages
-    : (manifest.packages || []);
-
-if (skipRemote) {
-  row('npm-dist-tags', 'YELLOW', 'skipped via --skip-remote');
-} else if (packages.length === 0) {
-  row('npm-dist-tags', 'RED', 'publish manifest is empty or unreadable');
-} else {
-  let latestMatch = 0;
-  let latestMismatch = [];
-  let nextMatch = 0;
-  let nextMismatch = [];
-  for (const pkg of packages) {
-    const distTags = run('npm', ['view', pkg, 'dist-tags', '--json']);
-    if (!distTags) {
-      latestMismatch.push(`${pkg} (npm view failed)`);
-      continue;
-    }
-    let parsed;
-    try {
-      parsed = JSON.parse(distTags);
-    } catch {
-      latestMismatch.push(`${pkg} (malformed npm view output)`);
-      continue;
-    }
-    if (parsed.latest === version) latestMatch += 1;
-    else latestMismatch.push(`${pkg} latest=${parsed.latest}`);
-    if (parsed.next === version) nextMatch += 1;
-    else nextMismatch.push(`${pkg} next=${parsed.next}`);
-  }
+/**
+ * Classify a parsed GitHub Release object against the declared stage.
+ *
+ * Pure helper: it does not read process / env, run `gh`, touch the
+ * network, write stdout, or exit. The caller handles the skip-remote,
+ * missing-release, and malformed-json cases; this function only judges a
+ * successfully parsed Release object, so the stage x state matrix can be
+ * unit-asserted deterministically without GitHub access.
+ *
+ * `release` has the parsed `gh release view --json` shape:
+ *   { tagName, isDraft, isPrerelease }.
+ *
+ * Returns { status: 'GREEN' | 'YELLOW' | 'RED', detail: string }.
+ *
+ * Matrix:
+ *   publish + draft/prerelease -> GREEN  (a later stage finalizes)
+ *   publish + finalized        -> RED    (finalized too early; check ordering)
+ *   promote + draft/prerelease -> GREEN  (finalize at --stage=final)
+ *   promote + finalized        -> YELLOW (already finalized; not required at promote)
+ *   final   + draft/prerelease -> RED    (expected finalized)
+ *   final   + finalized        -> GREEN
+ *   mode1   + draft/prerelease -> RED    (expected finalized)
+ *   mode1   + finalized        -> GREEN
+ */
+export function classifyGithubRelease(stage, release) {
+  const tag = release && release.tagName ? release.tagName : '(unknown tag)';
+  const isFinalized = !release.isDraft && !release.isPrerelease;
+  const stateLabel = release.isDraft
+    ? 'draft'
+    : release.isPrerelease
+      ? 'prerelease'
+      : 'finalized';
 
   if (stage === 'publish') {
-    if (nextMismatch.length === 0) {
-      row('npm-next', 'GREEN', `${nextMatch}/${packages.length} packages at next=${version}`);
+    return isFinalized
+      ? {
+          status: 'RED',
+          detail: `${tag} is finalized but stage=publish expected draft/prerelease; check workflow ordering`,
+        }
+      : {
+          status: 'GREEN',
+          detail: `${tag} is ${stateLabel}; a later stage will finalize`,
+        };
+  }
+
+  if (stage === 'promote') {
+    // Mode 2 finalizes the GitHub Release AFTER promotion, so a
+    // not-yet-finalized Release is expected at this stage. Finalization is
+    // tolerated but not required: the promote stage is never RED on the
+    // release-finalization state. Finalization is asserted at stage=final.
+    return isFinalized
+      ? {
+          status: 'YELLOW',
+          detail: `${tag} is already finalized; promote does not require finalization (asserted at stage=final)`,
+        }
+      : {
+          status: 'GREEN',
+          detail: `${tag} is ${stateLabel}; finalize at stage=final`,
+        };
+  }
+
+  // stage === 'final' || stage === 'mode1': a finalized Release is required.
+  return isFinalized
+    ? {
+        status: 'GREEN',
+        detail: `${tag} is finalized (non-draft, non-prerelease)`,
+      }
+    : {
+        status: 'RED',
+        detail: `${tag} is still ${stateLabel}; expected finalized at stage=${stage}`,
+      };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  let version = null;
+  let stage = null;
+  let skipRemote = false;
+  let strict = false;
+  let jsonOutput = false;
+  let allowStampPending = false;
+  let maxUpdatedAgeHours = 24;
+  const targetedPackages = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    // Accept a standalone "--" sentinel so invocations like
+    // `pnpm run verify:release-closeout -- --version 0.15.0 --stage promote`
+    // pass through cleanly; pnpm forwards the sentinel as a literal arg.
+    if (a === '--') continue;
+    if (a === '--version' && args[i + 1]) {
+      version = args[i + 1];
+      i += 1;
+    } else if (a === '--stage' && args[i + 1]) {
+      stage = args[i + 1];
+      i += 1;
+    } else if (a === '--package' && args[i + 1]) {
+      targetedPackages.push(args[i + 1]);
+      i += 1;
+    } else if (a === '--max-updated-age-hours' && args[i + 1]) {
+      maxUpdatedAgeHours = Number(args[i + 1]);
+      i += 1;
+    } else if (a === '--skip-remote') {
+      skipRemote = true;
+    } else if (a === '--strict') {
+      strict = true;
+    } else if (a === '--json') {
+      jsonOutput = true;
+    } else if (a === '--allow-stamp-pending') {
+      allowStampPending = true;
     } else {
-      row(
-        'npm-next',
-        'RED',
-        `${nextMatch}/${packages.length} packages at next=${version}; mismatches: ${nextMismatch.slice(0, 5).join(', ')}${nextMismatch.length > 5 ? `; +${nextMismatch.length - 5} more` : ''}`
-      );
+      process.stderr.write(`unknown argument: ${a}\n`);
+      process.exit(2);
     }
-    row('npm-latest', 'YELLOW', 'not audited at stage=publish (latest is pre-promotion)');
+  }
+
+  if (!version) {
+    process.stderr.write(
+      `usage: verify-release-closeout.mjs --version <X.Y.Z> --stage <${VALID_STAGES.join('|')}> [--skip-remote] [--strict] [--json]\n`
+    );
+    process.exit(2);
+  }
+
+  if (!stage || !VALID_STAGES.includes(stage)) {
+    process.stderr.write(
+      `error: --stage must be one of ${VALID_STAGES.join(', ')}\n`
+    );
+    process.exit(2);
+  }
+
+  const rows = [];
+
+  function row(name, status, detail) {
+    rows.push({ name, status, detail });
+  }
+
+  // 1 & 2. npm dist-tag reconciliation.
+  const manifestPath = resolve(REPO_ROOT, 'scripts/publish-manifest.json');
+  const manifest = loadJson(manifestPath);
+  const packages =
+    targetedPackages.length > 0 ? targetedPackages : (manifest.packages || []);
+
+  if (skipRemote) {
+    row('npm-dist-tags', 'YELLOW', 'skipped via --skip-remote');
+  } else if (packages.length === 0) {
+    row('npm-dist-tags', 'RED', 'publish manifest is empty or unreadable');
   } else {
-    if (latestMismatch.length === 0) {
-      row('npm-latest', 'GREEN', `${latestMatch}/${packages.length} packages at latest=${version}`);
-    } else {
-      row(
-        'npm-latest',
-        'RED',
-        `${latestMatch}/${packages.length} packages at latest=${version}; mismatches: ${latestMismatch.slice(0, 5).join(', ')}${latestMismatch.length > 5 ? `; +${latestMismatch.length - 5} more` : ''}`
-      );
+    let latestMatch = 0;
+    let latestMismatch = [];
+    let nextMatch = 0;
+    let nextMismatch = [];
+    for (const pkg of packages) {
+      const distTags = run('npm', ['view', pkg, 'dist-tags', '--json']);
+      if (!distTags) {
+        latestMismatch.push(`${pkg} (npm view failed)`);
+        continue;
+      }
+      let parsed;
+      try {
+        parsed = JSON.parse(distTags);
+      } catch {
+        latestMismatch.push(`${pkg} (malformed npm view output)`);
+        continue;
+      }
+      if (parsed.latest === version) latestMatch += 1;
+      else latestMismatch.push(`${pkg} latest=${parsed.latest}`);
+      if (parsed.next === version) nextMatch += 1;
+      else nextMismatch.push(`${pkg} next=${parsed.next}`);
     }
-    if (stage === 'promote') {
+
+    if (stage === 'publish') {
       if (nextMismatch.length === 0) {
         row('npm-next', 'GREEN', `${nextMatch}/${packages.length} packages at next=${version}`);
       } else {
         row(
           'npm-next',
-          'YELLOW',
-          `${nextMatch}/${packages.length} packages at next=${version}; next often retains the previous soak version`
+          'RED',
+          `${nextMatch}/${packages.length} packages at next=${version}; mismatches: ${nextMismatch.slice(0, 5).join(', ')}${nextMismatch.length > 5 ? `; +${nextMismatch.length - 5} more` : ''}`
         );
       }
+      row('npm-latest', 'YELLOW', 'not audited at stage=publish (latest is pre-promotion)');
     } else {
-      row('npm-next', 'YELLOW', 'not audited at stage=mode1');
-    }
-  }
-}
-
-// 3. Git tag.
-const tagRef = `v${version}`;
-const tagSha = run('git', ['rev-parse', '--verify', `${tagRef}^{commit}`], { cwd: REPO_ROOT });
-if (!tagSha) {
-  row('git-tag', 'RED', `tag ${tagRef} not found locally`);
-} else {
-  const reachable = run('git', ['merge-base', '--is-ancestor', tagSha, 'origin/main'], { cwd: REPO_ROOT });
-  row(
-    'git-tag',
-    reachable !== null ? 'GREEN' : 'YELLOW',
-    reachable !== null
-      ? `tag ${tagRef} points at ${tagSha.slice(0, 10)} (reachable from origin/main)`
-      : `tag ${tagRef} exists but origin/main reachability could not be verified (run 'git fetch origin main' if offline)`
-  );
-}
-
-// 4. GitHub Release.
-if (skipRemote) {
-  row('github-release', 'YELLOW', 'skipped via --skip-remote');
-} else {
-  const releaseJson = run('gh', ['release', 'view', tagRef, '--json', 'tagName,isDraft,isPrerelease,url']);
-  if (!releaseJson) {
-    row('github-release', 'RED', `no GitHub Release at tag ${tagRef}`);
-  } else {
-    let rel;
-    try {
-      rel = JSON.parse(releaseJson);
-    } catch {
-      row('github-release', 'RED', `malformed gh release view output for ${tagRef}`);
-      rel = null;
-    }
-    if (rel) {
-      if (stage === 'publish') {
-        if (rel.isDraft || rel.isPrerelease) {
-          row('github-release', 'GREEN', `${tagRef} is ${rel.isDraft ? 'draft' : 'prerelease'}; stage 2 will finalize`);
-        } else {
-          row(
-            'github-release',
-            'RED',
-            `${tagRef} is finalized but stage=publish expected draft/prerelease; check workflow ordering`
-          );
-        }
+      // promote | final | mode1 : the latest dist-tag must equal the version.
+      if (latestMismatch.length === 0) {
+        row('npm-latest', 'GREEN', `${latestMatch}/${packages.length} packages at latest=${version}`);
       } else {
-        if (!rel.isDraft && !rel.isPrerelease) {
-          row('github-release', 'GREEN', `${tagRef} is finalized (non-draft, non-prerelease)`);
-        } else {
-          row(
-            'github-release',
-            'RED',
-            `${tagRef} is still ${rel.isDraft ? 'draft' : 'prerelease'}; expected finalized at stage=${stage}`
-          );
-        }
+        row(
+          'npm-latest',
+          'RED',
+          `${latestMatch}/${packages.length} packages at latest=${version}; mismatches: ${latestMismatch.slice(0, 5).join(', ')}${latestMismatch.length > 5 ? `; +${latestMismatch.length - 5} more` : ''}`
+        );
       }
-    }
-  }
-}
-
-// 5. docs/releases/facts.json.
-const factsPath = resolve(REPO_ROOT, 'docs/releases/facts.json');
-const facts = loadJson(factsPath);
-if (facts.__error) {
-  row('facts.json', 'RED', `unreadable: ${facts.__error}`);
-} else {
-  const releaseDate = facts.release_date;
-  const distTag = facts.dist_tag;
-  const facts_version = facts.version || facts.current_version;
-  const problems = [];
-  if (!releaseDate || releaseDate === '') problems.push('release_date is empty');
-  if (facts_version && facts_version !== version) problems.push(`version=${facts_version} (expected ${version})`);
-  const expectedDistTag = stage === 'publish' ? 'next' : 'latest';
-  // --allow-stamp-pending: at stage=promote the post-promote stamp PR has
-  // not landed yet when this runs inline in promote-latest.yml, so
-  // facts.json.dist_tag is still `next`. Accept either `next` or `latest`
-  // in that narrow window. Local strict runs after the stamp PR merges do
-  // not pass this flag and get the full strict check.
-  if (distTag && distTag !== expectedDistTag) {
-    const allowed = allowStampPending && stage === 'promote' && distTag === 'next';
-    if (!allowed) {
-      problems.push(`dist_tag=${distTag} (expected ${expectedDistTag})`);
-    }
-  }
-  row(
-    'facts.json',
-    problems.length === 0 ? 'GREEN' : 'RED',
-    problems.length === 0
-      ? `release_date=${releaseDate} dist_tag=${distTag}`
-      : problems.join('; ')
-  );
-}
-
-// 6. docs/releases/current.json.
-const currentPath = resolve(REPO_ROOT, 'docs/releases/current.json');
-const current = loadJson(currentPath);
-if (current.__error) {
-  row('current.json', 'RED', `unreadable: ${current.__error}`);
-} else {
-  const current_version = current.version || current.current_version;
-  row(
-    'current.json',
-    current_version === version ? 'GREEN' : 'RED',
-    current_version === version
-      ? `version=${current_version}`
-      : `version=${current_version} (expected ${version})`
-  );
-}
-
-// 7. REPO_SURFACE_STATUS.json updated date.
-if (maxUpdatedAgeHours === 0) {
-  row('repo-surface-status', 'YELLOW', 'skipped via --max-updated-age-hours 0');
-} else {
-  const surfacePath = resolve(REPO_ROOT, 'REPO_SURFACE_STATUS.json');
-  const surface = loadJson(surfacePath);
-  if (surface.__error) {
-    row('repo-surface-status', 'RED', `unreadable: ${surface.__error}`);
-  } else {
-    const updated = surface.updated || surface.last_updated;
-    if (!updated) {
-      row('repo-surface-status', 'RED', 'updated field missing');
-    } else {
-      const ts = Date.parse(updated);
-      if (Number.isNaN(ts)) {
-        row('repo-surface-status', 'RED', `updated=${updated} is not a parseable date`);
-      } else {
-        const ageHours = (Date.now() - ts) / (60 * 60 * 1000);
-        if (ageHours <= maxUpdatedAgeHours) {
-          row('repo-surface-status', 'GREEN', `updated=${updated} (${ageHours.toFixed(1)}h old)`);
+      if (stage === 'promote' || stage === 'final') {
+        if (nextMismatch.length === 0) {
+          row('npm-next', 'GREEN', `${nextMatch}/${packages.length} packages at next=${version}`);
         } else {
           row(
-            'repo-surface-status',
+            'npm-next',
             'YELLOW',
-            `updated=${updated} is ${ageHours.toFixed(1)}h old (> ${maxUpdatedAgeHours}h); run pnpm release:stamp before finalizing`
+            `${nextMatch}/${packages.length} packages at next=${version}; next often retains the previous soak version`
           );
+        }
+      } else {
+        row('npm-next', 'YELLOW', 'not audited at stage=mode1');
+      }
+    }
+  }
+
+  // 3. Git tag.
+  const tagRef = `v${version}`;
+  const tagSha = run('git', ['rev-parse', '--verify', `${tagRef}^{commit}`], { cwd: REPO_ROOT });
+  if (!tagSha) {
+    row('git-tag', 'RED', `tag ${tagRef} not found locally`);
+  } else {
+    const reachable = run('git', ['merge-base', '--is-ancestor', tagSha, 'origin/main'], { cwd: REPO_ROOT });
+    row(
+      'git-tag',
+      reachable !== null ? 'GREEN' : 'YELLOW',
+      reachable !== null
+        ? `tag ${tagRef} points at ${tagSha.slice(0, 10)} (reachable from origin/main)`
+        : `tag ${tagRef} exists but origin/main reachability could not be verified (run 'git fetch origin main' if offline)`
+    );
+  }
+
+  // 4. GitHub Release.
+  if (skipRemote) {
+    row('github-release', 'YELLOW', 'skipped via --skip-remote');
+  } else {
+    const releaseJson = run('gh', ['release', 'view', tagRef, '--json', 'tagName,isDraft,isPrerelease,url']);
+    if (!releaseJson) {
+      row('github-release', 'RED', `no GitHub Release at tag ${tagRef}`);
+    } else {
+      let rel;
+      try {
+        rel = JSON.parse(releaseJson);
+      } catch {
+        rel = null;
+      }
+      if (!rel) {
+        row('github-release', 'RED', `malformed gh release view output for ${tagRef}`);
+      } else {
+        const verdict = classifyGithubRelease(stage, rel);
+        row('github-release', verdict.status, verdict.detail);
+      }
+    }
+  }
+
+  // 5. docs/releases/facts.json.
+  const factsPath = resolve(REPO_ROOT, 'docs/releases/facts.json');
+  const facts = loadJson(factsPath);
+  if (facts.__error) {
+    row('facts.json', 'RED', `unreadable: ${facts.__error}`);
+  } else {
+    const releaseDate = facts.release_date;
+    const distTag = facts.dist_tag;
+    const facts_version = facts.version || facts.current_version;
+    const problems = [];
+    if (!releaseDate || releaseDate === '') problems.push('release_date is empty');
+    if (facts_version && facts_version !== version) problems.push(`version=${facts_version} (expected ${version})`);
+    const expectedDistTag = stage === 'publish' ? 'next' : 'latest';
+    // --allow-stamp-pending: at stage=promote the post-promote stamp PR has
+    // not landed yet when this runs inline in promote-latest.yml, so
+    // facts.json.dist_tag is still `next`. Accept either `next` or `latest`
+    // in that narrow window. Local strict runs after the stamp PR merges do
+    // not pass this flag and get the full strict check.
+    if (distTag && distTag !== expectedDistTag) {
+      const allowed = allowStampPending && stage === 'promote' && distTag === 'next';
+      if (!allowed) {
+        problems.push(`dist_tag=${distTag} (expected ${expectedDistTag})`);
+      }
+    }
+    row(
+      'facts.json',
+      problems.length === 0 ? 'GREEN' : 'RED',
+      problems.length === 0
+        ? `release_date=${releaseDate} dist_tag=${distTag}`
+        : problems.join('; ')
+    );
+  }
+
+  // 6. docs/releases/current.json.
+  const currentPath = resolve(REPO_ROOT, 'docs/releases/current.json');
+  const current = loadJson(currentPath);
+  if (current.__error) {
+    row('current.json', 'RED', `unreadable: ${current.__error}`);
+  } else {
+    const current_version = current.version || current.current_version;
+    row(
+      'current.json',
+      current_version === version ? 'GREEN' : 'RED',
+      current_version === version
+        ? `version=${current_version}`
+        : `version=${current_version} (expected ${version})`
+    );
+  }
+
+  // 7. REPO_SURFACE_STATUS.json updated date. Independent staleness gate;
+  // unaffected by the release-state stage split.
+  if (maxUpdatedAgeHours === 0) {
+    row('repo-surface-status', 'YELLOW', 'skipped via --max-updated-age-hours 0');
+  } else {
+    const surfacePath = resolve(REPO_ROOT, 'REPO_SURFACE_STATUS.json');
+    const surface = loadJson(surfacePath);
+    if (surface.__error) {
+      row('repo-surface-status', 'RED', `unreadable: ${surface.__error}`);
+    } else {
+      const updated = surface.updated || surface.last_updated;
+      if (!updated) {
+        row('repo-surface-status', 'RED', 'updated field missing');
+      } else {
+        const ts = Date.parse(updated);
+        if (Number.isNaN(ts)) {
+          row('repo-surface-status', 'RED', `updated=${updated} is not a parseable date`);
+        } else {
+          const ageHours = (Date.now() - ts) / (60 * 60 * 1000);
+          if (ageHours <= maxUpdatedAgeHours) {
+            row('repo-surface-status', 'GREEN', `updated=${updated} (${ageHours.toFixed(1)}h old)`);
+          } else {
+            row(
+              'repo-surface-status',
+              'YELLOW',
+              `updated=${updated} is ${ageHours.toFixed(1)}h old (> ${maxUpdatedAgeHours}h); run pnpm release:stamp before finalizing`
+            );
+          }
         }
       }
     }
   }
-}
 
-const reds = rows.filter((r) => r.status === 'RED');
-const yellows = rows.filter((r) => r.status === 'YELLOW');
-const greens = rows.filter((r) => r.status === 'GREEN');
+  const reds = rows.filter((r) => r.status === 'RED');
+  const yellows = rows.filter((r) => r.status === 'YELLOW');
+  const greens = rows.filter((r) => r.status === 'GREEN');
 
-if (jsonOutput) {
-  process.stdout.write(
-    JSON.stringify(
-      {
-        version,
-        stage,
-        rows,
-        counts: { GREEN: greens.length, YELLOW: yellows.length, RED: reds.length },
-      },
-      null,
-      2
-    ) + '\n'
-  );
-} else {
-  process.stdout.write(`verify-release-closeout: version=${version} stage=${stage}\n`);
-  for (const r of rows) {
-    process.stdout.write(`  [${r.status}] ${r.name}: ${r.detail}\n`);
+  if (jsonOutput) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          version,
+          stage,
+          rows,
+          counts: { GREEN: greens.length, YELLOW: yellows.length, RED: reds.length },
+        },
+        null,
+        2
+      ) + '\n'
+    );
+  } else {
+    process.stdout.write(`verify-release-closeout: version=${version} stage=${stage}\n`);
+    for (const r of rows) {
+      process.stdout.write(`  [${r.status}] ${r.name}: ${r.detail}\n`);
+    }
+    process.stdout.write(
+      `summary: ${greens.length} GREEN / ${yellows.length} YELLOW / ${reds.length} RED\n`
+    );
   }
-  process.stdout.write(
-    `summary: ${greens.length} GREEN / ${yellows.length} YELLOW / ${reds.length} RED\n`
-  );
+
+  if (reds.length > 0) process.exit(1);
+  if (strict && yellows.length > 0) process.exit(1);
+  process.exit(0);
 }
 
-if (reds.length > 0) process.exit(1);
-if (strict && yellows.length > 0) process.exit(1);
-process.exit(0);
+// Main guard: importing this module (for example to unit-test
+// classifyGithubRelease) must not parse argv or run the CLI.
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : '';
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/verify-release-closeout.mjs
+++ b/scripts/verify-release-closeout.mjs
@@ -63,6 +63,13 @@ const REPO_ROOT = resolve(__dirname, '..');
 
 const VALID_STAGES = ['publish', 'promote', 'final', 'mode1'];
 
+// Bounded defaults for the subprocess helpers. Release tooling shells out to
+// npm / git / gh; a hung or runaway command must not block closeout
+// indefinitely or buffer without limit. Failed or timed-out commands still
+// return null, so the existing reporting semantics are unchanged.
+const COMMAND_TIMEOUT_MS = 60_000;
+const COMMAND_MAX_BUFFER = 10 * 1024 * 1024;
+
 function loadJson(path) {
   try {
     return JSON.parse(readFileSync(path, 'utf8'));
@@ -76,6 +83,8 @@ function run(cmd, cmdArgs, opts = {}) {
     return execFileSync(cmd, cmdArgs, {
       stdio: ['ignore', 'pipe', 'pipe'],
       encoding: 'utf8',
+      timeout: COMMAND_TIMEOUT_MS,
+      maxBuffer: COMMAND_MAX_BUFFER,
       ...opts,
     }).trim();
   } catch (_err) {
@@ -95,9 +104,13 @@ function run(cmd, cmdArgs, opts = {}) {
  * `release` has the parsed `gh release view --json` shape:
  *   { tagName, isDraft, isPrerelease }.
  *
- * Returns { status: 'GREEN' | 'YELLOW' | 'RED', detail: string }.
+ * Returns { status: 'GREEN' | 'YELLOW' | 'RED', detail: string }. The helper
+ * fails closed: an unknown stage or a malformed release object returns RED
+ * rather than falling through to a passing branch.
  *
  * Matrix:
+ *   unknown stage              -> RED    (fail closed)
+ *   malformed release object   -> RED    (fail closed)
  *   publish + draft/prerelease -> GREEN  (a later stage finalizes)
  *   publish + finalized        -> RED    (finalized too early; check ordering)
  *   promote + draft/prerelease -> GREEN  (finalize at --stage=final)
@@ -108,7 +121,17 @@ function run(cmd, cmdArgs, opts = {}) {
  *   mode1   + finalized        -> GREEN
  */
 export function classifyGithubRelease(stage, release) {
-  const tag = release && release.tagName ? release.tagName : '(unknown tag)';
+  if (!VALID_STAGES.includes(stage)) {
+    return { status: 'RED', detail: `invalid stage=${stage}` };
+  }
+  if (
+    !release ||
+    typeof release.isDraft !== 'boolean' ||
+    typeof release.isPrerelease !== 'boolean'
+  ) {
+    return { status: 'RED', detail: 'malformed GitHub Release object' };
+  }
+  const tag = release.tagName ? release.tagName : '(unknown tag)';
   const isFinalized = !release.isDraft && !release.isPrerelease;
   const stateLabel = release.isDraft
     ? 'draft'

--- a/scripts/verify-release-closeout.test.mjs
+++ b/scripts/verify-release-closeout.test.mjs
@@ -6,37 +6,67 @@
  * `node scripts/verify-release-closeout.test.mjs` or
  * `pnpm verify:release-closeout:test`.
  *
+ * The release version under test is derived at runtime from
+ * `docs/releases/current.json` (the current release recorded in the repo),
+ * not hardcoded, so the test does not rot when the release version moves.
+ * `docs/releases/facts.json` must agree with it; a mismatch fails early.
+ *
  * Two layers:
  *   - CLI behavior: argument parsing, stage validation, and the offline
- *     --skip-remote path against the live repository artifacts (the live
- *     `docs/releases/facts.json`, `docs/releases/current.json`, and
- *     `REPO_SURFACE_STATUS.json` are read against the current shipped
- *     version 0.15.0 which is known GREEN). Remote npm / gh paths are not
- *     exercised here so tests stay deterministic.
+ *     --skip-remote path against the live repository artifacts. The
+ *     REPO_SURFACE_STATUS.json freshness gate is intentionally skipped
+ *     (--max-updated-age-hours 0) so these release-state assertions stay
+ *     deterministic and clock-independent; freshness is exercised by the
+ *     script's own default behavior, not asserted here.
  *   - classifyGithubRelease unit matrix: the pure stage x state classifier
- *     is imported and asserted in-process, with no GitHub access.
+ *     is imported and asserted in-process, with no GitHub access, including
+ *     the fail-closed cases (unknown stage, malformed release object).
  *
  * Cases:
  *   1. missing --version: exit 2 with usage message
  *   2. invalid --stage: exit 2, error message lists the valid stages incl. final
  *   3. unknown argument: exit 2
  *   4. "--" sentinel accepted
- *   5. --skip-remote --stage promote on v0.15.0: exit 0 with 0 RED
+ *   5. --skip-remote --stage promote on the current release: exit 0 with 0 RED
  *   6. --json emits parseable JSON with rows and counts
  *   7. --strict flips exit code to 1 when any YELLOW row is present
  *   8. --allow-stamp-pending is accepted and keeps a GREEN facts.json GREEN
- *   9. --skip-remote --stage final on v0.15.0: exit 0 with 0 RED
+ *   9. --skip-remote --stage final on the current release: exit 0 with 0 RED
  *  10. classifyGithubRelease stage x state matrix
+ *  11. classifyGithubRelease fails closed on unknown stage / malformed release
  */
 
 import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { classifyGithubRelease } from './verify-release-closeout.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
 const SCRIPT = resolve(__dirname, 'verify-release-closeout.mjs');
+
+// Derive the release version under test from the tracked release manifest so
+// the test tracks the current release instead of a hardcoded literal.
+const current = JSON.parse(
+  readFileSync(resolve(REPO_ROOT, 'docs/releases/current.json'), 'utf8')
+);
+const facts = JSON.parse(
+  readFileSync(resolve(REPO_ROOT, 'docs/releases/facts.json'), 'utf8')
+);
+
+const CURRENT_VERSION = current.version;
+
+if (!CURRENT_VERSION) {
+  throw new Error('docs/releases/current.json must contain version');
+}
+
+if (facts.version !== CURRENT_VERSION) {
+  throw new Error(
+    `release facts/current mismatch: facts=${facts.version} current=${CURRENT_VERSION}`
+  );
+}
 
 let failures = 0;
 
@@ -75,7 +105,7 @@ try {
   );
 
   // Case 2: invalid stage; error must enumerate the valid stages incl. final.
-  const badStage = run(['--version', '0.15.0', '--stage', 'nope']);
+  const badStage = run(['--version', CURRENT_VERSION, '--stage', 'nope']);
   expect(
     'invalid --stage exits 2 and lists final',
     badStage.exitCode === 2 &&
@@ -85,7 +115,7 @@ try {
   );
 
   // Case 3: unknown argument.
-  const unknown = run(['--version', '0.15.0', '--stage', 'promote', '--what']);
+  const unknown = run(['--version', CURRENT_VERSION, '--stage', 'promote', '--what']);
   expect(
     'unknown argument exits 2',
     unknown.exitCode === 2 && unknown.stderr.includes('unknown argument'),
@@ -96,31 +126,32 @@ try {
   const sentinel = run([
     '--',
     '--version',
-    '0.15.0',
+    CURRENT_VERSION,
     '--stage',
     'promote',
     '--skip-remote',
     '--max-updated-age-hours',
-    '2000',
+    '0',
   ]);
   expect(
     '"--" sentinel is accepted',
-    sentinel.exitCode === 0 && sentinel.stdout.includes('version=0.15.0 stage=promote'),
+    sentinel.exitCode === 0 &&
+      sentinel.stdout.includes(`version=${CURRENT_VERSION} stage=promote`),
     `exit=${sentinel.exitCode} stdout=${JSON.stringify(sentinel.stdout.slice(0, 200))}`
   );
 
-  // Case 5: --skip-remote --stage promote on v0.15.0: exit 0, zero RED.
+  // Case 5: --skip-remote --stage promote on the current release: exit 0, zero RED.
   const offline = run([
     '--version',
-    '0.15.0',
+    CURRENT_VERSION,
     '--stage',
     'promote',
     '--skip-remote',
     '--max-updated-age-hours',
-    '2000',
+    '0',
   ]);
   expect(
-    '--skip-remote --stage promote on v0.15.0 exits 0 with zero RED',
+    '--skip-remote --stage promote on the current release exits 0 with zero RED',
     offline.exitCode === 0 &&
       offline.stdout.includes('0 RED') &&
       offline.stdout.includes('[GREEN] git-tag'),
@@ -130,12 +161,12 @@ try {
   // Case 6: --json emits valid JSON with rows and counts.
   const jsonRun = run([
     '--version',
-    '0.15.0',
+    CURRENT_VERSION,
     '--stage',
     'promote',
     '--skip-remote',
     '--max-updated-age-hours',
-    '2000',
+    '0',
     '--json',
   ]);
   let parsed = null;
@@ -148,7 +179,7 @@ try {
     '--json emits parseable JSON with rows and counts',
     jsonRun.exitCode === 0 &&
       parsed &&
-      parsed.version === '0.15.0' &&
+      parsed.version === CURRENT_VERSION &&
       parsed.stage === 'promote' &&
       Array.isArray(parsed.rows) &&
       parsed.rows.length >= 4 &&
@@ -158,16 +189,16 @@ try {
   );
 
   // Case 7: --strict flips exit code to 1 when YELLOW rows are present.
-  // Offline mode emits YELLOW rows for npm-dist-tags and github-release, so
-  // --strict must produce a nonzero exit.
+  // Offline mode emits YELLOW rows (npm-dist-tags, github-release, and the
+  // skipped repo-surface-status), so --strict must produce a nonzero exit.
   const strict = run([
     '--version',
-    '0.15.0',
+    CURRENT_VERSION,
     '--stage',
     'promote',
     '--skip-remote',
     '--max-updated-age-hours',
-    '2000',
+    '0',
     '--strict',
   ]);
   expect(
@@ -177,16 +208,16 @@ try {
   );
 
   // Case 8: --allow-stamp-pending is accepted at stage=promote and does
-  // not regress an already-stamped facts.json. Live facts.json has
+  // not regress an already-stamped facts.json. A released facts.json has
   // dist_tag=latest, so the facts.json row stays GREEN either way.
   const allowPending = run([
     '--version',
-    '0.15.0',
+    CURRENT_VERSION,
     '--stage',
     'promote',
     '--skip-remote',
     '--max-updated-age-hours',
-    '2000',
+    '0',
     '--allow-stamp-pending',
   ]);
   expect(
@@ -197,22 +228,22 @@ try {
     `exit=${allowPending.exitCode} stdout=${JSON.stringify(allowPending.stdout)}`
   );
 
-  // Case 9: --skip-remote --stage final on v0.15.0: exit 0, zero RED.
+  // Case 9: --skip-remote --stage final on the current release: exit 0, zero RED.
   // The github-release row is skipped (YELLOW) offline; facts.json and
-  // current.json must still be GREEN against the live 0.15.0 artifacts.
+  // current.json must still be GREEN against the live release artifacts.
   const finalStage = run([
     '--version',
-    '0.15.0',
+    CURRENT_VERSION,
     '--stage',
     'final',
     '--skip-remote',
     '--max-updated-age-hours',
-    '2000',
+    '0',
   ]);
   expect(
-    '--skip-remote --stage final on v0.15.0 exits 0 with zero RED',
+    '--skip-remote --stage final on the current release exits 0 with zero RED',
     finalStage.exitCode === 0 &&
-      finalStage.stdout.includes('version=0.15.0 stage=final') &&
+      finalStage.stdout.includes(`version=${CURRENT_VERSION} stage=final`) &&
       finalStage.stdout.includes('0 RED') &&
       finalStage.stdout.includes('[GREEN] facts.json') &&
       finalStage.stdout.includes('[GREEN] current.json'),
@@ -220,9 +251,10 @@ try {
   );
 
   // Case 10: classifyGithubRelease stage x state matrix (pure, no network).
-  const DRAFT = { tagName: 'v0.15.0', isDraft: true, isPrerelease: false };
-  const PRERELEASE = { tagName: 'v0.15.0', isDraft: false, isPrerelease: true };
-  const FINALIZED = { tagName: 'v0.15.0', isDraft: false, isPrerelease: false };
+  const tag = `v${CURRENT_VERSION}`;
+  const DRAFT = { tagName: tag, isDraft: true, isPrerelease: false };
+  const PRERELEASE = { tagName: tag, isDraft: false, isPrerelease: true };
+  const FINALIZED = { tagName: tag, isDraft: false, isPrerelease: false };
 
   const matrix = [
     ['publish', DRAFT, 'GREEN'],
@@ -255,6 +287,21 @@ try {
       `got=${JSON.stringify(verdict)}`
     );
   }
+
+  // Case 11: classifyGithubRelease fails closed.
+  const unknownStage = classifyGithubRelease('unknown', FINALIZED);
+  expect(
+    'classifyGithubRelease(unknown stage, finalized) -> RED',
+    unknownStage && unknownStage.status === 'RED',
+    `got=${JSON.stringify(unknownStage)}`
+  );
+
+  const malformedRelease = classifyGithubRelease('final', { tagName: tag, isDraft: false });
+  expect(
+    'classifyGithubRelease(final, malformed release) -> RED',
+    malformedRelease && malformedRelease.status === 'RED',
+    `got=${JSON.stringify(malformedRelease)}`
+  );
 } catch (err) {
   failures += 1;
   console.error('FAIL unexpected error:', err && err.stack ? err.stack : err);

--- a/scripts/verify-release-closeout.test.mjs
+++ b/scripts/verify-release-closeout.test.mjs
@@ -2,28 +2,38 @@
 /**
  * Tests for scripts/verify-release-closeout.mjs.
  *
- * The reconciler reads several tracked artifacts plus npm / GitHub Release
- * state. These tests cover argument parsing, stage validation, and the
- * offline skip-remote path using the live repository artifacts (the live
- * `docs/releases/facts.json`, `docs/releases/current.json`, and
- * `REPO_SURFACE_STATUS.json` are read against the current shipped version
- * 0.12.13 which is known GREEN). Remote npm / gh paths are not exercised
- * here so tests stay deterministic.
+ * Standalone Node test (NOT a Vitest file). Run it with
+ * `node scripts/verify-release-closeout.test.mjs` or
+ * `pnpm verify:release-closeout:test`.
+ *
+ * Two layers:
+ *   - CLI behavior: argument parsing, stage validation, and the offline
+ *     --skip-remote path against the live repository artifacts (the live
+ *     `docs/releases/facts.json`, `docs/releases/current.json`, and
+ *     `REPO_SURFACE_STATUS.json` are read against the current shipped
+ *     version 0.15.0 which is known GREEN). Remote npm / gh paths are not
+ *     exercised here so tests stay deterministic.
+ *   - classifyGithubRelease unit matrix: the pure stage x state classifier
+ *     is imported and asserted in-process, with no GitHub access.
  *
  * Cases:
  *   1. missing --version: exit 2 with usage message
- *   2. invalid --stage: exit 2 with stage-message error
+ *   2. invalid --stage: exit 2, error message lists the valid stages incl. final
  *   3. unknown argument: exit 2
  *   4. "--" sentinel accepted
- *   5. --skip-remote --stage promote on v0.12.13: exit 0 with 0 RED
+ *   5. --skip-remote --stage promote on v0.15.0: exit 0 with 0 RED
  *   6. --json emits parseable JSON with rows and counts
  *   7. --strict flips exit code to 1 when any YELLOW row is present
  *   8. --allow-stamp-pending is accepted and keeps a GREEN facts.json GREEN
+ *   9. --skip-remote --stage final on v0.15.0: exit 0 with 0 RED
+ *  10. classifyGithubRelease stage x state matrix
  */
 
 import { execFileSync } from 'node:child_process';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+import { classifyGithubRelease } from './verify-release-closeout.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SCRIPT = resolve(__dirname, 'verify-release-closeout.mjs');
@@ -64,16 +74,18 @@ try {
     `exit=${noVersion.exitCode} stderr=${JSON.stringify(noVersion.stderr)}`
   );
 
-  // Case 2: invalid stage.
-  const badStage = run(['--version', '0.12.13', '--stage', 'nope']);
+  // Case 2: invalid stage; error must enumerate the valid stages incl. final.
+  const badStage = run(['--version', '0.15.0', '--stage', 'nope']);
   expect(
-    'invalid --stage exits 2',
-    badStage.exitCode === 2 && badStage.stderr.includes('--stage must be one of'),
+    'invalid --stage exits 2 and lists final',
+    badStage.exitCode === 2 &&
+      badStage.stderr.includes('--stage must be one of') &&
+      badStage.stderr.includes('final'),
     `exit=${badStage.exitCode} stderr=${JSON.stringify(badStage.stderr)}`
   );
 
   // Case 3: unknown argument.
-  const unknown = run(['--version', '0.12.13', '--stage', 'promote', '--what']);
+  const unknown = run(['--version', '0.15.0', '--stage', 'promote', '--what']);
   expect(
     'unknown argument exits 2',
     unknown.exitCode === 2 && unknown.stderr.includes('unknown argument'),
@@ -84,7 +96,7 @@ try {
   const sentinel = run([
     '--',
     '--version',
-    '0.12.13',
+    '0.15.0',
     '--stage',
     'promote',
     '--skip-remote',
@@ -93,14 +105,14 @@ try {
   ]);
   expect(
     '"--" sentinel is accepted',
-    sentinel.exitCode === 0 && sentinel.stdout.includes('version=0.12.13 stage=promote'),
+    sentinel.exitCode === 0 && sentinel.stdout.includes('version=0.15.0 stage=promote'),
     `exit=${sentinel.exitCode} stdout=${JSON.stringify(sentinel.stdout.slice(0, 200))}`
   );
 
-  // Case 5: --skip-remote --stage promote on v0.12.13: exit 0, zero RED.
+  // Case 5: --skip-remote --stage promote on v0.15.0: exit 0, zero RED.
   const offline = run([
     '--version',
-    '0.12.13',
+    '0.15.0',
     '--stage',
     'promote',
     '--skip-remote',
@@ -108,7 +120,7 @@ try {
     '2000',
   ]);
   expect(
-    '--skip-remote on v0.12.13 exits 0 with zero RED',
+    '--skip-remote --stage promote on v0.15.0 exits 0 with zero RED',
     offline.exitCode === 0 &&
       offline.stdout.includes('0 RED') &&
       offline.stdout.includes('[GREEN] git-tag'),
@@ -118,7 +130,7 @@ try {
   // Case 6: --json emits valid JSON with rows and counts.
   const jsonRun = run([
     '--version',
-    '0.12.13',
+    '0.15.0',
     '--stage',
     'promote',
     '--skip-remote',
@@ -136,7 +148,7 @@ try {
     '--json emits parseable JSON with rows and counts',
     jsonRun.exitCode === 0 &&
       parsed &&
-      parsed.version === '0.12.13' &&
+      parsed.version === '0.15.0' &&
       parsed.stage === 'promote' &&
       Array.isArray(parsed.rows) &&
       parsed.rows.length >= 4 &&
@@ -150,7 +162,7 @@ try {
   // --strict must produce a nonzero exit.
   const strict = run([
     '--version',
-    '0.12.13',
+    '0.15.0',
     '--stage',
     'promote',
     '--skip-remote',
@@ -169,7 +181,7 @@ try {
   // dist_tag=latest, so the facts.json row stays GREEN either way.
   const allowPending = run([
     '--version',
-    '0.12.13',
+    '0.15.0',
     '--stage',
     'promote',
     '--skip-remote',
@@ -184,6 +196,65 @@ try {
       allowPending.stdout.includes('0 RED'),
     `exit=${allowPending.exitCode} stdout=${JSON.stringify(allowPending.stdout)}`
   );
+
+  // Case 9: --skip-remote --stage final on v0.15.0: exit 0, zero RED.
+  // The github-release row is skipped (YELLOW) offline; facts.json and
+  // current.json must still be GREEN against the live 0.15.0 artifacts.
+  const finalStage = run([
+    '--version',
+    '0.15.0',
+    '--stage',
+    'final',
+    '--skip-remote',
+    '--max-updated-age-hours',
+    '2000',
+  ]);
+  expect(
+    '--skip-remote --stage final on v0.15.0 exits 0 with zero RED',
+    finalStage.exitCode === 0 &&
+      finalStage.stdout.includes('version=0.15.0 stage=final') &&
+      finalStage.stdout.includes('0 RED') &&
+      finalStage.stdout.includes('[GREEN] facts.json') &&
+      finalStage.stdout.includes('[GREEN] current.json'),
+    `exit=${finalStage.exitCode} stdout=${JSON.stringify(finalStage.stdout)}`
+  );
+
+  // Case 10: classifyGithubRelease stage x state matrix (pure, no network).
+  const DRAFT = { tagName: 'v0.15.0', isDraft: true, isPrerelease: false };
+  const PRERELEASE = { tagName: 'v0.15.0', isDraft: false, isPrerelease: true };
+  const FINALIZED = { tagName: 'v0.15.0', isDraft: false, isPrerelease: false };
+
+  const matrix = [
+    ['publish', DRAFT, 'GREEN'],
+    ['publish', PRERELEASE, 'GREEN'],
+    ['publish', FINALIZED, 'RED'],
+    ['promote', DRAFT, 'GREEN'],
+    ['promote', PRERELEASE, 'GREEN'],
+    ['promote', FINALIZED, 'YELLOW'],
+    ['final', DRAFT, 'RED'],
+    ['final', PRERELEASE, 'RED'],
+    ['final', FINALIZED, 'GREEN'],
+    ['mode1', DRAFT, 'RED'],
+    ['mode1', PRERELEASE, 'RED'],
+    ['mode1', FINALIZED, 'GREEN'],
+  ];
+
+  for (const [stage, release, wantStatus] of matrix) {
+    const state = release.isDraft
+      ? 'draft'
+      : release.isPrerelease
+        ? 'prerelease'
+        : 'finalized';
+    const verdict = classifyGithubRelease(stage, release);
+    expect(
+      `classifyGithubRelease(${stage}, ${state}) -> ${wantStatus}`,
+      verdict &&
+        verdict.status === wantStatus &&
+        typeof verdict.detail === 'string' &&
+        verdict.detail.length > 0,
+      `got=${JSON.stringify(verdict)}`
+    );
+  }
 } catch (err) {
   failures += 1;
   console.error('FAIL unexpected error:', err && err.stack ? err.stack : err);


### PR DESCRIPTION
## Summary

Split the release-state stages in the post-release truth reconciler so that Mode 2 closeout reflects that the GitHub Release is finalized after promotion, not before. No protocol surface change.

## Scope

Tooling, its test, and release docs only. No wire, schema, signing, CLI, or runtime behavior change; no published-package change; no workflow change; no release-state JSON change; no dependency change. Public-surface sentinels are unchanged.