### PR TITLE
feat(examples): record MPP Payment-Receipt as a signed payment record

### DIFF
--- a/docs/SOLUTIONS/record-mpp-payment-receipts.md
+++ b/docs/SOLUTIONS/record-mpp-payment-receipts.md
@@ -1,0 +1,37 @@
+# Record MPP payment receipts as portable signed records
+
+MPP handles the payment flow. PEAC records the resulting payment event as a portable signed `org.peacprotocol/payment` record verifiable without MPP server logs.
+
+## Problem
+
+The "Payment" HTTP authentication scheme (`draft-ryan-httpauth-payment-01`, an active individual Internet-Draft and work in progress, not a finalized standard, used by Machine Payments Protocol implementations) returns a `Payment-Receipt` header on a successful `200` after an HTTP `402` challenge. That receipt proves to the server that payment happened, but the core header is base64url JSON, not a portable PEAC-verifiable signed record: it cannot travel and be independently verified outside the server that issued it.
+
+## What PEAC adds
+
+PEAC observes the `Payment-Receipt` and issues a signed, portable `org.peacprotocol/payment` record. For a saved record and issuer JWKS, a counterparty verifies it offline with only the issuer public key:
+
+```bash
+peac verify ./payment-record.jws --public-key ./issuer-jwks.json
+```
+
+PEAC records and verifies. It does not settle, authorize, authenticate, or replace the payment protocol.
+
+## Shape
+
+- Record type: `org.peacprotocol/payment` (the type the `peac samples generate` payment-event sample uses).
+- The registered `org.peacprotocol/commerce` extension carries the fields produced by `toCommerceExtensionFields()`: `payment_rail` (= `paymentauth`), `amount_minor`, `currency`, `reference`, and `env`. In this local demo `toCommerceExtensionFields()` supplies `env = live`; production integrations should assert environment from the upstream payment context.
+- An integrator extension (the example uses `com.example/mpp`) carries observational overflow: `status`, `method`, `timestamp`, `challenge_id`, `resource`, `upstream_receipt_digest`, and `payment_challenge_digest`. Digest values are self-describing (`sha256:<hex>`).
+
+This adds no new receipt type, extension group, wire change, schema change, or signing change.
+
+## Redaction and binding
+
+The raw `Payment-Receipt` is sensitive. The example binds it by digest and normalized fields; it does not log, store, or sign the raw header value. A counterparty re-binds the digest against the receipt it received to confirm they refer to the same payment, without the record ever carrying the raw credential material. The record binds the normalized 402 challenge identity (id, realm, method, intent, expires) and decoded request payload via `payment_challenge_digest`; amount and currency come from the challenge request, not from the `Payment-Receipt` header. The 402 challenge `request` fixture is JCS-serialized (RFC 8785) before base64url encoding, matching the draft's deterministic encoding requirement; the `Payment-Receipt` fixture remains base64url JSON.
+
+## MCP coexistence
+
+When the paid call is an MCP tool call, the PEAC receipt reference rides alongside the payment metadata in the same tool-result `_meta` tree, so a single response carries both the payment context and the portable signed record.
+
+## Runnable example
+
+See [`examples/mpp-payment-record/`](../../examples/mpp-payment-record/): a local, no-network demo that records a `Payment-Receipt`, verifies the record offline, demonstrates the `_meta` coexistence, and shows that tampering with the record fails verification (`E_INVALID_SIGNATURE`). It is the signed-record capstone on top of [`examples/paymentauth-evidence/`](../../examples/paymentauth-evidence/) (which is the parse + map example): it reuses the same `@peac/mappings-paymentauth` parser and `toCommerceExtensionFields()` mapper and introduces no new protocol surface.

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -9,7 +9,7 @@
     "tests": 11525,
     "test_files": 459,
     "published_packages": 36,
-    "build_targets": 105,
+    "build_targets": 106,
     "conformance_requirement_ids": 290,
     "conformance_sections": 32
   },

--- a/examples/mpp-payment-record/README.md
+++ b/examples/mpp-payment-record/README.md
@@ -1,0 +1,58 @@
+# MPP Payment Record Example
+
+MPP handles the payment flow. PEAC records the resulting payment event as a portable signed `org.peacprotocol/payment` record verifiable without MPP server logs.
+
+This is a draft-aligned composition example for the "Payment" HTTP authentication scheme (`draft-ryan-httpauth-payment-01`, an active individual Internet-Draft and work in progress, not a finalized standard). It shows how a service that already speaks the HTTP 402 + `Payment-Receipt` flow can record each payment event as a portable, signed record that a customer, auditor, counterparty, or dispute system can verify offline, without access to the server's logs.
+
+PEAC records and verifies. It does not settle, authorize, authenticate, or replace the payment protocol.
+
+## Where this fits (no duplication)
+
+This is the signed-record capstone on top of the existing paymentauth examples:
+
+- [`paymentauth-jsonrpc`](../paymentauth-jsonrpc/) - paymentauth carried over a JSON-RPC transport.
+- [`mpp-payment-attempt`](../mpp-payment-attempt/) - attempt/settlement evidence mapping (`fromMPPPaymentAttempt`/`fromMPPSettlement`).
+- [`paymentauth-evidence`](../paymentauth-evidence/) - parse + **map** a 402 challenge and `Payment-Receipt` to PEAC evidence.
+- **`mpp-payment-record` (this example)** - **sign** an `org.peacprotocol/payment` record, **verify it offline**, carry it in MCP `_meta`, and show tamper detection.
+
+It reuses the same `@peac/mappings-paymentauth` parser and `toCommerceExtensionFields()` mapper as `paymentauth-evidence`; it adds only the sign, verify, and carry layer.
+
+## What it shows
+
+1. A server returns `402 Payment Required` with a "Payment" challenge for a paid resource (the price lives in the challenge).
+2. The client pays; the server returns `200` with a `Payment-Receipt` header (base64url JSON).
+3. PEAC observes the receipt and issues a signed `org.peacprotocol/payment` record:
+   - the registered `org.peacprotocol/commerce` extension carries the fields produced by `toCommerceExtensionFields()` (`payment_rail = paymentauth`, `amount_minor`, `currency`, `reference`, `env`);
+   - an example-local `com.example/mpp` extension carries observational overflow (`status`, `method`, `timestamp`, `challenge_id`, `resource`, `upstream_receipt_digest`, `payment_challenge_digest`); digest values are self-describing (`sha256:<hex>`).
+
+   In this local demo `toCommerceExtensionFields()` supplies `env = live`; production integrations should assert environment from the upstream payment context.
+
+4. The record is verified offline with only the issuer public key.
+5. The same PEAC receipt reference coexists with payment metadata inside an MCP tool result `_meta` tree.
+6. Tampering with the record payload fails verification (`E_INVALID_SIGNATURE`).
+
+## Redaction and binding
+
+The raw `Payment-Receipt` is sensitive. The example binds it by digest and normalized fields; it does not log, store, or sign the raw header value. The record binds the normalized 402 challenge identity (id, realm, method, intent, expires) and decoded request payload via `payment_challenge_digest`; amount and currency come from the challenge request, not from the `Payment-Receipt` header.
+
+The 402 challenge `request` fixture is JCS-serialized (RFC 8785) before base64url encoding, matching the draft's deterministic encoding requirement; the `Payment-Receipt` fixture remains base64url JSON.
+
+## Run
+
+```bash
+pnpm demo               # full flow: record, verify offline, MCP _meta coexistence
+pnpm demo:tamper        # tamper check: a modified record fails the signature
+pnpm demo:show-record   # print the decoded record header and payload
+```
+
+No network, no external services. This demo generates an ephemeral local keypair for repeatable local execution; production issuers should use stable issuer-controlled signing keys.
+
+## Reused building blocks (no new protocol surface)
+
+This example adds no new receipt type, extension group, schema, wire version, signing envelope, or package API. It composes existing packages:
+
+- `@peac/mappings-paymentauth` - `parsePaymentauthChallenges`, `normalizeChallenge`, `parsePaymentauthReceipt`, `normalizeReceipt`, `toCommerceExtensionFields`
+- `@peac/protocol` - `issue`, `verifyLocal`
+- `@peac/schema` - `computeReceiptRef`
+- `@peac/mappings-mcp` - `attachReceiptToMeta`, `extractReceiptFromMetaAsync`
+- `@peac/crypto` - `generateKeypair`, `sha256Hex`, `jcsHash`

--- a/examples/mpp-payment-record/demo.ts
+++ b/examples/mpp-payment-record/demo.ts
@@ -1,0 +1,494 @@
+/**
+ * MPP Payment-Record Example (signed-record capstone)
+ *
+ * MPP handles the payment flow. PEAC records the resulting payment event as a
+ * portable signed org.peacprotocol/payment record verifiable without MPP
+ * server logs.
+ *
+ * This is a draft-aligned composition example for the "Payment" HTTP
+ * authentication scheme (draft-ryan-httpauth-payment-01, an active individual
+ * Internet-Draft, work in progress, not a finalized standard). A server
+ * returns HTTP 402 with a payment challenge; after the client pays, the server
+ * returns a Payment-Receipt header (base64url JSON). PEAC observes that receipt
+ * and issues a signed, portable payment record that a customer, auditor,
+ * counterparty, or dispute system can verify offline with only the issuer
+ * public key.
+ *
+ * Relationship to other examples:
+ * - examples/paymentauth-evidence  : parse + MAP paymentauth data to evidence.
+ * - examples/mpp-payment-attempt   : attempt/settlement evidence mapping.
+ * - examples/mpp-payment-record    : THIS example. The signed-record capstone:
+ *   sign org.peacprotocol/payment, verify offline, carry in MCP _meta, prove
+ *   tamper failure. It REUSES the @peac/mappings-paymentauth parser and the
+ *   toCommerceExtensionFields() mapper rather than re-implementing them.
+ *
+ * Boundaries (PEAC does not become a payment rail):
+ * - PEAC records and verifies; it does not settle, authorize, or authenticate.
+ * - The raw Payment-Receipt is sensitive. The example binds it by digest and
+ *   normalized fields; it does not log, store, or sign the raw header value.
+ * - The record binds the normalized 402 challenge identity and decoded request
+ *   payload via payment_challenge_digest; amount and currency come from the
+ *   challenge request, not from the Payment-Receipt header.
+ *
+ * Record type / extensions used here:
+ * - Registered record type org.peacprotocol/payment (the type the
+ *   `peac samples generate` payment-event sample uses).
+ * - Registered extension group org.peacprotocol/commerce carries the
+ *   normalized fields produced by toCommerceExtensionFields()
+ *   (payment_rail = paymentauth, amount_minor, currency, reference, env).
+ * - com.example/mpp is a well-formed but unregistered example-local extension
+ *   group carrying observational overflow (status, method, timestamp,
+ *   challenge_id, resource, upstream_receipt_digest, payment_challenge_digest).
+ *   Verification preserves it and surfaces an informational
+ *   unknown_extension_preserved warning.
+ *
+ * No network, no external services.
+ *
+ * Run:
+ *   pnpm demo               full flow (record, verify offline, MCP _meta coexist)
+ *   pnpm demo:tamper        tamper check (modified record fails signature)
+ *   pnpm demo:show-record   print the decoded record header and payload
+ */
+
+import { issue, verifyLocal } from '@peac/protocol';
+import { generateKeypair, sha256Hex, jcsHash, canonicalize } from '@peac/crypto';
+import { computeReceiptRef } from '@peac/schema';
+import { attachReceiptToMeta, extractReceiptFromMetaAsync } from '@peac/mappings-mcp';
+import {
+  parsePaymentauthChallenges,
+  parsePaymentauthReceipt,
+  normalizeChallenge,
+  normalizeReceipt,
+  toCommerceExtensionFields,
+  type NormalizedPaymentauthChallenge,
+} from '@peac/mappings-paymentauth';
+
+// Configuration (issuer = the service that observed the payment and records it)
+const ISSUER_URL = 'https://api.example.com';
+const KID = 'record-key-2026';
+const COMMERCE_EXT = 'org.peacprotocol/commerce';
+const MPP_EXT = 'com.example/mpp';
+
+/** base64url of plain JSON (used for the Payment-Receipt header, base64url JSON). */
+function toBase64urlJson(obj: unknown): string {
+  return Buffer.from(JSON.stringify(obj), 'utf8').toString('base64url');
+}
+
+/**
+ * base64url of RFC 8785 (JCS) canonical JSON. The draft requires the 402
+ * "Payment" challenge `request` JSON to be JCS-serialized before base64url.
+ */
+function toBase64urlJcs(obj: unknown): string {
+  return Buffer.from(canonicalize(obj), 'utf8').toString('base64url');
+}
+
+/**
+ * Canonical binding object for the observed 402 challenge: the normalized
+ * challenge identity (id, realm, method, intent, expires) plus the decoded
+ * request payload. A changed challenge id / method / expiry / amount all change
+ * payment_challenge_digest. It does not bind arbitrary or raw challenge
+ * parameters. Optional fields are set to null when absent for a deterministic,
+ * cross-language-safe shape.
+ */
+function challengeBindingForDigest(
+  challenge: NormalizedPaymentauthChallenge
+): Record<string, unknown> {
+  return {
+    id: challenge.id ?? null,
+    realm: challenge.realm ?? null,
+    method: challenge.method ?? null,
+    intent: challenge.intent ?? null,
+    expires: challenge.expires ?? null,
+    request: challenge.decodedRequest ?? null,
+  };
+}
+
+/**
+ * Simulated server: builds the 402 "Payment" challenge header (the price and
+ * context the server charges for). `method` is a neutral example value (not a
+ * real payment provider name).
+ */
+function serverChallengeHeader(): string {
+  const request = toBase64urlJcs({
+    amount: '500',
+    currency: 'USD',
+    recipient: 'acct_merchant',
+    resource: 'tool:market_data.quote',
+  });
+  return (
+    `Payment id="ch_4f9a21", realm="api.example.com", ` +
+    `method="example", intent="charge", expires="2026-06-15T12:05:00Z", ` +
+    `request="${request}"`
+  );
+}
+
+/** Simulated server: the Payment-Receipt header it returns on 200. */
+function serverPaymentReceiptHeader(): string {
+  return toBase64urlJson({
+    status: 'success',
+    method: 'example',
+    timestamp: '2026-06-15T12:00:00Z',
+    reference: 'pay_ch_4f9a21',
+  });
+}
+
+/**
+ * Describe a Payment-Receipt header for logs WITHOUT revealing it. The raw
+ * header is sensitive (draft-ryan-httpauth-payment-01); only a short digest is
+ * ever printed, never the prefix, suffix, or raw value.
+ */
+async function describePaymentReceiptHeader(header: string): Promise<string> {
+  const digest = await sha256Hex(header);
+  return `[redacted Payment-Receipt; sha256:${digest.slice(0, 16)}...]`;
+}
+
+/** Decode a compact JWS without verifying (display helper). */
+function decodeJws(jws: string): { header: unknown; payload: unknown } {
+  const [header, payload] = jws.split('.');
+  return {
+    header: JSON.parse(Buffer.from(header, 'base64url').toString('utf8')),
+    payload: JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')),
+  };
+}
+
+/** Modify one payload claim while keeping the original signature (tamper helper). */
+function tamperPayload(jws: string): string {
+  const [header, payload, signature] = jws.split('.');
+  const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as Record<
+    string,
+    unknown
+  >;
+  decoded.iss = 'https://attacker.example.com';
+  const reEncoded = Buffer.from(JSON.stringify(decoded), 'utf8').toString('base64url');
+  return `${header}.${reEncoded}.${signature}`;
+}
+
+export interface RecordResult {
+  jws: string;
+  receiptRef: Awaited<ReturnType<typeof computeReceiptRef>>;
+  upstreamReceiptDigest: string;
+  challengeDigest: string;
+}
+
+/**
+ * Observe a 402 "Payment" challenge and its Payment-Receipt header and issue a
+ * signed PEAC payment record (record type org.peacprotocol/payment).
+ *
+ * Reuses the @peac/mappings-paymentauth parser/normalizer and the
+ * toCommerceExtensionFields() mapper (the same path examples/paymentauth-evidence
+ * uses). Rejects a receipt whose status is not success or whose body is not a
+ * valid base64url JSON object (the parser/normalizer throw). The raw receipt is
+ * never embedded: the record binds a sha256 digest of it. payment_rail is the
+ * paymentauth rail (from the helper), not the receipt method. The record binds
+ * the normalized 402 challenge identity (id/realm/method/intent/expires) and
+ * decoded request payload via payment_challenge_digest; amount and currency come
+ * from the challenge request, not the Payment-Receipt header.
+ */
+export async function recordPaymentReceipt(
+  challengeHeader: string,
+  paymentReceiptHeader: string,
+  privateKey: Uint8Array
+): Promise<RecordResult> {
+  const [rawChallenge] = parsePaymentauthChallenges(challengeHeader);
+  if (!rawChallenge) {
+    throw new Error('no Payment challenge found in WWW-Authenticate header');
+  }
+  const challenge = normalizeChallenge(rawChallenge);
+  const raw = parsePaymentauthReceipt(paymentReceiptHeader);
+  const receipt = normalizeReceipt(raw); // throws on non-object / missing status+method
+
+  if (receipt.status !== 'success') {
+    throw new Error(`refusing to record a non-success payment receipt: status=${receipt.status}`);
+  }
+
+  // Reuse the canonical commerce-field mapper (rail = paymentauth, amount/currency
+  // from the 402 challenge request, reference from the receipt), the same call
+  // examples/paymentauth-evidence uses. Default (interop) mode; the helper defaults
+  // the commerce env to 'live', so a production integration should assert env from
+  // the upstream payment context.
+  const commerce = toCommerceExtensionFields(receipt, challenge);
+  if (!commerce?.amount_minor || !commerce.currency) {
+    throw new Error('challenge did not yield amount_minor + currency for the commerce extension');
+  }
+
+  // Bind the upstream receipt and the normalized 402 challenge (identity + request) by digest.
+  // Digest values are self-describing (sha256:<hex>), mirroring receipt_ref.
+  const upstreamReceiptDigest = `sha256:${await sha256Hex(raw.rawValue)}`;
+  // RFC 8785 JCS + SHA-256 via the canonical @peac/crypto helper (not a local rule).
+  const challengeDigest = `sha256:${await jcsHash(challengeBindingForDigest(challenge))}`;
+  const reqResource =
+    challenge.decodedRequest && typeof challenge.decodedRequest === 'object'
+      ? String((challenge.decodedRequest as Record<string, unknown>).resource ?? '')
+      : '';
+
+  const mppExt: Record<string, string> = {
+    record_role: 'payment-record',
+    status: receipt.status,
+    method: receipt.method, // payment method (distinct from payment_rail)
+    challenge_id: challenge.id,
+    resource: reqResource,
+    upstream_receipt_digest: upstreamReceiptDigest,
+    payment_challenge_digest: challengeDigest,
+    redaction_applied: 'true',
+  };
+  if (receipt.timestamp) mppExt.timestamp = receipt.timestamp;
+
+  const { jws } = await issue({
+    iss: ISSUER_URL,
+    kind: 'evidence',
+    type: 'org.peacprotocol/payment',
+    pillars: ['commerce'],
+    ...(receipt.timestamp ? { occurred_at: receipt.timestamp } : {}),
+    extensions: {
+      [COMMERCE_EXT]: commerce,
+      [MPP_EXT]: mppExt,
+    },
+    privateKey,
+    kid: KID,
+  });
+
+  return {
+    jws,
+    receiptRef: await computeReceiptRef(jws),
+    upstreamReceiptDigest,
+    challengeDigest,
+  };
+}
+
+/** MCP CallToolResult-shaped response with a top-level _meta carrier. */
+interface McpToolCallResult {
+  content: Array<{ type: 'text'; text: string }>;
+  structuredContent?: Record<string, unknown>;
+  _meta?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface MppDemoResult {
+  ok: boolean;
+  receiptRef: string;
+  signatureValid: boolean;
+  paymentRail?: string;
+  amountMinor?: string;
+  currency?: string;
+  digestMatches: boolean;
+  challengeDigestMatches: boolean;
+  warnings: string[];
+  /** True if the raw base64url receipt leaked into the signed payload. */
+  rawReceiptLeak: boolean;
+  mcpMeta: {
+    receiptInMeta: boolean;
+    paymentMetaCoexists: boolean;
+    metaReceiptVerifies: boolean;
+    payment?: {
+      challenge_id?: string;
+      payment_rail?: string;
+      amount_minor?: string;
+      currency?: string;
+      reference?: string;
+      env?: string;
+    };
+  };
+  tamper?: {
+    payloadTamperValid: boolean;
+    payloadTamperCode?: string;
+  };
+}
+
+export interface RunOptions {
+  tamper?: boolean;
+  showRecord?: boolean;
+  quiet?: boolean;
+}
+
+/**
+ * Run the full MPP payment-record demo and return a structured result. Prints
+ * a stage report unless quiet. Importing this module runs nothing; only the
+ * guarded main() at the bottom invokes it when the file is run directly.
+ */
+export async function runDemo(opts: RunOptions = {}): Promise<MppDemoResult> {
+  const { tamper = false, showRecord = false, quiet = false } = opts;
+  const log = quiet ? () => undefined : (msg = '') => console.log(msg);
+  const { privateKey, publicKey } = await generateKeypair();
+
+  log('\n=== PEAC MPP Payment-Record Demo ===\n');
+
+  // 1. Server returns HTTP 402 with a "Payment" challenge for a paid resource.
+  const challengeHeader = serverChallengeHeader();
+  const paymentReceiptHeader = serverPaymentReceiptHeader();
+  log('1. Server returns 402 Payment Required for a paid resource (price in the challenge).');
+
+  // 2. Client pays; server returns 200 with a Payment-Receipt header.
+  log('2. Client pays; server returns 200 with a Payment-Receipt header:');
+  log(`   Payment-Receipt: ${await describePaymentReceiptHeader(paymentReceiptHeader)}`);
+
+  // 3. PEAC observes the receipt and issues a signed payment record.
+  const rec = await recordPaymentReceipt(challengeHeader, paymentReceiptHeader, privateKey);
+  log('\n3. PEAC records a signed org.peacprotocol/payment record (raw receipt bound by digest):');
+  log(`   receipt_ref        = ${rec.receiptRef.slice(0, 27)}...`);
+  log(`   upstream_digest    = ${rec.upstreamReceiptDigest.slice(0, 27)}...`);
+  log(`   challenge_digest   = ${rec.challengeDigest.slice(0, 27)}...`);
+
+  if (showRecord) {
+    log('\n   Decoded record:');
+    log(JSON.stringify(decodeJws(rec.jws), null, 2));
+  }
+
+  const failed = (): MppDemoResult => ({
+    ok: false,
+    receiptRef: rec.receiptRef,
+    signatureValid: false,
+    digestMatches: false,
+    challengeDigestMatches: false,
+    warnings: [],
+    rawReceiptLeak: false,
+    mcpMeta: { receiptInMeta: false, paymentMetaCoexists: false, metaReceiptVerifies: false },
+  });
+
+  // 4. Counterparty verifies offline with only the issuer public key.
+  const verifyResult = await verifyLocal(rec.jws, publicKey, { issuer: ISSUER_URL });
+  if (!verifyResult.valid) {
+    console.error(`4. Offline verification FAILED: ${verifyResult.code} ${verifyResult.message}`);
+    return failed();
+  }
+  const exts = verifyResult.claims.extensions as Record<string, unknown> | undefined;
+  const commerce = exts?.[COMMERCE_EXT] as
+    | {
+        payment_rail?: string;
+        amount_minor?: string;
+        currency?: string;
+        reference?: string;
+        env?: string;
+      }
+    | undefined;
+  const mpp = exts?.[MPP_EXT] as
+    | { upstream_receipt_digest?: string; payment_challenge_digest?: string }
+    | undefined;
+  const warnings = verifyResult.warnings.map((w) => w.code);
+
+  // The counterparty re-receives the same raw receipt and challenge and re-binds.
+  const reDigest = `sha256:${await sha256Hex(paymentReceiptHeader)}`;
+  const digestMatches = reDigest === mpp?.upstream_receipt_digest;
+  const reChallenge = normalizeChallenge(parsePaymentauthChallenges(challengeHeader)[0]);
+  const reChallengeDigest = `sha256:${await jcsHash(challengeBindingForDigest(reChallenge))}`;
+  const challengeDigestMatches = reChallengeDigest === mpp?.payment_challenge_digest;
+
+  // Redaction invariant: the raw base64url receipt must not be in the payload.
+  const payloadStr = JSON.stringify(decodeJws(rec.jws).payload);
+  const rawReceiptLeak = payloadStr.includes(paymentReceiptHeader);
+
+  log('\n4. Counterparty verification (offline, public key only):');
+  log(`   signature valid = ${verifyResult.valid}`);
+  log(
+    `   payment_rail = ${commerce?.payment_rail}, amount = ${commerce?.amount_minor} ${commerce?.currency}`
+  );
+  log(`   upstream receipt digest re-binds = ${digestMatches}`);
+  log(`   402 challenge digest re-binds = ${challengeDigestMatches}`);
+  log(`   raw receipt present in record = ${rawReceiptLeak} (expected false)`);
+  if (warnings.length > 0) log(`   informational warnings: ${warnings.join(', ')}`);
+
+  // 5. MCP _meta coexistence: the PEAC receipt reference rides alongside the
+  //    payment metadata in the same _meta tree of an MCP tool result.
+  const baseResult: McpToolCallResult = {
+    content: [{ type: 'text', text: 'market_data.quote completed (paid).' }],
+    structuredContent: { quote: { symbol: 'EXMPL', price: '12.34' } },
+    _meta: {
+      [`${MPP_EXT}/payment`]: {
+        challenge_id: 'ch_4f9a21',
+        payment_rail: commerce?.payment_rail,
+        amount_minor: commerce?.amount_minor,
+        currency: commerce?.currency,
+        reference: commerce?.reference,
+        env: commerce?.env,
+      },
+    },
+  };
+  const withReceipt = attachReceiptToMeta(baseResult, {
+    receipt_ref: rec.receiptRef,
+    receipt_jws: rec.jws,
+  }) as McpToolCallResult;
+  const paymentMeta = withReceipt._meta?.[`${MPP_EXT}/payment`] as
+    | {
+        challenge_id?: string;
+        payment_rail?: string;
+        amount_minor?: string;
+        currency?: string;
+        reference?: string;
+        env?: string;
+      }
+    | undefined;
+  const paymentMetaCoexists = paymentMeta !== undefined;
+  const extracted = await extractReceiptFromMetaAsync(withReceipt);
+  const metaJws = extracted?.receipts[0]?.receipt_jws;
+  const metaVerify = metaJws
+    ? await verifyLocal(metaJws, publicKey, { issuer: ISSUER_URL })
+    : { valid: false as const };
+  log('\n5. MCP _meta coexistence:');
+  log(`   payment metadata + PEAC receipt both present in _meta = ${paymentMetaCoexists}`);
+  log(`   _meta-carried PEAC receipt verifies offline = ${metaVerify.valid}`);
+
+  const result: MppDemoResult = {
+    ok: true,
+    receiptRef: rec.receiptRef,
+    signatureValid: verifyResult.valid === true,
+    paymentRail: commerce?.payment_rail,
+    amountMinor: commerce?.amount_minor,
+    currency: commerce?.currency,
+    digestMatches,
+    challengeDigestMatches,
+    warnings,
+    rawReceiptLeak,
+    mcpMeta: {
+      receiptInMeta: Boolean(metaJws),
+      paymentMetaCoexists,
+      metaReceiptVerifies: metaVerify.valid === true,
+      payment: paymentMeta,
+    },
+  };
+
+  if (tamper) {
+    // Tamper: modify the record payload, keep the signature -> invalid signature.
+    const tamperedJws = tamperPayload(rec.jws);
+    const tamperedVerify = await verifyLocal(tamperedJws, publicKey, { issuer: ISSUER_URL });
+    log('\n6. Tamper check (modify the record payload, keep signature):');
+    log(`   valid = ${tamperedVerify.valid}`);
+    if (!tamperedVerify.valid) log(`   code  = ${tamperedVerify.code}`);
+    result.tamper = {
+      payloadTamperValid: tamperedVerify.valid === true,
+      payloadTamperCode: tamperedVerify.valid ? undefined : tamperedVerify.code,
+    };
+  }
+
+  // Verdict: every check the demo makes must hold.
+  result.ok =
+    result.signatureValid &&
+    result.digestMatches &&
+    result.challengeDigestMatches &&
+    result.paymentRail === 'paymentauth' &&
+    !result.rawReceiptLeak &&
+    result.mcpMeta.receiptInMeta &&
+    result.mcpMeta.paymentMetaCoexists &&
+    result.mcpMeta.metaReceiptVerifies &&
+    (!tamper ||
+      (!result.tamper!.payloadTamperValid &&
+        result.tamper!.payloadTamperCode === 'E_INVALID_SIGNATURE'));
+
+  if (result.ok) log('\n=== Demo Complete ===\n');
+  return result;
+}
+
+async function main(): Promise<void> {
+  const result = await runDemo({
+    tamper: process.argv.includes('--tamper'),
+    showRecord: process.argv.includes('--show-record'),
+  });
+  if (!result.ok) process.exitCode = 1;
+}
+
+// Run only when executed directly (pnpm demo), not when imported by a test.
+const invokedDirectly = process.argv[1] !== undefined && /demo\.ts$/.test(process.argv[1]);
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error('Demo failed:', err);
+    process.exitCode = 1;
+  });
+}

--- a/examples/mpp-payment-record/package.json
+++ b/examples/mpp-payment-record/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@peac/example-mpp-payment-record",
+  "version": "0.0.0",
+  "private": true,
+  "description": "PEAC example: record an MPP/paymentauth Payment-Receipt as a portable signed payment record (org.peacprotocol/payment) with offline verification and MCP _meta coexistence",
+  "type": "module",
+  "scripts": {
+    "demo": "tsx demo.ts",
+    "demo:tamper": "tsx demo.ts --tamper",
+    "demo:show-record": "tsx demo.ts --show-record",
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@peac/crypto": "workspace:*",
+    "@peac/mappings-mcp": "workspace:*",
+    "@peac/mappings-paymentauth": "workspace:*",
+    "@peac/protocol": "workspace:*",
+    "@peac/schema": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/examples/mpp-payment-record/tsconfig.json
+++ b/examples/mpp-payment-record/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true
+  },
+  "include": ["*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -571,6 +571,31 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
 
+  examples/mpp-payment-record:
+    dependencies:
+      '@peac/crypto':
+        specifier: workspace:*
+        version: link:../../packages/crypto
+      '@peac/mappings-mcp':
+        specifier: workspace:*
+        version: link:../../packages/mappings/mcp
+      '@peac/mappings-paymentauth':
+        specifier: workspace:*
+        version: link:../../packages/mappings/paymentauth
+      '@peac/protocol':
+        specifier: workspace:*
+        version: link:../../packages/protocol
+      '@peac/schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+    devDependencies:
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+
   examples/openclaw-capture:
     dependencies:
       '@peac/adapter-openclaw':

--- a/tests/tooling/mpp-payment-record-example.test.ts
+++ b/tests/tooling/mpp-payment-record-example.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Runtime smoke test for examples/mpp-payment-record.
+ *
+ * The example is a public, copy-paste artifact, so its end-to-end behavior is
+ * gated here, not just its types. This imports the demo's exported runDemo()
+ * and recordPaymentReceipt() in-process (vitest aliases @peac/* to source, so
+ * no build or example install is required) and asserts:
+ *   - the signed org.peacprotocol/payment record verifies offline and its
+ *     upstream-receipt digest and 402-challenge digest re-bind
+ *   - payment_rail is the paymentauth rail (not the receipt method)
+ *   - the raw Payment-Receipt is never logged or embedded in the signed payload
+ *   - the PEAC receipt coexists with payment metadata in an MCP _meta tree
+ *   - tampering with the record payload fails with E_INVALID_SIGNATURE
+ *   - malformed and non-success receipts are rejected
+ *
+ * No network, no subprocess.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { generateKeypair, jcsHash, canonicalize } from '@peac/crypto';
+import { runDemo, recordPaymentReceipt } from '../../examples/mpp-payment-record/demo';
+
+/** base64url of plain JSON (Payment-Receipt header). */
+function b64u(obj: unknown): string {
+  return Buffer.from(JSON.stringify(obj), 'utf8').toString('base64url');
+}
+
+/** base64url of RFC 8785 JCS JSON (the 402 challenge `request`, per the draft). */
+function b64uJcs(obj: unknown): string {
+  return Buffer.from(canonicalize(obj), 'utf8').toString('base64url');
+}
+
+// A valid 402 "Payment" challenge header (paymentauth form) for the negative tests.
+const CHALLENGE_HEADER =
+  `Payment id="ch_test", realm="api.example.com", method="example", intent="charge", ` +
+  `expires="2026-06-15T12:05:00Z", ` +
+  `request="${b64uJcs({ amount: '500', currency: 'USD', recipient: 'acct', resource: 'tool:test' })}"`;
+
+// The canonical binding the record commits to for CHALLENGE_HEADER (mirrors
+// challengeBindingForDigest in the demo): normalized challenge identity + decoded request.
+const CHALLENGE_BINDING = {
+  id: 'ch_test',
+  realm: 'api.example.com',
+  method: 'example',
+  intent: 'charge',
+  expires: '2026-06-15T12:05:00Z',
+  request: { amount: '500', currency: 'USD', recipient: 'acct', resource: 'tool:test' },
+};
+
+function decodePayload(jws: string): Record<string, unknown> {
+  return JSON.parse(Buffer.from(jws.split('.')[1], 'base64url').toString('utf8'));
+}
+
+describe('mpp-payment-record example', () => {
+  it('records, verifies offline, and re-binds the upstream and challenge digests', async () => {
+    const r = await runDemo({ quiet: true });
+    expect(r.signatureValid).toBe(true);
+    expect(r.amountMinor).toBe('500');
+    expect(r.currency).toBe('USD');
+    expect(r.digestMatches).toBe(true);
+    expect(r.challengeDigestMatches).toBe(true);
+    expect(r.ok).toBe(true);
+  });
+
+  it('uses the paymentauth rail for payment_rail (not the receipt method)', async () => {
+    const r = await runDemo({ quiet: true });
+    expect(r.paymentRail).toBe('paymentauth');
+
+    const { privateKey } = await generateKeypair();
+    const header = b64u({ status: 'success', method: 'example', reference: 'pay_1' });
+    const rec = await recordPaymentReceipt(CHALLENGE_HEADER, header, privateKey);
+    const exts = decodePayload(rec.jws).extensions as Record<string, Record<string, unknown>>;
+    expect(exts['org.peacprotocol/commerce'].payment_rail).toBe('paymentauth');
+    expect(exts['org.peacprotocol/commerce'].env).toBe('live');
+    expect(exts['org.peacprotocol/commerce'].method).toBeUndefined();
+    expect(exts['com.example/mpp'].method).toBe('example');
+  });
+
+  it('binds the normalized 402 challenge identity and request payload into the digest', async () => {
+    const { privateKey } = await generateKeypair();
+    const header = b64u({ status: 'success', method: 'example', reference: 'pay_1' });
+    const rec = await recordPaymentReceipt(CHALLENGE_HEADER, header, privateKey);
+    const exts = decodePayload(rec.jws).extensions as Record<string, Record<string, unknown>>;
+    expect(exts['com.example/mpp'].payment_challenge_digest).toBe(rec.challengeDigest);
+    // The digest binds the normalized challenge identity and decoded request (RFC 8785 JCS),
+    // self-describing as sha256:<hex>.
+    expect(`sha256:${await jcsHash(CHALLENGE_BINDING)}`).toBe(rec.challengeDigest);
+  });
+
+  it('records a challenge without expires and binds expires as null', async () => {
+    const { privateKey } = await generateKeypair();
+    const noExpiresHeader =
+      `Payment id="ch_noexp", realm="api.example.com", method="example", intent="charge", ` +
+      `request="${b64uJcs({ amount: '500', currency: 'USD', recipient: 'acct', resource: 'tool:test' })}"`;
+    const header = b64u({ status: 'success', method: 'example', reference: 'pay_1' });
+    const rec = await recordPaymentReceipt(noExpiresHeader, header, privateKey);
+    // expires absent -> bound as null (deterministic, cross-language-safe).
+    const binding = {
+      id: 'ch_noexp',
+      realm: 'api.example.com',
+      method: 'example',
+      intent: 'charge',
+      expires: null,
+      request: { amount: '500', currency: 'USD', recipient: 'acct', resource: 'tool:test' },
+    };
+    expect(`sha256:${await jcsHash(binding)}`).toBe(rec.challengeDigest);
+  });
+
+  it('detects a 402 challenge mismatch for amount, id, method, and expires', async () => {
+    const { privateKey } = await generateKeypair();
+    const header = b64u({ status: 'success', method: 'example', reference: 'pay_1' });
+    const rec = await recordPaymentReceipt(CHALLENGE_HEADER, header, privateKey);
+    const changedAmount = {
+      ...CHALLENGE_BINDING,
+      request: { ...CHALLENGE_BINDING.request, amount: '999' },
+    };
+    const changedId = { ...CHALLENGE_BINDING, id: 'ch_other' };
+    const changedMethod = { ...CHALLENGE_BINDING, method: 'other' };
+    const changedExpires = { ...CHALLENGE_BINDING, expires: '2030-01-01T00:00:00Z' };
+    expect(`sha256:${await jcsHash(changedAmount)}`).not.toBe(rec.challengeDigest);
+    expect(`sha256:${await jcsHash(changedId)}`).not.toBe(rec.challengeDigest);
+    expect(`sha256:${await jcsHash(changedMethod)}`).not.toBe(rec.challengeDigest);
+    expect(`sha256:${await jcsHash(changedExpires)}`).not.toBe(rec.challengeDigest);
+  });
+
+  it('encodes the 402 challenge request with JCS before base64url', () => {
+    // Deliberately unordered keys: JCS must reorder them, so JCS != JSON.stringify.
+    const unordered = {
+      resource: 'tool:test',
+      recipient: 'acct',
+      currency: 'USD',
+      amount: '500',
+    };
+    expect(b64uJcs(unordered)).not.toBe(b64u(unordered));
+    expect(Buffer.from(b64uJcs(unordered), 'base64url').toString('utf8')).toBe(
+      canonicalize(unordered)
+    );
+  });
+
+  it('never logs the raw Payment-Receipt header', async () => {
+    const lines: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((msg?: unknown) => {
+      lines.push(String(msg ?? ''));
+    });
+    try {
+      await runDemo({ quiet: false });
+    } finally {
+      spy.mockRestore();
+    }
+    const out = lines.join('\n');
+    // The deterministic raw header the demo's server emits must not appear.
+    const rawHeader = b64u({
+      status: 'success',
+      method: 'example',
+      timestamp: '2026-06-15T12:00:00Z',
+      reference: 'pay_ch_4f9a21',
+    });
+    expect(out).toContain('[redacted Payment-Receipt; sha256:');
+    expect(out).not.toContain(rawHeader);
+    // No long base64url run (raw receipt is long; digests are sliced short).
+    expect(out).not.toMatch(/[A-Za-z0-9_-]{50,}/);
+  });
+
+  it('never embeds the raw Payment-Receipt in the signed payload', async () => {
+    const r = await runDemo({ quiet: true });
+    expect(r.rawReceiptLeak).toBe(false);
+  });
+
+  it('carries the PEAC receipt alongside payment metadata in MCP _meta', async () => {
+    const r = await runDemo({ quiet: true });
+    expect(r.mcpMeta.receiptInMeta).toBe(true);
+    expect(r.mcpMeta.paymentMetaCoexists).toBe(true);
+    expect(r.mcpMeta.metaReceiptVerifies).toBe(true);
+    // The _meta payment metadata mirrors the non-sensitive signed commerce fields.
+    expect(r.mcpMeta.payment?.challenge_id).toBe('ch_4f9a21');
+    expect(r.mcpMeta.payment?.payment_rail).toBe('paymentauth');
+    expect(r.mcpMeta.payment?.amount_minor).toBe('500');
+    expect(r.mcpMeta.payment?.currency).toBe('USD');
+    expect(r.mcpMeta.payment?.reference).toBe('pay_ch_4f9a21');
+    expect(r.mcpMeta.payment?.env).toBe('live');
+  });
+
+  it('detects record tampering with an invalid signature', async () => {
+    const r = await runDemo({ tamper: true, quiet: true });
+    expect(r.tamper?.payloadTamperValid).toBe(false);
+    expect(r.tamper?.payloadTamperCode).toBe('E_INVALID_SIGNATURE');
+  });
+
+  it('reports an overall ok verdict with tamper checks enabled', async () => {
+    const r = await runDemo({ tamper: true, quiet: true });
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects an invalid base64url receipt', async () => {
+    const { privateKey } = await generateKeypair();
+    await expect(
+      recordPaymentReceipt(CHALLENGE_HEADER, '!!!not-base64url!!!', privateKey)
+    ).rejects.toThrow();
+  });
+
+  it('rejects a receipt whose decoded body is not a JSON object', async () => {
+    const { privateKey } = await generateKeypair();
+    const notJson = Buffer.from('not json', 'utf8').toString('base64url');
+    await expect(recordPaymentReceipt(CHALLENGE_HEADER, notJson, privateKey)).rejects.toThrow();
+  });
+
+  it('refuses to record a non-success payment receipt', async () => {
+    const { privateKey } = await generateKeypair();
+    const failed = b64u({ status: 'failed', method: 'example' });
+    await expect(recordPaymentReceipt(CHALLENGE_HEADER, failed, privateKey)).rejects.toThrow(
+      /non-success/
+    );
+  });
+
+  it('rejects a header with no Payment challenge', async () => {
+    const { privateKey } = await generateKeypair();
+    const receipt = b64u({ status: 'success', method: 'example', reference: 'pay_1' });
+    await expect(recordPaymentReceipt('Bearer realm="x"', receipt, privateKey)).rejects.toThrow(
+      /no Payment challenge/
+    );
+    await expect(recordPaymentReceipt('', receipt, privateKey)).rejects.toThrow(
+      /no Payment challenge/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds a runnable example that records a successful MPP/paymentauth `Payment-Receipt` as a signed `org.peacprotocol/payment` record, verifies it offline with the issuer public key, carries it alongside payment metadata in an MCP `_meta` tree, and shows tamper detection (`E_INVALID_SIGNATURE`).

It composes existing PEAC surfaces and adds no new protocol surface:

- `@peac/mappings-paymentauth` parses and normalizes the 402 challenge and `Payment-Receipt` (the same path as `examples/paymentauth-evidence`)
- `toCommerceExtensionFields()` maps paymentauth fields into the registered `org.peacprotocol/commerce` extension
- `@peac/protocol` issues and verifies the signed record
- `@peac/mappings-mcp` carries the receipt reference/JWS alongside payment metadata in MCP `_meta`
- `@peac/crypto` `jcsHash` binds the normalized 402 challenge identity and decoded request payload (RFC 8785)

PEAC records and verifies. It does not settle, authorize, authenticate, or replace the payment protocol.

## Security / privacy

The raw `Payment-Receipt` is sensitive. The example binds it by digest and normalized fields; it does not log, store, or sign the raw header value. Digest values are self-describing (`sha256:<hex>`). The 402 challenge `request` is JCS-serialized (RFC 8785) before base64url encoding; the `Payment-Receipt` fixture stays base64url JSON.

## Protocol surface

No new receipt type, extension group, schema, wire version, signing envelope, registry entry, or package API. `docs/releases/facts.json` updates `build_targets` from 105 to 106 for the new example build target.

## Validation

- `pnpm exec vitest run tests/tooling/mpp-payment-record-example.test.ts` (15 cases)
- `pnpm exec vitest run tests/tooling/no-source-to-test-imports.test.ts`
- `pnpm verify:release`
- `pnpm test`
- `pnpm build`
