### PR TITLE
chore(release): stamp v0.15.1 publish state

### DIFF
--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable surface classification for PEAC Protocol workspace. CI fails if any workspace member is missing. See docs/PACKAGE_STATUS.md for human-readable view.",
   "version": "0.13.0",
-  "updated": "2026-06-02",
+  "updated": "2026-06-11",
   "states": {
     "default": "Current recommended path. Actively maintained, Wire 0.2 native.",
     "supported": "Actively maintained, published, production-ready. May not be on default quickstart path.",

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -2,7 +2,7 @@
 
 Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scripts/generate-surface-status.mjs`.
 
-**Version:** 0.13.0 | **Updated:** 2026-06-02
+**Version:** 0.13.0 | **Updated:** 2026-06-11
 
 ## Layer 1
 

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -4,7 +4,7 @@
   "version": "0.15.1",
   "wire_format_version": "0.2",
   "dist_tag": "latest",
-  "release_date": "2026-06-01",
+  "release_date": "2026-06-11",
   "metrics": {
     "tests": 11525,
     "test_files": 459,


### PR DESCRIPTION
## Summary

Post-release state stamp for v0.15.1. Sets the release-state fields that are intentionally left at placeholder values in the release-prep PR and stamped after publish per docs/RELEASING.md.

## Changes

- `docs/releases/facts.json`: `release_date` 2026-06-01 -> 2026-06-11.
- `REPO_SURFACE_STATUS.json`: `updated` 2026-06-02 -> 2026-06-11 (and the derived `docs/SURFACE_STATUS.md` regenerated).

No version, schema, or behavior changes.

## Validation

- `release:stamp:check:publish` passes.
- `verify-release-closeout --stage final`: 7 GREEN / 0 YELLOW / 0 RED (npm latest+next at 0.15.1, signed tag reachable, GitHub Release finalized, facts/current stamped).
