### PR TITLE
docs: readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 > Signed action records for AI agents, APIs, and MCP tools.
 
-AI agents are starting to do real work: call APIs, run MCP tools, change data, trigger payments, and provision resources.
+AI agents, APIs, MCP tools, gateways, payment flows, and provisioning systems already perform real work across system and organizational boundaries.
 
-PEAC creates a signed record for those actions, so another system can verify what happened later without trusting screenshots, private logs, or "the agent said so."
+PEAC records what those systems report as portable signed interaction records, so another party can verify what happened later without trusting screenshots, private logs, or unverifiable assertions.
 
 **Record locally. Verify across boundaries.**
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # PEAC Protocol
 
-> Signed action records for AI agents, APIs, and MCP tools.
+> Signed action records for AI agents, APIs, MCP tools, and gateways.
 
-AI agents, APIs, MCP tools, gateways, payment flows, and provisioning systems already perform real work across system and organizational boundaries.
+Automated systems already call APIs, run MCP tools, make gateway decisions, report payment events, and provision resources across system boundaries.
 
-PEAC records what those systems report as portable signed interaction records, so another party can verify what happened later without trusting screenshots, private logs, or unverifiable assertions.
+PEAC records those actions, decisions, and events as portable signed interaction records, so another party can verify what happened later without relying on screenshots, private logs, or unverifiable assertions.
 
 **Record locally. Verify across boundaries.**
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # PEAC Protocol
 
-**Portable signed records for automated interactions.**
+> Signed action records for AI agents, APIs, and MCP tools.
 
-When logs are not enough, PEAC gives teams records another party can verify outside the system that produced them.
+AI agents are starting to do real work: call APIs, run MCP tools, change data, trigger payments, and provision resources.
 
-PEAC records what APIs, MCP tools, agent workflows, gateways, payment-adjacent flows, provisioning systems, runtimes, and audit systems report. It does not run those systems or make their decisions.
+PEAC creates a signed record for those actions, so another system can verify what happened later without trusting screenshots, private logs, or "the agent said so."
 
 **Record locally. Verify across boundaries.**
 

--- a/README.md
+++ b/README.md
@@ -83,14 +83,14 @@ scope: [`docs/WHAT-PEAC-STANDARDIZES.md`](docs/WHAT-PEAC-STANDARDIZES.md).
 
 ## Choose your path
 
-| If you...                                       | PEAC helps you...                                                                                                                      | Start here                                                                        |
-| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| Run an API or metered service                   | issue signed records for requests, responses, usage, and policy-visible outcomes                                                       | [API Provider Quickstart](docs/guides/quickstart-api-provider.md)                 |
-| Build MCP tools or agent workflows              | attach records to tool runs, command execution, handoffs, lifecycle events, and agent actions                                          | [MCP Integration Kit](integrator-kits/mcp/README.md) or `npx -y @peac/mcp-server` |
-| Build payment, gateway, or commerce flows       | preserve signed evidence around access, payment, settlement, mandate, gateway, and dispute events without operating the payment system | [Commerce evidence bundle](docs/SOLUTIONS/commerce-evidence-bundle.md)            |
-| Track provisioning or resource lifecycle events | record catalog, provider-link, account, credential, budget, subscription, domain, deployment, and resource events                      | [Provisioning lifecycle records](docs/SOLUTIONS/verify-agent-provisioning.md)     |
-| Need audit or review evidence                   | export portable records and bundles that can be referenced beside logs, traces, SIEMs, reports, and audit repositories                 | [Where PEAC fits](docs/WHERE-IT-FITS.md)                                          |
-| Need to verify a record                         | verify a signed PEAC record with the issuer's public key or a self-hosted verifier                                                     | [Agent Operator Quickstart](docs/guides/quickstart-agent-operator.md)             |
+| If you...                                       | PEAC helps you...                                                                                                                      | Start here                                                                                                                              |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Run an API or metered service                   | issue signed records for requests, responses, usage, and policy-visible outcomes                                                       | [API Provider Quickstart](docs/guides/quickstart-api-provider.md)                                                                       |
+| Build MCP tools or agent workflows              | attach records to tool runs, command execution, handoffs, lifecycle events, and agent actions                                          | [MCP Integration Kit](integrator-kits/mcp/README.md) or `npx -y @peac/mcp-server`                                                       |
+| Build payment, gateway, or commerce flows       | preserve signed evidence around access, payment, settlement, mandate, gateway, and dispute events without operating the payment system | [MCP gateway records](docs/SOLUTIONS/mcp-gateway-receipts.md) or [Commerce evidence bundle](docs/SOLUTIONS/commerce-evidence-bundle.md) |
+| Track provisioning or resource lifecycle events | record catalog, provider-link, account, credential, budget, subscription, domain, deployment, and resource events                      | [Provisioning lifecycle records](docs/SOLUTIONS/verify-agent-provisioning.md)                                                           |
+| Need audit or review evidence                   | export portable records and bundles that can be referenced beside logs, traces, SIEMs, reports, and audit repositories                 | [Where PEAC fits](docs/WHERE-IT-FITS.md)                                                                                                |
+| Need to verify a record                         | verify a signed PEAC record with the issuer's public key or a self-hosted verifier                                                     | [Agent Operator Quickstart](docs/guides/quickstart-agent-operator.md)                                                                   |
 
 Full path-by-role tree: [`docs/START_HERE.md`](docs/START_HERE.md).
 
@@ -114,7 +114,7 @@ const result = await verifyLocal(recordJws, publicKey, {
 });
 
 if (!result.valid) {
-  throw new Error(result.reason ?? 'PEAC record verification failed');
+  throw new Error(`${result.code}: ${result.message}`);
 }
 
 console.log(result.claims.iss, result.claims.kind, result.claims.type);
@@ -186,6 +186,7 @@ Practical recipes under [`docs/SOLUTIONS/`](docs/SOLUTIONS/):
 
 - [API record issuance](docs/SOLUTIONS/api-receipt-issuance.md)
 - [MCP tool-call records](docs/SOLUTIONS/mcp-tool-call-receipts.md)
+- [MCP gateway records](docs/SOLUTIONS/mcp-gateway-receipts.md)
 - [Agent action records](docs/SOLUTIONS/verify-agent-action.md)
 - [Gateway export records](docs/SOLUTIONS/verify-gateway-export.md)
 - [Commerce mandate records](docs/SOLUTIONS/verify-commerce-mandate.md)
@@ -200,6 +201,11 @@ Practical recipes under [`docs/SOLUTIONS/`](docs/SOLUTIONS/):
 - Verify a record locally with `verifyLocal()` or `pnpm dlx @peac/cli verify`.
 - Start the MCP server: `npx -y @peac/mcp-server`.
 - Run the minimal example: `pnpm --filter @peac/example-minimal demo`.
+- Run the MCP gateway records example:
+  ```bash
+  pnpm --filter @peac/example-mcp-gateway-receipts demo
+  pnpm --filter @peac/example-mcp-gateway-receipts demo:tamper
+  ```
 - Run the provisioning lifecycle example:
   ```bash
   pnpm --filter @peac/example-provisioning-lifecycle run issue


### PR DESCRIPTION
## Summary

Top-fold clarity improvement plus a final README polish. The headline uses "signed action records" (the developer-clear hook); the next paragraph defines the formal artifact as "portable signed interaction records" (the protocol-grade term covering decisions, observations, denials, payment events, provisioning events, gateway reports, and bundles). Present-tense framing; the canonical line "Record locally. Verify across boundaries." is unchanged.

## Scope (README.md only)

- New opening paragraphs (headline, present-tense context, formal definition).
- Quickstart fix: the failure object exposes `code` and `message` (there is no `reason` field); the example no longer throws dead fallback text.
- The MCP gateway records recipe is now discoverable: a Use-cases row, a Try-it entry running the example demo and tamper checks, and a start link in the Choose-your-path gateway row.
- Badges, the "What PEAC records" table content, boundary language, and all command conventions (npm install for libraries, pnpm dlx for one-off CLI, npx -y for the MCP server) are unchanged.
- No protocol behavior changes; no package, version, or schema changes.

## Validation

- prettier clean; `git diff --check` clean; tooling suite 955 passed (37 files); public-artifact and planning-leak scanners pass.
- Both documented demo commands verified end-to-end from the workspace root.
