### PR TITLE
build: audit-exception expiry release gate

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -141,6 +141,10 @@ main.
 
 1. All PRs for this release are merged to main
 2. No WIP commits in main
+3. Dependency audit exceptions are healthy: `node scripts/check-audit-exception-expiry.mjs` reports no expired or invalid entries. Resolve or renew any flagged exception in `security/audit-allowlist.json` before tagging (`--strict` also fails on entries past the renewal-review window).
+4. The NPM automation token is healthy and not near expiry (see "Pre-Release Token Verification" under npm Token Lifecycle); rotate it if needed.
+5. Provenance is retained: npm publish runs under OIDC Trusted Publishing with SLSA build provenance. Do not pass `--provenance false` for first-party packages outside the new-package bootstrap step.
+6. The release tag will be an SSH-signed annotated tag (see step 6).
 
 ## Release Steps
 
@@ -173,6 +177,7 @@ pnpm test
 ./scripts/guard.sh
 ./scripts/check-publish-list.sh
 node scripts/check-manifest-topo.mjs
+node scripts/check-audit-exception-expiry.mjs
 pnpm version:check
 ```
 
@@ -196,11 +201,14 @@ gh pr create --title "chore(release): vX.Y.Z" --body "Release vX.Y.Z"
 
 ### 6. After PR Merge
 
-Tag the release from main:
+Tag the release from main with an SSH-signed annotated tag. Configure signing
+once with `git config gpg.format ssh` and `git config user.signingkey
+<path-to-signing-key>`:
 
 ```bash
 git checkout main && git pull --ff-only origin main
-git tag vX.Y.Z
+git tag -s vX.Y.Z -m "vX.Y.Z"
+git tag -v vX.Y.Z         # verify the signature before pushing
 git push origin vX.Y.Z
 ```
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -141,7 +141,7 @@ main.
 
 1. All PRs for this release are merged to main
 2. No WIP commits in main
-3. Dependency audit exceptions are healthy: `node scripts/check-audit-exception-expiry.mjs` reports no expired or invalid entries. Resolve or renew any flagged exception in `security/audit-allowlist.json` before tagging (`--strict` also fails on entries past the renewal-review window).
+3. Dependency audit exceptions are release-ready: `node scripts/check-audit-exception-expiry.mjs --strict` exits 0. Resolve expired, invalid, expiring-soon, or review-stale exceptions in `security/audit-allowlist.json` before tagging.
 4. The NPM automation token is healthy and not near expiry (see "Pre-Release Token Verification" under npm Token Lifecycle); rotate it if needed.
 5. Provenance is retained: npm publish runs under OIDC Trusted Publishing with SLSA build provenance. Do not pass `--provenance false` for first-party packages outside the new-package bootstrap step.
 6. The release tag will be an SSH-signed annotated tag (see step 6).
@@ -177,7 +177,7 @@ pnpm test
 ./scripts/guard.sh
 ./scripts/check-publish-list.sh
 node scripts/check-manifest-topo.mjs
-node scripts/check-audit-exception-expiry.mjs
+node scripts/check-audit-exception-expiry.mjs --strict
 pnpm version:check
 ```
 

--- a/scripts/check-audit-exception-expiry.mjs
+++ b/scripts/check-audit-exception-expiry.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * Audit-exception expiry / review check.
+ *
+ * A focused, offline, network-free release-hygiene gate over the dependency
+ * audit allowlist (`security/audit-allowlist.json`). It reuses the shared
+ * `parseAllowlist()` validator from `scripts/audit-gate-lib.mjs` (the same
+ * logic `scripts/audit-gate.mjs` applies during the full audit) and reports
+ * the allowlist's expiry / renewal-review health, without running `pnpm
+ * audit`. Run it during release-prep so no audit exception silently expires
+ * or goes past its renewal-review window across a release.
+ *
+ * Verdict:
+ *   RED    - one or more entries are expired or invalid (fail closed).
+ *   YELLOW - one or more entries are expiring soon (<= 14 days) or were
+ *            added more than 30 days ago without a reviewed_at date.
+ *   GREEN  - no expired / invalid entries and no warnings.
+ *
+ * Exit codes:
+ *   0  GREEN, or YELLOW without --strict.
+ *   1  RED, or YELLOW with --strict.
+ *   2  Usage error.
+ *
+ * Flags:
+ *   --strict   Pass strict mode to parseAllowlist (entries older than the
+ *              60-day review window without reviewed_at are rejected as
+ *              invalid) and fail (exit 1) on any YELLOW warning.
+ *   --json     Emit the evaluation result as JSON.
+ *
+ * Usage:
+ *   node scripts/check-audit-exception-expiry.mjs
+ *   node scripts/check-audit-exception-expiry.mjs --strict
+ *   node scripts/check-audit-exception-expiry.mjs --json
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { parseAllowlist, EXPIRY_WARNING_DAYS } from './audit-gate-lib.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+const ALLOWLIST_PATH = resolve(REPO_ROOT, 'security/audit-allowlist.json');
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+/**
+ * Evaluate the audit allowlist's expiry / review health.
+ *
+ * Pure helper: it does not read the filesystem, env, or argv, and does not
+ * print or exit. It delegates all validation to parseAllowlist() and maps
+ * the result to a GREEN / YELLOW / RED verdict, so the verdict can be
+ * unit-asserted deterministically with a fixed `now`.
+ *
+ * @param {object} raw - Parsed allowlist JSON (the { allowlist: [...] } shape).
+ * @param {Date} [now] - Reference date (defaults to current time).
+ * @param {{ strict?: boolean }} [opts] - strict passes through to parseAllowlist.
+ * @returns {{ status: 'GREEN'|'YELLOW'|'RED', expired: string[], invalid: string[],
+ *             warnings: string[], active: Array<object>, counts: object }}
+ */
+export function evaluateAllowlistExpiry(raw, now = new Date(), opts = {}) {
+  const strict = opts.strict === true;
+  const { active, expired, invalid, warnings } = parseAllowlist(raw, now, { strict });
+
+  // Display-only view of the validated active entries with days-to-expiry.
+  // parseAllowlist has already validated expires_at as strict YYYY-MM-DD, so
+  // these dates parse cleanly.
+  const activeEntries = [];
+  for (const entry of active.values()) {
+    const expiry = new Date(entry.expires_at + 'T00:00:00Z');
+    const daysToExpiry = Math.ceil((expiry - now) / MS_PER_DAY);
+    activeEntries.push({
+      advisory_id: entry.advisory_id,
+      scope: entry.scope,
+      expires_at: entry.expires_at,
+      days_to_expiry: daysToExpiry,
+      reviewed_at: entry.reviewed_at || null,
+    });
+  }
+  activeEntries.sort((a, b) => a.days_to_expiry - b.days_to_expiry);
+
+  let status = 'GREEN';
+  if (expired.length > 0 || invalid.length > 0) status = 'RED';
+  else if (warnings.length > 0) status = 'YELLOW';
+
+  return {
+    status,
+    expired,
+    invalid,
+    warnings,
+    active: activeEntries,
+    counts: {
+      active: activeEntries.length,
+      expired: expired.length,
+      invalid: invalid.length,
+      warnings: warnings.length,
+    },
+  };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  let strict = false;
+  let jsonOutput = false;
+
+  for (const a of args) {
+    if (a === '--') continue;
+    else if (a === '--strict') strict = true;
+    else if (a === '--json') jsonOutput = true;
+    else {
+      process.stderr.write(`unknown argument: ${a}\n`);
+      process.stderr.write('usage: check-audit-exception-expiry.mjs [--strict] [--json]\n');
+      process.exit(2);
+    }
+  }
+
+  let raw;
+  try {
+    raw = JSON.parse(readFileSync(ALLOWLIST_PATH, 'utf-8'));
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      // No allowlist file means no exceptions to expire.
+      if (jsonOutput) {
+        process.stdout.write(
+          JSON.stringify(
+            { status: 'GREEN', expired: [], invalid: [], warnings: [], active: [], counts: { active: 0, expired: 0, invalid: 0, warnings: 0 } },
+            null,
+            2
+          ) + '\n'
+        );
+      } else {
+        process.stdout.write('check-audit-exception-expiry: no allowlist file; no exceptions to check\n');
+        process.stdout.write('summary: GREEN\n');
+      }
+      process.exit(0);
+    }
+    process.stderr.write(`error: could not read ${ALLOWLIST_PATH}: ${err.message}\n`);
+    process.exit(1);
+  }
+
+  const result = evaluateAllowlistExpiry(raw, new Date(), { strict });
+
+  if (jsonOutput) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+  } else {
+    process.stdout.write(
+      `check-audit-exception-expiry: ${result.counts.active} active / ${result.counts.expired} expired / ${result.counts.invalid} invalid / ${result.counts.warnings} warning(s) (strict=${strict})\n`
+    );
+    for (const id of result.expired) {
+      process.stdout.write(`  [RED] expired: ${id}\n`);
+    }
+    for (const desc of result.invalid) {
+      process.stdout.write(`  [RED] invalid: ${desc}\n`);
+    }
+    for (const w of result.warnings) {
+      process.stdout.write(`  [YELLOW] ${w}\n`);
+    }
+    if (result.active.length > 0) {
+      process.stdout.write(`  active exceptions (warn at <= ${EXPIRY_WARNING_DAYS} days to expiry):\n`);
+      for (const e of result.active) {
+        process.stdout.write(
+          `    - ${e.advisory_id} scope=${e.scope} expires ${e.expires_at} in ${e.days_to_expiry}d reviewed ${e.reviewed_at || '(none)'}\n`
+        );
+      }
+    }
+    process.stdout.write(`summary: ${result.status}\n`);
+  }
+
+  if (result.status === 'RED') process.exit(1);
+  if (strict && result.status === 'YELLOW') process.exit(1);
+  process.exit(0);
+}
+
+// Main guard: importing this module (for example to unit-test
+// evaluateAllowlistExpiry) must not parse argv, read the allowlist, or exit.
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : '';
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/check-audit-exception-expiry.mjs
+++ b/scripts/check-audit-exception-expiry.mjs
@@ -22,15 +22,20 @@
  *   2  Usage error.
  *
  * Flags:
- *   --strict   Pass strict mode to parseAllowlist (entries older than the
- *              60-day review window without reviewed_at are rejected as
- *              invalid) and fail (exit 1) on any YELLOW warning.
- *   --json     Emit the evaluation result as JSON.
+ *   --strict           Pass strict mode to parseAllowlist (entries older
+ *                      than the 60-day review window without reviewed_at are
+ *                      rejected as invalid) and fail (exit 1) on any YELLOW
+ *                      warning. This is the release-gate mode.
+ *   --json             Emit the evaluation result as JSON.
+ *   --allowlist <path> Read the allowlist from <path> instead of the default
+ *                      security/audit-allowlist.json (relative paths resolve
+ *                      from the current working directory). Useful for tests.
  *
  * Usage:
  *   node scripts/check-audit-exception-expiry.mjs
  *   node scripts/check-audit-exception-expiry.mjs --strict
  *   node scripts/check-audit-exception-expiry.mjs --json
+ *   node scripts/check-audit-exception-expiry.mjs --allowlist <path> --strict
  */
 
 import { readFileSync } from 'node:fs';
@@ -103,21 +108,32 @@ function main() {
   const args = process.argv.slice(2);
   let strict = false;
   let jsonOutput = false;
+  let allowlistPath = ALLOWLIST_PATH;
 
-  for (const a of args) {
+  const usage = 'usage: check-audit-exception-expiry.mjs [--strict] [--json] [--allowlist <path>]\n';
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
     if (a === '--') continue;
     else if (a === '--strict') strict = true;
     else if (a === '--json') jsonOutput = true;
-    else {
+    else if (a === '--allowlist') {
+      if (!args[i + 1]) {
+        process.stderr.write('error: --allowlist requires a path\n');
+        process.stderr.write(usage);
+        process.exit(2);
+      }
+      allowlistPath = resolve(process.cwd(), args[i + 1]);
+      i += 1;
+    } else {
       process.stderr.write(`unknown argument: ${a}\n`);
-      process.stderr.write('usage: check-audit-exception-expiry.mjs [--strict] [--json]\n');
+      process.stderr.write(usage);
       process.exit(2);
     }
   }
 
   let raw;
   try {
-    raw = JSON.parse(readFileSync(ALLOWLIST_PATH, 'utf-8'));
+    raw = JSON.parse(readFileSync(allowlistPath, 'utf-8'));
   } catch (err) {
     if (err && err.code === 'ENOENT') {
       // No allowlist file means no exceptions to expire.
@@ -135,7 +151,7 @@ function main() {
       }
       process.exit(0);
     }
-    process.stderr.write(`error: could not read ${ALLOWLIST_PATH}: ${err.message}\n`);
+    process.stderr.write(`error: could not read ${allowlistPath}: ${err.message}\n`);
     process.exit(1);
   }
 

--- a/tests/scripts/check-audit-exception-expiry.test.ts
+++ b/tests/scripts/check-audit-exception-expiry.test.ts
@@ -8,11 +8,20 @@
  * the verdict mapping, not the validator internals.
  */
 
-import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { afterAll, beforeAll, describe, it, expect } from 'vitest';
 
 import { evaluateAllowlistExpiry } from '../../scripts/check-audit-exception-expiry.mjs';
 
-// Fixed reference date for every case.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = resolve(__dirname, '..', '..', 'scripts', 'check-audit-exception-expiry.mjs');
+
+// Fixed reference date for every pure-helper case.
 const NOW = new Date('2026-06-06T00:00:00Z');
 
 let seq = 0;
@@ -112,5 +121,111 @@ describe('evaluateAllowlistExpiry', () => {
       '2026-07-01',
       '2026-08-20',
     ]);
+  });
+});
+
+describe('check-audit-exception-expiry CLI', () => {
+  let dir: string;
+  let healthy: string;
+  let warning: string;
+
+  // Fixture dates are computed from the real current date because the CLI
+  // uses new Date() at runtime; the synthetic files keep the CLI tests off
+  // the live security/audit-allowlist.json.
+  function ymd(offsetDays: number) {
+    return new Date(Date.now() + offsetDays * 86400000).toISOString().slice(0, 10);
+  }
+
+  function entry(overrides: Record<string, unknown> = {}) {
+    seq += 1;
+    return {
+      advisory_id: `GHSA-cli-${String(seq).padStart(4, '0')}-abcd`,
+      package: 'vulnerable',
+      reason: 'Transitive dev dependency, no exposure in our usage',
+      why_not_exploitable:
+        'The vulnerable code path requires attacker-supplied input that never reaches this transitive dev dependency in our usage',
+      where_used: 'Root devDependency chain: parent@1.0.0 -> vulnerable@2.0.0',
+      expires_at: ymd(60),
+      remediation: 'Upstream fix tracked; bump when released',
+      issue_url: 'https://github.com/peacprotocol/peac/issues/1',
+      scope: 'dev',
+      dependency_chain: ['parent@1.0.0', 'vulnerable@2.0.0'],
+      verified_by: 'pnpm why vulnerable',
+      owner: 'maintainer',
+      added_at: ymd(-5),
+      reviewed_at: ymd(-5),
+      ...overrides,
+    };
+  }
+
+  function runCli(args: string[]) {
+    let stdout = '';
+    let exitCode = 0;
+    try {
+      stdout = execFileSync('node', [SCRIPT, ...args], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        encoding: 'utf8',
+      });
+    } catch (err) {
+      const e = err as { status?: number; stdout?: Buffer | string };
+      exitCode = e.status ?? -1;
+      stdout = (e.stdout || '').toString();
+    }
+    return { stdout, exitCode };
+  }
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'peac-audit-allowlist-'));
+    healthy = join(dir, 'healthy.json');
+    warning = join(dir, 'warning.json');
+    writeFileSync(healthy, JSON.stringify({ allowlist: [entry()] }));
+    writeFileSync(warning, JSON.stringify({ allowlist: [entry({ expires_at: ymd(5) })] }));
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('--allowlist healthy --json exits 0 with GREEN JSON', () => {
+    const r = runCli(['--allowlist', healthy, '--json']);
+    expect(r.exitCode).toBe(0);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.status).toBe('GREEN');
+  });
+
+  it('--allowlist warning exits 0 with YELLOW (default mode)', () => {
+    const r = runCli(['--allowlist', warning]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('summary: YELLOW');
+  });
+
+  it('--allowlist warning --strict exits 1', () => {
+    const r = runCli(['--allowlist', warning, '--strict']);
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toContain('summary: YELLOW');
+  });
+
+  it('--allowlist with no path exits 2', () => {
+    expect(runCli(['--allowlist']).exitCode).toBe(2);
+  });
+
+  it('unknown argument exits 2', () => {
+    expect(runCli(['--nope']).exitCode).toBe(2);
+  });
+
+  it('importing the module does not execute main()', () => {
+    const url = JSON.stringify(pathToFileURL(SCRIPT).href);
+    const out = execFileSync(
+      'node',
+      [
+        '--input-type=module',
+        '-e',
+        `import(${url}).then((m) => process.stdout.write(typeof m.evaluateAllowlistExpiry));`,
+      ],
+      { encoding: 'utf8' }
+    );
+    // If main() ran on import it would print the report and exit; a clean
+    // "function" with no summary line proves the main guard holds.
+    expect(out).toBe('function');
   });
 });

--- a/tests/scripts/check-audit-exception-expiry.test.ts
+++ b/tests/scripts/check-audit-exception-expiry.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for scripts/check-audit-exception-expiry.mjs.
+ *
+ * Exercises the pure evaluateAllowlistExpiry() helper with synthetic
+ * allowlist data and a fixed reference date, so the GREEN / YELLOW / RED
+ * verdict is deterministic and clock-independent. The helper delegates all
+ * validation to parseAllowlist() (no reimplementation); these tests assert
+ * the verdict mapping, not the validator internals.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { evaluateAllowlistExpiry } from '../../scripts/check-audit-exception-expiry.mjs';
+
+// Fixed reference date for every case.
+const NOW = new Date('2026-06-06T00:00:00Z');
+
+let seq = 0;
+
+function makeEntry(overrides: Record<string, unknown> = {}) {
+  seq += 1;
+  return {
+    advisory_id: `GHSA-test-${String(seq).padStart(4, '0')}-abcd`,
+    package: 'vulnerable',
+    reason: 'Transitive dev dependency, no exposure in our usage',
+    why_not_exploitable:
+      'The vulnerable code path requires attacker-supplied input that never reaches this transitive dev dependency in our usage',
+    where_used: 'Root devDependency chain: parent@1.0.0 -> vulnerable@2.0.0',
+    expires_at: '2026-08-01',
+    remediation: 'Upstream fix tracked; bump when released',
+    issue_url: 'https://github.com/peacprotocol/peac/issues/1',
+    scope: 'dev',
+    dependency_chain: ['parent@1.0.0', 'vulnerable@2.0.0'],
+    verified_by: 'pnpm why vulnerable',
+    owner: 'maintainer',
+    added_at: '2026-06-01',
+    ...overrides,
+  };
+}
+
+function withAllowlist(entries: Array<Record<string, unknown>>) {
+  return { allowlist: entries };
+}
+
+describe('evaluateAllowlistExpiry', () => {
+  it('returns GREEN for a healthy allowlist', () => {
+    const raw = withAllowlist([
+      makeEntry({ expires_at: '2026-08-01', added_at: '2026-06-01', reviewed_at: '2026-06-01' }),
+    ]);
+    const result = evaluateAllowlistExpiry(raw, NOW);
+    expect(result.status).toBe('GREEN');
+    expect(result.counts.active).toBe(1);
+    expect(result.counts.warnings).toBe(0);
+  });
+
+  it('returns GREEN for an empty allowlist', () => {
+    expect(evaluateAllowlistExpiry(withAllowlist([]), NOW).status).toBe('GREEN');
+  });
+
+  it('returns GREEN when there is no allowlist array', () => {
+    expect(evaluateAllowlistExpiry({}, NOW).status).toBe('GREEN');
+  });
+
+  it('returns RED on an expired entry', () => {
+    const raw = withAllowlist([makeEntry({ expires_at: '2026-06-01' })]);
+    const result = evaluateAllowlistExpiry(raw, NOW);
+    expect(result.status).toBe('RED');
+    expect(result.expired.length).toBe(1);
+  });
+
+  it('returns RED on an invalid entry (missing required field)', () => {
+    const raw = withAllowlist([makeEntry({ package: undefined })]);
+    const result = evaluateAllowlistExpiry(raw, NOW);
+    expect(result.status).toBe('RED');
+    expect(result.invalid.length).toBe(1);
+  });
+
+  it('returns YELLOW for an entry expiring within the warning window', () => {
+    const raw = withAllowlist([
+      makeEntry({ expires_at: '2026-06-15', added_at: '2026-06-01', reviewed_at: '2026-06-01' }),
+    ]);
+    const result = evaluateAllowlistExpiry(raw, NOW);
+    expect(result.status).toBe('YELLOW');
+    expect(result.counts.warnings).toBe(1);
+    expect(result.counts.active).toBe(1);
+  });
+
+  it('returns YELLOW for an entry past the review window without reviewed_at', () => {
+    const raw = withAllowlist([makeEntry({ added_at: '2026-04-20' })]); // 47 days before NOW
+    const result = evaluateAllowlistExpiry(raw, NOW);
+    expect(result.status).toBe('YELLOW');
+    expect(result.counts.warnings).toBe(1);
+  });
+
+  it('fails closed: a long-unreviewed entry becomes RED under strict', () => {
+    // Added more than the 60-day review window before NOW, no reviewed_at.
+    const raw = withAllowlist([makeEntry({ added_at: '2026-03-01' })]);
+    const lenient = evaluateAllowlistExpiry(raw, NOW, { strict: false });
+    expect(lenient.status).toBe('YELLOW');
+    const strict = evaluateAllowlistExpiry(raw, NOW, { strict: true });
+    expect(strict.status).toBe('RED');
+    expect(strict.invalid.length).toBe(1);
+  });
+
+  it('sorts active entries by ascending days-to-expiry', () => {
+    const raw = withAllowlist([
+      makeEntry({ expires_at: '2026-08-20', reviewed_at: '2026-06-01' }),
+      makeEntry({ expires_at: '2026-07-01', reviewed_at: '2026-06-01' }),
+    ]);
+    const result = evaluateAllowlistExpiry(raw, NOW);
+    expect(result.active.map((e: { expires_at: string }) => e.expires_at)).toEqual([
+      '2026-07-01',
+      '2026-08-20',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Add a focused, offline release-hygiene gate over the dependency audit allowlist so no audit exception silently expires or goes past its renewal-review window across a release. No protocol surface change.

## Scope

Tooling, its test, and release docs only. No wire, schema, signing, CLI, or runtime behavior change; no published-package change; no workflow change; no dependency change. The audit allowlist data (`security/audit-allowlist.json`) is not modified. Public-surface sentinels are unchanged.