### PR TITLE
fix(mcp): quickstart session handling, modern carrier demo, current pins

### DIFF
--- a/examples/mcp-http-quickstart/quickstart.ts
+++ b/examples/mcp-http-quickstart/quickstart.ts
@@ -15,26 +15,70 @@
 import { generateKeypair, issue, verifyLocal } from '@peac/protocol';
 
 const MCP_URL = process.env.MCP_URL ?? 'http://127.0.0.1:3000/mcp';
+const MCP_PROTOCOL_VERSION = '2025-11-25';
 
 interface JsonRpcResponse {
   jsonrpc: '2.0';
   id: number;
-  result?: { content?: Array<{ type: string; text: string }> };
+  result?: {
+    content?: Array<{ type: string; text: string }>;
+    structuredContent?: Record<string, unknown>;
+    isError?: boolean;
+  };
   error?: { code: number; message: string };
 }
 
-async function mcpCall(method: string, params: Record<string, unknown>): Promise<JsonRpcResponse> {
+let requestId = 0;
+
+/**
+ * POST a JSON-RPC request to the MCP endpoint.
+ *
+ * Streamable HTTP responses can arrive as plain JSON or as a Server-Sent
+ * Events stream; both are handled. The `Mcp-Session-Id` response header from
+ * `initialize` must be echoed on every subsequent request.
+ */
+async function mcpCall(
+  method: string,
+  params: Record<string, unknown>,
+  sessionId?: string
+): Promise<{ body: JsonRpcResponse; sessionId?: string }> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json, text/event-stream',
+  };
+  if (sessionId) {
+    headers['Mcp-Session-Id'] = sessionId;
+  }
+
   const res = await fetch(MCP_URL, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      jsonrpc: '2.0',
-      id: 1,
-      method,
-      params,
-    }),
+    headers,
+    body: JSON.stringify({ jsonrpc: '2.0', id: ++requestId, method, params }),
   });
-  return (await res.json()) as JsonRpcResponse;
+
+  const responseSessionId = res.headers.get('mcp-session-id') ?? undefined;
+  const contentType = res.headers.get('content-type') ?? '';
+  const raw = await res.text();
+
+  let body: JsonRpcResponse;
+  if (contentType.includes('text/event-stream')) {
+    // Take the last `data:` event line as the JSON-RPC response.
+    const dataLines = raw
+      .split('\n')
+      .filter((line) => line.startsWith('data:'))
+      .map((line) => line.slice(5).trim())
+      .filter((line) => line.length > 0);
+    if (dataLines.length === 0) {
+      throw new Error(`Empty SSE response (HTTP ${res.status})`);
+    }
+    body = JSON.parse(dataLines[dataLines.length - 1]) as JsonRpcResponse;
+  } else if (contentType.includes('application/json')) {
+    body = JSON.parse(raw) as JsonRpcResponse;
+  } else {
+    throw new Error(`Unexpected response (HTTP ${res.status}): ${raw.slice(0, 200)}`);
+  }
+
+  return { body, sessionId: responseSessionId };
 }
 
 async function main() {
@@ -57,40 +101,58 @@ async function main() {
 
   // Step 3: Verify via MCP server (HTTP transport)
   console.log('2. Verifying via MCP server (HTTP)...');
+  let mcpVerified = false;
   try {
-    // Initialize session
-    const initRes = await mcpCall('initialize', {
-      protocolVersion: '2025-03-26',
+    // Initialize the session; capture Mcp-Session-Id from the response headers.
+    const init = await mcpCall('initialize', {
+      protocolVersion: MCP_PROTOCOL_VERSION,
       capabilities: {},
       clientInfo: { name: 'quickstart', version: '1.0.0' },
     });
 
-    if (initRes.error) {
-      console.log(`   MCP server not running at ${MCP_URL}`);
-      console.log('   Start it with: npx -y @peac/mcp-server --transport http --port 3000\n');
-      console.log('   Falling back to local verification...');
+    if (init.body.error) {
+      console.log(`   MCP initialize FAILED: ${init.body.error.message}`);
+    } else if (!init.sessionId) {
+      console.log('   MCP initialize returned no Mcp-Session-Id header');
     } else {
-      console.log('   MCP session initialized');
+      console.log(`   MCP session initialized (Mcp-Session-Id: ${init.sessionId.slice(0, 8)}...)`);
 
-      // Call peac_verify tool
-      const verifyRes = await mcpCall('tools/call', {
-        name: 'peac_verify',
-        arguments: { receipt: jws },
-      });
+      // Notify initialized, then call the peac_verify tool. The tool input
+      // field for the compact JWS is `jws`; passing the public key keeps the
+      // verification offline (no issuer discovery).
+      await mcpCall('notifications/initialized', {}, init.sessionId);
+      const verifyRes = await mcpCall(
+        'tools/call',
+        {
+          name: 'peac_verify',
+          arguments: { jws, public_key_base64url: Buffer.from(publicKey).toString('base64url') },
+        },
+        init.sessionId
+      );
 
-      if (verifyRes.result?.content?.[0]) {
-        const text = verifyRes.result.content[0].text;
+      if (verifyRes.body.error) {
+        console.log(`   MCP peac_verify FAILED: ${verifyRes.body.error.message}`);
+      } else if (verifyRes.body.result?.content?.[0]) {
+        const text = verifyRes.body.result.content[0].text;
         console.log(`   MCP verify result: ${text.slice(0, 100)}...`);
+        mcpVerified = true;
+      } else {
+        console.log('   MCP peac_verify returned no content');
       }
     }
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     console.log(`   MCP server not reachable at ${MCP_URL} (${reason})`);
-    console.log('   Falling back to local verification...');
+    console.log('   Start it with: npx -y @peac/mcp-server --transport http --port 3000');
   }
 
-  // Step 4: Always verify locally as proof
-  console.log('\n3. Local verification (always works)...');
+  if (!mcpVerified) {
+    console.log('   NOTE: the MCP HTTP path did NOT verify the receipt.');
+    console.log('   The local verification below is a FALLBACK, not the MCP path.');
+  }
+
+  // Step 4: Always verify locally as proof (offline; no network)
+  console.log(`\n3. Local verification (${mcpVerified ? 'cross-check' : 'FALLBACK'})...`);
   const result = await verifyLocal(jws, publicKey);
   if (result.valid) {
     console.log('   Verified: true');
@@ -99,9 +161,13 @@ async function main() {
     console.log(`   Kind:     ${result.claims.kind}`);
   } else {
     console.log(`   Verification failed: ${result.code}`);
+    process.exitCode = 1;
   }
 
-  console.log('\nQuickstart complete.');
+  console.log(`\nQuickstart complete. MCP path verified: ${mcpVerified}`);
 }
 
-main().catch(console.error);
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/examples/mcp-http-quickstart/quickstart.ts
+++ b/examples/mcp-http-quickstart/quickstart.ts
@@ -1,8 +1,8 @@
 /**
  * MCP Streamable HTTP Quickstart
  *
- * Demonstrates issuing and verifying a PEAC receipt via the MCP server
- * over Streamable HTTP transport. Completes in under 30 seconds.
+ * Demonstrates a minimal local issue-and-verify flow against the MCP server
+ * over Streamable HTTP transport.
  *
  * Prerequisites:
  *   Start the MCP server in another terminal:
@@ -16,6 +16,7 @@ import { generateKeypair, issue, verifyLocal } from '@peac/protocol';
 
 const MCP_URL = process.env.MCP_URL ?? 'http://127.0.0.1:3000/mcp';
 const MCP_PROTOCOL_VERSION = '2025-11-25';
+const ISSUER = 'https://quickstart.example.com';
 
 interface JsonRpcResponse {
   jsonrpc: '2.0';
@@ -30,18 +31,7 @@ interface JsonRpcResponse {
 
 let requestId = 0;
 
-/**
- * POST a JSON-RPC request to the MCP endpoint.
- *
- * Streamable HTTP responses can arrive as plain JSON or as a Server-Sent
- * Events stream; both are handled. The `Mcp-Session-Id` response header from
- * `initialize` must be echoed on every subsequent request.
- */
-async function mcpCall(
-  method: string,
-  params: Record<string, unknown>,
-  sessionId?: string
-): Promise<{ body: JsonRpcResponse; sessionId?: string }> {
+function buildHeaders(sessionId?: string): Record<string, string> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     Accept: 'application/json, text/event-stream',
@@ -49,10 +39,24 @@ async function mcpCall(
   if (sessionId) {
     headers['Mcp-Session-Id'] = sessionId;
   }
+  return headers;
+}
 
+/**
+ * POST a JSON-RPC request (with an `id`) to the MCP endpoint.
+ *
+ * Streamable HTTP responses can arrive as plain JSON or as a Server-Sent
+ * Events stream; both are handled. The `Mcp-Session-Id` response header from
+ * `initialize` must be echoed on every subsequent request.
+ */
+async function mcpRequest(
+  method: string,
+  params: Record<string, unknown>,
+  sessionId?: string
+): Promise<{ body: JsonRpcResponse; sessionId?: string }> {
   const res = await fetch(MCP_URL, {
     method: 'POST',
-    headers,
+    headers: buildHeaders(sessionId),
     body: JSON.stringify({ jsonrpc: '2.0', id: ++requestId, method, params }),
   });
 
@@ -81,6 +85,27 @@ async function mcpCall(
   return { body, sessionId: responseSessionId };
 }
 
+/**
+ * POST a JSON-RPC notification (no `id`, no response body expected) to the
+ * MCP endpoint.
+ */
+async function mcpNotify(
+  method: string,
+  params: Record<string, unknown>,
+  sessionId: string
+): Promise<void> {
+  const res = await fetch(MCP_URL, {
+    method: 'POST',
+    headers: buildHeaders(sessionId),
+    body: JSON.stringify({ jsonrpc: '2.0', method, params }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`MCP notification failed (HTTP ${res.status}): ${text.slice(0, 200)}`);
+  }
+}
+
 async function main() {
   console.log('MCP Streamable HTTP Quickstart\n');
 
@@ -91,7 +116,7 @@ async function main() {
   // Step 2: Issue a receipt locally
   console.log('1. Issuing a receipt...');
   const { jws } = await issue({
-    iss: 'https://quickstart.example.com',
+    iss: ISSUER,
     kind: 'evidence',
     type: 'org.peacprotocol/mcp-tool-call',
     privateKey,
@@ -104,7 +129,7 @@ async function main() {
   let mcpVerified = false;
   try {
     // Initialize the session; capture Mcp-Session-Id from the response headers.
-    const init = await mcpCall('initialize', {
+    const init = await mcpRequest('initialize', {
       protocolVersion: MCP_PROTOCOL_VERSION,
       capabilities: {},
       clientInfo: { name: 'quickstart', version: '1.0.0' },
@@ -117,15 +142,19 @@ async function main() {
     } else {
       console.log(`   MCP session initialized (Mcp-Session-Id: ${init.sessionId.slice(0, 8)}...)`);
 
-      // Notify initialized, then call the peac_verify tool. The tool input
-      // field for the compact JWS is `jws`; passing the public key keeps the
-      // verification offline (no issuer discovery).
-      await mcpCall('notifications/initialized', {}, init.sessionId);
-      const verifyRes = await mcpCall(
+      // Complete the handshake, then call the peac_verify tool. The tool input
+      // field for the compact JWS is `jws`; the public key keeps verification
+      // offline, and `issuer` binds the expected issuer.
+      await mcpNotify('notifications/initialized', {}, init.sessionId);
+      const verifyRes = await mcpRequest(
         'tools/call',
         {
           name: 'peac_verify',
-          arguments: { jws, public_key_base64url: Buffer.from(publicKey).toString('base64url') },
+          arguments: {
+            jws,
+            public_key_base64url: Buffer.from(publicKey).toString('base64url'),
+            issuer: ISSUER,
+          },
         },
         init.sessionId
       );
@@ -153,7 +182,7 @@ async function main() {
 
   // Step 4: Always verify locally as proof (offline; no network)
   console.log(`\n3. Local verification (${mcpVerified ? 'cross-check' : 'FALLBACK'})...`);
-  const result = await verifyLocal(jws, publicKey);
+  const result = await verifyLocal(jws, publicKey, { issuer: ISSUER });
   if (result.valid) {
     console.log('   Verified: true');
     console.log(`   Issuer:   ${result.claims.iss}`);

--- a/examples/mcp-http-quickstart/quickstart.ts
+++ b/examples/mcp-http-quickstart/quickstart.ts
@@ -17,6 +17,7 @@ import { generateKeypair, issue, verifyLocal } from '@peac/protocol';
 const MCP_URL = process.env.MCP_URL ?? 'http://127.0.0.1:3000/mcp';
 const MCP_PROTOCOL_VERSION = '2025-11-25';
 const ISSUER = 'https://quickstart.example.com';
+const REQUEST_TIMEOUT_MS = 10_000;
 
 interface JsonRpcResponse {
   jsonrpc: '2.0';
@@ -58,6 +59,7 @@ async function mcpRequest(
     method: 'POST',
     headers: buildHeaders(sessionId),
     body: JSON.stringify({ jsonrpc: '2.0', id: ++requestId, method, params }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
 
   const responseSessionId = res.headers.get('mcp-session-id') ?? undefined;
@@ -98,12 +100,15 @@ async function mcpNotify(
     method: 'POST',
     headers: buildHeaders(sessionId),
     body: JSON.stringify({ jsonrpc: '2.0', method, params }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
 
   if (!res.ok) {
     const text = await res.text();
     throw new Error(`MCP notification failed (HTTP ${res.status}): ${text.slice(0, 200)}`);
   }
+  // Drain the body to release the connection.
+  await res.arrayBuffer();
 }
 
 async function main() {

--- a/examples/mcp-tool-call/README.md
+++ b/examples/mcp-tool-call/README.md
@@ -46,7 +46,7 @@ const result = await verifyLocal(extracted.receipts[0].receipt_jws, publicKey, {
 });
 ```
 
-The record uses the example custom type URI `org.peacprotocol/mcp-tool-call`, which is intentionally unregistered; verification surfaces an informational `type_unregistered` warning.
+The record uses the integrator-defined type URI `org.peacprotocol/mcp-tool-call`; verification surfaces an informational `type_unregistered` warning for type values outside the registry.
 
 ## Files
 

--- a/examples/mcp-tool-call/README.md
+++ b/examples/mcp-tool-call/README.md
@@ -1,12 +1,13 @@
 # MCP Tool Call Example
 
-Demonstrates MCP (Model Context Protocol) tool integration with PEAC receipts.
+Demonstrates MCP (Model Context Protocol) tool integration with PEAC records using the `_meta` Evidence Carrier Contract.
 
 ## What This Shows
 
-1. **Paid MCP Tools**: Server exposes tools that cost money
-2. **Receipt Attachment**: Receipts attached to tool responses
-3. **Receipt Verification**: Client extracts and verifies receipts
+1. **Record issuance**: the server issues a signed record for a paid tool call
+2. **Carrier attachment**: the record travels in top-level MCP `_meta` keys (`org.peacprotocol/receipt_ref` + `org.peacprotocol/receipt_jws`)
+3. **Offline verification**: the client extracts the carrier, checks `receipt_ref` consistency, and verifies the Ed25519 signature with the issuer public key
+4. **Tamper detection**: a modified carrier fails the `receipt_ref` consistency check; a modified payload fails signature verification (`E_INVALID_SIGNATURE`)
 
 ## Running the Demo
 
@@ -16,35 +17,36 @@ pnpm demo
 
 ## Key Concepts
 
-### Receipt Attachment
+### Carrier Attachment
 
-Receipts are attached to MCP tool responses:
+The record is attached to the MCP tool result via top-level `_meta`:
 
 ```typescript
-import { createPaidToolResponse, extractReceipt } from '@peac/mappings-mcp';
+import { computeReceiptRef } from '@peac/schema';
+import { attachReceiptToMeta } from '@peac/mappings-mcp';
 
-// Server attaches receipt
-const response = createPaidToolResponse(toolName, result, receiptJWS, {
-  cost_cents: 5,
-  currency: 'USD',
+const receipt_ref = await computeReceiptRef(jws);
+const response = attachReceiptToMeta(
+  { content, structuredContent },
+  { receipt_ref, receipt_jws: jws }
+);
+```
+
+### Extraction and Verification
+
+```typescript
+import { extractReceiptFromMetaAsync } from '@peac/mappings-mcp';
+import { verifyLocal } from '@peac/protocol';
+
+const extracted = await extractReceiptFromMetaAsync(response);
+// extracted.violations is non-empty if receipt_ref does not match the JWS
+
+const result = await verifyLocal(extracted.receipts[0].receipt_jws, publicKey, {
+  issuer: 'https://mcp-provider.example.com',
 });
-
-// Client extracts receipt
-const receipt = extractReceipt(response);
 ```
 
-### Verification Flow
-
-```typescript
-import { verify } from '@peac/crypto';
-import { hasReceipt, extractReceipt } from '@peac/mappings-mcp';
-
-if (hasReceipt(response)) {
-  const receipt = extractReceipt(response);
-  const { valid, payload } = await verify(receipt, publicKey);
-  console.log(`Paid ${payload.amt} ${payload.cur}`);
-}
-```
+The record uses the example custom type URI `org.peacprotocol/mcp-tool-call`, which is intentionally unregistered; verification surfaces an informational `type_unregistered` warning.
 
 ## Files
 

--- a/examples/mcp-tool-call/demo.ts
+++ b/examples/mcp-tool-call/demo.ts
@@ -11,12 +11,9 @@
  * 4. Two tamper checks show how modification is detected: a carrier
  *    receipt_ref mismatch and an invalid Ed25519 signature
  *
- * The record uses `type: 'org.peacprotocol/mcp-tool-call'`. This is an example
- * custom type URI used by the MCP recipe. It is not a registered PEAC extension
- * group or registered receipt type. The reference public verifier
- * (`@peac/protocol.verifyLocal()`) emits a `type_unregistered` warning for
- * unregistered type values, which downstream policy logic may treat as
- * informational.
+ * The record uses the integrator-defined type URI
+ * `org.peacprotocol/mcp-tool-call`; verification surfaces an informational
+ * `type_unregistered` warning for type values outside the registry.
  *
  * This example uses local stubs - no external services required.
  */
@@ -62,9 +59,8 @@ async function mcpToolHandler(params: {
   const query = params.args.query as string;
   const toolResult = await webSearchTool(query);
 
-  // Issue a signed record. The `type` value is an example custom URI used by
-  // this MCP recipe; it is not a registered PEAC receipt type, so verification
-  // will surface a `type_unregistered` warning.
+  // Issue a signed record with an integrator-defined type URI; verification
+  // surfaces an informational `type_unregistered` warning for such types.
   const { jws } = await issue({
     iss: ISSUER_URL,
     kind: 'evidence',
@@ -149,7 +145,7 @@ async function mcpClient(params: { privateKey: Uint8Array; publicKey: Uint8Array
   console.log(`3. Carrier extracted: receipt_ref consistency OK (0 violations)`);
 
   // Verify offline with the issuer public key. Expect a `type_unregistered`
-  // warning because org.peacprotocol/mcp-tool-call is intentionally unregistered.
+  // warning for the integrator-defined type URI.
   const carrierJws = extracted.receipts[0].receipt_jws!;
   const verifyResult = await verifyLocal(carrierJws, params.publicKey, { issuer: ISSUER_URL });
   if (verifyResult.valid) {

--- a/examples/mcp-tool-call/demo.ts
+++ b/examples/mcp-tool-call/demo.ts
@@ -1,10 +1,15 @@
 /**
  * MCP Tool Call Example
  *
- * Demonstrates MCP tool integration with PEAC records:
- * 1. MCP server exposes a paid tool
- * 2. A signed record is attached to the tool response via the _meta carrier
- * 3. Client extracts and verifies the record
+ * Demonstrates MCP tool integration with PEAC records using the v0.11.1+
+ * Evidence Carrier Contract:
+ * 1. An MCP server executes a tool and issues a signed record
+ * 2. The record is attached to the tool result via top-level MCP `_meta`
+ *    carrier keys (`org.peacprotocol/receipt_ref` + `org.peacprotocol/receipt_jws`)
+ * 3. A client extracts the carrier, checks receipt_ref consistency, and
+ *    verifies the record offline with the issuer public key
+ * 4. Two tamper checks show how modification is detected: a carrier
+ *    receipt_ref mismatch and an invalid Ed25519 signature
  *
  * The record uses `type: 'org.peacprotocol/mcp-tool-call'`. This is an example
  * custom type URI used by the MCP recipe. It is not a registered PEAC extension
@@ -18,12 +23,8 @@
 
 import { issue, verifyLocal } from '@peac/protocol';
 import { generateKeypair } from '@peac/crypto';
-import {
-  extractReceipt,
-  hasReceipt,
-  createPaidToolResponse,
-  type MCPToolResponse,
-} from '@peac/mappings-mcp';
+import { computeReceiptRef } from '@peac/schema';
+import { attachReceiptToMeta, extractReceiptFromMetaAsync } from '@peac/mappings-mcp';
 
 // Configuration
 const ISSUER_URL = 'https://mcp-provider.example.com';
@@ -31,32 +32,40 @@ const TOOL_NAME = 'web-search';
 const COST_PER_CALL_CENTS = 5; // $0.05
 const CURRENCY = 'USD';
 
+/** MCP CallToolResult-shaped response with the top-level _meta carrier. */
+interface McpToolCallResult {
+  content: Array<{ type: 'text'; text: string }>;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+  _meta?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
 /**
  * Simulated MCP tool that performs a web search.
  */
 async function webSearchTool(query: string): Promise<{ results: string[] }> {
-  // Simulate search
   return {
     results: [`Result 1 for "${query}"`, `Result 2 for "${query}"`, `Result 3 for "${query}"`],
   };
 }
 
 /**
- * MCP server handler for paid tool calls.
+ * MCP server handler: execute the tool, issue a signed record, and attach it
+ * to the result via the top-level `_meta` carrier.
  */
 async function mcpToolHandler(params: {
   tool: string;
   args: Record<string, unknown>;
   privateKey: Uint8Array;
-}): Promise<MCPToolResponse> {
-  // Execute tool
+}): Promise<McpToolCallResult> {
   const query = params.args.query as string;
   const toolResult = await webSearchTool(query);
 
   // Issue a signed record. The `type` value is an example custom URI used by
   // this MCP recipe; it is not a registered PEAC receipt type, so verification
   // will surface a `type_unregistered` warning.
-  const receiptResult = await issue({
+  const { jws } = await issue({
     iss: ISSUER_URL,
     kind: 'evidence',
     type: 'org.peacprotocol/mcp-tool-call',
@@ -75,74 +84,126 @@ async function mcpToolHandler(params: {
     kid: 'mcp-key-2025',
   });
 
-  // Attach receipt to response
-  const response = createPaidToolResponse(params.tool, toolResult, receiptResult.jws, {
-    cost_cents: COST_PER_CALL_CENTS,
-    currency: CURRENCY,
-  });
+  // receipt_ref is sha256 of the JWS; attachReceiptToMeta writes both values
+  // into top-level _meta under the org.peacprotocol/ carrier keys while
+  // preserving the rest of the MCP result.
+  const receipt_ref = await computeReceiptRef(jws);
 
-  return response;
+  const result: McpToolCallResult = {
+    content: [{ type: 'text', text: `Tool ${params.tool} completed.` }],
+    structuredContent: { ...toolResult, cost_cents: COST_PER_CALL_CENTS, currency: CURRENCY },
+  };
+
+  return attachReceiptToMeta(result, { receipt_ref, receipt_jws: jws }) as McpToolCallResult;
+}
+
+/** Flip one character of a string at the given index (tamper helper). */
+function flipChar(value: string, index: number): string {
+  const original = value[index];
+  const replacement = original === 'A' ? 'B' : 'A';
+  return value.slice(0, index) + replacement + value.slice(index + 1);
+}
+
+/** Modify one payload claim while keeping the original signature (tamper helper). */
+function tamperPayload(jws: string): string {
+  const [header, payload, signature] = jws.split('.');
+  const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as Record<
+    string,
+    unknown
+  >;
+  decoded.iss = 'https://attacker.example.com';
+  const reEncoded = Buffer.from(JSON.stringify(decoded), 'utf8').toString('base64url');
+  return `${header}.${reEncoded}.${signature}`;
 }
 
 /**
- * MCP client that makes paid tool calls.
+ * MCP client: extract the carrier from _meta, verify offline, then run the
+ * two tamper checks.
  */
 async function mcpClient(params: { privateKey: Uint8Array; publicKey: Uint8Array }): Promise<void> {
   console.log('\n=== PEAC MCP Tool Call Demo ===\n');
 
-  // Make a few tool calls
-  const queries = ['PEAC protocol', 'cryptographic receipts', 'agent commerce'];
+  const query = 'PEAC protocol';
+  console.log(`1. Tool call: ${TOOL_NAME}("${query}")`);
 
-  for (const query of queries) {
-    console.log(`\n--- Tool Call: "${query}" ---`);
+  const response = await mcpToolHandler({
+    tool: TOOL_NAME,
+    args: { query },
+    privateKey: params.privateKey,
+  });
 
-    const response = await mcpToolHandler({
-      tool: TOOL_NAME,
-      args: { query },
-      privateKey: params.privateKey,
-    });
+  const refKey = 'org.peacprotocol/receipt_ref';
+  const jwsKey = 'org.peacprotocol/receipt_jws';
+  console.log(`2. Record attached via top-level _meta carrier keys:`);
+  console.log(`   ${refKey} = ${String(response._meta?.[refKey]).slice(0, 24)}...`);
+  console.log(`   ${jwsKey} = ${String(response._meta?.[jwsKey]).slice(0, 24)}... `);
 
-    // Check for record
-    if (hasReceipt(response)) {
-      const receipt = extractReceipt(response);
-      console.log(`  Record attached: ${receipt!.length} chars`);
-
-      // Verify record. Expect a `type_unregistered` warning because
-      // org.peacprotocol/mcp-tool-call is intentionally unregistered.
-      const result = await verifyLocal(receipt!, params.publicKey, { issuer: ISSUER_URL });
-      if (result.valid) {
-        const commerce = (
-          result.claims.extensions as
-            | { 'org.peacprotocol/commerce'?: { amount_minor?: string; currency?: string } }
-            | undefined
-        )?.['org.peacprotocol/commerce'];
-        const typeUnregistered = result.warnings.some((w) => w.code === 'type_unregistered');
-        console.log(`  Record valid: true`);
-        console.log(`  Amount: ${commerce?.amount_minor ?? '?'} ${commerce?.currency ?? '?'}`);
-        console.log(`  Warning type_unregistered (expected): ${typeUnregistered}`);
-      } else {
-        console.error(`  Record invalid: ${result.code} ${result.message}`);
-      }
-    }
-
-    // Show results
-    const result = response.result as { results: string[] };
-    console.log(`  Results: ${result.results.length} items`);
+  // Extract with receipt_ref consistency check (async variant verifies that
+  // receipt_ref matches sha256 of receipt_jws).
+  const extracted = await extractReceiptFromMetaAsync(response);
+  if (!extracted || extracted.receipts.length === 0) {
+    console.error(`   Extraction failed: ${extracted?.violations.join('; ') ?? 'no carrier'}`);
+    process.exitCode = 1;
+    return;
   }
+  console.log(`3. Carrier extracted: receipt_ref consistency OK (0 violations)`);
+
+  // Verify offline with the issuer public key. Expect a `type_unregistered`
+  // warning because org.peacprotocol/mcp-tool-call is intentionally unregistered.
+  const carrierJws = extracted.receipts[0].receipt_jws!;
+  const verifyResult = await verifyLocal(carrierJws, params.publicKey, { issuer: ISSUER_URL });
+  if (verifyResult.valid) {
+    const commerce = (
+      verifyResult.claims.extensions as
+        | { 'org.peacprotocol/commerce'?: { amount_minor?: string; currency?: string } }
+        | undefined
+    )?.['org.peacprotocol/commerce'];
+    const typeUnregistered = verifyResult.warnings.some((w) => w.code === 'type_unregistered');
+    console.log(`4. Offline verification: valid = true`);
+    console.log(`   Amount: ${commerce?.amount_minor ?? '?'} ${commerce?.currency ?? '?'}`);
+    console.log(`   Warning type_unregistered (expected): ${typeUnregistered}`);
+  } else {
+    console.error(`4. Offline verification FAILED: ${verifyResult.code} ${verifyResult.message}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  // Tamper check 1: flip one character of receipt_jws inside _meta. The
+  // carrier's receipt_ref no longer matches sha256 of the JWS, so the async
+  // extractor rejects the carrier with a violation.
+  const tamperedCarrier: McpToolCallResult = {
+    ...response,
+    _meta: { ...response._meta, [jwsKey]: flipChar(carrierJws, carrierJws.length - 2) },
+  };
+  const tamperedExtract = await extractReceiptFromMetaAsync(tamperedCarrier);
+  const refMismatch =
+    tamperedExtract !== null &&
+    tamperedExtract.receipts.length === 0 &&
+    tamperedExtract.violations.length > 0;
+  console.log(`5. Tamper check 1 (flip one char of receipt_jws in _meta):`);
+  console.log(`   carrier rejected = ${refMismatch}`);
+  console.log(`   violation: ${tamperedExtract?.violations[0] ?? 'none'}`);
+  if (!refMismatch) process.exitCode = 1;
+
+  // Tamper check 2: modify a payload claim but keep the original signature.
+  // The Ed25519 signature check fails even though the JWS still parses.
+  const tamperedJws = tamperPayload(carrierJws);
+  const tamperedVerify = await verifyLocal(tamperedJws, params.publicKey, { issuer: ISSUER_URL });
+  console.log(`6. Tamper check 2 (modify payload claim, keep signature):`);
+  console.log(`   valid = ${tamperedVerify.valid}`);
+  console.log(`   code  = ${tamperedVerify.valid ? 'n/a' : tamperedVerify.code}`);
+  if (tamperedVerify.valid) process.exitCode = 1;
 
   console.log('\n=== Demo Complete ===\n');
 }
 
 // Main execution
 async function main() {
-  // Generate keypair for demo
   const { privateKey, publicKey } = await generateKeypair();
-
-  // Run client
-  await mcpClient({
-    privateKey,
-    publicKey,
-  });
+  await mcpClient({ privateKey, publicKey });
 }
 
-main().catch(console.error);
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/examples/mcp-tool-call/package.json
+++ b/examples/mcp-tool-call/package.json
@@ -2,7 +2,7 @@
   "name": "@peac/example-mcp-tool-call",
   "version": "0.0.0",
   "private": true,
-  "description": "PEAC MCP tool call example - paid MCP tool with receipt proof and budget enforcement",
+  "description": "PEAC MCP tool-call example with signed records and offline verification",
   "type": "module",
   "scripts": {
     "demo": "tsx demo.ts",

--- a/surfaces/plugin-pack/claude-code/.mcp.json
+++ b/surfaces/plugin-pack/claude-code/.mcp.json
@@ -4,7 +4,7 @@
     "peac": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@peac/mcp-server@0.14.5"],
+      "args": ["-y", "@peac/mcp-server@0.15.0"],
       "env": {}
     }
   }

--- a/surfaces/plugin-pack/codex/codex-config.pinned.json
+++ b/surfaces/plugin-pack/codex/codex-config.pinned.json
@@ -3,7 +3,7 @@
   "mcpServers": {
     "peac": {
       "command": "npx",
-      "args": ["-y", "@peac/mcp-server@0.14.5"],
+      "args": ["-y", "@peac/mcp-server@0.15.0"],
       "env": {}
     }
   }

--- a/surfaces/plugin-pack/cursor/mcp.json
+++ b/surfaces/plugin-pack/cursor/mcp.json
@@ -3,7 +3,7 @@
   "mcpServers": {
     "peac": {
       "command": "npx",
-      "args": ["-y", "@peac/mcp-server@0.14.5"],
+      "args": ["-y", "@peac/mcp-server@0.15.0"],
       "env": {}
     }
   }

--- a/surfaces/plugin-pack/vscode/mcp.json
+++ b/surfaces/plugin-pack/vscode/mcp.json
@@ -4,7 +4,7 @@
     "peac": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@peac/mcp-server@0.14.5"],
+      "args": ["-y", "@peac/mcp-server@0.15.0"],
       "env": {}
     }
   }


### PR DESCRIPTION
## Summary

Fixes the MCP HTTP quickstart so it exercises the real MCP path, modernizes the MCP tool-call example to the current `_meta` evidence carrier with explicit tamper-detection checks, and updates plugin-pack pins to the published `0.15.0` server. Examples and configuration pins only; no package source, wire format, schema, or runtime behavior changes.

## Scope

- `examples/mcp-http-quickstart/quickstart.ts`
- `examples/mcp-tool-call/demo.ts`, `examples/mcp-tool-call/README.md`, `examples/mcp-tool-call/package.json`
- `surfaces/plugin-pack/{claude-code/.mcp.json, cursor/mcp.json, codex/codex-config.pinned.json, vscode/mcp.json}`

Explicitly not changed: any published package source, tool schemas, the carrier format, transports.

## Changes

- HTTP quickstart: calls `peac_verify` with the correct `jws` input field (was `receipt`) plus the public key (offline verification) and an `issuer` expectation (issuer binding), captures the `Mcp-Session-Id` header from `initialize` and reuses it on subsequent requests, sends the current `2025-11-25` protocol version with an `Accept` header covering JSON and SSE responses, sends `notifications/initialized` as a proper JSON-RPC notification (no `id`) via a dedicated helper that drains the response body, applies a 10s request timeout to all fetch calls, and labels local verification explicitly as a fallback when the MCP path did not verify (no more silent fallback).
- MCP tool-call example: replaces the legacy top-level `peac_receipt` helper with the current carrier (`computeReceiptRef` + `attachReceiptToMeta` + `extractReceiptFromMetaAsync`, top-level `_meta` keys), and adds two tamper checks: a modified `receipt_jws` is rejected by the `receipt_ref` consistency check, and a modified payload fails Ed25519 verification with `E_INVALID_SIGNATURE`. The `type_unregistered` warning for integrator-defined type URI values remains documented and asserted.
- Plugin-pack pins: `@peac/mcp-server@0.14.5` -> `@peac/mcp-server@0.15.0` across the four client configs.
- Example package description updated to match the current example scope.

## Validation

- `@peac/mappings-mcp` tests: 81 passed. `@peac/mcp-server` tests: 289 passed.
- `examples/mcp-tool-call`: `tsc --noEmit` clean; `pnpm demo` runs end-to-end with both tamper checks failing as expected.
- `examples/mcp-http-quickstart`: verified against a locally started `--transport http` server (session header honored, `peac_verify` returns PASSED through the MCP path) and against an unreachable server (fallback clearly labeled, exit reflects state).
- Prettier and whitespace checks pass on all touched files.
