### PR TITLE
chore(security): renew dependency-audit allowlist review dates

### DIFF
--- a/security/audit-allowlist.json
+++ b/security/audit-allowlist.json
@@ -179,7 +179,8 @@
       "dependency_chain": ["@vitest/coverage-v8@4.1.0", "vitest@4.1.0", "vite@6.4.1"],
       "verified_by": "pnpm audit --prod shows no HIGH for vite; pnpm why vite confirms vitest-only path",
       "owner": "jithinraj",
-      "added_at": "2026-04-07"
+      "added_at": "2026-04-07",
+      "reviewed_at": "2026-06-07"
     },
     {
       "advisory_id": "GHSA-737v-mqg7-c878",
@@ -194,7 +195,8 @@
       "dependency_chain": ["transitive dev dependency"],
       "verified_by": "pnpm audit --prod shows no HIGH for defu",
       "owner": "jithinraj",
-      "added_at": "2026-04-07"
+      "added_at": "2026-04-07",
+      "reviewed_at": "2026-06-07"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Renew the renewal-review date on the two dependency-audit allowlist entries that crossed the 60-day review window, which the strict audit gate (`AUDIT_STRICT=1`) rejects. No code or dependency change.

## Scope

`security/audit-allowlist.json` only. Sets `reviewed_at: "2026-06-07"` on `GHSA-p9ff-h696-f583` (vite, via vitest) and `GHSA-737v-mqg7-c878` (defu, transitive dev dependency). No other field changes; `expires_at` (2026-07-06) is unchanged.

## Why

Both entries were added 2026-04-07 without a `reviewed_at` date. After 60 days the strict audit gate fails closed with "added 61 day(s) ago without reviewed_at (strict mode requires review within 60 days)". This is the intended periodic re-confirmation mechanism, not a new vulnerability.

## Re-confirmation

Both advisories remain dev-only and are not present in any published package:
- `GHSA-p9ff-h696-f583` (vite dev-server arbitrary file read, HIGH): only used during local test runs via `@vitest/coverage-v8 -> vitest -> vite`; not in published packages or production deployments.
- `GHSA-737v-mqg7-c878` (defu prototype pollution, HIGH): transitive dev dependency in build/test tooling; no user-controlled input reaches it in production.

## Validation

- `AUDIT_STRICT=1 node scripts/audit-gate.mjs`: OK (12 active exceptions, 0 invalid).
- `node scripts/check-audit-exception-expiry.mjs --strict`: GREEN.
- `pnpm format:check` passes.
