### PR TITLE
fix(security): centralize strict issuer-origin allowlist checks

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -11,6 +11,9 @@
 export { CANONICAL_ERROR_CODES, type PeacErrorCode } from './codes.js';
 import { CANONICAL_ERROR_CODES, type PeacErrorCode } from './codes.js';
 
+// Canonical issuer-origin allowlist check shared across surfaces.
+export { isAllowedIssuerOrigin } from './issuer-origin.js';
+
 /**
  * Base URI for RFC 9457 Problem Details type field.
  */

--- a/packages/contracts/src/issuer-origin.ts
+++ b/packages/contracts/src/issuer-origin.ts
@@ -1,0 +1,85 @@
+/**
+ * Canonical issuer-origin allowlist check.
+ *
+ * Surfaces use this helper to decide whether a receipt or TAP issuer origin is
+ * configured as trusted. The comparison is intentionally origin-based
+ * (scheme + host + port), not host-only, and fails closed for malformed inputs.
+ *
+ * Runtime-neutral by construction: it uses only the standard URL API and runs
+ * unchanged on Node, Workers, Deno, and Bun. It performs no DNS resolution, no
+ * network access, and no private-IP checks; outbound-fetch SSRF protection is a
+ * separate fetch-layer concern.
+ */
+
+// True if the string contains an ASCII control character (C0 range or DEL).
+// Used to reject smuggled control characters that the URL API might otherwise
+// strip during parsing. Implemented as a code-unit scan rather than a regex
+// escape range to keep this security-sensitive source free of escape sequences.
+function hasAsciiControl(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || code === 0x7f) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Normalize a value to its https origin, or null if it is not an acceptable
+ * issuer origin. Acceptable means: no surrounding or embedded ASCII control
+ * characters or whitespace, a parseable absolute URL, the `https:` scheme, and
+ * no userinfo (username/password). Path, query, and fragment are not part of an
+ * origin and are ignored.
+ */
+function toHttpsOrigin(value: string): string | null {
+  // Reject surrounding whitespace and embedded ASCII control characters before
+  // parsing. The URL API would otherwise strip some of these, which could let a
+  // padded or smuggled-control-character entry compare equal to a clean one.
+  if (value.trim() !== value || hasAsciiControl(value)) {
+    return null;
+  }
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'https:') {
+    return null;
+  }
+  if (url.username !== '' || url.password !== '') {
+    return null;
+  }
+  return url.origin;
+}
+
+/**
+ * Returns true iff `candidate` matches an entry in `allowlist` by https origin.
+ *
+ * Comparison is by URL origin (scheme + host + port); a default `:443` is
+ * normalized away by the `URL` API, a non-default port must match exactly, and
+ * a scheme mismatch (e.g. an `http:` candidate against an `https:` entry) never
+ * matches.
+ *
+ * Fails closed:
+ * - an empty allowlist returns false;
+ * - a candidate that is not a parseable absolute https URL, or that carries
+ *   userinfo or control characters, returns false;
+ * - a malformed or non-https allowlist entry is skipped (it never matches) but
+ *   does not prevent a later valid entry from matching.
+ *
+ * There is no wildcard, suffix, regex, or raw-string fallback matching.
+ */
+export function isAllowedIssuerOrigin(candidate: string, allowlist: readonly string[]): boolean {
+  const candidateOrigin = toHttpsOrigin(candidate);
+  if (candidateOrigin === null) {
+    return false;
+  }
+  for (const entry of allowlist) {
+    if (toHttpsOrigin(entry) === candidateOrigin) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/contracts/tests/issuer-origin.test.ts
+++ b/packages/contracts/tests/issuer-origin.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+
+import { isAllowedIssuerOrigin } from '../src/issuer-origin.js';
+
+const ALLOW = ['https://issuer.example.com'];
+
+describe('isAllowedIssuerOrigin', () => {
+  it('matches an exact https origin', () => {
+    expect(isAllowedIssuerOrigin('https://issuer.example.com', ALLOW)).toBe(true);
+  });
+
+  it('ignores path on the candidate (origin-only match)', () => {
+    expect(isAllowedIssuerOrigin('https://issuer.example.com/.well-known/jwks.json', ALLOW)).toBe(
+      true
+    );
+  });
+
+  it('ignores query and fragment on the candidate', () => {
+    expect(isAllowedIssuerOrigin('https://issuer.example.com/p?a=1#frag', ALLOW)).toBe(true);
+  });
+
+  it('normalizes the default :443 port', () => {
+    expect(isAllowedIssuerOrigin('https://issuer.example.com:443', ALLOW)).toBe(true);
+    expect(
+      isAllowedIssuerOrigin('https://issuer.example.com', ['https://issuer.example.com:443'])
+    ).toBe(true);
+  });
+
+  it('rejects a non-default port mismatch', () => {
+    expect(isAllowedIssuerOrigin('https://issuer.example.com:8443', ALLOW)).toBe(false);
+    expect(
+      isAllowedIssuerOrigin('https://issuer.example.com', ['https://issuer.example.com:8443'])
+    ).toBe(false);
+  });
+
+  it('rejects a scheme mismatch (http candidate vs https allowlist)', () => {
+    expect(isAllowedIssuerOrigin('http://issuer.example.com', ALLOW)).toBe(false);
+  });
+
+  it('rejects an http candidate even against an http allowlist entry (https-only)', () => {
+    expect(isAllowedIssuerOrigin('http://issuer.example.com', ['http://issuer.example.com'])).toBe(
+      false
+    );
+  });
+
+  it('rejects a candidate carrying userinfo', () => {
+    expect(isAllowedIssuerOrigin('https://user:pass@issuer.example.com', ALLOW)).toBe(false);
+    expect(isAllowedIssuerOrigin('https://user@issuer.example.com', ALLOW)).toBe(false);
+  });
+
+  it('skips an allowlist entry carrying userinfo (it never matches)', () => {
+    expect(
+      isAllowedIssuerOrigin('https://issuer.example.com', ['https://user:pass@issuer.example.com'])
+    ).toBe(false);
+  });
+
+  it('returns false for a malformed candidate', () => {
+    expect(isAllowedIssuerOrigin('not a url', ALLOW)).toBe(false);
+    expect(isAllowedIssuerOrigin('', ALLOW)).toBe(false);
+  });
+
+  it('skips a malformed allowlist entry but still matches a later valid entry', () => {
+    expect(
+      isAllowedIssuerOrigin('https://issuer.example.com', ['::::', 'https://issuer.example.com'])
+    ).toBe(true);
+  });
+
+  it('returns false for an empty allowlist', () => {
+    expect(isAllowedIssuerOrigin('https://issuer.example.com', [])).toBe(false);
+  });
+
+  it('ignores path, query, and fragment on an allowlist entry (origin allowlist, not a path ACL)', () => {
+    expect(
+      isAllowedIssuerOrigin('https://issuer.example.com', [
+        'https://issuer.example.com/path?x=1#frag',
+      ])
+    ).toBe(true);
+  });
+
+  it('rejects a candidate with surrounding whitespace', () => {
+    expect(isAllowedIssuerOrigin('  https://issuer.example.com  ', ALLOW)).toBe(false);
+  });
+
+  it('skips an allowlist entry with surrounding whitespace', () => {
+    expect(
+      isAllowedIssuerOrigin('https://issuer.example.com', [' https://issuer.example.com '])
+    ).toBe(false);
+  });
+
+  it('rejects a candidate containing an embedded ASCII control character', () => {
+    // Built from a code point to keep this source file pure ASCII.
+    const withControl = `https://issuer.example.com${String.fromCharCode(0x01)}`;
+    expect(isAllowedIssuerOrigin(withControl, ALLOW)).toBe(false);
+  });
+
+  it('skips an allowlist entry containing a control character', () => {
+    const entryWithControl = `https://issuer.example.com${String.fromCharCode(0x09)}`;
+    expect(isAllowedIssuerOrigin('https://issuer.example.com', [entryWithControl])).toBe(false);
+  });
+
+  it('normalizes host and scheme case via the URL API', () => {
+    expect(isAllowedIssuerOrigin('HTTPS://Issuer.Example.COM', ALLOW)).toBe(true);
+  });
+
+  it('treats an IDN and its punycode form as the same origin', () => {
+    // The WHATWG URL API normalizes IDN host labels to punycode. The Unicode
+    // label is built from code points so this source file stays pure ASCII; it
+    // is the Cyrillic word "primer", whose punycode form is "xn--e1afmkfd".
+    const label = String.fromCodePoint(0x43f, 0x440, 0x438, 0x43c, 0x435, 0x440);
+    const idnHost = `https://${label}.example`;
+    expect(isAllowedIssuerOrigin('https://xn--e1afmkfd.example', [idnHost])).toBe(true);
+  });
+
+  it('does not match a different host', () => {
+    expect(isAllowedIssuerOrigin('https://evil.example.com', ALLOW)).toBe(false);
+  });
+
+  it('does not do suffix or wildcard matching', () => {
+    expect(isAllowedIssuerOrigin('https://sub.issuer.example.com', ALLOW)).toBe(false);
+    expect(isAllowedIssuerOrigin('https://issuer.example.com', ['https://*.example.com'])).toBe(
+      false
+    );
+  });
+
+  it('requires a trailing-dot host to match exactly (no manual normalization)', () => {
+    // A trailing-dot FQDN is a distinct origin under the URL API; it must not
+    // silently match the dotless form.
+    expect(isAllowedIssuerOrigin('https://issuer.example.com./', ALLOW)).toBe(false);
+  });
+});

--- a/packages/worker-shared/src/config.ts
+++ b/packages/worker-shared/src/config.ts
@@ -6,6 +6,8 @@
  * @packageDocumentation
  */
 
+import { isAllowedIssuerOrigin } from '@peac/contracts';
+
 import type { WorkerConfig } from './types.js';
 
 /**
@@ -113,23 +115,8 @@ function matchGlob(path: string, pattern: string): boolean {
  * @returns true if issuer is in allowlist
  */
 export function isIssuerAllowed(issuer: string, allowlist: string[]): boolean {
-  // Empty allowlist should be handled by caller before reaching here
-  if (allowlist.length === 0) {
-    return false;
-  }
-
-  // Normalize issuer to origin
-  try {
-    const issuerOrigin = new URL(issuer).origin;
-    return allowlist.some((allowed) => {
-      try {
-        const allowedOrigin = new URL(allowed).origin;
-        return issuerOrigin === allowedOrigin;
-      } catch {
-        return false;
-      }
-    });
-  } catch {
-    return false;
-  }
+  // Delegates to the single canonical issuer-origin allowlist check so the
+  // trust decision cannot drift across surfaces. Fails closed on an empty
+  // allowlist, a malformed issuer, or a non-https / userinfo-bearing issuer.
+  return isAllowedIssuerOrigin(issuer, allowlist);
 }

--- a/surfaces/nextjs/middleware/src/handler.ts
+++ b/surfaces/nextjs/middleware/src/handler.ts
@@ -5,6 +5,7 @@
  * Runtime-neutral for testability.
  */
 
+import { isAllowedIssuerOrigin } from '@peac/contracts';
 import { createResolver, type JwksKeyResolver } from '@peac/jwks-cache';
 import {
   verifyTapProof,
@@ -36,24 +37,6 @@ function hasTapHeaders(headers: Record<string, string>): boolean {
     headers['signature-input'] ?? headers['Signature-Input'] ?? headers['SIGNATURE-INPUT'];
   const signature = headers['signature'] ?? headers['Signature'] ?? headers['SIGNATURE'];
   return Boolean(signatureInput && signature);
-}
-
-/**
- * Check if an issuer origin is in the allowlist.
- *
- * The issuer must already be a validated origin (see issuerFromKeyid); this
- * compares it against allowlist entries by origin.
- */
-function isIssuerAllowed(issuerOrigin: string, allowlist: string[]): boolean {
-  return allowlist.some((allowed) => {
-    try {
-      const allowedOrigin = new URL(allowed).origin;
-      return allowedOrigin === issuerOrigin;
-    } catch {
-      // If allowed entry is not a valid URL, compare as-is
-      return allowed === issuerOrigin;
-    }
-  });
 }
 
 /**
@@ -251,7 +234,10 @@ export async function handleRequest(
     );
   }
 
-  // Create JWKS resolver with issuer allowlist
+  // JWKS-fetch host allowlist (SSRF fetch guard). @peac/jwks-cache passes this
+  // callback only the parsed JWKS hostname, so it is host-only by contract and is
+  // NOT the issuer-origin trust decision; issuer-origin allowlist enforcement uses
+  // @peac/contracts isAllowedIssuerOrigin below.
   const keyResolver = createResolver({
     isAllowedHost: (host) => {
       if (config.unsafeAllowAnyIssuer) {
@@ -312,7 +298,7 @@ export async function handleRequest(
         'TAP keyid must be an absolute https URL identifying the issuer'
       );
     }
-    if (!isIssuerAllowed(issuer, config.issuerAllowlist)) {
+    if (!isAllowedIssuerOrigin(issuer, config.issuerAllowlist)) {
       return createErrorHandlerResponse(ErrorCodes.ISSUER_NOT_ALLOWED, 'Issuer not in allowlist');
     }
   }

--- a/surfaces/workers/akamai/src/index.ts
+++ b/surfaces/workers/akamai/src/index.ts
@@ -89,7 +89,11 @@ export function createOnClientRequest(config?: PeacVerifierConfig) {
   ): Promise<void> {
     const workerConfig = parseConfig(request);
 
-    // Create JWKS resolver with issuer allowlist (or allow all if UNSAFE mode)
+    // JWKS-fetch host allowlist (SSRF fetch guard). @peac/jwks-cache passes this
+    // callback only the parsed JWKS hostname, so it is host-only by contract and
+    // is NOT the issuer-origin trust decision. Issuer-origin allowlist enforcement
+    // happens in @peac/worker-shared handleVerification via @peac/contracts
+    // isAllowedIssuerOrigin.
     const keyResolver = createResolver({
       isAllowedHost: (host) => {
         if (workerConfig.unsafeAllowAnyIssuer) {
@@ -226,6 +230,11 @@ export async function handleRequest(
   config: WorkerConfig,
   edgeKVConfig?: EdgeKVConfig
 ): Promise<Response> {
+  // JWKS-fetch host allowlist (SSRF fetch guard). @peac/jwks-cache passes this
+  // callback only the parsed JWKS hostname, so it is host-only by contract and is
+  // NOT the issuer-origin trust decision. Issuer-origin allowlist enforcement
+  // happens in @peac/worker-shared handleVerification via @peac/contracts
+  // isAllowedIssuerOrigin.
   const keyResolver = createResolver({
     isAllowedHost: (host) => {
       if (config.unsafeAllowAnyIssuer) {

--- a/surfaces/workers/cloudflare/src/index.ts
+++ b/surfaces/workers/cloudflare/src/index.ts
@@ -75,7 +75,11 @@ function resultToResponse(result: HandlerResult): Response {
 async function handleRequest(request: Request, env: Env): Promise<Response> {
   const config = parseConfig(env);
 
-  // Create JWKS resolver with issuer allowlist (or allow all if UNSAFE mode)
+  // JWKS-fetch host allowlist (SSRF fetch guard). @peac/jwks-cache passes this
+  // callback only the parsed JWKS hostname, so it is host-only by contract and
+  // is NOT the issuer-origin trust decision. Issuer-origin allowlist enforcement
+  // happens in @peac/worker-shared handleVerification via @peac/contracts
+  // isAllowedIssuerOrigin.
   const keyResolver = createResolver({
     isAllowedHost: (host) => {
       if (config.unsafeAllowAnyIssuer) {

--- a/surfaces/workers/fastly/src/index.ts
+++ b/surfaces/workers/fastly/src/index.ts
@@ -75,7 +75,11 @@ export function createHandler(backendConfig: FastlyBackendConfig) {
   return async function handleRequest(request: Request): Promise<Response> {
     const config = parseConfig(configDictName);
 
-    // Create JWKS resolver with issuer allowlist (or allow all if UNSAFE mode)
+    // JWKS-fetch host allowlist (SSRF fetch guard). @peac/jwks-cache passes this
+    // callback only the parsed JWKS hostname, so it is host-only by contract and
+    // is NOT the issuer-origin trust decision. Issuer-origin allowlist enforcement
+    // happens in @peac/worker-shared handleVerification via @peac/contracts
+    // isAllowedIssuerOrigin.
     const keyResolver = createResolver({
       isAllowedHost: (host) => {
         if (config.unsafeAllowAnyIssuer) {

--- a/tests/tooling/issuer-origin-allowlist-boundary.test.ts
+++ b/tests/tooling/issuer-origin-allowlist-boundary.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Issuer-origin allowlist trust-boundary regression guard (static).
+ *
+ * The issuer-origin allowlist decision is centralized in
+ * `@peac/contracts` `isAllowedIssuerOrigin` so it cannot drift across surfaces.
+ * This test statically asserts that the divergent open-coded checks do not creep
+ * back: no raw-string allowlist fallback, no host-only origin comparison in the
+ * issuer-trust path, and every surface routes through the canonical helper. It
+ * is source-text based so it also covers surfaces without a runtime harness.
+ *
+ * This guard covers the strict edge/middleware issuer-origin trust paths only.
+ * Intentionally out of scope:
+ *  - JWKS-fetch `isAllowedHost(host)` callbacks, which receive a bare hostname
+ *    and enforce a separate fetch-host boundary;
+ *  - `@peac/worker-core` `isIssuerAllowed`, whose exported API supports opaque
+ *    non-URL identifiers;
+ *  - `@peac/protocol` verifier allowlist behavior, whose permissive semantics
+ *    differ from the strict edge/middleware surfaces covered here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '..', '..');
+const read = (rel: string) => readFileSync(resolve(ROOT, rel), 'utf8');
+
+// Surfaces that make the issuer-origin allowlist decision.
+const ISSUER_ALLOWLIST_SURFACES = [
+  'packages/worker-shared/src/config.ts',
+  'surfaces/nextjs/middleware/src/handler.ts',
+];
+
+describe('issuer-origin allowlist trust boundary (static guard)', () => {
+  it.each(ISSUER_ALLOWLIST_SURFACES)(
+    '%s routes the issuer check through @peac/contracts isAllowedIssuerOrigin',
+    (file) => {
+      const src = read(file);
+      expect(src).toMatch(/isAllowedIssuerOrigin/);
+      expect(src).toMatch(/from '@peac\/contracts'/);
+    }
+  );
+
+  it.each(ISSUER_ALLOWLIST_SURFACES)(
+    '%s has no raw-string allowlist fallback comparison',
+    (file) => {
+      // The old nextjs fallback compared a raw allowlist entry to the issuer.
+      expect(read(file)).not.toMatch(/return\s+allowed\s*===\s*issuerOrigin/);
+    }
+  );
+
+  it.each(ISSUER_ALLOWLIST_SURFACES)(
+    '%s does not re-derive the issuer allowlist by hand via new URL(...).origin',
+    (file) => {
+      // The canonical helper owns origin normalization; surfaces must not
+      // open-code an `new URL(allowed).origin === ...` loop again.
+      expect(read(file)).not.toMatch(/new URL\([^)]*\)\.origin\s*===/);
+    }
+  );
+
+  it('the canonical helper stays runtime-neutral (no Node-only imports)', () => {
+    const src = read('packages/contracts/src/issuer-origin.ts');
+    expect(src).not.toMatch(/from 'node:/);
+    expect(src).not.toMatch(/require\(/);
+    expect(src).not.toMatch(/\bnode:(net|dns|crypto|http|https)\b/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `isAllowedIssuerOrigin` in `@peac/contracts` and routes the strict
edge/middleware issuer-origin allowlist checks through it.

The helper compares HTTPS origins (scheme + host + port), not host-only values;
it rejects userinfo, malformed input, surrounding-whitespace or embedded
ASCII-control-character input, and non-HTTPS schemes; and it fails closed for an
empty allowlist. There is no wildcard, suffix, regex, or raw-string fallback
matching.

## Changes

- Adds `@peac/contracts` `isAllowedIssuerOrigin(candidate, allowlist)`.
- Routes `@peac/worker-shared` `isIssuerAllowed` through the canonical helper
  (Cloudflare, Fastly, and Akamai already use it via their `worker-shared`
  re-export).
- Removes the Next.js middleware raw-string fallback and routes its
  issuer-origin check through the canonical helper.
- Adds tests: exact HTTPS origin match, default `:443` normalization and
  non-default port mismatch, path/query/fragment normalization (both candidate
  and allowlist entry), malformed-entry skip, userinfo rejection, IDN/punycode
  equivalence, surrounding-whitespace and embedded-control-character rejection,
  case normalization, and no wildcard/suffix matching.
- Adds a static trust-boundary guard for the strict issuer-origin allowlist
  paths.
- Clarifies in comments that the Cloudflare/Fastly/Akamai/Next.js
  `isAllowedHost(host)` callbacks are JWKS-fetch host guards (they receive only a
  parsed hostname), not issuer-origin trust decisions.

## Non-goals / deferred

- JWKS / fetch-host / private-IP / DNS SSRF policy is not changed in this PR.
- `@peac/worker-core` `isIssuerAllowed` semantics are not changed in this PR
  (its exported API supports opaque non-URL identifiers).
- `@peac/protocol` verifier allowlist semantics are not changed in this PR
  (its default is permissive and accepts non-HTTPS issuers; `@peac/protocol`
  does not depend on `@peac/contracts`).
- No wire, schema, signing, registry, receipt-type, extension-group, error-code,
  or sentinel change.

## Validation

- `@peac/contracts` tests, the static trust-boundary guard, and the Next.js
  middleware tests all pass.
- API-contract and kernel/protocol public-surface stability tests pass; no
  monitored sentinel drift. The new export is an intentional additive
  `@peac/contracts` public API.
- `pnpm typecheck:core`, `pnpm build`, Prettier, and `git diff --check` clean.
