### PR TITLE
chore(security): clear audit gate for current high advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
       "path-to-regexp@>=8.0.0": ">=8.4.0",
       "yaml": "2.8.3",
       "@hono/node-server": ">=1.19.13",
-      "hono": ">=4.12.18",
+      "hono": ">=4.12.25",
       "fast-uri@<3.1.2": ">=3.1.2",
       "ip-address@<=10.1.0": ">=10.1.1",
       "protobufjs": "8.0.2",
@@ -167,7 +167,8 @@
       "esbuild@<0.25.0": ">=0.25.0",
       "undici@<6.24.0": ">=6.24.0",
       "postcss@<8.5.10": ">=8.5.10",
-      "vite@<6.4.2": ">=6.4.2"
+      "form-data@<4.0.6": ">=4.0.6",
+      "vite@<6.4.2": ">=8.0.16"
     },
     "overridesComments": {
       "minimatch": "Cross-major pin to 10.2.4: typescript-estree requires ^9.0.4 but 9.x has no patch for GHSA-3ppc-4f35-3m26. minimatch 10.x is API-compatible (same globbing interface). 10.2.4 patches GHSA-7r86-cg39-jmmj and GHSA-23c5-xmqv-rm74 (ReDoS). Drops Node 18 (fine: repo baseline is >=22.0.0). Lint verified clean.",
@@ -185,8 +186,9 @@
       "esbuild@<0.25.0": "Range-scoped to <0.25.0 only (forces patched 0.25.0+, fixes GHSA-67mh-4wv8-2f99 dev-server CORS bypass). Dev-only via wrangler / @esbuild-plugins/node-globals-polyfill peer / @esbuild-plugins/node-modules-polyfill peer (all ship esbuild 0.17.19). Newer esbuild instances at 0.25.12+ already pulled by vitest/tsx are unaffected.",
       "undici@<6.24.0": "Range-scoped to <6.24.0 only (forces patched 6.24.0+, fixes GHSA-4992-7rv2-5pvq CRLF injection via upgrade and GHSA-2mjp-6q6p-2qxm HTTP request/response smuggling). Dev-only via wrangler -> miniflare which bundles undici 5.29.0. @peac/net-node already uses undici 6.24.0+ (production path unaffected).",
       "postcss@<8.5.10": "Range-scoped to <8.5.10 only (forces patched 8.5.10+, fixes GHSA-qx2v-qp2m-jg93 XSS via unescaped </style> in CSS Stringify output). Dev-only via next 15.5.x (bundles postcss 8.4.31 internally) and vite. Workspace doesn't import postcss directly; affects build tooling only.",
-      "vite@<6.4.2": "Range-scoped to <6.4.2 only (forces patched 6.4.2+, fixes GHSA-p9ff-h696-f583 arbitrary file read via dev server WebSocket and GHSA-4w7w-66w2-5vf9 path traversal in optimized deps .map handling). Dev-only via vitest/@vitest/coverage-v8. pnpm resolves the override to vite 8.0.10 in practice; full test suite passes.",
-      "hono": "Bumped from >=4.12.12 to >=4.12.18 to pull patches for CVE-2026-44455 (bodyLimit() bypass for chunked / unknown-length requests), CVE-2026-44456 (hono/jsx unvalidated JSX tag names), CVE-2026-44457 (CSS declaration injection via Style Object Values in JSX SSR), CVE-2026-44458 (Cache Middleware ignores Vary: Authorization / Vary: Cookie), and CVE-2026-44459 (improper validation of NumericDate JWT claims). Prod dep via apps/api, apps/sandbox-issuer, packages/mcp-server, packages/server.",
+      "form-data@<4.0.6": "Range-scoped to <4.0.6 only (forces patched 4.0.6+, fixes GHSA-hmw2-7cc7-3qxx CRLF injection via unescaped multipart field/filename). Dev-only via the supertest/superagent HTTP test client used by @peac/middleware-express tests; not in any published package.",
+      "vite@<6.4.2": "Range-scoped to <6.4.2 only (forces patched, now floored at >=8.0.16, fixes GHSA-p9ff-h696-f583 arbitrary file read via dev server WebSocket, GHSA-4w7w-66w2-5vf9 path traversal in optimized deps .map handling, and GHSA-fx2h-pf6j-xcff server.fs.deny bypass on Windows alternate paths). Dev-only via vitest/@vitest/coverage-v8 and apps/verifier (internal app); pnpm resolves the override to vite 8.0.16; full test suite passes.",
+      "hono": "Bumped to >=4.12.25 to pull patches for CVE-2026-44455 (bodyLimit() bypass for chunked / unknown-length requests), CVE-2026-44456 (hono/jsx unvalidated JSX tag names), CVE-2026-44457 (CSS declaration injection via Style Object Values in JSX SSR), CVE-2026-44458 (Cache Middleware ignores Vary: Authorization / Vary: Cookie), CVE-2026-44459 (improper validation of NumericDate JWT claims), and GHSA-88fw-hqm2-52qc (CORS Middleware reflects any Origin, patched in 4.12.25). Prod dep via apps/api, apps/sandbox-issuer, packages/mcp-server, packages/server.",
       "fast-uri@<3.1.2": "Range-scoped to <3.1.2 only (forces patched 3.1.2+, fixes CVE-2026-6321 path traversal via percent-encoded dot segments and CVE-2026-6322 host confusion via percent-encoded authority delimiters). Transitive prod dep via ajv / ajv-formats (in @peac/protocol, @peac/receipts, apps/api) and @modelcontextprotocol/sdk (in @peac/mcp-server).",
       "ip-address@<=10.1.0": "Range-scoped to <=10.1.0 only (forces patched 10.1.1+, fixes CVE-2026-42338 XSS in Address6 HTML-emitting methods). Transitive prod dep via @modelcontextprotocol/sdk -> express-rate-limit."
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   path-to-regexp@>=8.0.0: '>=8.4.0'
   yaml: 2.8.3
   '@hono/node-server': '>=1.19.13'
-  hono: '>=4.12.18'
+  hono: '>=4.12.25'
   fast-uri@<3.1.2: '>=3.1.2'
   ip-address@<=10.1.0: '>=10.1.1'
   protobufjs: 8.0.2
@@ -24,7 +24,8 @@ overrides:
   esbuild@<0.25.0: '>=0.25.0'
   undici@<6.24.0: '>=6.24.0'
   postcss@<8.5.10: '>=8.5.10'
-  vite@<6.4.2: '>=6.4.2'
+  form-data@<4.0.6: '>=4.0.6'
+  vite@<6.4.2: '>=8.0.16'
 
 importers:
 
@@ -110,7 +111,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: '>=1.19.13'
-        version: 1.19.13(hono@4.12.18)
+        version: 1.19.13(hono@4.12.25)
       '@peac/crypto':
         specifier: workspace:*
         version: link:../../packages/crypto
@@ -136,8 +137,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/schema
       hono:
-        specifier: '>=4.12.18'
-        version: 4.12.18
+        specifier: '>=4.12.25'
+        version: 4.12.25
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -171,7 +172,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: '>=1.19.13'
-        version: 1.19.13(hono@4.12.18)
+        version: 1.19.13(hono@4.12.25)
       '@peac/crypto':
         specifier: workspace:*
         version: link:../../packages/crypto
@@ -185,8 +186,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/schema
       hono:
-        specifier: '>=4.12.18'
-        version: 4.12.18
+        specifier: '>=4.12.25'
+        version: 4.12.25
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -226,11 +227,11 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
       vite:
-        specifier: '>=6.4.2'
-        version: 8.0.10(@types/node@22.19.11)(tsx@4.21.0)(yaml@2.8.3)
+        specifier: '>=8.0.16'
+        version: 8.0.16(@types/node@22.19.11)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.8(@types/node@22.19.11)(@vitest/coverage-v8@4.1.8)(vite@8.0.10)
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(@vitest/coverage-v8@4.1.8)(vite@8.0.16)
 
   examples/a2a-gateway-pattern:
     dependencies:
@@ -2078,7 +2079,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: '>=1.19.13'
-        version: 1.19.13(hono@4.12.18)
+        version: 1.19.13(hono@4.12.25)
       '@peac/protocol':
         specifier: workspace:*
         version: link:../protocol
@@ -2086,8 +2087,8 @@ importers:
         specifier: workspace:*
         version: link:../schema
       hono:
-        specifier: '>=4.12.18'
-        version: 4.12.18
+        specifier: '>=4.12.25'
+        version: 4.12.25
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -3906,13 +3907,13 @@ packages:
       - '@emnapi/runtime'
     dev: true
 
-  /@hono/node-server@1.19.13(hono@4.12.18):
+  /@hono/node-server@1.19.13(hono@4.12.25):
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.18'
+      hono: '>=4.12.25'
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.25
     dev: false
 
   /@humanfs/core@0.19.1:
@@ -4683,7 +4684,7 @@ packages:
       '@cfworker/json-schema':
         optional: true
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.18)
+      '@hono/node-server': 1.19.13(hono@4.12.25)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -4693,7 +4694,7 @@ packages:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.0(express@5.2.1)
-      hono: 4.12.18
+      hono: 4.12.25
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -5250,10 +5251,6 @@ packages:
     dev: true
     optional: true
 
-  /@oxc-project/types@0.127.0:
-    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
-    dev: true
-
   /@oxc-project/types@0.133.0:
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
     dev: true
@@ -5285,15 +5282,6 @@ packages:
     engines: {node: '>=18'}
     dev: true
 
-  /@rolldown/binding-android-arm64@1.0.0-rc.17:
-    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rolldown/binding-android-arm64@1.0.3:
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5303,28 +5291,10 @@ packages:
     dev: true
     optional: true
 
-  /@rolldown/binding-darwin-arm64@1.0.0-rc.17:
-    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rolldown/binding-darwin-arm64@1.0.3:
     resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rolldown/binding-darwin-x64@1.0.0-rc.17:
-    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
@@ -5339,29 +5309,11 @@ packages:
     dev: true
     optional: true
 
-  /@rolldown/binding-freebsd-x64@1.0.0-rc.17:
-    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rolldown/binding-freebsd-x64@1.0.3:
     resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17:
-    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
     requiresBuild: true
     dev: true
     optional: true
@@ -5375,26 +5327,8 @@ packages:
     dev: true
     optional: true
 
-  /@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17:
-    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rolldown/binding-linux-arm64-gnu@1.0.3:
     resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rolldown/binding-linux-arm64-musl@1.0.0-rc.17:
-    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -5411,28 +5345,10 @@ packages:
     dev: true
     optional: true
 
-  /@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17:
-    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rolldown/binding-linux-ppc64-gnu@1.0.3:
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17:
-    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
     os: [linux]
     requiresBuild: true
     dev: true
@@ -5447,26 +5363,8 @@ packages:
     dev: true
     optional: true
 
-  /@rolldown/binding-linux-x64-gnu@1.0.0-rc.17:
-    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rolldown/binding-linux-x64-gnu@1.0.3:
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rolldown/binding-linux-x64-musl@1.0.0-rc.17:
-    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -5483,33 +5381,12 @@ packages:
     dev: true
     optional: true
 
-  /@rolldown/binding-openharmony-arm64@1.0.0-rc.17:
-    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rolldown/binding-openharmony-arm64@1.0.3:
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
     requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rolldown/binding-wasm32-wasi@1.0.0-rc.17:
-    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
-    requiresBuild: true
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     dev: true
     optional: true
 
@@ -5525,28 +5402,10 @@ packages:
     dev: true
     optional: true
 
-  /@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17:
-    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rolldown/binding-win32-arm64-msvc@1.0.3:
     resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rolldown/binding-win32-x64-msvc@1.0.0-rc.17:
-    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
@@ -5560,10 +5419,6 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
-
-  /@rolldown/pluginutils@1.0.0-rc.17:
-    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
-    dev: true
 
   /@rolldown/pluginutils@1.0.1:
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
@@ -6021,7 +5876,7 @@ packages:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
       '@types/node': 22.19.11
-      form-data: 4.0.5
+      form-data: 4.0.6
     dev: true
 
   /@types/supertest@7.2.0:
@@ -6370,7 +6225,7 @@ packages:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@22.19.11)(@vitest/coverage-v8@4.1.8)(vite@8.0.16)
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(@vitest/coverage-v8@4.1.8)(vite@8.0.16)
     dev: true
 
   /@vitest/expect@4.1.8:
@@ -6384,28 +6239,11 @@ packages:
       tinyrainbow: 3.1.0
     dev: true
 
-  /@vitest/mocker@4.1.8(vite@8.0.10):
-    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
-    peerDependencies:
-      msw: ^2.4.9
-      vite: '>=6.4.2'
-    peerDependenciesMeta:
-      msw:
-        optional: true
-      vite:
-        optional: true
-    dependencies:
-      '@vitest/spy': 4.1.8
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-      vite: 8.0.10(@types/node@22.19.11)(tsx@4.21.0)(yaml@2.8.3)
-    dev: true
-
   /@vitest/mocker@4.1.8(vite@8.0.16):
     resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: '>=6.4.2'
+      vite: '>=8.0.16'
     peerDependenciesMeta:
       msw:
         optional: true
@@ -6415,7 +6253,7 @@ packages:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
-      vite: 8.0.16(@types/node@22.19.11)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@22.19.11)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.3)
     dev: true
 
   /@vitest/pretty-format@4.1.8:
@@ -7495,7 +7333,7 @@ packages:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
     dev: true
 
   /esbuild@0.25.12:
@@ -8045,14 +7883,14 @@ packages:
       signal-exit: 4.1.0
     dev: true
 
-  /form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  /form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
     dev: true
 
@@ -8265,12 +8103,19 @@ packages:
     dependencies:
       function-bind: 1.1.2
 
+  /hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      function-bind: 1.1.2
+    dev: true
+
   /highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
     dev: true
 
-  /hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  /hono@4.12.25:
+    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
     engines: {node: '>=16.9.0'}
     dev: false
 
@@ -10174,31 +10019,6 @@ packages:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
     dev: true
 
-  /rolldown@1.0.0-rc.17:
-    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    dependencies:
-      '@oxc-project/types': 0.127.0
-      '@rolldown/pluginutils': 1.0.0-rc.17
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.17
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
-    dev: true
-
   /rolldown@1.0.3:
     resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -10795,7 +10615,7 @@ packages:
       cookiejar: 2.1.4
       debug: 4.4.3
       fast-safe-stringify: 2.1.1
-      form-data: 4.0.5
+      form-data: 4.0.6
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
@@ -10918,14 +10738,6 @@ packages:
 
   /tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-    dev: true
-
-  /tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -11473,62 +11285,7 @@ packages:
       - zod
     dev: false
 
-  /vite@8.0.10(@types/node@22.19.11)(tsx@4.21.0)(yaml@2.8.3):
-    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.1.0
-      esbuild: ^0.27.0 || ^0.28.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: 2.8.3
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      '@vitejs/devtools':
-        optional: true
-      esbuild:
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-    dependencies:
-      '@types/node': 22.19.11
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.12
-      rolldown: 1.0.0-rc.17
-      tinyglobby: 0.2.16
-      tsx: 4.21.0
-      yaml: 2.8.3
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: true
-
-  /vite@8.0.16(@types/node@22.19.11)(tsx@4.21.0)(yaml@2.8.3):
+  /vite@8.0.16(@types/node@22.19.11)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.3):
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
@@ -11572,6 +11329,7 @@ packages:
         optional: true
     dependencies:
       '@types/node': 22.19.11
+      esbuild: 0.27.3
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.15
@@ -11599,7 +11357,7 @@ packages:
       '@vitest/ui': 4.1.8
       happy-dom: '*'
       jsdom: '*'
-      vite: '>=6.4.2'
+      vite: '>=8.0.16'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -11645,141 +11403,7 @@ packages:
       tinyexec: 1.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@22.19.11)(tsx@4.21.0)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    transitivePeerDependencies:
-      - msw
-    dev: true
-
-  /vitest@4.1.8(@types/node@22.19.11)(@vitest/coverage-v8@4.1.8)(vite@8.0.10):
-    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
-    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@opentelemetry/api': ^1.9.0
-      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.8
-      '@vitest/browser-preview': 4.1.8
-      '@vitest/browser-webdriverio': 4.1.8
-      '@vitest/coverage-istanbul': 4.1.8
-      '@vitest/coverage-v8': 4.1.8
-      '@vitest/ui': 4.1.8
-      happy-dom: '*'
-      jsdom: '*'
-      vite: '>=6.4.2'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@opentelemetry/api':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser-playwright':
-        optional: true
-      '@vitest/browser-preview':
-        optional: true
-      '@vitest/browser-webdriverio':
-        optional: true
-      '@vitest/coverage-istanbul':
-        optional: true
-      '@vitest/coverage-v8':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-    dependencies:
-      '@types/node': 22.19.11
-      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
-      '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.10)
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/runner': 4.1.8
-      '@vitest/snapshot': 4.1.8
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@22.19.11)(tsx@4.21.0)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    transitivePeerDependencies:
-      - msw
-    dev: true
-
-  /vitest@4.1.8(@types/node@22.19.11)(@vitest/coverage-v8@4.1.8)(vite@8.0.16):
-    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
-    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@opentelemetry/api': ^1.9.0
-      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.8
-      '@vitest/browser-preview': 4.1.8
-      '@vitest/browser-webdriverio': 4.1.8
-      '@vitest/coverage-istanbul': 4.1.8
-      '@vitest/coverage-v8': 4.1.8
-      '@vitest/ui': 4.1.8
-      happy-dom: '*'
-      jsdom: '*'
-      vite: '>=6.4.2'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@opentelemetry/api':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser-playwright':
-        optional: true
-      '@vitest/browser-preview':
-        optional: true
-      '@vitest/browser-webdriverio':
-        optional: true
-      '@vitest/coverage-istanbul':
-        optional: true
-      '@vitest/coverage-v8':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-    dependencies:
-      '@types/node': 22.19.11
-      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
-      '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.16)
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/runner': 4.1.8
-      '@vitest/snapshot': 4.1.8
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@22.19.11)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@22.19.11)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - msw

--- a/security/audit-allowlist.json
+++ b/security/audit-allowlist.json
@@ -219,6 +219,22 @@
       "owner": "jithinraj",
       "added_at": "2026-06-13",
       "reviewed_at": "2026-06-13"
+    },
+    {
+      "advisory_id": "GHSA-96hv-2xvq-fx4p",
+      "package": "ws",
+      "reason": "ws memory-exhaustion DoS from tiny fragments/data chunks (HIGH, GHSA-96hv-2xvq-fx4p). ws >=8.0.0 <8.21.0; resolved 8.18.0 via the Cloudflare Workers local dev simulator (wrangler -> miniflare) and 8.18.3 via the erc8004-feedback example. No published @peac/* package depends on ws.",
+      "why_not_exploitable": "ws is used only by miniflare (the local Cloudflare Workers simulator) during development and by one example. It is not in any published package and processes no untrusted production traffic (prod audit shows no high). Patched in ws >= 8.21.0; wrangler 3.x pins the transitive ws version.",
+      "where_used": "surfaces/workers/cloudflare devDependency: wrangler@3.114.17 -> miniflare -> ws@8.18.0; examples/erc8004-feedback -> viem -> ws@8.18.3",
+      "expires_at": "2026-09-13",
+      "remediation": "Adopt ws >= 8.21.0 when wrangler/miniflare bump their transitive ws, or evaluate wrangler 4.x.",
+      "issue_url": "https://github.com/advisories/GHSA-96hv-2xvq-fx4p",
+      "scope": "dev",
+      "dependency_chain": ["wrangler@3.114.17", "miniflare", "ws@8.18.0"],
+      "verified_by": "pnpm audit --prod shows no high advisories; pnpm why ws confirms the wrangler/miniflare dev path and the erc8004-feedback example path.",
+      "owner": "jithinraj",
+      "added_at": "2026-06-16",
+      "reviewed_at": "2026-06-16"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Clears the strict audit gate after newly published high-severity advisories appeared, including one in a production dependency (`hono`). Remediated with a patch-first approach via the existing `pnpm.overrides` mechanism; only the toolchain-pinned `ws` advisory is time-boxed in the allowlist. The production audit phase is clean.

- `hono` (`GHSA-88fw-hqm2-52qc`, CORS middleware reflects any Origin): override floor raised to `>=4.12.25`. Production dependency (apps/api, `@peac/server`, `@peac/mcp-server`).
- `form-data` (`GHSA-hmw2-7cc7-3qxx`, CRLF/multipart injection): override added at `>=4.0.6`. Dev/test only via the supertest/superagent HTTP client used by `@peac/middleware-express` tests.
- `vite` (`GHSA-fx2h-pf6j-xcff`, `server.fs.deny` bypass on Windows alternate paths): existing dev-only Vite override floor raised to `>=8.0.16`. Dev/test only via `apps/verifier` (internal app) and vitest.
- `ws` (`GHSA-96hv-2xvq-fx4p`, memory-exhaustion DoS): kept as a time-bounded dev-scope allowlist entry (expires `2026-09-13`) because it is pinned through `wrangler`/`miniflare` and example paths; a force-upgrade to `>=8.21.0` needs a separate `wrangler` 4.x evaluation.

## Scope

No published-package runtime behavior, protocol, schema, wire, registry, or API change. Only dependency version floors plus one allowlist entry.

Files changed:

- `package.json`
- `pnpm-lock.yaml`
- `security/audit-allowlist.json`

The lockfile change is a net reduction from deduplicating the old vulnerable Vite subtree.

## Validation

- `AUDIT_STRICT=1 node scripts/audit-gate.mjs` (prod + full, green)
- `node scripts/check-audit-exception-expiry.mjs`
- `bash scripts/ci/forbid-strings.sh`
- `git diff --check`
- `pnpm verify:release`
- `pnpm test` (465 files / 11627 tests)
- `pnpm build`
