### PR TITLE
chore(repo): ignore local state and allowlist esbuild dev advisory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ examples/*/generated/
 # Backup files
 *.bak
 *.backup
+
+# Local state artifacts (not part of the published protocol surface)
+/state/

--- a/.prettierignore
+++ b/.prettierignore
@@ -43,3 +43,6 @@ docs/evidence-pack/
 
 # example generated outputs (canonical bytes must not be reformatted)
 examples/erc8004-feedback/generated/
+
+# Local state artifacts (not part of the published protocol surface)
+/state/

--- a/security/audit-allowlist.json
+++ b/security/audit-allowlist.json
@@ -197,6 +197,28 @@
       "owner": "jithinraj",
       "added_at": "2026-04-07",
       "reviewed_at": "2026-06-07"
+    },
+    {
+      "advisory_id": "GHSA-gv7w-rqvm-qjhr",
+      "package": "esbuild",
+      "reason": "esbuild dev server allows any website to send requests and read responses (HIGH, GHSA-gv7w-rqvm-qjhr). esbuild >=0.17.0 <0.28.1; current resolved 0.27.3 pulled transitively by the test toolchain (vitest -> vite -> tsx -> esbuild, and tsx -> esbuild).",
+      "why_not_exploitable": "The advisory affects esbuild's HTTP dev server (serve mode). PEAC never runs esbuild's serve mode; esbuild is used only as a transpiler/bundler by tsx and vite during local test and dev runs. No published @peac/* package depends on esbuild (prod audit shows no high), so there is no production code path or shipped artifact exposure.",
+      "where_used": "devDependencies only: @vitest/coverage-v8 -> vitest -> vite -> tsx -> esbuild; and tsx -> esbuild.",
+      "expires_at": "2026-09-11",
+      "remediation": "Adopt the patched esbuild (>=0.28.1) when tsx/vite/vitest bump their transitive esbuild, or add a pnpm.overrides pin once toolchain compatibility with esbuild 0.28.x is confirmed.",
+      "issue_url": "https://github.com/advisories/GHSA-gv7w-rqvm-qjhr",
+      "scope": "dev",
+      "dependency_chain": [
+        "@vitest/coverage-v8@4.1.8",
+        "vitest@4.1.8",
+        "vite@8.0.16",
+        "tsx@4.21.0",
+        "esbuild@0.27.3"
+      ],
+      "verified_by": "pnpm audit --prod shows no high advisories; pnpm why esbuild confirms the tsx/vite/vitest dev-only resolution path.",
+      "owner": "jithinraj",
+      "added_at": "2026-06-13",
+      "reviewed_at": "2026-06-13"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Two local-CI hygiene fixes that together unblock the pre-push and CI gates (collapsed into one chore PR because they are circularly dependent: the audit fix needs the state ignore to pass the local format gate, and the state-ignore PR needs the audit fix to pass the audit gate).

## Changes

1. **Ignore local state artifacts** — adds `/state/` to `.gitignore` and `.prettierignore`. 
2. **Allowlist esbuild dev-server advisory** — adds a time-bounded, dev-scoped allowlist entry for GHSA-gv7w-rqvm-qjhr (esbuild dev server; HIGH). esbuild is used only as a transpiler by the test toolchain (`vitest` -> `vite` -> `tsx` -> `esbuild`); no published `@peac/*` package depends on esbuild (`pnpm audit --prod` shows no high), and PEAC never runs esbuild serve mode. Entry: `scope` dev, `expires_at` 2026-09-11, `reviewed_at` 2026-06-13, full chain + remediation. Mirrors the existing allowlist handling of the sibling esbuild advisory GHSA-67mh-4wv8-2f99.

No code, package, protocol, wire, or schema change.
