### PR TITLE
fix(conformance): align bundle-vector digest references with SHA-256 contract

### DIFF
--- a/packages/crypto/tests/hash.test.ts
+++ b/packages/crypto/tests/hash.test.ts
@@ -36,6 +36,15 @@ describe('Hash Utilities', () => {
       const result = await sha256Hex('');
       expect(result).toBe('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
     });
+
+    it('returns bare hex without the sha256: reference prefix (digest contract)', async () => {
+      // sha256Hex is the canonical bare-hex digest helper: it returns bare hex.
+      // The `sha256:` reference prefix is applied only at the receipt_ref /
+      // digest-reference boundary (e.g. computeReceiptRef), never inside the hash.
+      const result = await sha256Hex('hello');
+      expect(result.startsWith('sha256:')).toBe(false);
+      expect(result).toMatch(/^[0-9a-f]{64}$/);
+    });
   });
 
   describe('sha256Bytes', () => {

--- a/packages/schema/src/carrier.ts
+++ b/packages/schema/src/carrier.ts
@@ -111,11 +111,20 @@ export const CarrierMetaSchema = z.object({
 // ---------------------------------------------------------------------------
 
 /**
- * Canonical receipt_ref computation (single source of truth).
+ * Canonical receipt_ref boundary helper.
  *
- * Computes SHA-256 of the UTF-8 bytes of the compact JWS string as emitted.
- * All carrier adapters MUST use this function rather than computing SHA-256
- * locally, to ensure consistency across protocols (correction item 4).
+ * Computes SHA-256 over the UTF-8 bytes of the compact JWS string as emitted,
+ * then applies the `sha256:` reference prefix at the receipt_ref boundary. The
+ * digest body is bare lowercase hex; the prefix is part of the reference format,
+ * not the hash primitive.
+ *
+ * Carrier adapters should use this helper rather than recomputing receipt_ref
+ * locally, so receipt references stay byte-identical across transports.
+ *
+ * SHA-256 is implemented here directly via `crypto.subtle` because
+ * `@peac/schema` is Layer 1 and depends only on `@peac/kernel`; importing
+ * `@peac/crypto` would introduce an up-layer dependency. The schema and crypto
+ * digest paths are locked together by the SHA-256 boundary-contract tooling test.
  */
 export async function computeReceiptRef(jws: string): Promise<ReceiptRef> {
   if (!globalThis.crypto?.subtle) {

--- a/scripts/generate-bundle-vectors.ts
+++ b/scripts/generate-bundle-vectors.ts
@@ -8,7 +8,9 @@
  *
  * Usage: npx tsx scripts/generate-bundle-vectors.ts
  *
- * CI should run this and assert `git diff --exit-code` to detect drift.
+ * Drift checks should compare extracted bundle contents and expected report
+ * hashes. Raw ZIP container bytes are not currently the semantic drift boundary
+ * because ZIP metadata can vary even when bundle contents are unchanged.
  */
 
 import * as fs from 'fs';
@@ -19,6 +21,7 @@ import { createHash } from 'crypto';
 const cryptoModule = require('../packages/crypto/dist/index.cjs') as {
   sign: (payload: unknown, privateKey: Uint8Array, kid: string) => Promise<string>;
   canonicalize: (obj: unknown) => string;
+  sha256Hex: (data: Uint8Array | string) => Promise<string>;
 };
 
 // Import test-only utilities from testkit (separate export for tree-shaking)
@@ -37,15 +40,21 @@ const auditModule = require('../packages/audit/dist/index.cjs') as {
   serializeReport: (report: VerificationReport, pretty?: boolean) => string;
 };
 
-const { sign, canonicalize } = cryptoModule;
+const { sign, canonicalize, sha256Hex } = cryptoModule;
 const { generateKeypairFromSeed } = testkitModule;
 const { createDisputeBundle, verifyBundle } = auditModule;
 
 /**
- * Compute SHA-256 hash with sha256:<hex> prefix format.
+ * Digest-reference value in `sha256:<hex>` form (the bundle digest /
+ * `receipt_ref` reference format).
+ *
+ * The bundle digest fields use the same bare-hex SHA-256 contract as
+ * `@peac/crypto.sha256Hex` (imported above): `sha256Hex` returns bare hex, and
+ * this helper applies the `sha256:` reference prefix only at the bundle
+ * digest-reference boundary, mirroring `computeReceiptRef` in `@peac/schema`.
  */
-function sha256Hex(data: Buffer | string): string {
-  return `sha256:${createHash('sha256').update(data).digest('hex')}`;
+async function digestRef(data: Buffer | string): Promise<string> {
+  return `sha256:${await sha256Hex(data)}`;
 }
 
 // Type definitions
@@ -523,11 +532,12 @@ async function generateDuplicateReceiptBundle(
   const keysJson = Buffer.from(JSON.stringify(jwks, null, 2));
 
   // Compute file hashes
-  const receiptsHash = sha256Hex(receiptsNdjson);
-  const keysHash = sha256Hex(keysJson);
+  const receiptsHash = await digestRef(receiptsNdjson);
+  const keysHash = await digestRef(keysJson);
 
   // Build the ZIP manually to bypass createDisputeBundle's validation
-  // Disable compression to ensure byte-identical output across platforms
+  // Disable compression and set a fixed mtime to reduce ZIP-container variability.
+  // Semantic drift is checked against extracted bundle contents, not raw ZIP bytes.
   const mtime = new Date(FIXED_CREATED_AT);
   const zipOptions = { mtime, compress: false };
   const zipfile = new yazl.ZipFile();
@@ -544,12 +554,12 @@ async function generateDuplicateReceiptBundle(
       {
         receipt_id: 'duplicate-receipt-id',
         issued_at: FIXED_ISSUED_AT_1,
-        receipt_hash: sha256Hex(receipt1),
+        receipt_hash: await digestRef(receipt1),
       },
       {
         receipt_id: 'duplicate-receipt-id', // Same receipt_id!
         issued_at: FIXED_ISSUED_AT_2,
-        receipt_hash: sha256Hex(receipt2),
+        receipt_hash: await digestRef(receipt2),
       },
     ],
     keys: [{ kid: 'key-001', alg: 'EdDSA' }],
@@ -560,7 +570,7 @@ async function generateDuplicateReceiptBundle(
   };
 
   // Compute content_hash = SHA-256 of JCS(manifest without content_hash)
-  const contentHash = sha256Hex(canonicalize(manifestWithoutHash));
+  const contentHash = await digestRef(canonicalize(manifestWithoutHash));
 
   const manifest = {
     ...manifestWithoutHash,

--- a/tests/tooling/sha256-boundary-contract.test.ts
+++ b/tests/tooling/sha256-boundary-contract.test.ts
@@ -1,0 +1,67 @@
+/**
+ * SHA-256 boundary-contract golden lock.
+ *
+ * PEAC computes SHA-256 digests in two places by necessity:
+ *
+ *  - `@peac/crypto` `sha256Hex` (Layer 2) is the canonical bare-hex SHA-256
+ *    helper. It returns BARE lowercase hex; the `sha256:` reference prefix is
+ *    applied only at the digest-reference boundary.
+ *  - `@peac/schema` `computeReceiptRef` (Layer 1) reimplements SHA-256 directly
+ *    via `crypto.subtle` and returns `sha256:<hex>`. It CANNOT import
+ *    `@peac/crypto` without an up-layer dependency violation (schema depends
+ *    only on `@peac/kernel`), so the two implementations are deliberately
+ *    separate.
+ *
+ * This test is the regression gate that locks the two implementations together:
+ * `computeReceiptRef(jws)` MUST be byte-identical to
+ * `'sha256:' + (await sha256Hex(jws))`. Tests are not layer-constrained, so this
+ * is the one place both can be imported and compared. If this ever diverges,
+ * receipt_ref values stop matching across boundaries and "verify across
+ * boundaries" breaks. It is a consistency lock, not a format change: Wire 0.2
+ * and every committed receipt_ref stay byte-identical.
+ *
+ * The bundle-vector digest content lock (content_hash / file hashes /
+ * receipt_hash / report_hash) lives in `packages/audit/tests/bundle-vectors.test.ts`,
+ * which verifies the committed vectors through the real verifier; the bundle
+ * generator (`scripts/generate-bundle-vectors.ts`) follows the same
+ * bare-hex + boundary-prefix contract via its local `digestRef` helper.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { sha256Hex } from '@peac/crypto';
+import { computeReceiptRef } from '@peac/schema';
+
+// Inputs intentionally include compact-JWS-shaped strings and non-JWS strings.
+// This parity test only requires byte-identical SHA-256 input handling across
+// the schema and crypto digest paths.
+const INPUTS = [
+  'eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJkaWQ6a2V5OnoxMjMifQ.c2lnbmF0dXJl',
+  'eyJ.eyJ.different',
+  '',
+  'a',
+  'unicode-éü✓-payload',
+  'x'.repeat(4096),
+];
+
+describe('SHA-256 boundary contract: computeReceiptRef matches crypto.sha256Hex', () => {
+  it.each(INPUTS)(
+    'computeReceiptRef(input) === "sha256:" + sha256Hex(input) [len %#]',
+    async (input) => {
+      const viaSchema = await computeReceiptRef(input);
+      const viaCrypto = `sha256:${await sha256Hex(input)}`;
+      expect(viaSchema).toBe(viaCrypto);
+    }
+  );
+
+  it('computeReceiptRef applies the sha256: prefix exactly once over bare hex', async () => {
+    const ref = await computeReceiptRef(INPUTS[0]);
+    expect(ref).toMatch(/^sha256:[0-9a-f]{64}$/);
+    // The hex body must be the bare crypto digest (prefix is a boundary concern).
+    expect(ref.slice('sha256:'.length)).toBe(await sha256Hex(INPUTS[0]));
+  });
+
+  it('sha256Hex itself never carries the reference prefix', async () => {
+    expect((await sha256Hex(INPUTS[0])).startsWith('sha256:')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Locks PEAC's SHA-256 reference-boundary contract for receipt and bundle digest references.

SHA-256 is computed in two places by design:

- `@peac/crypto` `sha256Hex` returns bare lowercase hex; the `sha256:` reference
  prefix is applied only at the digest-reference boundary.
- `@peac/schema` `computeReceiptRef` reimplements SHA-256 via `crypto.subtle` and
  returns `sha256:<hex>`. It cannot import `@peac/crypto` without an up-layer
  dependency (`@peac/schema` depends only on `@peac/kernel`), so the two
  implementations are deliberately separate.

This change documents the digest boundary contract, makes the bundle-vector
generator use the canonical bare-hex SHA-256 helper with an explicit
digest-reference boundary wrapper, and adds a golden regression test that ties
the schema and crypto implementations together.

## Scope

- No wire, schema, signing, public API, receipt type, extension group, registry,
  or sentinel change.
- No committed fixture or conformance-vector changes.
- The bundle vectors were regenerated, extracted, and compared against the
  committed vector contents; extracted inner bundle contents were byte-identical.
  Raw ZIP container bytes are not currently reproducible, and the vector-index
  manifest has a pre-existing version-staleness issue tracked separately.
- Runtime behavior unchanged; this is consistency hardening plus tests and
  documentation.

## Changes

- `scripts/generate-bundle-vectors.ts`: the generator now uses the canonical
  `@peac/crypto` `sha256Hex` (already imported for `sign`/`canonicalize`) instead
  of a second local SHA-256 implementation. A small `digestRef` helper applies
  the `sha256:` reference prefix at the boundary; all digest emission sites route
  through it, mirroring `computeReceiptRef`.
- `packages/schema/src/carrier.ts`: comment on `computeReceiptRef` documenting the
  deliberate layering constraint and the boundary-only prefix (behavior unchanged).
- `packages/crypto/tests/hash.test.ts`: explicit assertion that `sha256Hex` returns
  bare hex without the reference prefix.
- `tests/tooling/sha256-boundary-contract.test.ts` (new): golden lock asserting
  `computeReceiptRef(jws)` is byte-identical to `"sha256:" + sha256Hex(jws)` across
  a range of inputs, so the schema and crypto SHA-256 paths cannot drift.

## Validation

- `packages/crypto` hash tests, `packages/schema` carrier tests, `packages/audit`
  bundle-vector tests, and the new boundary-contract test all pass.
- API-contract and kernel/protocol public-surface stability tests pass (no surface drift).
- `pnpm typecheck:core`, `pnpm build`, Prettier, and `git diff --check` clean.
- Bundle vectors regenerated, extracted, and confirmed content-identical to the
  committed vectors.
