### PR TITLE
fix(mcp): align recipe, docs, and transport log with current API

### DIFF
--- a/docs/SOLUTIONS/mcp-tool-call-receipts.md
+++ b/docs/SOLUTIONS/mcp-tool-call-receipts.md
@@ -51,16 +51,15 @@ Prerequisites: Node 22+, pnpm 8+. An MCP client to call the server (the shipped 
    async function handleToolCall(toolName, args, ctx) {
      const result = await runTool(toolName, args);
 
-     // digestOf is application-defined. In production, hash a canonicalized,
-     // redacted argument object; do not sign raw secrets.
+     // Minimal record: issuer, kind, type, and signature. For production
+     // tool-call facts (tool name, argument digests), use a registered
+     // extension group via the `extensions` option rather than ad-hoc
+     // fields; never include raw arguments or secrets in a record.
      const { jws } = await issue({
        iss: 'https://mcp.example.com',
        kind: 'evidence',
        type: 'org.peacprotocol/mcp-tool-call',
        pillars: ['attribution'],
-       ext: {
-         attribution: { tool: toolName, arguments_digest: digestOf(args) },
-       },
        privateKey: ctx.privateKey,
        kid: ctx.kid,
      });
@@ -97,7 +96,7 @@ Prerequisites: Node 22+, pnpm 8+. An MCP client to call the server (the shipped 
    const result = await verifyLocal(carrier.receipt_jws, publicKey, {
      issuer: 'https://mcp.example.com',
    });
-   console.log(result.valid, result.claims?.type, result.claims?.ext?.attribution);
+   console.log(result.valid, result.claims?.type, result.claims?.kind);
    ```
 
 5. Explore a runnable example:
@@ -121,7 +120,7 @@ A tool-call response carrying a PEAC record looks like this (MCP content + `_met
 }
 ```
 
-Decoded, the record carries the `kind: evidence` / `type: org.peacprotocol/mcp-tool-call` shape with an `attribution` extension group referencing the tool name and a digest of the arguments. The MCP server ran the tool; PEAC recorded what happened.
+Decoded, the record carries the `kind: evidence` / `type: org.peacprotocol/mcp-tool-call` shape. Production deployments can add tool-call facts (tool name, argument digests) through a registered extension group via the `extensions` option; see the runnable example for an extension-carrying record. The MCP server ran the tool; PEAC recorded what happened.
 
 ## Validated with
 

--- a/docs/SOLUTIONS/mcp-tool-call-receipts.md
+++ b/docs/SOLUTIONS/mcp-tool-call-receipts.md
@@ -45,42 +45,59 @@ Prerequisites: Node 22+, pnpm 8+. An MCP client to call the server (the shipped 
 
    ```typescript
    import { issue } from '@peac/protocol';
-   import { toMcpMeta } from '@peac/mappings-mcp';
+   import { computeReceiptRef } from '@peac/schema';
+   import { attachReceiptToMeta } from '@peac/mappings-mcp';
 
    async function handleToolCall(toolName, args, ctx) {
      const result = await runTool(toolName, args);
 
-     const jws = await issue(
-       {
-         iss: 'https://mcp.example.com',
-         kind: 'evidence',
-         type: 'org.peacprotocol/mcp-tool-call',
-         pillars: ['attribution'],
-         ext: {
-           attribution: { tool: toolName, arguments_digest: digestOf(args) },
-         },
+     // digestOf is application-defined. In production, hash a canonicalized,
+     // redacted argument object; do not sign raw secrets.
+     const { jws } = await issue({
+       iss: 'https://mcp.example.com',
+       kind: 'evidence',
+       type: 'org.peacprotocol/mcp-tool-call',
+       pillars: ['attribution'],
+       ext: {
+         attribution: { tool: toolName, arguments_digest: digestOf(args) },
        },
-       ctx.privateKey
-     );
+       privateKey: ctx.privateKey,
+       kid: ctx.kid,
+     });
 
-     return {
-       content: result.content,
-       _meta: toMcpMeta({ receipt_jws: jws }),
-     };
+     // receipt_ref is sha256(receipt_jws); attachReceiptToMeta writes both
+     // into top-level _meta under the org.peacprotocol/ carrier keys,
+     // preserving the rest of the MCP result untouched.
+     const receipt_ref = await computeReceiptRef(jws);
+
+     return attachReceiptToMeta(
+       {
+         content: result.content,
+         structuredContent: result.structuredContent,
+         isError: result.isError,
+       },
+       { receipt_ref, receipt_jws: jws }
+     );
    }
    ```
+
+   The runnable example is the source of truth for exact imports and execution: see [`examples/mcp-tool-call/`](../../examples/mcp-tool-call/).
 
 4. Verify the record from the MCP client:
 
    ```typescript
-   import { fromMcpMeta } from '@peac/mappings-mcp';
+   import { extractReceiptFromMetaAsync } from '@peac/mappings-mcp';
    import { verifyLocal } from '@peac/protocol';
 
-   const { receipt_jws } = fromMcpMeta(response._meta);
-   const result = await verifyLocal(receipt_jws, publicKey, {
+   // extractReceiptFromMetaAsync also checks receipt_ref == sha256(receipt_jws).
+   const extracted = await extractReceiptFromMetaAsync(response);
+   const carrier = extracted?.receipts[0];
+   if (!carrier?.receipt_jws) throw new Error('no PEAC receipt in _meta');
+
+   const result = await verifyLocal(carrier.receipt_jws, publicKey, {
      issuer: 'https://mcp.example.com',
    });
-   console.log(result.valid, result.claims.type, result.claims.ext.attribution);
+   console.log(result.valid, result.claims?.type, result.claims?.ext?.attribution);
    ```
 
 5. Explore a runnable example:

--- a/docs/SOLUTIONS/mcp-tool-call-receipts.md
+++ b/docs/SOLUTIONS/mcp-tool-call-receipts.md
@@ -1,6 +1,6 @@
 # MCP tool-call records
 
-> **Outcome:** Your MCP server emits a signed record for every tool call so downstream agents, auditors, or counterparties can verify what tool ran, what arguments were used, and what the result was — offline, with just your public key.
+> **Outcome:** Your MCP server attaches a portable signed record to a tool response so downstream agents, auditors, or counterparties can verify the record offline with your public key. Production deployments can bind tool name, argument digests, and result digests through a registered extension/profile.
 >
 > **Audience:** MCP server operator.
 >
@@ -19,7 +19,7 @@ PEAC packages:
 - `@peac/mcp-server` — MCP server with built-in record tools (`peac_verify`, `peac_inspect`, `peac_decode`, `peac_issue`, `peac_create_bundle`).
 - `@peac/mappings-mcp` — MCP `_meta` carrier mapping.
 - `@peac/protocol` — issuance and offline verification.
-- `@peac/crypto` — Ed25519 signing.
+- `@peac/schema` — receipt reference calculation.
 
 Prerequisites: Node 22+, pnpm 8+. An MCP client to call the server (the shipped examples use the MCP SDK stdio transport).
 
@@ -32,7 +32,7 @@ Prerequisites: Node 22+, pnpm 8+. An MCP client to call the server (the shipped 
 1. Install dependencies:
 
    ```bash
-   pnpm add @peac/mcp-server @peac/mappings-mcp @peac/protocol @peac/crypto
+   pnpm add @peac/mcp-server @peac/mappings-mcp @peac/protocol @peac/schema
    ```
 
 2. Start the server for local exploration:

--- a/docs/specs/INTEROP.md
+++ b/docs/specs/INTEROP.md
@@ -115,7 +115,7 @@ const result = rslToControlPurposes(['ai-all', 'search']);
 
 ### 4.3 Package
 
-`@peac/mcp-server` provides 8 tools for issuing and verifying receipts over MCP (stdio and Streamable HTTP transports). Evidence is carried in MCP `_meta` keys `org.peacprotocol/receipt_ref` and `org.peacprotocol/receipt_jws`:
+`@peac/mcp-server` provides 5 tools for issuing and verifying receipts over MCP (stdio and Streamable HTTP transports): `peac_verify`, `peac_inspect`, `peac_decode`, `peac_issue`, and `peac_create_bundle` (the latter two require an Ed25519 issuer key). Evidence is carried in MCP `_meta` keys `org.peacprotocol/receipt_ref` and `org.peacprotocol/receipt_jws`:
 
 ```typescript
 // MCP server issues and verifies receipts as tool responses.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -102,9 +102,9 @@ const result = await handleVerify({
   input: { jws: 'eyJ...', public_key_base64url: '...' },
   policy,
   context: {
-    version: '0.12.4',
+    version: '0.15.0',
     policyHash,
-    protocolVersion: '0.2',
+    protocolVersion: '2025-11-25',
   },
 });
 ```
@@ -119,7 +119,7 @@ const result = await handleVerify({
 | `peac_issue`         | Issue a PEAC signed interaction record from provided claims.    | Requires `--issuer-key` and `--issuer-id`                  |
 | `peac_create_bundle` | Create a PEAC bundle from signed records and related artifacts. | Requires `--issuer-key`, `--issuer-id`, and `--bundle-dir` |
 
-All tool responses include `_meta` with `serverVersion`, `policyHash`, `protocolVersion`, and `registeredTools`.
+All structured tool outputs include a schema-declared `_meta` audit block with `serverVersion`, `policyHash`, `protocolVersion`, and `registeredTools`. This is separate from the top-level MCP `_meta` carrier used by `@peac/mappings-mcp` to attach PEAC receipt references.
 
 ## Integrates With
 

--- a/packages/mcp-server/src/http-transport.ts
+++ b/packages/mcp-server/src/http-transport.ts
@@ -508,7 +508,7 @@ export async function createHttpTransport(
     server.on('error', reject);
     server.listen(port, host, () => {
       process.stderr.write(`[${SERVER_NAME}] HTTP transport listening on http://${host}:${port}\n`);
-      process.stderr.write(`  Transport: Streamable HTTP (MCP 2025-06-18)\n`);
+      process.stderr.write(`  Transport: Streamable HTTP (MCP ${MCP_PROTOCOL_VERSION})\n`);
       process.stderr.write(
         `  Auth: unprotected mode (no token validation); PRM discovery per RFC 9728\n`
       );


### PR DESCRIPTION
## Summary

Aligns the MCP recipe, MCP server docs, and the HTTP transport startup log with the current public API and versions. Documentation and one log-string change only; no protocol surface, wire format, schema, or runtime behavior changes.

## Scope

- `docs/SOLUTIONS/mcp-tool-call-receipts.md`
- `docs/specs/INTEROP.md`
- `packages/mcp-server/README.md`
- `packages/mcp-server/src/http-transport.ts` (startup log string only)

Explicitly not changed: tool schemas, the `_meta` carrier format, transport behavior, any package exports.

## Changes

- The MCP recipe now uses the real exported API: `attachReceiptToMeta`, `extractReceiptFromMetaAsync`, and `computeReceiptRef`, with the current single-options-object `issue()` signature. The attach example preserves the full MCP result (`content`, `structuredContent`, `isError`). The short snippet stays minimal and points production tool-call facts to registered extension/profile usage through `extensions`; the runnable example is referenced as the source of truth. The recipe's dependency list and install command match the snippet imports, and the stated outcome matches what the minimal record binds.
- `docs/specs/INTEROP.md` states the correct MCP tool count (5) and enumerates the tools.
- `packages/mcp-server/README.md` sample context uses the current `0.15.0` server version and `2025-11-25` protocol version, and clarifies that the schema-declared structured-output `_meta` audit block is separate from the top-level MCP `_meta` receipt carrier.
- The HTTP transport startup log derives its protocol version from the `MCP_PROTOCOL_VERSION` constant instead of a hardcoded string.

## Validation

- `tsc --noEmit` for `@peac/mcp-server` passes.
- Prettier and whitespace checks pass on all four files.
- Grep confirms no stale function names, tool counts, or version strings remain in the touched files.
