### PR TITLE
feat(cli): offline receipt verification with a local public key

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -27,6 +27,9 @@ import { readFileBufferSnapshot } from './lib/safe-file.js';
 /** Upper bound for a public-key file (a JWK/JWKS is well under 1 KiB). */
 const MAX_PUBLIC_KEY_FILE_BYTES = 16_384;
 
+/** Upper bound for a receipt JWS file passed to `peac verify`. */
+const MAX_VERIFY_JWS_FILE_BYTES = 512 * 1024;
+
 const program = new Command();
 
 program
@@ -49,10 +52,27 @@ program
   )
   .action(async (jwsInput: string, options: { verbose?: boolean; publicKey?: string }) => {
     try {
-      // Check if input is a file path
+      // Check if input is a file path; file reads are bounded.
       let jws = jwsInput;
       if (fs.existsSync(jwsInput)) {
-        jws = fs.readFileSync(jwsInput, 'utf-8').trim();
+        try {
+          jws = readFileBufferSnapshot(jwsInput, { maxBytes: MAX_VERIFY_JWS_FILE_BYTES })
+            .toString('utf8')
+            .trim();
+        } catch (readErr) {
+          const code = (readErr as NodeJS.ErrnoException).code;
+          if (code === 'E_PEAC_FILE_TOO_LARGE') {
+            console.log(
+              `Verification failed: receipt file exceeds ${MAX_VERIFY_JWS_FILE_BYTES} bytes`
+            );
+          } else if (code === 'EISDIR') {
+            console.log('Verification failed: receipt path is a directory');
+          } else {
+            console.log('Verification failed: could not read receipt file');
+          }
+          process.exitCode = 1;
+          return;
+        }
       }
 
       // Offline mode: verify the signature locally against a supplied public

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,7 +5,7 @@
  */
 
 import { Command, CommanderError } from 'commander';
-import { verifyReceipt } from '@peac/protocol';
+import { verifyReceipt, verifyLocal } from '@peac/protocol';
 import { parseIssuerConfig, fetchIssuerConfig } from '@peac/protocol';
 import { decode } from '@peac/crypto';
 import { PEACReceiptClaims } from '@peac/schema';
@@ -21,6 +21,7 @@ import { recordCommand } from './commands/record-command.js';
 import { emitCommand } from './commands/emit-lifecycle.js';
 import { formatOutput } from './utils.js';
 import { getVersion } from './lib/version.js';
+import { parsePublicKey } from './lib/public-key.js';
 
 const program = new Command();
 
@@ -38,12 +39,59 @@ program
   .description('Verify a PEAC receipt JWS')
   .argument('<jws>', 'JWS compact serialization or path to file containing JWS')
   .option('-v, --verbose', 'Show detailed output')
-  .action(async (jwsInput: string, options: { verbose?: boolean }) => {
+  .option(
+    '--public-key <path>',
+    'Verify offline with a public Ed25519 JWK or single-key JWKS file (no network)'
+  )
+  .action(async (jwsInput: string, options: { verbose?: boolean; publicKey?: string }) => {
     try {
       // Check if input is a file path
       let jws = jwsInput;
       if (fs.existsSync(jwsInput)) {
         jws = fs.readFileSync(jwsInput, 'utf-8').trim();
+      }
+
+      // Offline mode: verify the signature locally against a supplied public
+      // key. No network / JWKS discovery. Structure validation is performed by
+      // verifyLocal, so this path does not assume a payment-receipt shape.
+      if (options.publicKey) {
+        console.log('Verifying PEAC receipt offline...\n');
+
+        let keyContent: string;
+        try {
+          keyContent = fs.readFileSync(options.publicKey, 'utf-8');
+        } catch {
+          console.log('Verification failed: could not read public key file');
+          process.exitCode = 1;
+          return;
+        }
+
+        let publicKey: Uint8Array;
+        try {
+          publicKey = parsePublicKey(keyContent);
+        } catch (keyErr) {
+          console.log(
+            `Verification failed: ${keyErr instanceof Error ? keyErr.message : 'invalid public key'}`
+          );
+          process.exitCode = 1;
+          return;
+        }
+
+        const localResult = await verifyLocal(jws, publicKey);
+        if (localResult.valid) {
+          console.log('Signature valid (offline).');
+          console.log(
+            '   Verified the receipt signature and declared receipt structure against the supplied public key.'
+          );
+          process.exitCode = 0;
+        } else {
+          console.log(`Verification failed: ${localResult.message}`);
+          if (localResult.code) {
+            console.log(`   Code: ${localResult.code}`);
+          }
+          process.exitCode = 1;
+        }
+        return;
       }
 
       console.log('Verifying PEAC receipt...\n');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,6 +22,10 @@ import { emitCommand } from './commands/emit-lifecycle.js';
 import { formatOutput } from './utils.js';
 import { getVersion } from './lib/version.js';
 import { parsePublicKey } from './lib/public-key.js';
+import { readFileBufferSnapshot } from './lib/safe-file.js';
+
+/** Upper bound for a public-key file (a JWK/JWKS is well under 1 KiB). */
+const MAX_PUBLIC_KEY_FILE_BYTES = 16_384;
 
 const program = new Command();
 
@@ -59,9 +63,20 @@ program
 
         let keyContent: string;
         try {
-          keyContent = fs.readFileSync(options.publicKey, 'utf-8');
-        } catch {
-          console.log('Verification failed: could not read public key file');
+          keyContent = readFileBufferSnapshot(options.publicKey, {
+            maxBytes: MAX_PUBLIC_KEY_FILE_BYTES,
+          }).toString('utf8');
+        } catch (readErr) {
+          const code = (readErr as NodeJS.ErrnoException).code;
+          if (code === 'E_PEAC_FILE_TOO_LARGE') {
+            console.log(
+              `Verification failed: public key file exceeds ${MAX_PUBLIC_KEY_FILE_BYTES} bytes`
+            );
+          } else if (code === 'EISDIR') {
+            console.log('Verification failed: public key path is a directory');
+          } else {
+            console.log('Verification failed: could not read public key file');
+          }
           process.exitCode = 1;
           return;
         }

--- a/packages/cli/src/lib/public-key.ts
+++ b/packages/cli/src/lib/public-key.ts
@@ -1,0 +1,76 @@
+/**
+ * Public verification key loader for offline `peac verify --public-key`.
+ *
+ * Accepts either a bare public Ed25519 JWK or a single-key JWKS
+ * (`{ "keys": [jwk] }`). Fails closed: rejects private key material, empty or
+ * multi-key JWKS, non-Ed25519 keys, and malformed input. Error messages are
+ * user-safe and never echo key material.
+ *
+ * Conversion and the base64url / 32-byte length check reuse the canonical
+ * `jwkToPublicKeyBytes()` from `@peac/crypto`; this module only handles file
+ * shape, container selection, and the private-key guard.
+ */
+
+import { jwkToPublicKeyBytes } from '@peac/crypto';
+
+/**
+ * Parse the contents of a public-key file into raw Ed25519 public key bytes.
+ *
+ * @param content - UTF-8 contents of the public-key file (bare JWK or single-key JWKS).
+ * @returns The 32-byte Ed25519 public key.
+ * @throws Error with a user-safe message on any invalid / unsupported input.
+ */
+export function parsePublicKey(content: string): Uint8Array {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    throw new Error('public key file is not valid JSON');
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('public key file must be a JWK or single-key JWKS object');
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  // Single-key JWKS container: { keys: [ jwk ] }.
+  let jwk: Record<string, unknown>;
+  if ('keys' in obj) {
+    const keys = obj.keys;
+    if (!Array.isArray(keys) || keys.length === 0) {
+      throw new Error('JWKS contains no keys');
+    }
+    if (keys.length > 1) {
+      throw new Error(
+        'JWKS contains multiple keys; a single-key JWKS is required (multi-key JWKS is not supported)'
+      );
+    }
+    const first = keys[0];
+    if (first === null || typeof first !== 'object' || Array.isArray(first)) {
+      throw new Error('JWKS key entry is not a JWK object');
+    }
+    jwk = first as Record<string, unknown>;
+  } else {
+    jwk = obj;
+  }
+
+  if ('d' in jwk) {
+    throw new Error('public key required: the file contains private key material');
+  }
+
+  const { kty, crv, x } = jwk as { kty?: unknown; crv?: unknown; x?: unknown };
+  if (kty !== 'OKP' || crv !== 'Ed25519') {
+    throw new Error('unsupported key: expected a public Ed25519 JWK (kty "OKP", crv "Ed25519")');
+  }
+  if (typeof x !== 'string' || x.length === 0) {
+    throw new Error('invalid JWK: missing public key value "x"');
+  }
+
+  try {
+    return jwkToPublicKeyBytes({ kty: 'OKP', crv: 'Ed25519', x });
+  } catch {
+    // jwkToPublicKeyBytes throws on bad base64url or wrong length.
+    throw new Error('invalid JWK: "x" is not a 32-byte base64url Ed25519 public key');
+  }
+}

--- a/packages/cli/tests/public-key.test.ts
+++ b/packages/cli/tests/public-key.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for the offline public-key loader in
+ * `packages/cli/src/lib/public-key.ts` (`peac verify --public-key`).
+ *
+ * Covers the acceptance matrix (bare public Ed25519 JWK, single-key JWKS)
+ * and the fail-closed rejection matrix (private key material, multi-key /
+ * empty JWKS, non-Ed25519 keys, missing or malformed `x`, invalid JSON).
+ * Error messages must be user-safe and never echo key material.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parsePublicKey } from '../src/lib/public-key.js';
+
+const VALID_X = Buffer.alloc(32, 7).toString('base64url');
+const VALID_JWK = { kty: 'OKP', crv: 'Ed25519', x: VALID_X };
+
+describe('parsePublicKey', () => {
+  describe('accepts', () => {
+    it('a bare public Ed25519 JWK', () => {
+      const bytes = parsePublicKey(JSON.stringify(VALID_JWK));
+      expect(bytes).toBeInstanceOf(Uint8Array);
+      expect(bytes.length).toBe(32);
+    });
+
+    it('a single-key JWKS container', () => {
+      const bytes = parsePublicKey(JSON.stringify({ keys: [VALID_JWK] }));
+      expect(bytes.length).toBe(32);
+    });
+
+    it('a JWK with extra non-private members (kid, alg, use)', () => {
+      const jwk = { ...VALID_JWK, kid: 'sandbox-1', alg: 'EdDSA', use: 'sig' };
+      expect(parsePublicKey(JSON.stringify(jwk)).length).toBe(32);
+    });
+  });
+
+  describe('rejects (fail closed)', () => {
+    it('private key material (d present) in a bare JWK', () => {
+      const jwk = { ...VALID_JWK, d: Buffer.alloc(32, 9).toString('base64url') };
+      expect(() => parsePublicKey(JSON.stringify(jwk))).toThrow(/private key material/);
+    });
+
+    it('private key material (d present) inside a JWKS', () => {
+      const jwk = { ...VALID_JWK, d: Buffer.alloc(32, 9).toString('base64url') };
+      expect(() => parsePublicKey(JSON.stringify({ keys: [jwk] }))).toThrow(/private key material/);
+    });
+
+    it('a multi-key JWKS', () => {
+      expect(() => parsePublicKey(JSON.stringify({ keys: [VALID_JWK, VALID_JWK] }))).toThrow(
+        /multiple keys/
+      );
+    });
+
+    it('an empty JWKS', () => {
+      expect(() => parsePublicKey(JSON.stringify({ keys: [] }))).toThrow(/no keys/);
+    });
+
+    it('a JWKS whose keys member is not an array', () => {
+      expect(() => parsePublicKey(JSON.stringify({ keys: 'nope' }))).toThrow(/no keys/);
+    });
+
+    it('a JWKS entry that is not an object', () => {
+      expect(() => parsePublicKey(JSON.stringify({ keys: ['nope'] }))).toThrow(/not a JWK object/);
+    });
+
+    it('a non-OKP key type', () => {
+      expect(() => parsePublicKey(JSON.stringify({ kty: 'EC', crv: 'P-256', x: VALID_X }))).toThrow(
+        /Ed25519/
+      );
+    });
+
+    it('a non-Ed25519 curve', () => {
+      expect(() =>
+        parsePublicKey(JSON.stringify({ kty: 'OKP', crv: 'X25519', x: VALID_X }))
+      ).toThrow(/Ed25519/);
+    });
+
+    it('a JWK missing x', () => {
+      expect(() => parsePublicKey(JSON.stringify({ kty: 'OKP', crv: 'Ed25519' }))).toThrow(
+        /missing public key value/
+      );
+    });
+
+    it('a JWK with empty x', () => {
+      expect(() => parsePublicKey(JSON.stringify({ kty: 'OKP', crv: 'Ed25519', x: '' }))).toThrow(
+        /missing public key value/
+      );
+    });
+
+    it('an x that is not 32 bytes', () => {
+      const shortX = Buffer.alloc(16, 7).toString('base64url');
+      expect(() =>
+        parsePublicKey(JSON.stringify({ kty: 'OKP', crv: 'Ed25519', x: shortX }))
+      ).toThrow(/32-byte/);
+    });
+
+    it('an x that is not base64url', () => {
+      expect(() =>
+        parsePublicKey(JSON.stringify({ kty: 'OKP', crv: 'Ed25519', x: '!!!not-base64url!!!' }))
+      ).toThrow(/32-byte/);
+    });
+
+    it('invalid JSON', () => {
+      expect(() => parsePublicKey('{not json')).toThrow(/not valid JSON/);
+    });
+
+    it('a JSON array', () => {
+      expect(() => parsePublicKey(JSON.stringify([VALID_JWK]))).toThrow(/JWK or single-key JWKS/);
+    });
+
+    it('a JSON primitive', () => {
+      expect(() => parsePublicKey(JSON.stringify('key'))).toThrow(/JWK or single-key JWKS/);
+    });
+  });
+
+  describe('error hygiene', () => {
+    it('never echoes key material in error messages', () => {
+      const secret = Buffer.alloc(32, 9).toString('base64url');
+      const jwk = { ...VALID_JWK, d: secret };
+      try {
+        parsePublicKey(JSON.stringify(jwk));
+        expect.unreachable('expected parsePublicKey to throw');
+      } catch (err) {
+        expect((err as Error).message).not.toContain(secret);
+        expect((err as Error).message).not.toContain(VALID_X);
+      }
+    });
+  });
+});

--- a/packages/cli/tests/samples-verify.test.ts
+++ b/packages/cli/tests/samples-verify.test.ts
@@ -4,9 +4,9 @@
  * remain rejection fixtures.
  *
  * Spawns the built CLI (`samples generate`) and checks the generated records
- * programmatically with verifyLocal() against the generated sandbox JWKS, so
- * the check does not depend on the not-yet-merged `peac verify --public-key`
- * flag. Asserts the event-time semantics (`--now` sets occurred_at, not iat),
+ * programmatically with verifyLocal() against the generated sandbox JWKS,
+ * independent of the `peac verify --public-key` CLI flag (covered by
+ * verify-public-key-cli.test.ts). Asserts the event-time semantics (`--now` sets occurred_at, not iat),
  * kid handling, and that a payload-tampered record fails.
  */
 

--- a/packages/cli/tests/samples-verify.test.ts
+++ b/packages/cli/tests/samples-verify.test.ts
@@ -4,9 +4,9 @@
  * remain rejection fixtures.
  *
  * Spawns the built CLI (`samples generate`) and checks the generated records
- * programmatically with verifyLocal() against the generated sandbox JWKS,
- * independent of the `peac verify --public-key` CLI flag (covered by
- * verify-public-key-cli.test.ts). Asserts the event-time semantics (`--now` sets occurred_at, not iat),
+ * programmatically with verifyLocal() against the generated sandbox JWKS, so
+ * the check does not depend on the not-yet-merged `peac verify --public-key`
+ * flag. Asserts the event-time semantics (`--now` sets occurred_at, not iat),
  * kid handling, and that a payload-tampered record fails.
  */
 

--- a/packages/cli/tests/verify-public-key-cli.test.ts
+++ b/packages/cli/tests/verify-public-key-cli.test.ts
@@ -1,0 +1,107 @@
+/**
+ * CLI wiring tests for `peac verify --public-key <path>`.
+ *
+ * Spawns the built CLI to prove the offline flag works end-to-end against
+ * generated samples: a valid record verifies (exit 0), a tampered record
+ * fails (non-zero), and unusable key files (private material, oversized,
+ * directory, missing) are rejected with user-safe messages.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI_PATH = join(__dirname, '..', 'dist', 'index.cjs');
+
+interface CliResult {
+  status: number;
+  stdout: string;
+}
+
+function runVerify(args: string[]): CliResult {
+  try {
+    const stdout = execFileSync('node', [CLI_PATH, 'verify', ...args], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf8',
+    });
+    return { status: 0, stdout };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string };
+    return { status: e.status ?? -1, stdout: e.stdout ?? '' };
+  }
+}
+
+let samplesDir: string;
+let validJwsPath: string;
+let jwksPath: string;
+
+beforeAll(() => {
+  samplesDir = mkdtempSync(join(tmpdir(), 'peac-verify-pk-'));
+  execFileSync('node', [CLI_PATH, 'samples', 'generate', '-o', samplesDir], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: 'utf8',
+  });
+  validJwsPath = join(samplesDir, 'valid', 'basic-record.jws');
+  jwksPath = join(samplesDir, 'bundles', 'sandbox-jwks.json');
+});
+
+describe('peac verify --public-key (CLI wiring)', () => {
+  it('verifies a valid sample offline with the sandbox JWKS', () => {
+    const { status, stdout } = runVerify([validJwsPath, '--public-key', jwksPath]);
+    expect(status).toBe(0);
+    expect(stdout).toContain('Signature valid (offline)');
+  });
+
+  it('fails on a tampered record', () => {
+    const jws = readFileSync(validJwsPath, 'utf8').trim();
+    const tamperedPath = join(samplesDir, 'tampered.jws');
+    writeFileSync(tamperedPath, `${jws.slice(0, -1)}${jws.endsWith('A') ? 'B' : 'A'}`);
+
+    const { status, stdout } = runVerify([tamperedPath, '--public-key', jwksPath]);
+    expect(status).not.toBe(0);
+    expect(stdout).toContain('E_INVALID_SIGNATURE');
+  });
+
+  it('rejects a key file containing private key material', () => {
+    const privatePath = join(samplesDir, 'private.jwk.json');
+    writeFileSync(
+      privatePath,
+      JSON.stringify({
+        kty: 'OKP',
+        crv: 'Ed25519',
+        x: Buffer.alloc(32, 7).toString('base64url'),
+        d: Buffer.alloc(32, 9).toString('base64url'),
+      })
+    );
+
+    const { status, stdout } = runVerify([validJwsPath, '--public-key', privatePath]);
+    expect(status).not.toBe(0);
+    expect(stdout).toContain('private key material');
+  });
+
+  it('rejects an oversized key file', () => {
+    const bigPath = join(samplesDir, 'big-key.json');
+    writeFileSync(bigPath, `{"pad":"${'x'.repeat(20_000)}"}`);
+
+    const { status, stdout } = runVerify([validJwsPath, '--public-key', bigPath]);
+    expect(status).not.toBe(0);
+    expect(stdout).toContain('exceeds');
+  });
+
+  it('rejects a directory as the key path', () => {
+    const { status, stdout } = runVerify([validJwsPath, '--public-key', samplesDir]);
+    expect(status).not.toBe(0);
+    expect(stdout).toContain('directory');
+  });
+
+  it('rejects a missing key path', () => {
+    const missingPath = join(samplesDir, 'does-not-exist.json');
+    const { status, stdout } = runVerify([validJwsPath, '--public-key', missingPath]);
+    expect(status).not.toBe(0);
+    expect(stdout).toContain('could not read public key file');
+  });
+});

--- a/packages/cli/tests/verify-public-key-cli.test.ts
+++ b/packages/cli/tests/verify-public-key-cli.test.ts
@@ -3,19 +3,21 @@
  *
  * Spawns the built CLI to prove the offline flag works end-to-end against
  * generated samples: a valid record verifies (exit 0), a tampered record
- * fails (non-zero), and unusable key files (private material, oversized,
- * directory, missing) are rejected with user-safe messages.
+ * fails (non-zero), unusable key files (private material, oversized,
+ * directory, missing) are rejected, and bounded receipt-file reads reject
+ * oversized files and directory paths with user-safe messages.
  */
 
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLI_PATH = join(__dirname, '..', 'dist', 'index.cjs');
+const SPAWN_TIMEOUT_MS = 15_000;
 
 interface CliResult {
   status: number;
@@ -27,6 +29,7 @@ function runVerify(args: string[]): CliResult {
     const stdout = execFileSync('node', [CLI_PATH, 'verify', ...args], {
       stdio: ['ignore', 'pipe', 'pipe'],
       encoding: 'utf8',
+      timeout: SPAWN_TIMEOUT_MS,
     });
     return { status: 0, stdout };
   } catch (err) {
@@ -44,9 +47,14 @@ beforeAll(() => {
   execFileSync('node', [CLI_PATH, 'samples', 'generate', '-o', samplesDir], {
     stdio: ['ignore', 'pipe', 'pipe'],
     encoding: 'utf8',
+    timeout: SPAWN_TIMEOUT_MS,
   });
   validJwsPath = join(samplesDir, 'valid', 'basic-record.jws');
   jwksPath = join(samplesDir, 'bundles', 'sandbox-jwks.json');
+});
+
+afterAll(() => {
+  rmSync(samplesDir, { recursive: true, force: true });
 });
 
 describe('peac verify --public-key (CLI wiring)', () => {
@@ -58,8 +66,14 @@ describe('peac verify --public-key (CLI wiring)', () => {
 
   it('fails on a tampered record', () => {
     const jws = readFileSync(validJwsPath, 'utf8').trim();
+    // Flip a mid-signature character: the final base64url character of an
+    // Ed25519 signature carries 4 ignored padding bits, so tampering there
+    // can decode to identical bytes. A mid-segment flip always changes the
+    // signature.
+    const i = jws.length - 10;
+    const tampered = `${jws.slice(0, i)}${jws[i] === 'x' ? 'y' : 'x'}${jws.slice(i + 1)}`;
     const tamperedPath = join(samplesDir, 'tampered.jws');
-    writeFileSync(tamperedPath, `${jws.slice(0, -1)}${jws.endsWith('A') ? 'B' : 'A'}`);
+    writeFileSync(tamperedPath, tampered);
 
     const { status, stdout } = runVerify([tamperedPath, '--public-key', jwksPath]);
     expect(status).not.toBe(0);
@@ -103,5 +117,22 @@ describe('peac verify --public-key (CLI wiring)', () => {
     const { status, stdout } = runVerify([validJwsPath, '--public-key', missingPath]);
     expect(status).not.toBe(0);
     expect(stdout).toContain('could not read public key file');
+  });
+});
+
+describe('peac verify receipt-file input (bounded reads)', () => {
+  it('rejects an oversized receipt file', () => {
+    const bigJwsPath = join(samplesDir, 'big-receipt.jws');
+    writeFileSync(bigJwsPath, 'a'.repeat(600 * 1024));
+
+    const { status, stdout } = runVerify([bigJwsPath, '--public-key', jwksPath]);
+    expect(status).not.toBe(0);
+    expect(stdout).toContain('receipt file exceeds');
+  });
+
+  it('rejects a directory as the receipt path', () => {
+    const { status, stdout } = runVerify([samplesDir, '--public-key', jwksPath]);
+    expect(status).not.toBe(0);
+    expect(stdout).toContain('receipt path is a directory');
   });
 });

--- a/packages/cli/tests/verify-public-key-cli.test.ts
+++ b/packages/cli/tests/verify-public-key-cli.test.ts
@@ -10,13 +10,16 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const CLI_PATH = join(__dirname, '..', 'dist', 'index.cjs');
+// Resolve the built CLI whether vitest runs with the package root or the
+// repository root as cwd.
+const PKG_ROOT = existsSync(join(process.cwd(), 'dist', 'index.cjs'))
+  ? process.cwd()
+  : join(process.cwd(), 'packages', 'cli');
+const CLI_PATH = join(PKG_ROOT, 'dist', 'index.cjs');
 const SPAWN_TIMEOUT_MS = 15_000;
 
 interface CliResult {


### PR DESCRIPTION
## Summary

Adds an offline verification path to `peac verify`: `--public-key <path>` verifies a receipt JWS against a local public Ed25519 JWK or single-key JWKS with no network access. The existing network verification path is unchanged when the flag is omitted. Public surface change: adds the CLI flag `peac verify --public-key <path>`. No package exports, wire format, schema, signing, or registry changes.

## Scope

- `packages/cli/src/index.ts` (verify command option + offline branch)
- `packages/cli/src/lib/public-key.ts` (new key loader)
- `packages/cli/tests/public-key.test.ts` (new key-loader tests)
- `packages/cli/tests/verify-public-key-cli.test.ts` (new command wiring tests)

Explicitly not changed: `verifyReceipt` network resolution, `verifyLocal` semantics, any published package other than the CLI.

## Changes

- `peac verify <jws> --public-key <path>` reads a bare public Ed25519 JWK or a single-key JWKS file and verifies via `verifyLocal` (signature plus declared receipt structure), entirely offline.
- The key loader fails closed: it rejects files containing private key material (`d`), multi-key or empty JWKS, non-Ed25519 keys, and missing or malformed `x` values. Byte conversion reuses the canonical `jwkToPublicKeyBytes` from `@peac/crypto`. Error messages never echo key material.
- File reads in the verify command are bounded via the existing fd-bound snapshot helper: public-key files at 16 KiB and receipt files at 512 KiB. Oversized files, directories, and missing paths are rejected with user-safe messages that do not echo paths or content.
- Works directly with generated samples:

```bash
npx @peac/cli samples generate -o ./peac-samples
npx @peac/cli verify ./peac-samples/valid/basic-record.jws --public-key ./peac-samples/bundles/sandbox-jwks.json
```

## Validation

- CLI test suite: 286 passed, including the key-loader acceptance and rejection matrix, an error-hygiene check, and command wiring tests that spawn the built CLI with timeouts and temp-dir cleanup (valid sample verifies; tampered record, private-key file, oversized key file, directory key path, missing key path, oversized receipt file, and directory receipt path all fail non-zero).
- End-to-end against the built CLI: generated samples verify offline (exit 0); a tampered JWS fails with `E_INVALID_SIGNATURE` (exit 1); a private-key file is rejected (exit 1); invalid samples fail closed (exit 1); omitting the flag exercises the unchanged network path.
- `tsc --noEmit`, Prettier, and whitespace checks pass.
