### PR TITLE
build: OTel version-currency gate

### DIFF
--- a/packages/telemetry-otel/src/index.ts
+++ b/packages/telemetry-otel/src/index.ts
@@ -24,7 +24,8 @@
  * ```
  */
 
-export const TELEMETRY_OTEL_VERSION = '0.9.22';
+// Package version (single source of truth in ./version.ts).
+export { TELEMETRY_OTEL_VERSION } from './version.js';
 
 // Main provider
 export { createOtelProvider, type OtelProviderOptions } from './provider.js';

--- a/packages/telemetry-otel/src/privacy.ts
+++ b/packages/telemetry-otel/src/privacy.ts
@@ -9,7 +9,12 @@ import { hashIdentifier } from '@peac/privacy';
 import type { TelemetryConfig, PrivacyMode } from '@peac/telemetry';
 
 /**
- * Default salt for hashing (should be configured per deployment)
+ * Default salt for hashing (should be configured per deployment).
+ *
+ * Stable hash seed retained for backward-compatible pseudonymization. Do
+ * NOT update this when the package version changes; doing so would alter
+ * every hashed identifier. The embedded "v0.9.22" is a fixed seed string,
+ * not a version to track.
  */
 const DEFAULT_SALT = 'peac-telemetry-v0.9.22';
 

--- a/packages/telemetry-otel/src/provider.ts
+++ b/packages/telemetry-otel/src/provider.ts
@@ -15,6 +15,7 @@ import type {
 } from '@peac/telemetry';
 import { PEAC_ATTRS, PEAC_EVENTS } from '@peac/telemetry';
 import { hashIssuer, hashKid } from './privacy.js';
+import { TELEMETRY_OTEL_VERSION } from './version.js';
 import {
   createMetrics,
   recordReceiptIssued,
@@ -38,15 +39,17 @@ export interface OtelProviderOptions extends TelemetryConfig {
   meterName?: string;
 
   /**
-   * Version for tracer/meter (defaults to 0.9.22)
+   * Version for tracer/meter (defaults to the @peac/telemetry-otel package version)
    */
   version?: string;
 }
 
 /**
- * PEAC telemetry version
+ * PEAC telemetry version emitted on spans/metrics as peac.version. Derived
+ * from the single package-version source (./version.ts), not hardcoded, so
+ * it cannot drift from the package version.
  */
-const TELEMETRY_VERSION = '0.9.22';
+const TELEMETRY_VERSION = TELEMETRY_OTEL_VERSION;
 
 /**
  * Default tracer/meter name

--- a/packages/telemetry-otel/src/version.ts
+++ b/packages/telemetry-otel/src/version.ts
@@ -1,0 +1,8 @@
+/**
+ * Single source of truth for the @peac/telemetry-otel package version.
+ *
+ * Tracks the PEAC package / release version (docs/releases/current.json),
+ * NOT the OpenTelemetry API/SDK version. Kept in sync by
+ * scripts/verify-doc-version-currency.mjs.
+ */
+export const TELEMETRY_OTEL_VERSION = '0.15.0';

--- a/packages/telemetry-otel/tests/import-smoke.test.ts
+++ b/packages/telemetry-otel/tests/import-smoke.test.ts
@@ -42,6 +42,14 @@ describe('import without SDK', () => {
     expect(typeof mod.TELEMETRY_OTEL_VERSION).toBe('string');
   });
 
+  it('TELEMETRY_OTEL_VERSION equals the package version', async () => {
+    const mod = await import('../src/index.js');
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const pkg = JSON.parse(readFileSync(resolve(__dirname, '../package.json'), 'utf-8'));
+    expect(mod.TELEMETRY_OTEL_VERSION).toBe(pkg.version);
+  });
+
   it('createOtelProvider works with no-op API (no SDK registered)', async () => {
     // No SDK setup -- the API provides no-op tracer/meter by default
     const { createOtelProvider } = await import('../src/index.js');

--- a/scripts/verify-doc-version-currency.mjs
+++ b/scripts/verify-doc-version-currency.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+/**
+ * Version-currency gate for source surfaces.
+ *
+ * Some version-bearing constants and pins are stamped by hand at release
+ * time and are not covered by `pnpm version:bump` or the release verifier
+ * (for example the @peac/telemetry-otel package-version constant and the
+ * smithery.yaml mcp-server pin). When a release moves forward those sites
+ * silently drift. This gate reads the current release version from
+ * `docs/releases/current.json` (the source of truth) and fails if any
+ * enumerated source site does not match it. It produces actionable
+ * file:line output and is deterministic / network-free.
+ *
+ * This gate is deliberately narrow: it checks SOURCE constants and pins, not
+ * markdown banners. Stale version banners in evergreen docs are already
+ * gated by tests/tooling/docs-version-banner-truth.test.ts, and this gate
+ * does not duplicate that.
+ *
+ * Exit codes:
+ *   0  Every enumerated site matches the current release version.
+ *   1  At least one site is stale or its pattern was not found (fail closed).
+ *   2  Usage error.
+ *
+ * Flags:
+ *   --json          Emit the result as JSON.
+ *   --root <dir>    Resolve the source-of-truth file and all sites under
+ *                   <dir> instead of the repository root (relative paths
+ *                   resolve from the current working directory). Used by
+ *                   tests to drive a synthetic tree.
+ *
+ * Usage:
+ *   node scripts/verify-doc-version-currency.mjs
+ *   node scripts/verify-doc-version-currency.mjs --json
+ *   node scripts/verify-doc-version-currency.mjs --root <dir>
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+
+/**
+ * Enumerated version-bearing source sites that must equal the current
+ * release version. Each pattern's first capture group is the version.
+ */
+export const SITES = [
+  {
+    label: 'TELEMETRY_OTEL_VERSION',
+    file: 'packages/telemetry-otel/src/version.ts',
+    pattern: /TELEMETRY_OTEL_VERSION\s*=\s*['"]([^'"]+)['"]/,
+  },
+  {
+    label: 'smithery mcp-server pin',
+    file: 'packages/mcp-server/smithery.yaml',
+    pattern: /@peac\/mcp-server@(\d+\.\d+\.\d+)/,
+  },
+];
+
+/**
+ * Anti-drift guards: patterns that must NOT appear. These catch a hardcoded
+ * version literal where the value should derive from the single source
+ * (./version.ts) instead, so the same drift class cannot reappear.
+ */
+export const FORBIDDEN = [
+  {
+    label: 'provider.ts hardcoded TELEMETRY_VERSION literal',
+    file: 'packages/telemetry-otel/src/provider.ts',
+    pattern: /TELEMETRY_VERSION\s*=\s*['"]\d+\.\d+\.\d+['"]/,
+    message:
+      'derive the telemetry version from TELEMETRY_OTEL_VERSION (./version.js); do not hardcode a version literal',
+  },
+];
+
+/**
+ * Check a single site's content against the expected version.
+ *
+ * Pure: no filesystem, env, stdout, or exit. The caller reads the file and
+ * the source of truth, so this maps deterministically for unit tests.
+ *
+ * @param {string} content - The file content to scan.
+ * @param {RegExp} pattern - Pattern whose first capture group is the version.
+ * @param {string} expected - The expected (current) version.
+ * @returns {{ ok: boolean, value: string|null, reason: string|null }}
+ */
+export function checkSite(content, pattern, expected) {
+  const m = content.match(pattern);
+  if (!m) {
+    return { ok: false, value: null, reason: 'version pattern not found' };
+  }
+  const value = m[1];
+  if (value === expected) {
+    return { ok: true, value, reason: null };
+  }
+  return { ok: false, value, reason: `found ${value}, expected ${expected}` };
+}
+
+/**
+ * Check that a forbidden anti-drift pattern is absent from content.
+ *
+ * Pure: no filesystem, env, stdout, or exit. Returns ok=true when the
+ * forbidden pattern is NOT present.
+ *
+ * @param {string} content - The file content to scan.
+ * @param {RegExp} pattern - Pattern that must not match.
+ * @returns {{ ok: boolean }}
+ */
+export function checkForbidden(content, pattern) {
+  return { ok: !pattern.test(content) };
+}
+
+function lineOf(content, pattern) {
+  const m = content.match(pattern);
+  if (!m || m.index === undefined) return 0;
+  return content.slice(0, m.index).split('\n').length;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  let jsonOutput = false;
+  let root = REPO_ROOT;
+
+  const usage = 'usage: verify-doc-version-currency.mjs [--json] [--root <dir>]\n';
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--') continue;
+    else if (a === '--json') jsonOutput = true;
+    else if (a === '--root') {
+      if (!args[i + 1]) {
+        process.stderr.write('error: --root requires a path\n');
+        process.stderr.write(usage);
+        process.exit(2);
+      }
+      root = resolve(process.cwd(), args[i + 1]);
+      i += 1;
+    } else {
+      process.stderr.write(`unknown argument: ${a}\n`);
+      process.stderr.write(usage);
+      process.exit(2);
+    }
+  }
+
+  let expected;
+  try {
+    const current = JSON.parse(readFileSync(resolve(root, 'docs/releases/current.json'), 'utf-8'));
+    expected = current.version;
+  } catch (err) {
+    process.stderr.write(`error: could not read docs/releases/current.json: ${err.message}\n`);
+    process.exit(1);
+  }
+  if (!expected) {
+    process.stderr.write('error: docs/releases/current.json has no version\n');
+    process.exit(1);
+  }
+
+  const rows = [];
+  for (const site of SITES) {
+    const path = resolve(root, site.file);
+    let content;
+    try {
+      content = readFileSync(path, 'utf-8');
+    } catch (err) {
+      rows.push({
+        label: site.label,
+        file: site.file,
+        line: 0,
+        ok: false,
+        value: null,
+        reason: `unreadable: ${err.message}`,
+      });
+      continue;
+    }
+    const result = checkSite(content, site.pattern, expected);
+    rows.push({
+      label: site.label,
+      file: site.file,
+      line: result.value === null ? 0 : lineOf(content, site.pattern),
+      ok: result.ok,
+      value: result.value,
+      reason: result.reason,
+    });
+  }
+
+  for (const guard of FORBIDDEN) {
+    const path = resolve(root, guard.file);
+    let content;
+    try {
+      content = readFileSync(path, 'utf-8');
+    } catch (err) {
+      rows.push({
+        label: guard.label,
+        file: guard.file,
+        line: 0,
+        ok: false,
+        value: null,
+        reason: `unreadable: ${err.message}`,
+      });
+      continue;
+    }
+    const result = checkForbidden(content, guard.pattern);
+    rows.push({
+      label: guard.label,
+      file: guard.file,
+      line: result.ok ? 0 : lineOf(content, guard.pattern),
+      ok: result.ok,
+      value: null,
+      reason: result.ok ? null : guard.message,
+    });
+  }
+
+  const failed = rows.filter((r) => !r.ok);
+
+  if (jsonOutput) {
+    process.stdout.write(
+      JSON.stringify({ expected, rows, ok: failed.length === 0 }, null, 2) + '\n'
+    );
+  } else {
+    process.stdout.write(`verify-doc-version-currency: expected version=${expected}\n`);
+    for (const r of rows) {
+      const tag = r.ok ? 'OK' : 'STALE';
+      const loc = r.line > 0 ? `${r.file}:${r.line}` : r.file;
+      process.stdout.write(`  [${tag}] ${r.label} (${loc})${r.ok ? '' : `: ${r.reason}`}\n`);
+    }
+    process.stdout.write(
+      failed.length === 0
+        ? `summary: all ${rows.length} site(s) current\n`
+        : `summary: ${failed.length} of ${rows.length} site(s) stale\n`
+    );
+  }
+
+  process.exit(failed.length === 0 ? 0 : 1);
+}
+
+// Main guard: importing this module (for example to unit-test checkSite or
+// SITES) must not parse argv, read files, or exit.
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : '';
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/tests/tooling/doc-version-currency.test.ts
+++ b/tests/tooling/doc-version-currency.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for scripts/verify-doc-version-currency.mjs.
+ *
+ * The gate checks enumerated version-bearing SOURCE sites (the
+ * @peac/telemetry-otel package-version source and the smithery.yaml
+ * mcp-server pin) against docs/releases/current.json, plus an anti-drift
+ * guard that the telemetry provider does not reintroduce a hardcoded
+ * version literal. It is intentionally narrow and does NOT cover markdown
+ * version banners; those are gated by
+ * tests/tooling/docs-version-banner-truth.test.ts, so this suite does not
+ * duplicate them.
+ *
+ * Two layers:
+ *   - checkSite / checkForbidden unit cases (pure, synthetic content).
+ *   - CLI smoke cases driving the script against a synthetic tree via
+ *     --root, so the live repo files are not required to be at any
+ *     particular version for the test to be deterministic.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { afterAll, beforeAll, describe, it, expect } from 'vitest';
+
+import {
+  checkSite,
+  checkForbidden,
+  SITES,
+  FORBIDDEN,
+} from '../../scripts/verify-doc-version-currency.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = resolve(__dirname, '..', '..', 'scripts', 'verify-doc-version-currency.mjs');
+
+const TELEMETRY_SITE = SITES.find((s: { label: string }) => s.label === 'TELEMETRY_OTEL_VERSION');
+const SMITHERY_SITE = SITES.find((s: { label: string }) => s.label === 'smithery mcp-server pin');
+const PROVIDER_GUARD = FORBIDDEN.find((g: { label: string }) => g.label.startsWith('provider.ts'));
+
+describe('checkSite', () => {
+  it('passes when the version matches', () => {
+    const r = checkSite(
+      "export const TELEMETRY_OTEL_VERSION = '0.15.0';",
+      TELEMETRY_SITE.pattern,
+      '0.15.0'
+    );
+    expect(r.ok).toBe(true);
+    expect(r.value).toBe('0.15.0');
+  });
+
+  it('fails when the version is stale', () => {
+    const r = checkSite(
+      "export const TELEMETRY_OTEL_VERSION = '0.9.22';",
+      TELEMETRY_SITE.pattern,
+      '0.15.0'
+    );
+    expect(r.ok).toBe(false);
+    expect(r.value).toBe('0.9.22');
+    expect(r.reason).toContain('expected 0.15.0');
+  });
+
+  it('fails when the pattern is not found', () => {
+    const r = checkSite('export const SOMETHING_ELSE = 1;', TELEMETRY_SITE.pattern, '0.15.0');
+    expect(r.ok).toBe(false);
+    expect(r.value).toBeNull();
+    expect(r.reason).toContain('not found');
+  });
+
+  it('matches the smithery mcp-server pin pattern', () => {
+    const r = checkSite(
+      "const args = ['-y', '@peac/mcp-server@0.15.0'];",
+      SMITHERY_SITE.pattern,
+      '0.15.0'
+    );
+    expect(r.ok).toBe(true);
+    expect(r.value).toBe('0.15.0');
+  });
+});
+
+describe('checkForbidden', () => {
+  it('fails when a hardcoded version literal is present', () => {
+    const r = checkForbidden("const TELEMETRY_VERSION = '0.9.22';", PROVIDER_GUARD.pattern);
+    expect(r.ok).toBe(false);
+  });
+
+  it('passes when the version is derived from the single source', () => {
+    const r = checkForbidden(
+      'const TELEMETRY_VERSION = TELEMETRY_OTEL_VERSION;',
+      PROVIDER_GUARD.pattern
+    );
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('verify-doc-version-currency CLI', () => {
+  let root: string;
+
+  function writeTree(opts: {
+    current: string;
+    version?: string;
+    smithery?: string;
+    versionConst?: boolean;
+    providerHardcoded?: boolean;
+  }) {
+    const dir = mkdtempSync(join(tmpdir(), 'peac-doc-currency-'));
+    mkdirSync(join(dir, 'docs', 'releases'), { recursive: true });
+    mkdirSync(join(dir, 'packages', 'telemetry-otel', 'src'), { recursive: true });
+    mkdirSync(join(dir, 'packages', 'mcp-server'), { recursive: true });
+    writeFileSync(
+      join(dir, 'docs', 'releases', 'current.json'),
+      JSON.stringify({ version: opts.current })
+    );
+    const versionTs =
+      opts.versionConst === false
+        ? ''
+        : `export const TELEMETRY_OTEL_VERSION = '${opts.version ?? opts.current}';\n`;
+    writeFileSync(join(dir, 'packages', 'telemetry-otel', 'src', 'version.ts'), versionTs);
+    const providerTs = opts.providerHardcoded
+      ? "const TELEMETRY_VERSION = '0.0.1';\n"
+      : "import { TELEMETRY_OTEL_VERSION } from './version.js';\nconst TELEMETRY_VERSION = TELEMETRY_OTEL_VERSION;\n";
+    writeFileSync(join(dir, 'packages', 'telemetry-otel', 'src', 'provider.ts'), providerTs);
+    writeFileSync(
+      join(dir, 'packages', 'mcp-server', 'smithery.yaml'),
+      `const args = ['-y', '@peac/mcp-server@${opts.smithery ?? opts.current}'];\n`
+    );
+    return dir;
+  }
+
+  function runCli(args: string[]) {
+    let stdout = '';
+    let exitCode = 0;
+    try {
+      stdout = execFileSync('node', [SCRIPT, ...args], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        encoding: 'utf8',
+      });
+    } catch (err) {
+      const e = err as { status?: number; stdout?: Buffer | string };
+      exitCode = e.status ?? -1;
+      stdout = (e.stdout || '').toString();
+    }
+    return { stdout, exitCode };
+  }
+
+  const created: string[] = [];
+  function repo(opts: Parameters<typeof writeTree>[0]) {
+    const d = writeTree(opts);
+    created.push(d);
+    return d;
+  }
+
+  beforeAll(() => {
+    root = repo({ current: '9.9.9' });
+  });
+
+  afterAll(() => {
+    for (const d of created) rmSync(d, { recursive: true, force: true });
+  });
+
+  it('exits 0 when every site matches and provider derives the version', () => {
+    const r = runCli(['--root', root]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('all 3 site(s) current');
+  });
+
+  it('exits 1 when a site is stale', () => {
+    const d = repo({ current: '9.9.9', version: '0.0.1' });
+    const r = runCli(['--root', d]);
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toContain('STALE');
+  });
+
+  it('exits 1 (fail closed) when a pattern is missing', () => {
+    const d = repo({ current: '9.9.9', versionConst: false });
+    const r = runCli(['--root', d]);
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toContain('not found');
+  });
+
+  it('exits 1 when provider.ts hardcodes a version literal', () => {
+    const d = repo({ current: '9.9.9', providerHardcoded: true });
+    const r = runCli(['--root', d]);
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toContain('do not hardcode');
+  });
+
+  it('--root with no path exits 2', () => {
+    expect(runCli(['--root']).exitCode).toBe(2);
+  });
+
+  it('unknown argument exits 2', () => {
+    expect(runCli(['--nope']).exitCode).toBe(2);
+  });
+
+  it('importing the module does not execute main()', () => {
+    const url = JSON.stringify(pathToFileURL(SCRIPT).href);
+    const out = execFileSync(
+      'node',
+      [
+        '--input-type=module',
+        '-e',
+        `import(${url}).then((m) => process.stdout.write(typeof m.checkSite));`,
+      ],
+      { encoding: 'utf8' }
+    );
+    expect(out).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary

Add a version-currency gate for source surfaces and correct a stale telemetry package-version constant in the optional OpenTelemetry adapter. No protocol surface change.

## Scope

Tooling, its test, release-version source surfaces, and the optional `@peac/telemetry-otel` adapter. No PEAC record shape, schema, registry, wire format, conformance vector, or signing change. No OpenTelemetry dependency or lockfile bump. The only runtime-observable change is that the telemetry adapter now reports the correct package version in the optional `peac.version` span/metric attribute (see below). Public-surface sentinels are unchanged.

## OpenTelemetry comparison (inspected, no bump needed)

| Surface | PEAC value | Current upstream | Action |
|---|---|---|---|
| `@opentelemetry/api` | `^1.9.0` | 1.9.1 | none (range covers latest) |
| `@opentelemetry/sdk-metrics` | `^2.0.0` | 2.7.1 | none (range covers latest) |
| `@opentelemetry/sdk-trace-base` | `^2.0.0` | 2.7.1 | none (range covers latest) |
| `@opentelemetry/exporter-trace-otlp-http` (example only) | `^0.212.0` | 0.218.0 | none (example-only; no bump-for-latest) |

OpenTelemetry Specification is currently 1.57.0 and semantic-conventions 1.41.1; PEAC hardcodes no schema URL or semconv pin and references no `OTEL_*` environment variables (prior matches were PEAC internal identifiers). The MCP Registry wording already reads "Preview" with no overclaim. PEAC composes with OpenTelemetry as an optional, vendor-neutral adapter and is not an observability backend.


## Notes

No OpenTelemetry dependency or lockfile bump. Historical `0.9.22` references (CHANGELOG, the architecture ADR, the privacy hash seed, and privacy filter-input test fixtures) are intentionally left unchanged.
