### PR TITLE
docs(readme): offline verification one-liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,11 @@ Practical recipes under [`docs/SOLUTIONS/`](docs/SOLUTIONS/):
 ## Try it in 5 minutes
 
 - Verify a record locally with `verifyLocal()` or `pnpm dlx @peac/cli verify`.
+- Generate sample records and verify one offline with just a public key:
+  ```bash
+  pnpm dlx @peac/cli samples generate -o ./s
+  pnpm dlx @peac/cli verify ./s/valid/basic-record.jws --public-key ./s/bundles/sandbox-jwks.json
+  ```
 - Start the MCP server: `npx -y @peac/mcp-server`.
 - Run the minimal example: `pnpm --filter @peac/example-minimal demo`.
 - Run the MCP gateway records example:


### PR DESCRIPTION
## Summary

Adds the offline verification one-liner to the README "Try it in 5 minutes" section. With v0.15.1 published to npm latest, `pnpm dlx @peac/cli verify --public-key` works from a clean machine, so a reader can generate sample records and verify one offline with just a public key, no install.