### PR TITLE
feat(mappings-ucp): request-shaped HTTP Message Signatures verifier

### DIFF
--- a/packages/http-signatures/src/base.ts
+++ b/packages/http-signatures/src/base.ts
@@ -6,6 +6,7 @@
  */
 
 import { ParsedSignatureParams, SignatureRequest } from './types.js';
+import { ErrorCodes, HttpSignatureError } from './errors.js';
 
 /**
  * Build signature base string for verification.
@@ -16,18 +17,35 @@ import { ParsedSignatureParams, SignatureRequest } from './types.js';
  */
 export function buildSignatureBase(
   request: SignatureRequest,
-  params: ParsedSignatureParams
+  params: ParsedSignatureParams,
+  options: { preferSerializedParams?: boolean } = {}
 ): string {
   const lines: string[] = [];
 
-  // Add each covered component
+  // Add each covered component. RFC 9421 Section 2.5: if a component identifier
+  // has already been added to the signature base, base generation MUST fail.
+  const seenComponents = new Set<string>();
   for (const component of params.coveredComponents) {
+    if (seenComponents.has(component)) {
+      throw new HttpSignatureError(
+        ErrorCodes.SIGNATURE_INPUT_MALFORMED,
+        `Duplicate covered component: ${component}`
+      );
+    }
+    seenComponents.add(component);
     const value = getComponentValue(request, component);
     lines.push(`"${component}": ${value}`);
   }
 
-  // Add signature params line
-  const paramsLine = buildSignatureParamsLine(params);
+  // Add signature params line. RFC 9421 requires the @signature-params value to
+  // be byte-identical to the serialized Signature-Input member that was signed.
+  // When the caller opts in and the parser captured that exact serialization,
+  // reuse it verbatim; otherwise reconstruct it (the default, and the only option
+  // for programmatically built params that have no serialized form).
+  const paramsLine =
+    options.preferSerializedParams && params.signatureParamsValue !== undefined
+      ? params.signatureParamsValue
+      : buildSignatureParamsLine(params);
   lines.push(`"@signature-params": ${paramsLine}`);
 
   return lines.join('\n');
@@ -137,8 +155,12 @@ function buildSignatureParamsLine(params: ParsedSignatureParams): string {
   const components = params.coveredComponents.map((c) => `"${c}"`).join(' ');
   let line = `(${components})`;
 
-  // Add required parameters in canonical order
-  line += `;created=${params.created}`;
+  // Emit parameters in canonical order, skipping optional ones that are absent.
+  // For the PEAC/TAP path created and alg are always present, so this is
+  // byte-identical to the previous unconditional output.
+  if (params.created !== undefined) {
+    line += `;created=${params.created}`;
+  }
 
   if (params.expires !== undefined) {
     line += `;expires=${params.expires}`;
@@ -149,7 +171,10 @@ function buildSignatureParamsLine(params: ParsedSignatureParams): string {
   }
 
   line += `;keyid="${params.keyid}"`;
-  line += `;alg="${params.alg}"`;
+
+  if (params.alg !== undefined) {
+    line += `;alg="${params.alg}"`;
+  }
 
   if (params.tag !== undefined) {
     line += `;tag="${params.tag}"`;

--- a/packages/http-signatures/src/parser.ts
+++ b/packages/http-signatures/src/parser.ts
@@ -23,10 +23,24 @@ export function parseSignatureInput(headerValue: string): Map<string, ParsedSign
   const members = splitDictionaryMembers(headerValue);
 
   for (const member of members) {
+    // Structured-field parsing is not best-effort: a malformed member fails the
+    // whole header rather than being skipped.
     const parsed = parseDictionaryMember(member.trim());
-    if (parsed) {
-      results.set(parsed.label, parsed.params);
+    if (!parsed) {
+      throw new HttpSignatureError(
+        ErrorCodes.SIGNATURE_INPUT_MALFORMED,
+        `Malformed Signature-Input member: ${member.trim()}`
+      );
     }
+    // RFC 9421: signature labels must be unique. Fail closed on a duplicate
+    // rather than silently overwriting an earlier definition.
+    if (results.has(parsed.label)) {
+      throw new HttpSignatureError(
+        ErrorCodes.SIGNATURE_INPUT_MALFORMED,
+        `Duplicate signature label in Signature-Input: ${parsed.label}`
+      );
+    }
+    results.set(parsed.label, parsed.params);
   }
 
   return results;
@@ -46,22 +60,48 @@ export function parseSignatureHeader(
   const results = new Map<string, { bytes: Uint8Array; base64: string }>();
 
   const members = splitDictionaryMembers(headerValue);
+  const seenLabels = new Set<string>();
 
   for (const member of members) {
-    const [label, value] = splitKeyValue(member.trim());
-    if (!label || !value) continue;
+    const trimmed = member.trim();
+    const [label, value] = splitKeyValue(trimmed);
+    // Fail closed on a malformed member rather than skipping it.
+    if (!label || !value) {
+      throw new HttpSignatureError(
+        ErrorCodes.SIGNATURE_INPUT_MALFORMED,
+        `Malformed Signature member: ${trimmed}`
+      );
+    }
 
-    // Extract base64 from :...: byte sequence format
+    // RFC 9421: a label may appear at most once in the Signature header.
+    if (seenLabels.has(label)) {
+      throw new HttpSignatureError(
+        ErrorCodes.SIGNATURE_INPUT_MALFORMED,
+        `Duplicate signature label in Signature: ${label}`
+      );
+    }
+    seenLabels.add(label);
+
+    // The value MUST be a structured-field byte sequence (:base64:).
     const match = value.match(/^:([A-Za-z0-9+/=_-]+):$/);
-    if (!match) continue;
+    if (!match) {
+      throw new HttpSignatureError(
+        ErrorCodes.SIGNATURE_INPUT_MALFORMED,
+        `Malformed Signature byte sequence for label "${label}"`
+      );
+    }
 
     const base64 = match[1];
+    let bytes: Uint8Array;
     try {
-      const bytes = base64ToBytes(base64);
-      results.set(label, { bytes, base64 });
+      bytes = base64ToBytes(base64);
     } catch {
-      // Skip invalid base64
+      throw new HttpSignatureError(
+        ErrorCodes.SIGNATURE_INPUT_MALFORMED,
+        `Invalid base64 in Signature for label "${label}"`
+      );
     }
+    results.set(label, { bytes, base64 });
   }
 
   return results;
@@ -78,8 +118,11 @@ export function parseSignatureHeader(
 export function parseSignature(
   signatureInput: string,
   signature: string,
-  label?: string
+  label?: string,
+  options: { requireAlg?: boolean; requireCreated?: boolean } = {}
 ): ParsedSignature {
+  const { requireAlg = true, requireCreated = true } = options;
+
   if (!signatureInput) {
     throw new HttpSignatureError(
       ErrorCodes.SIGNATURE_INPUT_MALFORMED,
@@ -131,14 +174,14 @@ export function parseSignature(
     );
   }
 
-  if (!params.alg) {
+  if (requireAlg && !params.alg) {
     throw new HttpSignatureError(
       ErrorCodes.SIGNATURE_PARAM_MISSING,
       'Missing required parameter: alg'
     );
   }
 
-  if (params.created === undefined || params.created === null) {
+  if (requireCreated && (params.created === undefined || params.created === null)) {
     throw new HttpSignatureError(
       ErrorCodes.SIGNATURE_PARAM_MISSING,
       'Missing required parameter: created'
@@ -233,10 +276,23 @@ function parseDictionaryMember(
 
   const params: ParsedSignatureParams = {
     keyid: String(rawParams.keyid ?? ''),
-    alg: String(rawParams.alg ?? ''),
-    created: rawParams.created !== undefined ? Number(rawParams.created) : 0,
     coveredComponents,
+    // Preserve the exact serialized inner-list-plus-parameters for this label so
+    // callers can build an RFC 9421-faithful @signature-params line. `rest` is
+    // the dictionary member value (everything after `label=`), already trimmed.
+    signatureParamsValue: rest,
   };
+
+  // alg and created are optional at the parse layer (RFC 9421). When absent they
+  // stay undefined rather than defaulting to '' / 0, so a profile that omits them
+  // (e.g. UCP) is represented faithfully and never fabricates a created=0 base.
+  if (rawParams.alg !== undefined) {
+    params.alg = String(rawParams.alg);
+  }
+
+  if (rawParams.created !== undefined) {
+    params.created = Number(rawParams.created);
+  }
 
   if (rawParams.expires !== undefined) {
     params.expires = Number(rawParams.expires);
@@ -254,14 +310,38 @@ function parseDictionaryMember(
 }
 
 /**
- * Parse inner list content (space-separated quoted strings).
+ * Parse inner list content: space-separated quoted strings (the covered
+ * components). Fail closed on anything else (a bare/unquoted token, component
+ * parameters, or trailing garbage) rather than silently extracting only the
+ * quoted parts.
  */
 function parseInnerList(content: string): string[] {
+  const trimmed = content.trim();
+  if (trimmed === '') {
+    return [];
+  }
   const items: string[] = [];
-  const regex = /"([^"]*)"/g;
-  let match;
-  while ((match = regex.exec(content)) !== null) {
-    items.push(match[1]);
+  let pos = 0;
+  while (pos < trimmed.length) {
+    if (trimmed[pos] === ' ') {
+      pos++;
+      continue;
+    }
+    if (trimmed[pos] !== '"') {
+      throw new HttpSignatureError(
+        ErrorCodes.SIGNATURE_INPUT_MALFORMED,
+        `Malformed covered-component list near: ${trimmed.slice(pos)}`
+      );
+    }
+    const end = trimmed.indexOf('"', pos + 1);
+    if (end === -1) {
+      throw new HttpSignatureError(
+        ErrorCodes.SIGNATURE_INPUT_MALFORMED,
+        'Unterminated quoted string in covered-component list'
+      );
+    }
+    items.push(trimmed.slice(pos + 1, end));
+    pos = end + 1;
   }
   return items;
 }

--- a/packages/http-signatures/src/types.ts
+++ b/packages/http-signatures/src/types.ts
@@ -24,10 +24,19 @@ export type KeyResolver = (keyid: string) => Promise<SignatureVerifier | null>;
 export interface ParsedSignatureParams {
   /** Key identifier */
   keyid: string;
-  /** Algorithm (must be "ed25519" for PEAC) */
-  alg: string;
-  /** Unix timestamp when signature was created */
-  created: number;
+  /**
+   * Algorithm. Optional per RFC 9421: some profiles omit `alg` from
+   * Signature-Input and derive the algorithm from the resolved key (e.g. UCP
+   * derives ES256/ES384 from the JWK `crv`). The PEAC/TAP path requires it via
+   * `parseSignature(..., { requireAlg: true })`, which is the default.
+   */
+  alg?: string;
+  /**
+   * Unix timestamp when the signature was created. Optional per RFC 9421;
+   * some profiles (e.g. UCP) omit it and handle replay at the business layer.
+   * Required for the PEAC/TAP path via the default `requireCreated: true`.
+   */
+  created?: number;
   /** Unix timestamp when signature expires (optional) */
   expires?: number;
   /** Nonce for replay prevention (optional) */
@@ -36,6 +45,14 @@ export interface ParsedSignatureParams {
   tag?: string;
   /** Covered component identifiers */
   coveredComponents: string[];
+  /**
+   * Exact serialized `@signature-params` value (the inner list plus parameters)
+   * for this label, as received in Signature-Input. RFC 9421 requires the
+   * signature base to reuse this exact serialization rather than a reconstructed
+   * one; `buildSignatureBase(..., { preferSerializedParams: true })` uses it when
+   * present. Populated by the parser; absent for programmatically built params.
+   */
+  signatureParamsValue?: string;
 }
 
 /**

--- a/packages/http-signatures/src/verify.ts
+++ b/packages/http-signatures/src/verify.ts
@@ -139,6 +139,10 @@ export function isCreatedInFuture(
   now: number = Math.floor(Date.now() / 1000),
   skewSeconds: number = 60
 ): boolean {
+  // A signature with no `created` parameter cannot be classified as future-dated.
+  if (params.created === undefined) {
+    return false;
+  }
   return params.created > now + skewSeconds;
 }
 

--- a/packages/http-signatures/tests/signature-params.test.ts
+++ b/packages/http-signatures/tests/signature-params.test.ts
@@ -1,0 +1,184 @@
+/**
+ * RFC 9421 signature-parameter handling: optional alg/created and exact
+ * @signature-params preservation.
+ *
+ * These cover the parser/base capabilities relied on by profiles that omit alg
+ * and created (e.g. UCP derives the algorithm from the key) and that require the
+ * signature base to reuse the exact serialized Signature-Input value rather than
+ * a reconstructed one. The default (strict, reconstruct) behavior used by the
+ * PEAC/TAP path is unchanged and is asserted here too.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { generateKeyPairSync, sign as nodeSign, verify as nodeVerify } from 'node:crypto';
+import { parseSignature, parseSignatureInput, parseSignatureHeader } from '../src/parser.js';
+import { buildSignatureBase, signatureBaseToBytes } from '../src/base.js';
+import { HttpSignatureError } from '../src/errors.js';
+
+const DUMMY_SIG = 'sig1=:dGVzdHNpZ25hdHVyZQ==:';
+const REQUEST = { method: 'POST', url: 'https://merchant.example.com/p', headers: {} };
+
+describe('parseSignature: optional alg/created', () => {
+  it('requires alg and created by default (strict PEAC/TAP path)', () => {
+    const noAlg = 'sig1=("@method");created=1700000000;keyid="k1"';
+    const noCreated = 'sig1=("@method");keyid="k1";alg="ed25519"';
+    expect(() => parseSignature(noAlg, DUMMY_SIG)).toThrow(HttpSignatureError);
+    expect(() => parseSignature(noCreated, DUMMY_SIG)).toThrow(HttpSignatureError);
+  });
+
+  it('allows missing alg and created when opted out (UCP derives alg from key crv)', () => {
+    const input = 'sig1=("@method" "@authority" "@path");keyid="k1"';
+    const parsed = parseSignature(input, DUMMY_SIG, undefined, {
+      requireAlg: false,
+      requireCreated: false,
+    });
+    expect(parsed.params.alg).toBeUndefined();
+    expect(parsed.params.created).toBeUndefined();
+    expect(parsed.params.keyid).toBe('k1');
+  });
+
+  it('still requires keyid even in lenient mode', () => {
+    const input = 'sig1=("@method");alg="ecdsa-p256-sha256"';
+    expect(() =>
+      parseSignature(input, DUMMY_SIG, undefined, { requireAlg: false, requireCreated: false })
+    ).toThrow(HttpSignatureError);
+  });
+
+  it('does not fabricate created=0 / alg="" when absent', () => {
+    const input = 'sig1=("@method");keyid="k1"';
+    const parsed = parseSignature(input, DUMMY_SIG, undefined, {
+      requireAlg: false,
+      requireCreated: false,
+    });
+    expect(parsed.params.created).not.toBe(0);
+    expect(parsed.params.alg).not.toBe('');
+  });
+});
+
+describe('exact @signature-params preservation', () => {
+  it('captures the exact serialized signature params value', () => {
+    const value = '("@method" "@path");keyid="k1";created=1700000000';
+    const map = parseSignatureInput(`sig1=${value}`);
+    expect(map.get('sig1')?.signatureParamsValue).toBe(value);
+  });
+
+  it('preserves exact param order with preferSerializedParams=true', () => {
+    const orderA = '("@method" "@path");keyid="k1";created=1700000000;alg="ed25519"';
+    const orderB = '("@method" "@path");created=1700000000;alg="ed25519";keyid="k1"';
+    const reqA = parseSignature(`sig1=${orderA}`, DUMMY_SIG);
+    const reqB = parseSignature(`sig1=${orderB}`, DUMMY_SIG);
+
+    const baseA = buildSignatureBase(REQUEST, reqA.params, { preferSerializedParams: true });
+    const baseB = buildSignatureBase(REQUEST, reqB.params, { preferSerializedParams: true });
+
+    expect(baseA.endsWith(`"@signature-params": ${orderA}`)).toBe(true);
+    expect(baseB.endsWith(`"@signature-params": ${orderB}`)).toBe(true);
+    expect(baseA).not.toBe(baseB);
+  });
+
+  it('default (reconstruction) yields canonical order regardless of input order', () => {
+    const orderB = '("@method");created=1700000000;alg="ed25519";keyid="k1"';
+    const reqB = parseSignature(`sig1=${orderB}`, DUMMY_SIG);
+    const base = buildSignatureBase(REQUEST, reqB.params);
+    expect(
+      base.endsWith('"@signature-params": ("@method");created=1700000000;keyid="k1";alg="ed25519"')
+    ).toBe(true);
+  });
+
+  it('Ed25519 roundtrip: a non-canonical param order verifies only with exact preservation', () => {
+    const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+    // Non-canonical order: keyid precedes created (reconstruction would reorder).
+    const value = '("@method" "@path");keyid="k1";created=1700000000;alg="ed25519"';
+    const parsed = parseSignature(`sig1=${value}`, DUMMY_SIG);
+
+    const exactBase = buildSignatureBase(REQUEST, parsed.params, { preferSerializedParams: true });
+    const sigBytes = nodeSign(null, signatureBaseToBytes(exactBase), privateKey);
+
+    // Exact preservation: verifies.
+    expect(nodeVerify(null, signatureBaseToBytes(exactBase), publicKey, sigBytes)).toBe(true);
+
+    // Reconstruction produces a different base, so the same signature fails there.
+    const reconBase = buildSignatureBase(REQUEST, parsed.params);
+    expect(reconBase).not.toBe(exactBase);
+    expect(nodeVerify(null, signatureBaseToBytes(reconBase), publicKey, sigBytes)).toBe(false);
+  });
+});
+
+describe('duplicate / mismatched signature labels (RFC 9421)', () => {
+  it('rejects a duplicate label in Signature-Input', () => {
+    const input =
+      'sig1=("@method");keyid="k1";created=1;alg="ed25519", sig1=("@path");keyid="k2";created=2;alg="ed25519"';
+    expect(() => parseSignatureInput(input)).toThrow(HttpSignatureError);
+  });
+
+  it('rejects a duplicate label in Signature', () => {
+    expect(() => parseSignatureHeader('sig1=:dGVzdA==:, sig1=:b3RoZXJzaWc=:')).toThrow(
+      HttpSignatureError
+    );
+  });
+
+  it('rejects mismatched labels across Signature-Input and Signature', () => {
+    const input = 'sig1=("@method");keyid="k1";created=1;alg="ed25519"';
+    expect(() => parseSignature(input, 'sig2=:dGVzdA==:')).toThrow(HttpSignatureError);
+  });
+
+  it('accepts multiple unique labels and resolves the requested one', () => {
+    const input =
+      'sig1=("@method");keyid="k1";created=1;alg="ed25519", sig2=("@path");keyid="k2";created=2;alg="ed25519"';
+    const sig = 'sig1=:dGVzdA==:, sig2=:b3RoZXJzaWc=:';
+    const parsed = parseSignature(input, sig, 'sig2');
+    expect(parsed.params.keyid).toBe('k2');
+  });
+});
+
+describe('duplicate covered components (RFC 9421 Section 2.5)', () => {
+  it('rejects a duplicate derived component', () => {
+    expect(() =>
+      buildSignatureBase(REQUEST, { keyid: 'k1', coveredComponents: ['@method', '@method'] })
+    ).toThrow(HttpSignatureError);
+  });
+
+  it('rejects a duplicate header component', () => {
+    expect(() =>
+      buildSignatureBase(REQUEST, {
+        keyid: 'k1',
+        coveredComponents: ['@method', 'content-type', 'content-type'],
+      })
+    ).toThrow(HttpSignatureError);
+  });
+
+  it('accepts a unique component set', () => {
+    expect(() =>
+      buildSignatureBase(REQUEST, {
+        keyid: 'k1',
+        coveredComponents: ['@method', '@authority', '@path'],
+      })
+    ).not.toThrow();
+  });
+});
+
+describe('fail-closed parsing of malformed members (RFC 8941)', () => {
+  it('rejects Signature-Input with a trailing malformed member', () => {
+    const input = 'sig1=("@method");keyid="k1";created=1;alg="ed25519", garbage';
+    expect(() => parseSignatureInput(input)).toThrow(HttpSignatureError);
+  });
+
+  it('rejects a malformed member in the Signature header', () => {
+    expect(() => parseSignatureHeader('sig1=:dGVzdA==:, garbage')).toThrow(HttpSignatureError);
+  });
+
+  it('rejects a Signature value that is not a byte sequence', () => {
+    expect(() => parseSignatureHeader('sig1=not-byte-sequence')).toThrow(HttpSignatureError);
+  });
+
+  it('rejects an inner list containing an unquoted token', () => {
+    const input = 'sig1=("@method" garbage);keyid="k1";created=1;alg="ed25519"';
+    expect(() => parseSignatureInput(input)).toThrow(HttpSignatureError);
+  });
+
+  it('still parses a well-formed multi-signature header', () => {
+    const input =
+      'sig1=("@method");keyid="k1";created=1;alg="ed25519", sig2=("@path");keyid="k2";created=2;alg="ed25519"';
+    expect(parseSignatureInput(input).size).toBe(2);
+  });
+});

--- a/packages/mappings/tap/src/mapper.ts
+++ b/packages/mappings/tap/src/mapper.ts
@@ -109,7 +109,8 @@ export async function verifyTapProof(
       protocol: 'visa-tap',
       tag: parsed.params.tag ?? 'unknown',
       keyid: parsed.params.keyid,
-      created: parsed.params.created,
+      // validateTapTimeConstraints has already guaranteed both are present.
+      created: parsed.params.created!,
       expires: parsed.params.expires!,
       nonce: parsed.params.nonce,
       coveredComponents: parsed.params.coveredComponents,

--- a/packages/mappings/tap/src/validator.ts
+++ b/packages/mappings/tap/src/validator.ts
@@ -20,7 +20,11 @@ import { ErrorCodes, TapError } from './errors.js';
  * @throws TapError if validation fails
  */
 export function validateTapTimeConstraints(params: ParsedSignatureParams, now: number): void {
-  // Validate expires is present for TAP
+  // Validate created and expires are present for TAP. They are optional at the
+  // RFC 9421 parse layer, but TAP requires both (window + freshness). Fail closed.
+  if (params.created === undefined) {
+    throw new TapError(ErrorCodes.TAP_TIME_INVALID, 'TAP signatures must have created parameter');
+  }
   if (params.expires === undefined) {
     throw new TapError(ErrorCodes.TAP_TIME_INVALID, 'TAP signatures must have expires parameter');
   }
@@ -54,10 +58,11 @@ export function validateTapTimeConstraints(params: ParsedSignatureParams, now: n
 /**
  * Validate TAP algorithm.
  *
- * @param alg - Algorithm from signature params
- * @throws TapError if algorithm is not ed25519
+ * @param alg - Algorithm from signature params (optional at the parse layer; TAP
+ *   requires it, so an absent algorithm fails closed here).
+ * @throws TapError if algorithm is missing or not ed25519
  */
-export function validateTapAlgorithm(alg: string): void {
+export function validateTapAlgorithm(alg: string | undefined): void {
   if (alg !== TAP_CONSTANTS.REQUIRED_ALGORITHM) {
     throw new TapError(
       ErrorCodes.TAP_ALGORITHM_INVALID,

--- a/packages/mappings/ucp/package.json
+++ b/packages/mappings/ucp/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "@peac/adapter-core": "workspace:*",
+    "@peac/http-signatures": "workspace:*",
     "@peac/kernel": "workspace:*",
     "@peac/schema": "workspace:*",
     "jose": "^5.2.0"

--- a/packages/mappings/ucp/src/errors.ts
+++ b/packages/mappings/ucp/src/errors.ts
@@ -15,6 +15,24 @@ export const ErrorCodes = {
   SIGNATURE_ALGORITHM_UNSUPPORTED: 'E_UCP_SIGNATURE_ALGORITHM_UNSUPPORTED',
   SIGNATURE_B64_INVALID: 'E_UCP_SIGNATURE_B64_INVALID',
 
+  // RFC 9421 HTTP Message Signature errors (400 - malformed)
+  HTTP_SIGNATURE_INPUT_MISSING: 'E_UCP_HTTP_SIGNATURE_INPUT_MISSING',
+  HTTP_SIGNATURE_MISSING: 'E_UCP_HTTP_SIGNATURE_MISSING',
+  HTTP_SIGNATURE_MALFORMED: 'E_UCP_HTTP_SIGNATURE_MALFORMED',
+  HTTP_SIGNATURE_COMPONENT_MISSING: 'E_UCP_HTTP_SIGNATURE_COMPONENT_MISSING',
+
+  // RFC 9530 Content-Digest errors (all 400: malformed request / integrity)
+  CONTENT_DIGEST_MISSING: 'E_UCP_CONTENT_DIGEST_MISSING',
+  CONTENT_DIGEST_MALFORMED: 'E_UCP_CONTENT_DIGEST_MALFORMED',
+  CONTENT_DIGEST_UNSUPPORTED: 'E_UCP_CONTENT_DIGEST_UNSUPPORTED',
+  CONTENT_DIGEST_MISMATCH: 'E_UCP_CONTENT_DIGEST_MISMATCH',
+
+  // Body required to verify a digest-covered request (400 - malformed)
+  BODY_REQUIRED: 'E_UCP_BODY_REQUIRED',
+
+  // Signer identity binding (401 - auth failure)
+  AGENT_MISMATCH: 'E_UCP_AGENT_MISMATCH',
+
   // Key errors (401 - auth failure)
   KEY_NOT_FOUND: 'E_UCP_KEY_NOT_FOUND',
   KEY_ALGORITHM_MISMATCH: 'E_UCP_KEY_ALGORITHM_MISMATCH',
@@ -55,6 +73,15 @@ export const ErrorHttpStatus: Record<ErrorCode, number> = {
   [ErrorCodes.SIGNATURE_MALFORMED]: 400,
   [ErrorCodes.SIGNATURE_ALGORITHM_UNSUPPORTED]: 400,
   [ErrorCodes.SIGNATURE_B64_INVALID]: 400,
+  // UCP maps a malformed/incomplete signed request to 400.
+  [ErrorCodes.HTTP_SIGNATURE_MALFORMED]: 400,
+  [ErrorCodes.HTTP_SIGNATURE_COMPONENT_MISSING]: 400,
+  [ErrorCodes.CONTENT_DIGEST_MISSING]: 400,
+  [ErrorCodes.CONTENT_DIGEST_MALFORMED]: 400,
+  [ErrorCodes.CONTENT_DIGEST_UNSUPPORTED]: 400,
+  // UCP: digest_mismatch is a request-integrity (400) error, not 401.
+  [ErrorCodes.CONTENT_DIGEST_MISMATCH]: 400,
+  [ErrorCodes.BODY_REQUIRED]: 400,
   [ErrorCodes.PAYLOAD_EMPTY]: 400,
   [ErrorCodes.PAYLOAD_NOT_JSON]: 400,
   [ErrorCodes.PAYLOAD_TOO_LARGE]: 400,
@@ -64,11 +91,16 @@ export const ErrorHttpStatus: Record<ErrorCode, number> = {
   [ErrorCodes.ORDER_MISSING_TOTALS]: 400,
 
   // 401 - Unauthorized (auth failure)
+  // UCP maps signature_missing to 401 (missing credentials), so the RFC 9421
+  // missing-header codes are 401, not 400.
+  [ErrorCodes.HTTP_SIGNATURE_INPUT_MISSING]: 401,
+  [ErrorCodes.HTTP_SIGNATURE_MISSING]: 401,
   [ErrorCodes.KEY_NOT_FOUND]: 401,
   [ErrorCodes.KEY_ALGORITHM_MISMATCH]: 401,
   [ErrorCodes.KEY_CURVE_MISMATCH]: 401,
   [ErrorCodes.SIGNATURE_INVALID]: 401,
   [ErrorCodes.VERIFICATION_FAILED]: 401,
+  [ErrorCodes.AGENT_MISMATCH]: 401,
 
   // 500 - Internal Server Error
   [ErrorCodes.EVIDENCE_SERIALIZATION_FAILED]: 500,

--- a/packages/mappings/ucp/src/http-signature.ts
+++ b/packages/mappings/ucp/src/http-signature.ts
@@ -1,0 +1,720 @@
+/**
+ * @peac/mappings-ucp - RFC 9421 HTTP Message Signature verification
+ *
+ * Verifies UCP request and webhook signatures using the current UCP signing
+ * model: RFC 9421 HTTP Message Signatures (`Signature-Input` / `Signature`)
+ * with an RFC 9530 `Content-Digest` computed over the raw body bytes.
+ *
+ * This is distinct from the legacy `Request-Signature` detached-JWS path in
+ * `verify.ts` (`verifyUcpWebhookSignature`). The two schemes do NOT silently
+ * fall back to each other: the caller selects which one to verify, and a
+ * failure for the selected scheme is surfaced, never quietly downgraded.
+ *
+ * This verifier covers request-shaped UCP signatures (method / authority / path
+ * / headers / body). UCP response signatures use `@status` instead of `@method`
+ * and are a separate component model, out of scope here.
+ *
+ * UCP specifics enforced here (per https://ucp.dev/specification/signatures/):
+ * - The algorithm is RESOLVED from the signing key's `crv` (P-256 -> ES256,
+ *   P-384 -> ES384). UCP does not include a JOSE/JWA `alg` in `Signature-Input`;
+ *   if a signer includes an `alg` parameter anyway it is treated as advisory and
+ *   accepted only when it is consistent with the key curve.
+ * - `created` is OPTIONAL (UCP handles replay at the business layer through
+ *   idempotency keys), so the signature is parsed leniently.
+ * - The required signed-component set is enforced (see UcpComponentPolicy):
+ *   `@method`, `@authority`, `@path`; `@query` when the URL has a query;
+ *   `ucp-agent` when that header is present; `idempotency-key` for
+ *   state-changing methods; `content-digest` + `content-type` when a body is
+ *   present.
+ * - Signatures are fixed-width raw `r||s` (IEEE P1363): 64 bytes for P-256, 96
+ *   for P-384. DER is rejected by an explicit length check.
+ *
+ * Implementation notes:
+ * - ECDSA verification uses WebCrypto (`crypto.subtle`), which expects raw
+ *   `r||s`, so no new external dependency is introduced for ES256/ES384.
+ * - RFC 9421 header parsing and signature-base construction are reused from
+ *   `@peac/http-signatures`. The signature base is built with
+ *   `preferSerializedParams: true` so the `@signature-params` line is the exact
+ *   serialized `Signature-Input` value that was signed (RFC 9421 Section 2.5),
+ *   not a reconstructed one. That package's Ed25519-only `verifySignature` is
+ *   intentionally not used.
+ * - `Content-Digest` is verified over the raw request body bytes with no JSON
+ *   canonicalization (UCP binds raw bytes). JCS is only relevant to the separate
+ *   AP2 mandate layer, which is out of scope here.
+ */
+
+import {
+  parseSignature,
+  buildSignatureBase,
+  signatureBaseToBytes,
+  HttpSignatureError,
+  type ParsedSignature,
+  type SignatureRequest,
+} from '@peac/http-signatures';
+import type {
+  UcpComponentPolicy,
+  VerifyUcpHttpSignatureOptions,
+  VerifyUcpHttpSignatureResult,
+} from './types.js';
+import { ErrorCodes, type ErrorCode } from './errors.js';
+import { sha256Bytes } from './util.js';
+import { findSigningKey } from './verify.js';
+
+/**
+ * ECDSA parameters resolved from a signing key's curve. ES256 (P-256) is
+ * required by UCP; ES384 (P-384) is optional. No other curve is accepted.
+ */
+const CURVE_PARAMS: Record<
+  string,
+  {
+    alg: 'ES256' | 'ES384';
+    hash: 'SHA-256' | 'SHA-384';
+    /** Fixed-width raw (r||s) signature length in bytes (rejects DER). */
+    rawSignatureLength: number;
+  }
+> = {
+  'P-256': { alg: 'ES256', hash: 'SHA-256', rawSignatureLength: 64 },
+  'P-384': { alg: 'ES384', hash: 'SHA-384', rawSignatureLength: 96 },
+};
+
+/**
+ * RFC 9421 ECDSA algorithm tokens mapped to the curve they imply. Used only for
+ * an optional consistency check when a signer redundantly includes `alg`.
+ */
+const ALG_TOKEN_CURVE: Record<string, 'P-256' | 'P-384'> = {
+  'ecdsa-p256-sha256': 'P-256',
+  'ecdsa-p384-sha384': 'P-384',
+};
+
+const STATE_CHANGING_METHODS = new Set(['POST', 'PUT', 'DELETE', 'PATCH']);
+
+/**
+ * Build a failing result with optional evidence fields.
+ */
+function fail(
+  code: ErrorCode,
+  message: string,
+  extra?: Partial<VerifyUcpHttpSignatureResult>
+): VerifyUcpHttpSignatureResult {
+  return { valid: false, error_code: code, error_message: message, ...extra };
+}
+
+/**
+ * Case-insensitive header lookup.
+ */
+function getHeader(headers: Record<string, string>, name: string): string | undefined {
+  const lower = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === lower) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Whether the request URL carries a non-empty query string.
+ */
+function hasQueryString(url: string): boolean {
+  try {
+    return new URL(url).search !== '';
+  } catch {
+    const i = url.indexOf('?');
+    return i !== -1 && i < url.length - 1;
+  }
+}
+
+/**
+ * Decode standard or URL-safe base64 to bytes. Returns null on failure.
+ */
+function base64ToBytes(b64: string): Uint8Array | null {
+  try {
+    if (typeof Buffer !== 'undefined' && typeof Buffer.from === 'function') {
+      return new Uint8Array(Buffer.from(b64, 'base64'));
+    }
+    const normalized = b64.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), '=');
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Constant-time byte-array equality (defense in depth; digests are not secret).
+ */
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a[i] ^ b[i];
+  }
+  return diff === 0;
+}
+
+type DigestParse =
+  | { ok: true; digests: Map<string, string> }
+  | { ok: false; code: ErrorCode; message: string };
+
+/**
+ * Strictly parse an RFC 9530 / RFC 8941 Content-Digest dictionary. Every member
+ * must be exactly `algorithm=:base64:`; a malformed member, a duplicate
+ * algorithm, or an empty value rejects the whole header rather than being
+ * silently ignored. Base64 byte-sequences contain no commas, so splitting the
+ * top-level dictionary on commas is safe.
+ */
+function parseContentDigestStrict(headerValue: string): DigestParse {
+  const digests = new Map<string, string>();
+  const members = headerValue.split(',');
+
+  for (const raw of members) {
+    const member = raw.trim();
+    if (!member) {
+      return {
+        ok: false,
+        code: ErrorCodes.CONTENT_DIGEST_MALFORMED,
+        message: 'Content-Digest contains an empty member',
+      };
+    }
+    const match = member.match(/^([A-Za-z0-9-]+)=:([A-Za-z0-9+/=]+):$/);
+    if (!match) {
+      return {
+        ok: false,
+        code: ErrorCodes.CONTENT_DIGEST_MALFORMED,
+        message: `Content-Digest member is malformed: ${member}`,
+      };
+    }
+    const algName = match[1].toLowerCase();
+    if (digests.has(algName)) {
+      return {
+        ok: false,
+        code: ErrorCodes.CONTENT_DIGEST_MALFORMED,
+        message: `Content-Digest has a duplicate algorithm: ${algName}`,
+      };
+    }
+    digests.set(algName, match[2]);
+  }
+
+  if (digests.size === 0) {
+    return {
+      ok: false,
+      code: ErrorCodes.CONTENT_DIGEST_MALFORMED,
+      message: 'Content-Digest header is empty',
+    };
+  }
+
+  return { ok: true, digests };
+}
+
+type DigestOutcome = { ok: true } | { ok: false; code: ErrorCode; message: string };
+
+/**
+ * Verify a Content-Digest header against the raw request body bytes (sha-256).
+ */
+function verifyContentDigest(body: Uint8Array, headerValue: string | undefined): DigestOutcome {
+  if (!headerValue || !headerValue.trim()) {
+    return {
+      ok: false,
+      code: ErrorCodes.CONTENT_DIGEST_MISSING,
+      message: 'Missing Content-Digest header for a request with a body',
+    };
+  }
+
+  const parsed = parseContentDigestStrict(headerValue);
+  if (!parsed.ok) {
+    return parsed;
+  }
+
+  const provided = parsed.digests.get('sha-256');
+  if (!provided) {
+    return {
+      ok: false,
+      code: ErrorCodes.CONTENT_DIGEST_UNSUPPORTED,
+      message: `Content-Digest must include sha-256; got: ${[...parsed.digests.keys()].join(', ')}`,
+    };
+  }
+
+  const providedBytes = base64ToBytes(provided);
+  if (!providedBytes) {
+    return {
+      ok: false,
+      code: ErrorCodes.CONTENT_DIGEST_MALFORMED,
+      message: 'Content-Digest sha-256 value is not valid base64',
+    };
+  }
+
+  if (!bytesEqual(providedBytes, sha256Bytes(body))) {
+    return {
+      ok: false,
+      code: ErrorCodes.CONTENT_DIGEST_MISMATCH,
+      message: 'Content-Digest does not match the raw request body',
+    };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Components that must be in the signed set for a UCP request (the `ucp-request`
+ * policy; `signature-only` skips this). UCP defines no separate webhook set, so
+ * webhook deliveries use the same requirements, including idempotency-key.
+ */
+function requiredComponents(
+  method: string,
+  url: string,
+  headers: Record<string, string>,
+  hasBody: boolean
+): string[] {
+  const required = ['@method', '@authority', '@path'];
+  if (hasQueryString(url)) {
+    required.push('@query');
+  }
+  if (getHeader(headers, 'ucp-agent') !== undefined) {
+    required.push('ucp-agent');
+  }
+  if (STATE_CHANGING_METHODS.has(method.toUpperCase())) {
+    required.push('idempotency-key');
+  }
+  if (hasBody) {
+    required.push('content-digest', 'content-type');
+  }
+  return required;
+}
+
+type AgentParse = { ok: true; profileUrl: string } | { ok: false; reason: string };
+
+/** A bare RFC 8941 token / sf-key (sufficient for the UCP-Agent members we accept). */
+const SF_KEY = /^[a-z*][a-z0-9_\-.*]*$/;
+const SF_TOKEN = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * Strictly parse a `UCP-Agent` header. UCP defines it as an RFC 8941 dictionary
+ * with a REQUIRED `profile` member whose value is a quoted HTTPS URL, e.g.
+ * `UCP-Agent: profile="https://platform.example/.well-known/ucp"`. This is a
+ * minimal UCP-scoped parser (not a general structured-field parser): it splits
+ * members (respecting quoted strings), requires each member to be `key=value`
+ * with a well-formed value (quoted string, token, integer, or boolean), requires
+ * exactly one `profile` whose value is a quoted non-empty HTTPS URL, and rejects
+ * duplicates, unquoted/empty/non-HTTPS profiles, and malformed members. It never
+ * fetches the URL.
+ */
+function parseUcpAgentProfile(header: string): AgentParse {
+  // Split into dictionary members on commas that are not inside a quoted string.
+  const members: string[] = [];
+  let current = '';
+  let inString = false;
+  for (let i = 0; i < header.length; i++) {
+    const ch = header[i];
+    if (ch === '"') {
+      inString = !inString;
+      current += ch;
+    } else if (ch === ',' && !inString) {
+      members.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  members.push(current);
+  if (inString) {
+    return { ok: false, reason: 'unterminated quoted string' };
+  }
+
+  let profileUrl: string | undefined;
+  let profileCount = 0;
+
+  for (const raw of members) {
+    const member = raw.trim();
+    if (member === '') {
+      return { ok: false, reason: 'empty dictionary member' };
+    }
+    const eq = member.indexOf('=');
+    if (eq === -1) {
+      return { ok: false, reason: `malformed member (expected key=value): ${member}` };
+    }
+    const key = member.slice(0, eq).trim();
+    const value = member.slice(eq + 1).trim();
+    if (!SF_KEY.test(key)) {
+      return { ok: false, reason: `malformed member key: ${key}` };
+    }
+    const isQuoted = value.length >= 2 && value.startsWith('"') && value.endsWith('"');
+    const valueOk =
+      isQuoted || SF_TOKEN.test(value) || /^-?\d+$/.test(value) || value === '?0' || value === '?1';
+    if (!valueOk) {
+      return { ok: false, reason: `malformed member value for ${key}` };
+    }
+    if (key === 'profile') {
+      profileCount += 1;
+      if (profileCount > 1) {
+        return { ok: false, reason: 'duplicate profile member' };
+      }
+      if (!isQuoted) {
+        return { ok: false, reason: 'profile value must be a quoted string' };
+      }
+      profileUrl = value.slice(1, -1);
+    }
+  }
+
+  if (profileUrl === undefined) {
+    return { ok: false, reason: 'missing profile member' };
+  }
+  // Validate the profile URL by parsing it, not by prefix matching.
+  if (/\s/.test(profileUrl)) {
+    return { ok: false, reason: 'profile URL contains whitespace' };
+  }
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(profileUrl);
+  } catch {
+    return { ok: false, reason: 'profile is not a valid URL' };
+  }
+  if (parsedUrl.protocol !== 'https:') {
+    return { ok: false, reason: 'profile must be an https URL' };
+  }
+  if (!parsedUrl.host) {
+    return { ok: false, reason: 'profile URL has no host' };
+  }
+  if (parsedUrl.username !== '' || parsedUrl.password !== '') {
+    return { ok: false, reason: 'profile URL must not contain credentials' };
+  }
+  return { ok: true, profileUrl };
+}
+
+/**
+ * Verify an ECDSA raw (r||s) signature with WebCrypto using a public JWK.
+ * Returns false on any import/verify failure (never throws for normal failures).
+ */
+async function verifyEcdsaRaw(
+  publicJwk: { crv: 'P-256' | 'P-384'; x: string; y: string },
+  namedCurve: 'P-256' | 'P-384',
+  hash: 'SHA-256' | 'SHA-384',
+  signature: Uint8Array,
+  data: Uint8Array
+): Promise<boolean> {
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle) {
+    throw new Error('WebCrypto subtle is unavailable in this runtime');
+  }
+
+  try {
+    const key = await subtle.importKey(
+      'jwk',
+      { kty: 'EC', crv: namedCurve, x: publicJwk.x, y: publicJwk.y },
+      { name: 'ECDSA', namedCurve },
+      false,
+      ['verify']
+    );
+    return await subtle.verify({ name: 'ECDSA', hash: { name: hash } }, key, signature, data);
+  } catch {
+    // Malformed key material or verification error -> not verifiable.
+    return false;
+  }
+}
+
+/**
+ * Verify a UCP RFC 9421 HTTP Message Signature.
+ *
+ * Never falls back to the legacy `Request-Signature` / RFC 7797 path.
+ */
+export async function verifyUcpHttpSignature(
+  options: VerifyUcpHttpSignatureOptions
+): Promise<VerifyUcpHttpSignatureResult> {
+  const {
+    signature_input,
+    signature,
+    method,
+    url,
+    headers,
+    body_bytes,
+    profile,
+    label,
+    component_policy = 'ucp-request',
+    expected_profile_url,
+  } = options;
+
+  // 1. Presence checks (explicit; distinct error codes).
+  if (!signature_input || !signature_input.trim()) {
+    return fail(ErrorCodes.HTTP_SIGNATURE_INPUT_MISSING, 'Missing Signature-Input header');
+  }
+  if (!signature || !signature.trim()) {
+    return fail(ErrorCodes.HTTP_SIGNATURE_MISSING, 'Missing Signature header');
+  }
+
+  // 2. Parse RFC 9421 headers. alg and created are optional for UCP; keyid is
+  //    still required by the parser.
+  let parsed: ParsedSignature;
+  try {
+    parsed = parseSignature(signature_input, signature, label, {
+      requireAlg: false,
+      requireCreated: false,
+    });
+  } catch (err) {
+    const message =
+      err instanceof HttpSignatureError || err instanceof Error
+        ? err.message
+        : 'Failed to parse HTTP signature';
+    return fail(ErrorCodes.HTTP_SIGNATURE_MALFORMED, message);
+  }
+
+  const params = parsed.params;
+  const covered = params.coveredComponents;
+
+  // 2a. Preflight the derived request inputs. RFC 9421 derived components must
+  //     reflect real values; an empty method/authority/path would bind nothing.
+  //     UCP is HTTPS-based, so the request URL must be an absolute https URL.
+  // The method must be a valid HTTP token with no surrounding or internal
+  // whitespace (RFC 7230); `@method` binds it verbatim into the signature base.
+  if (!method || method.trim() !== method || !/^[A-Za-z!#$%&'*+.^_`|~-]+$/.test(method)) {
+    return fail(
+      ErrorCodes.HTTP_SIGNATURE_MALFORMED,
+      'Request method is empty or not a valid token',
+      {
+        keyid: params.keyid,
+      }
+    );
+  }
+  let requestUrl: URL;
+  try {
+    requestUrl = new URL(url);
+  } catch {
+    return fail(ErrorCodes.HTTP_SIGNATURE_MALFORMED, 'Request URL must be an absolute URL', {
+      keyid: params.keyid,
+    });
+  }
+  if (requestUrl.protocol !== 'https:') {
+    return fail(ErrorCodes.HTTP_SIGNATURE_MALFORMED, 'Request URL must use https', {
+      keyid: params.keyid,
+    });
+  }
+  if (!requestUrl.host) {
+    return fail(ErrorCodes.HTTP_SIGNATURE_MALFORMED, 'Request URL has no authority', {
+      keyid: params.keyid,
+    });
+  }
+  if (!requestUrl.pathname.startsWith('/')) {
+    return fail(ErrorCodes.HTTP_SIGNATURE_MALFORMED, 'Request path must begin with /', {
+      keyid: params.keyid,
+    });
+  }
+
+  // 3. Resolve the signing key by keyid -> signing_keys[].kid.
+  const key = findSigningKey(profile, params.keyid);
+  if (!key) {
+    return fail(ErrorCodes.KEY_NOT_FOUND, `Key not found in profile: ${params.keyid}`, {
+      keyid: params.keyid,
+      covered_components: covered,
+    });
+  }
+
+  // 4. Key must be a public EC key.
+  if (key.kty !== 'EC') {
+    return fail(ErrorCodes.KEY_ALGORITHM_MISMATCH, `Expected EC key, got ${key.kty}`, {
+      keyid: params.keyid,
+    });
+  }
+  if (!key.x || !key.y) {
+    return fail(ErrorCodes.KEY_ALGORITHM_MISMATCH, 'Signing key is missing x/y coordinates', {
+      keyid: params.keyid,
+    });
+  }
+  if ((key as { d?: unknown }).d !== undefined) {
+    return fail(
+      ErrorCodes.KEY_ALGORITHM_MISMATCH,
+      'Signing key must be a public key (private "d" present)',
+      { keyid: params.keyid }
+    );
+  }
+
+  // 5. Resolve the algorithm from the key's curve (UCP does not send alg).
+  const curveParams = CURVE_PARAMS[key.crv];
+  if (!curveParams) {
+    return fail(
+      ErrorCodes.KEY_CURVE_MISMATCH,
+      `Unsupported key curve: ${key.crv} (UCP requires P-256, optionally P-384)`,
+      { keyid: params.keyid }
+    );
+  }
+
+  // 6. If the signer redundantly included alg, it must be consistent with the key.
+  if (params.alg !== undefined) {
+    const expectedCurve = ALG_TOKEN_CURVE[params.alg.toLowerCase()];
+    if (expectedCurve === undefined || expectedCurve !== key.crv) {
+      return fail(
+        ErrorCodes.SIGNATURE_ALGORITHM_UNSUPPORTED,
+        `Signature-Input alg "${params.alg}" is not consistent with key curve ${key.crv}`,
+        { keyid: params.keyid, covered_components: covered }
+      );
+    }
+  }
+
+  // 7. Signature must be fixed-width raw (r||s); DER is rejected by length.
+  if (parsed.signatureBytes.length !== curveParams.rawSignatureLength) {
+    return fail(
+      ErrorCodes.SIGNATURE_MALFORMED,
+      `Expected a ${curveParams.rawSignatureLength}-byte raw (r||s) ${curveParams.alg} signature, ` +
+        `got ${parsed.signatureBytes.length} bytes (DER encoding is not accepted)`,
+      { keyid: params.keyid }
+    );
+  }
+
+  // 8. Enforce the required signed-component policy.
+  const hasBody = body_bytes !== undefined && body_bytes.length > 0;
+  if (component_policy !== 'signature-only') {
+    const required = requiredComponents(method, url, headers, hasBody);
+
+    // 8a. Each required component must be in the signed set.
+    const uncovered = required.filter((c) => !covered.includes(c));
+    if (uncovered.length > 0) {
+      return fail(
+        ErrorCodes.HTTP_SIGNATURE_COMPONENT_MISSING,
+        `Required signed components missing: ${uncovered.join(', ')}`,
+        { keyid: params.keyid, covered_components: covered }
+      );
+    }
+
+    // 8b. A required header component must also be present and non-empty:
+    //     buildSignatureBase yields '' for a missing header, so signing the name
+    //     alone is not equivalent to signing a real value. content-digest is
+    //     handled in step 9 (so a missing one reports a digest-specific error).
+    const emptyHeaders = required.filter((c) => {
+      if (c.startsWith('@') || c === 'content-digest') {
+        return false;
+      }
+      const value = getHeader(headers, c);
+      return value === undefined || value.trim() === '';
+    });
+    if (emptyHeaders.length > 0) {
+      return fail(
+        ErrorCodes.HTTP_SIGNATURE_COMPONENT_MISSING,
+        `Required signed header(s) absent or empty: ${emptyHeaders.join(', ')}`,
+        { keyid: params.keyid, covered_components: covered }
+      );
+    }
+  }
+
+  // 9. Content-Digest verification over the raw body bytes.
+  const digestHeader = getHeader(headers, 'content-digest');
+  let contentDigestVerified = false;
+  if (hasBody) {
+    const skipForSignatureOnly =
+      component_policy === 'signature-only' &&
+      !(covered.includes('content-digest') && digestHeader);
+    if (!skipForSignatureOnly) {
+      const outcome = verifyContentDigest(body_bytes as Uint8Array, digestHeader);
+      if (!outcome.ok) {
+        return fail(outcome.code, outcome.message, {
+          keyid: params.keyid,
+          covered_components: covered,
+        });
+      }
+      contentDigestVerified = true;
+    }
+  } else if (
+    component_policy !== 'signature-only' &&
+    (covered.includes('content-digest') || digestHeader !== undefined)
+  ) {
+    // A signature covers (or the request carries) a Content-Digest, but no body
+    // was supplied to verify it against. Fail closed.
+    return fail(
+      ErrorCodes.BODY_REQUIRED,
+      'content-digest is signed or present but no request body was provided to verify it',
+      { keyid: params.keyid, covered_components: covered }
+    );
+  }
+
+  // 10. Build the signature base (exact serialized params) and verify ECDSA.
+  //     buildSignatureBase throws on a duplicate covered component (RFC 9421
+  //     Section 2.5); surface that as a clean malformed result, never a throw.
+  const request: SignatureRequest = { method, url, headers };
+  let baseBytes: Uint8Array;
+  try {
+    const base = buildSignatureBase(request, params, { preferSerializedParams: true });
+    baseBytes = signatureBaseToBytes(base);
+  } catch (err) {
+    return fail(
+      ErrorCodes.HTTP_SIGNATURE_MALFORMED,
+      err instanceof Error ? err.message : 'Invalid signature base',
+      { keyid: params.keyid, covered_components: covered }
+    );
+  }
+
+  let signatureValid: boolean;
+  try {
+    signatureValid = await verifyEcdsaRaw(
+      { crv: key.crv as 'P-256' | 'P-384', x: key.x, y: key.y },
+      key.crv as 'P-256' | 'P-384',
+      curveParams.hash,
+      parsed.signatureBytes,
+      baseBytes
+    );
+  } catch (err) {
+    return fail(
+      ErrorCodes.VERIFICATION_FAILED,
+      `Signature verification error: ${err instanceof Error ? err.message : String(err)}`,
+      { keyid: params.keyid, covered_components: covered }
+    );
+  }
+
+  if (!signatureValid) {
+    return fail(ErrorCodes.SIGNATURE_INVALID, 'HTTP Message Signature verification failed', {
+      keyid: params.keyid,
+      covered_components: covered,
+      alg: curveParams.alg,
+    });
+  }
+
+  // 11. Signer-profile handling. UCP-Agent is a signed identity-binding component.
+  //     Under the strict request policy it is validated whenever the header is
+  //     present (not only when a profile is expected); a binding is also enforced
+  //     when expected_profile_url is supplied. Only a SIGNED ucp-agent is trusted.
+  let signerProfileUrl: string | undefined;
+  const agentHeader = getHeader(headers, 'ucp-agent');
+  const mustValidateAgent =
+    expected_profile_url !== undefined ||
+    (component_policy === 'ucp-request' && agentHeader !== undefined);
+
+  if (mustValidateAgent) {
+    if (!covered.includes('ucp-agent')) {
+      return fail(
+        ErrorCodes.AGENT_MISMATCH,
+        'UCP-Agent must be a signed component to bind the signer profile',
+        { keyid: params.keyid, covered_components: covered }
+      );
+    }
+    if (!agentHeader || !agentHeader.trim()) {
+      return fail(ErrorCodes.AGENT_MISMATCH, 'UCP-Agent header is absent or empty', {
+        keyid: params.keyid,
+      });
+    }
+    const parsedAgent = parseUcpAgentProfile(agentHeader);
+    if (!parsedAgent.ok) {
+      return fail(ErrorCodes.AGENT_MISMATCH, `Invalid UCP-Agent: ${parsedAgent.reason}`, {
+        keyid: params.keyid,
+      });
+    }
+    signerProfileUrl = parsedAgent.profileUrl;
+    if (expected_profile_url !== undefined && signerProfileUrl !== expected_profile_url) {
+      return fail(
+        ErrorCodes.AGENT_MISMATCH,
+        'UCP-Agent profile does not match the expected profile URL',
+        { keyid: params.keyid }
+      );
+    }
+  }
+
+  return {
+    valid: true,
+    alg: curveParams.alg,
+    keyid: params.keyid,
+    covered_components: covered,
+    content_digest_verified: contentDigestVerified,
+    ...(signerProfileUrl !== undefined ? { signer_profile_url: signerProfileUrl } : {}),
+  };
+}

--- a/packages/mappings/ucp/src/index.ts
+++ b/packages/mappings/ucp/src/index.ts
@@ -1,13 +1,20 @@
 /**
  * @peac/mappings-ucp
  *
- * Google Universal Commerce Protocol (UCP) mapping to PEAC receipts
- * and dispute evidence.
+ * Universal Commerce Protocol (UCP) mapping to PEAC receipts and dispute
+ * evidence.
  *
- * Features:
- * - Webhook signature verification (raw-first, JCS fallback)
- * - UCP order to PEAC receipt mapping
- * - Dispute evidence generation for @peac/audit bundles
+ * Signature verification:
+ * - `verifyUcpHttpSignature` verifies the current UCP signing model:
+ *   request-shaped RFC 9421 HTTP Message Signatures (ES256/ES384) with an
+ *   RFC 9530 Content-Digest over raw body bytes. Response signatures (which use
+ *   `@status`) are out of scope.
+ * - `verifyUcpWebhookSignature` remains for the legacy `Request-Signature`
+ *   detached-JWS (RFC 7797) compatibility path; the two never silently fall back
+ *   to each other.
+ *
+ * Also: UCP order to PEAC receipt mapping and dispute evidence generation for
+ * @peac/audit bundles.
  *
  * @example
  * ```ts
@@ -76,6 +83,11 @@ export type {
   // Verification types
   VerifyUcpWebhookOptions,
   VerifyUcpWebhookResult,
+  // RFC 9421 HTTP Message Signature verification types
+  UcpHttpSignatureAlgorithm,
+  UcpComponentPolicy,
+  VerifyUcpHttpSignatureOptions,
+  VerifyUcpHttpSignatureResult,
   // Order types
   UcpLineItem,
   UcpOrder,
@@ -92,8 +104,11 @@ export { UCP_EVIDENCE_VERSION } from './types.js';
 export { ErrorCodes, ErrorHttpStatus, UcpError, ucpError } from './errors.js';
 export type { ErrorCode } from './errors.js';
 
-// Verification
+// Verification (legacy Request-Signature / RFC 7797 detached JWS)
 export { verifyUcpWebhookSignature, parseDetachedJws, findSigningKey } from './verify.js';
+
+// Verification (current UCP model: RFC 9421 HTTP Message Signatures)
+export { verifyUcpHttpSignature } from './http-signature.js';
 
 // Mapping
 export { mapUcpOrderToReceipt, extractLineItemSummary, calculateOrderStats } from './mapper.js';

--- a/packages/mappings/ucp/src/types.ts
+++ b/packages/mappings/ucp/src/types.ts
@@ -345,6 +345,129 @@ export interface VerifyUcpWebhookResult {
   error_message?: string;
 }
 
+// ---------------------------------------------------------------------------
+// RFC 9421 HTTP Message Signature verification (current UCP signing model)
+// ---------------------------------------------------------------------------
+
+/**
+ * HTTP Message Signature algorithm (RFC 9421) supported for UCP.
+ *
+ * UCP requires ES256 (P-256); ES384 (P-384) is OPTIONAL. Ed25519 is not used
+ * at the UCP wire layer, so it is intentionally excluded here.
+ *
+ * This is the algorithm RESOLVED from the signing key's curve (P-256 -> ES256,
+ * P-384 -> ES384), not a value read from the `Signature-Input` `alg` parameter:
+ * UCP does not include `alg` in `Signature-Input`.
+ */
+export type UcpHttpSignatureAlgorithm = 'ES256' | 'ES384';
+
+/**
+ * Required signed-component policy for UCP HTTP Message Signature verification.
+ *
+ * - `ucp-request` (default): the full UCP request policy. Always requires
+ *   `@method`, `@authority`, `@path`; `@query` when the URL has a query string;
+ *   `ucp-agent` when a `UCP-Agent` header is present; `idempotency-key` for
+ *   state-changing methods (POST/PUT/DELETE/PATCH); and `content-digest` +
+ *   `content-type` when a body is present. This also applies to webhook
+ *   deliveries: UCP does not define a separate webhook component set, and
+ *   webhook POSTs are not exempt from the idempotency-key requirement.
+ * - `signature-only`: low-level mode. Verifies the signature and, when a body is
+ *   present and covered, the Content-Digest, but does NOT enforce the required
+ *   component set. Use only when the caller enforces component coverage itself.
+ *
+ * Note: UCP response signatures use `@status` instead of `@method` and are a
+ * separate component model; this verifier covers request-shaped signatures only.
+ */
+export type UcpComponentPolicy = 'ucp-request' | 'signature-only';
+
+/**
+ * Options for verifying a UCP request/webhook RFC 9421 HTTP Message Signature.
+ *
+ * This is the current UCP signing model (`Signature-Input` / `Signature` /
+ * `Content-Digest` over raw body bytes), distinct from the legacy
+ * `Request-Signature` detached-JWS path verified by `verifyUcpWebhookSignature`.
+ * There is no silent fallback between the two: the caller selects the scheme.
+ */
+export interface VerifyUcpHttpSignatureOptions {
+  /** RFC 9421 `Signature-Input` header value. */
+  signature_input: string;
+
+  /** RFC 9421 `Signature` header value. */
+  signature: string;
+
+  /** HTTP method (e.g. 'POST'). */
+  method: string;
+
+  /** Absolute request URL (used for `@authority` / `@path` / `@query` derived components). */
+  url: string;
+
+  /** Request headers (case-insensitive lookup; e.g. `content-digest`, `ucp-agent`). */
+  headers: Record<string, string>;
+
+  /**
+   * Raw request body bytes. Required (and bound via `content-digest`) whenever a
+   * body is present; never JSON-canonicalized before digesting (UCP binds raw bytes).
+   */
+  body_bytes?: Uint8Array;
+
+  /**
+   * Pre-resolved UCP party profile (the `/.well-known/ucp` document). Resolving it
+   * is the caller's responsibility (SSRF-safe, host-allowlisted); tests pass a fixture.
+   * No network I/O happens inside this function.
+   */
+  profile: UcpProfile;
+
+  /** Optional specific signature label to verify (defaults to the first in `Signature-Input`). */
+  label?: string;
+
+  /**
+   * Required signed-component policy. Defaults to `'ucp-request'` (strict). Use
+   * `'signature-only'` for low-level verification without component enforcement.
+   */
+  component_policy?: UcpComponentPolicy;
+
+  /**
+   * Optional expected signer profile URL to bind. When provided, the `ucp-agent`
+   * component MUST be signed, the `UCP-Agent` header MUST be present and parse as
+   * an RFC 8941 dictionary with a quoted HTTPS `profile` member, and that profile
+   * URL MUST equal this value; otherwise verification fails. An unsigned component
+   * is never trusted. This verifier never fetches the profile URL (SSRF stays out).
+   */
+  expected_profile_url?: string;
+}
+
+/**
+ * Result of verifying a UCP RFC 9421 HTTP Message Signature.
+ */
+export interface VerifyUcpHttpSignatureResult {
+  /** Whether the signature (and `Content-Digest`, when present) verified. */
+  valid: boolean;
+
+  /** Algorithm resolved from the signing key's curve (P-256 -> ES256, P-384 -> ES384). */
+  alg?: UcpHttpSignatureAlgorithm;
+
+  /** `keyid` from `Signature-Input`, matched against `signing_keys[].kid`. */
+  keyid?: string;
+
+  /** Covered components from `Signature-Input` (for evidence capture). */
+  covered_components?: string[];
+
+  /** Whether a `Content-Digest` was present and verified over the raw body bytes. */
+  content_digest_verified?: boolean;
+
+  /**
+   * The signer profile URL parsed from a signed `UCP-Agent` header, when one was
+   * present and validated (evidence for the caller; never fetched here).
+   */
+  signer_profile_url?: string;
+
+  /** Error code (`E_UCP_*`) when invalid. */
+  error_code?: string;
+
+  /** Error message when invalid. */
+  error_message?: string;
+}
+
 /**
  * UCP order line item for receipt mapping.
  */

--- a/packages/mappings/ucp/tests/http-signature.test.ts
+++ b/packages/mappings/ucp/tests/http-signature.test.ts
@@ -1,0 +1,734 @@
+/**
+ * @peac/mappings-ucp - RFC 9421 HTTP Message Signature verification tests
+ *
+ * Exercises the current UCP signing model (`verifyUcpHttpSignature`):
+ *  - the algorithm is resolved from the key curve; `alg` is NOT in Signature-Input;
+ *  - `created` is optional;
+ *  - the required signed-component set is enforced;
+ *  - Content-Digest is verified strictly over raw body bytes;
+ *  - signatures are fixed-width raw r||s (DER rejected).
+ *
+ * The test signer uses node:crypto to construct fixtures with explicit control
+ * over raw vs DER encoding and over the exact serialized Signature-Input value;
+ * the verifier under test uses WebCrypto. Keys are generated at runtime.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { generateKeyPairSync, createHash, sign as nodeSign } from 'node:crypto';
+import type { KeyObject } from 'node:crypto';
+import * as jose from 'jose';
+import {
+  buildSignatureBase,
+  signatureBaseToBytes,
+  type ParsedSignatureParams,
+} from '@peac/http-signatures';
+import { verifyUcpHttpSignature } from '../src/http-signature.js';
+import { verifyUcpWebhookSignature } from '../src/verify.js';
+import { ErrorCodes, ErrorHttpStatus } from '../src/errors.js';
+import type { UcpComponentPolicy, UcpProfile, UcpSigningKey } from '../src/types.js';
+
+const DEFAULT_URL = 'https://merchant.example.com/ucp/webhooks';
+const DEFAULT_PROFILE_URL = 'https://platform.example.com/.well-known/ucp';
+const DEFAULT_AGENT = `profile="${DEFAULT_PROFILE_URL}"`;
+const STATE_CHANGING = new Set(['POST', 'PUT', 'DELETE', 'PATCH']);
+
+function makeKeypair(
+  namedCurve: 'P-256' | 'P-384',
+  kid: string
+): { privateKey: KeyObject; signingKey: UcpSigningKey } {
+  const { publicKey, privateKey } = generateKeyPairSync('ec', { namedCurve });
+  const jwk = publicKey.export({ format: 'jwk' }) as { crv: string; x: string; y: string };
+  const signingKey: UcpSigningKey = {
+    kty: 'EC',
+    crv: jwk.crv as UcpSigningKey['crv'],
+    kid,
+    x: jwk.x,
+    y: jwk.y,
+  };
+  return { privateKey, signingKey };
+}
+
+function contentDigest(body: Uint8Array): string {
+  return `sha-256=:${createHash('sha256').update(body).digest('base64')}:`;
+}
+
+function hasQuery(url: string): boolean {
+  const i = url.indexOf('?');
+  return i !== -1 && i < url.length - 1;
+}
+
+interface FixtureOptions {
+  curve?: 'P-256' | 'P-384';
+  method?: string;
+  url?: string;
+  agent?: string | null; // null -> omit UCP-Agent header
+  body?: Uint8Array | null; // null -> no body
+  covered?: string[]; // override the signed component set
+  created?: number; // include a created parameter
+  algToken?: string; // include a (UCP-redundant) alg parameter
+  paramOrder?: 'created-first' | 'keyid-first';
+}
+
+interface Fixture {
+  signature_input: string;
+  signature: string;
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body_bytes?: Uint8Array;
+  profile: UcpProfile;
+  kid: string;
+  privateKey: KeyObject;
+  covered: string[];
+}
+
+function defaultCovered(
+  method: string,
+  url: string,
+  hasBody: boolean,
+  agentPresent: boolean
+): string[] {
+  const c = ['@method', '@authority', '@path'];
+  if (hasQuery(url)) c.push('@query');
+  if (agentPresent) c.push('ucp-agent');
+  if (STATE_CHANGING.has(method.toUpperCase())) c.push('idempotency-key');
+  if (hasBody) c.push('content-digest', 'content-type');
+  return c;
+}
+
+/**
+ * Build a self-consistent valid UCP RFC 9421 fixture. The signer constructs the
+ * exact serialized signature-params value and signs the base produced from it
+ * (preferSerializedParams), so the verifier (which also uses the exact value)
+ * agrees byte-for-byte.
+ */
+function buildFixture(opts: FixtureOptions = {}): Fixture {
+  const curve = opts.curve ?? 'P-256';
+  const hash = curve === 'P-256' ? 'sha256' : 'sha384';
+  const kid = 'ucp-key-1';
+  const method = opts.method ?? 'POST';
+  const url = opts.url ?? DEFAULT_URL;
+  const agentPresent = opts.agent !== null;
+  const agent = opts.agent ?? DEFAULT_AGENT;
+  const hasBody = opts.body !== null;
+  const body = opts.body === null ? undefined : (opts.body ?? new TextEncoder().encode('{"id":1}'));
+
+  const covered = opts.covered ?? defaultCovered(method, url, hasBody, agentPresent);
+  const { privateKey, signingKey } = makeKeypair(curve, kid);
+
+  const headers: Record<string, string> = {};
+  if (agentPresent) headers['ucp-agent'] = agent;
+  if (STATE_CHANGING.has(method.toUpperCase())) headers['idempotency-key'] = 'idem-123';
+  if (body) {
+    headers['content-type'] = 'application/json';
+    headers['content-digest'] = contentDigest(body);
+  }
+
+  const components = covered.map((c) => `"${c}"`).join(' ');
+  let paramsValue = `(${components})`;
+  if (opts.created !== undefined && opts.paramOrder === 'created-first') {
+    paramsValue += `;created=${opts.created};keyid="${kid}"`;
+  } else if (opts.created !== undefined) {
+    paramsValue += `;keyid="${kid}";created=${opts.created}`;
+  } else {
+    paramsValue += `;keyid="${kid}"`;
+  }
+  if (opts.algToken !== undefined) {
+    paramsValue += `;alg="${opts.algToken}"`;
+  }
+
+  const signerParams: ParsedSignatureParams = {
+    keyid: kid,
+    coveredComponents: covered,
+    signatureParamsValue: paramsValue,
+  };
+  const base = buildSignatureBase({ method, url, headers }, signerParams, {
+    preferSerializedParams: true,
+  });
+  const sig = nodeSign(hash, signatureBaseToBytes(base), {
+    key: privateKey,
+    dsaEncoding: 'ieee-p1363',
+  });
+
+  return {
+    signature_input: `sig1=${paramsValue}`,
+    signature: `sig1=:${sig.toString('base64')}:`,
+    method,
+    url,
+    headers,
+    body_bytes: body,
+    profile: { version: '1.0', business_id: 'merchant.example.com', signing_keys: [signingKey] },
+    kid,
+    privateKey,
+    covered,
+  };
+}
+
+function verify(fx: Fixture, overrides: Record<string, unknown> = {}) {
+  return verifyUcpHttpSignature({
+    signature_input: fx.signature_input,
+    signature: fx.signature,
+    method: fx.method,
+    url: fx.url,
+    headers: fx.headers,
+    body_bytes: fx.body_bytes,
+    profile: fx.profile,
+    ...overrides,
+  });
+}
+
+describe('verifyUcpHttpSignature: valid UCP signatures', () => {
+  it('verifies ES256 with no alg and no created (canonical UCP)', async () => {
+    const fx = buildFixture();
+    const result = await verify(fx);
+    expect(result.valid).toBe(true);
+    expect(result.alg).toBe('ES256');
+    expect(result.keyid).toBe(fx.kid);
+    expect(result.content_digest_verified).toBe(true);
+  });
+
+  it('verifies ES384 (optional) with no alg and no created', async () => {
+    const fx = buildFixture({ curve: 'P-384' });
+    const result = await verify(fx);
+    expect(result.valid).toBe(true);
+    expect(result.alg).toBe('ES384');
+  });
+
+  it('verifies when an optional created parameter is present', async () => {
+    const fx = buildFixture({ created: 1750000000 });
+    expect((await verify(fx)).valid).toBe(true);
+  });
+
+  it('verifies with a redundant but consistent alg parameter', async () => {
+    const fx = buildFixture({ algToken: 'ecdsa-p256-sha256' });
+    expect((await verify(fx)).valid).toBe(true);
+  });
+
+  it('preserves exact param order: created-first and keyid-first both verify', async () => {
+    const a = await verify(buildFixture({ created: 1750000000, paramOrder: 'created-first' }));
+    const b = await verify(buildFixture({ created: 1750000000, paramOrder: 'keyid-first' }));
+    expect(a.valid).toBe(true);
+    expect(b.valid).toBe(true);
+  });
+
+  it('verifies a GET request with no body (minimal component set)', async () => {
+    const fx = buildFixture({ method: 'GET', body: null, agent: null });
+    const result = await verify(fx);
+    expect(result.valid).toBe(true);
+    expect(result.content_digest_verified).toBe(false);
+  });
+
+  it('verifies a query URL when @query is signed', async () => {
+    const url = 'https://merchant.example.com/ucp/orders?status=open';
+    const fx = buildFixture({ method: 'GET', body: null, agent: null, url });
+    expect((await verify(fx)).valid).toBe(true);
+  });
+
+  it('requires idempotency-key for a webhook-style POST (no spec exemption)', async () => {
+    const covered = [
+      '@method',
+      '@authority',
+      '@path',
+      'ucp-agent',
+      'content-digest',
+      'content-type',
+    ];
+    const fx = buildFixture({ covered }); // POST, omits idempotency-key
+    expect((await verify(fx)).error_code).toBe(ErrorCodes.HTTP_SIGNATURE_COMPONENT_MISSING);
+  });
+
+  it('signature-only policy verifies a minimal covered set', async () => {
+    const fx = buildFixture({ method: 'GET', body: null, agent: null, covered: ['@method'] });
+    expect(
+      (await verify(fx, { component_policy: 'signature-only' as UcpComponentPolicy })).valid
+    ).toBe(true);
+  });
+});
+
+describe('verifyUcpHttpSignature: header / parse failures', () => {
+  it('rejects a missing Signature-Input', async () => {
+    const fx = buildFixture();
+    expect((await verify(fx, { signature_input: '' })).error_code).toBe(
+      ErrorCodes.HTTP_SIGNATURE_INPUT_MISSING
+    );
+  });
+
+  it('rejects a missing Signature', async () => {
+    const fx = buildFixture();
+    expect((await verify(fx, { signature: '' })).error_code).toBe(
+      ErrorCodes.HTTP_SIGNATURE_MISSING
+    );
+  });
+
+  it('rejects a malformed Signature-Input', async () => {
+    const fx = buildFixture();
+    expect((await verify(fx, { signature_input: 'not a structured field' })).error_code).toBe(
+      ErrorCodes.HTTP_SIGNATURE_MALFORMED
+    );
+  });
+});
+
+describe('verifyUcpHttpSignature: key / algorithm failures', () => {
+  it('rejects an unknown keyid', async () => {
+    const fx = buildFixture();
+    const profile: UcpProfile = {
+      ...fx.profile,
+      signing_keys: [{ ...fx.profile.signing_keys[0], kid: 'other' }],
+    };
+    expect((await verify(fx, { profile })).error_code).toBe(ErrorCodes.KEY_NOT_FOUND);
+  });
+
+  it('rejects an unsupported key curve', async () => {
+    const fx = buildFixture();
+    const profile: UcpProfile = {
+      ...fx.profile,
+      signing_keys: [{ ...fx.profile.signing_keys[0], crv: 'P-521' as UcpSigningKey['crv'] }],
+    };
+    expect((await verify(fx, { profile })).error_code).toBe(ErrorCodes.KEY_CURVE_MISMATCH);
+  });
+
+  it('rejects a public key carrying a private "d"', async () => {
+    const fx = buildFixture();
+    const profile: UcpProfile = {
+      ...fx.profile,
+      signing_keys: [
+        { ...fx.profile.signing_keys[0], d: 'PRIVATE' } as UcpSigningKey & { d: string },
+      ],
+    };
+    expect((await verify(fx, { profile })).error_code).toBe(ErrorCodes.KEY_ALGORITHM_MISMATCH);
+  });
+
+  it('rejects a redundant alg that conflicts with the key curve', async () => {
+    const fx = buildFixture({ algToken: 'ecdsa-p384-sha384' }); // key is P-256
+    expect((await verify(fx)).error_code).toBe(ErrorCodes.SIGNATURE_ALGORITHM_UNSUPPORTED);
+  });
+
+  it('rejects a DER-encoded signature (raw r||s required)', async () => {
+    const fx = buildFixture();
+    const params: ParsedSignatureParams = {
+      keyid: fx.kid,
+      coveredComponents: fx.covered,
+      signatureParamsValue: fx.signature_input.slice('sig1='.length),
+    };
+    const base = buildSignatureBase(
+      { method: fx.method, url: fx.url, headers: fx.headers },
+      params,
+      {
+        preferSerializedParams: true,
+      }
+    );
+    const der = nodeSign('sha256', signatureBaseToBytes(base), { key: fx.privateKey }); // DER default
+    expect((await verify(fx, { signature: `sig1=:${der.toString('base64')}:` })).error_code).toBe(
+      ErrorCodes.SIGNATURE_MALFORMED
+    );
+  });
+});
+
+describe('verifyUcpHttpSignature: required component policy', () => {
+  const cases: Array<{ name: string; covered: string[]; opts?: FixtureOptions }> = [
+    {
+      name: '@method',
+      covered: [
+        '@authority',
+        '@path',
+        'ucp-agent',
+        'idempotency-key',
+        'content-digest',
+        'content-type',
+      ],
+    },
+    {
+      name: '@authority',
+      covered: [
+        '@method',
+        '@path',
+        'ucp-agent',
+        'idempotency-key',
+        'content-digest',
+        'content-type',
+      ],
+    },
+    {
+      name: '@path',
+      covered: [
+        '@method',
+        '@authority',
+        'ucp-agent',
+        'idempotency-key',
+        'content-digest',
+        'content-type',
+      ],
+    },
+    {
+      name: 'idempotency-key (POST)',
+      covered: ['@method', '@authority', '@path', 'ucp-agent', 'content-digest', 'content-type'],
+    },
+    {
+      name: 'content-type (body)',
+      covered: ['@method', '@authority', '@path', 'ucp-agent', 'idempotency-key', 'content-digest'],
+    },
+    {
+      name: 'content-digest (body)',
+      covered: ['@method', '@authority', '@path', 'ucp-agent', 'idempotency-key', 'content-type'],
+    },
+    {
+      name: 'ucp-agent (header present)',
+      covered: [
+        '@method',
+        '@authority',
+        '@path',
+        'idempotency-key',
+        'content-digest',
+        'content-type',
+      ],
+    },
+  ];
+
+  for (const c of cases) {
+    it(`rejects when ${c.name} is not signed`, async () => {
+      const fx = buildFixture({ covered: c.covered, ...c.opts });
+      expect((await verify(fx)).error_code).toBe(ErrorCodes.HTTP_SIGNATURE_COMPONENT_MISSING);
+    });
+  }
+
+  it('rejects a query URL when @query is not signed', async () => {
+    const url = 'https://merchant.example.com/ucp/orders?status=open';
+    const covered = [
+      '@method',
+      '@authority',
+      '@path',
+      'ucp-agent',
+      'idempotency-key',
+      'content-digest',
+      'content-type',
+    ];
+    const fx = buildFixture({ url, covered });
+    expect((await verify(fx)).error_code).toBe(ErrorCodes.HTTP_SIGNATURE_COMPONENT_MISSING);
+  });
+});
+
+describe('verifyUcpHttpSignature: required header presence (covered != present)', () => {
+  it('rejects a POST where idempotency-key is covered but the header is absent', async () => {
+    const fx = buildFixture(); // idempotency-key covered + present
+    const headers = { ...fx.headers };
+    delete headers['idempotency-key'];
+    expect((await verify(fx, { headers })).error_code).toBe(
+      ErrorCodes.HTTP_SIGNATURE_COMPONENT_MISSING
+    );
+  });
+
+  it('rejects a POST where idempotency-key is covered but the header is whitespace', async () => {
+    const fx = buildFixture();
+    const headers = { ...fx.headers, 'idempotency-key': '   ' };
+    expect((await verify(fx, { headers })).error_code).toBe(
+      ErrorCodes.HTTP_SIGNATURE_COMPONENT_MISSING
+    );
+  });
+
+  it('rejects a body request where content-type is covered but the header is absent', async () => {
+    const fx = buildFixture();
+    const headers = { ...fx.headers };
+    delete headers['content-type'];
+    expect((await verify(fx, { headers })).error_code).toBe(
+      ErrorCodes.HTTP_SIGNATURE_COMPONENT_MISSING
+    );
+  });
+
+  it('rejects a body request where content-type is covered but the header is empty', async () => {
+    const fx = buildFixture();
+    const headers = { ...fx.headers, 'content-type': '' };
+    expect((await verify(fx, { headers })).error_code).toBe(
+      ErrorCodes.HTTP_SIGNATURE_COMPONENT_MISSING
+    );
+  });
+});
+
+describe('UCP error HTTP status mapping', () => {
+  it('maps digest mismatch to 400 and missing signature to 401', () => {
+    expect(ErrorHttpStatus[ErrorCodes.CONTENT_DIGEST_MISMATCH]).toBe(400);
+    expect(ErrorHttpStatus[ErrorCodes.HTTP_SIGNATURE_INPUT_MISSING]).toBe(401);
+    expect(ErrorHttpStatus[ErrorCodes.HTTP_SIGNATURE_MISSING]).toBe(401);
+    expect(ErrorHttpStatus[ErrorCodes.SIGNATURE_INVALID]).toBe(401);
+    expect(ErrorHttpStatus[ErrorCodes.SIGNATURE_ALGORITHM_UNSUPPORTED]).toBe(400);
+  });
+});
+
+describe('verifyUcpHttpSignature: Content-Digest', () => {
+  it('rejects a missing Content-Digest when a body is present', async () => {
+    const fx = buildFixture();
+    const headers = { ...fx.headers };
+    delete headers['content-digest'];
+    expect((await verify(fx, { headers })).error_code).toBe(ErrorCodes.CONTENT_DIGEST_MISSING);
+  });
+
+  it('rejects a Content-Digest that does not match the body', async () => {
+    const fx = buildFixture();
+    const tampered = new TextEncoder().encode('{"id":"TAMPERED"}');
+    expect((await verify(fx, { body_bytes: tampered })).error_code).toBe(
+      ErrorCodes.CONTENT_DIGEST_MISMATCH
+    );
+  });
+
+  it('rejects a malformed Content-Digest member', async () => {
+    const fx = buildFixture();
+    const headers = { ...fx.headers, 'content-digest': 'sha-256=not-a-byte-sequence' };
+    expect((await verify(fx, { headers })).error_code).toBe(ErrorCodes.CONTENT_DIGEST_MALFORMED);
+  });
+
+  it('rejects a duplicate sha-256 member', async () => {
+    const fx = buildFixture();
+    const dup = fx.headers['content-digest'];
+    const headers = { ...fx.headers, 'content-digest': `${dup}, ${dup}` };
+    expect((await verify(fx, { headers })).error_code).toBe(ErrorCodes.CONTENT_DIGEST_MALFORMED);
+  });
+
+  it('rejects an invalid base64 sha-256 value', async () => {
+    const fx = buildFixture();
+    const headers = { ...fx.headers, 'content-digest': 'sha-256=:not*base64*:' };
+    expect((await verify(fx, { headers })).error_code).toBe(ErrorCodes.CONTENT_DIGEST_MALFORMED);
+  });
+
+  it('rejects a Content-Digest without sha-256 (only sha-512)', async () => {
+    const fx = buildFixture();
+    const headers = { ...fx.headers, 'content-digest': 'sha-512=:dGVzdA==:' };
+    expect((await verify(fx, { headers })).error_code).toBe(ErrorCodes.CONTENT_DIGEST_UNSUPPORTED);
+  });
+
+  it('fails closed when content-digest is signed but no body is provided', async () => {
+    const fx = buildFixture();
+    expect((await verify(fx, { body_bytes: undefined })).error_code).toBe(ErrorCodes.BODY_REQUIRED);
+  });
+});
+
+describe('verifyUcpHttpSignature: signature integrity and binding', () => {
+  it('rejects a tampered covered component (signature base mismatch)', async () => {
+    const fx = buildFixture();
+    expect((await verify(fx, { url: 'https://merchant.example.com/ucp/OTHER' })).error_code).toBe(
+      ErrorCodes.SIGNATURE_INVALID
+    );
+  });
+
+  it('does not fall back to legacy when verified against a different key', async () => {
+    const fx = buildFixture();
+    const other = makeKeypair('P-256', fx.kid);
+    const profile: UcpProfile = { ...fx.profile, signing_keys: [other.signingKey] };
+    expect((await verify(fx, { profile })).error_code).toBe(ErrorCodes.SIGNATURE_INVALID);
+  });
+
+  it('binds a signed UCP-Agent profile when expected_profile_url matches', async () => {
+    const fx = buildFixture();
+    expect((await verify(fx, { expected_profile_url: DEFAULT_PROFILE_URL })).valid).toBe(true);
+  });
+
+  it('rejects when the signed UCP-Agent profile does not match expected', async () => {
+    const fx = buildFixture();
+    expect(
+      (
+        await verify(fx, {
+          expected_profile_url: 'https://attacker.example.com/.well-known/ucp',
+        })
+      ).error_code
+    ).toBe(ErrorCodes.AGENT_MISMATCH);
+  });
+
+  it('rejects a non-HTTPS UCP-Agent profile', async () => {
+    const fx = buildFixture({ agent: 'profile="http://platform.example.com/.well-known/ucp"' });
+    expect(
+      (await verify(fx, { expected_profile_url: 'http://platform.example.com/.well-known/ucp' }))
+        .error_code
+    ).toBe(ErrorCodes.AGENT_MISMATCH);
+  });
+
+  it('rejects a UCP-Agent header with no profile member', async () => {
+    const fx = buildFixture({ agent: 'version="1.0"' });
+    expect((await verify(fx, { expected_profile_url: DEFAULT_PROFILE_URL })).error_code).toBe(
+      ErrorCodes.AGENT_MISMATCH
+    );
+  });
+
+  it('rejects an unquoted (malformed) UCP-Agent profile value', async () => {
+    const fx = buildFixture({ agent: `profile=${DEFAULT_PROFILE_URL}` });
+    expect((await verify(fx, { expected_profile_url: DEFAULT_PROFILE_URL })).error_code).toBe(
+      ErrorCodes.AGENT_MISMATCH
+    );
+  });
+
+  it('rejects expected_profile_url when ucp-agent is not a signed component', async () => {
+    const fx = buildFixture({ method: 'GET', body: null, agent: null });
+    expect((await verify(fx, { expected_profile_url: DEFAULT_PROFILE_URL })).error_code).toBe(
+      ErrorCodes.AGENT_MISMATCH
+    );
+  });
+
+  it('returns signer_profile_url for a valid signed UCP-Agent', async () => {
+    const fx = buildFixture();
+    const result = await verify(fx);
+    expect(result.valid).toBe(true);
+    expect(result.signer_profile_url).toBe(DEFAULT_PROFILE_URL);
+  });
+});
+
+describe('verifyUcpHttpSignature: strict UCP-Agent dictionary', () => {
+  // Under ucp-request a present UCP-Agent is validated even without expected_profile_url.
+  it('rejects a duplicate profile member', async () => {
+    const fx = buildFixture({
+      agent: `profile="${DEFAULT_PROFILE_URL}", profile="https://evil.example/.well-known/ucp"`,
+    });
+    expect((await verify(fx)).error_code).toBe(ErrorCodes.AGENT_MISMATCH);
+  });
+
+  it('rejects a malformed extra member', async () => {
+    const fx = buildFixture({ agent: `profile="${DEFAULT_PROFILE_URL}", garbage` });
+    expect((await verify(fx)).error_code).toBe(ErrorCodes.AGENT_MISMATCH);
+  });
+
+  it('rejects an empty profile value', async () => {
+    const fx = buildFixture({ agent: 'profile=""' });
+    expect((await verify(fx)).error_code).toBe(ErrorCodes.AGENT_MISMATCH);
+  });
+
+  it('rejects a non-HTTPS profile even without expected_profile_url', async () => {
+    const fx = buildFixture({ agent: 'profile="http://platform.example.com/.well-known/ucp"' });
+    expect((await verify(fx)).error_code).toBe(ErrorCodes.AGENT_MISMATCH);
+  });
+
+  it('rejects a missing profile member', async () => {
+    const fx = buildFixture({ agent: 'version="1.0"' });
+    expect((await verify(fx)).error_code).toBe(ErrorCodes.AGENT_MISMATCH);
+  });
+
+  it('accepts a valid profile alongside a well-formed extra member', async () => {
+    const fx = buildFixture({ agent: `version="1.0", profile="${DEFAULT_PROFILE_URL}"` });
+    const result = await verify(fx);
+    expect(result.valid).toBe(true);
+    expect(result.signer_profile_url).toBe(DEFAULT_PROFILE_URL);
+  });
+
+  it('rejects profile="https:///" (no host)', async () => {
+    const fx = buildFixture({ agent: 'profile="https:///"' });
+    expect((await verify(fx)).error_code).toBe(ErrorCodes.AGENT_MISMATCH);
+  });
+
+  it('rejects a profile URL containing whitespace', async () => {
+    const fx = buildFixture({
+      agent: 'profile="https://platform.example.com/.well-known/ucp ok"',
+    });
+    expect((await verify(fx)).error_code).toBe(ErrorCodes.AGENT_MISMATCH);
+  });
+
+  it('rejects a profile URL with embedded credentials', async () => {
+    const fx = buildFixture({
+      agent: 'profile="https://user:pass@platform.example.com/.well-known/ucp"',
+    });
+    expect((await verify(fx)).error_code).toBe(ErrorCodes.AGENT_MISMATCH);
+  });
+});
+
+describe('verifyUcpHttpSignature: request preflight + mixed-case headers', () => {
+  it('rejects an empty method', async () => {
+    const fx = buildFixture();
+    expect((await verify(fx, { method: '   ' })).error_code).toBe(
+      ErrorCodes.HTTP_SIGNATURE_MALFORMED
+    );
+  });
+
+  it('rejects a method with surrounding whitespace', async () => {
+    const fx = buildFixture();
+    expect((await verify(fx, { method: ' POST ' })).error_code).toBe(
+      ErrorCodes.HTTP_SIGNATURE_MALFORMED
+    );
+  });
+
+  it('rejects a method with an internal space', async () => {
+    const fx = buildFixture();
+    expect((await verify(fx, { method: 'PO ST' })).error_code).toBe(
+      ErrorCodes.HTTP_SIGNATURE_MALFORMED
+    );
+  });
+
+  it('accepts a valid PATCH method', async () => {
+    const fx = buildFixture({ method: 'PATCH' });
+    expect((await verify(fx)).valid).toBe(true);
+  });
+
+  it('rejects a relative (non-absolute) URL', async () => {
+    const fx = buildFixture();
+    expect((await verify(fx, { url: '/ucp/webhooks' })).error_code).toBe(
+      ErrorCodes.HTTP_SIGNATURE_MALFORMED
+    );
+  });
+
+  it('rejects a non-HTTPS request URL', async () => {
+    const fx = buildFixture();
+    expect((await verify(fx, { url: 'http://merchant.example.com/ucp/webhooks' })).error_code).toBe(
+      ErrorCodes.HTTP_SIGNATURE_MALFORMED
+    );
+  });
+
+  it('handles mixed-case required header names', async () => {
+    const fx = buildFixture();
+    const headers: Record<string, string> = {
+      'Content-Type': fx.headers['content-type'],
+      'Content-Digest': fx.headers['content-digest'],
+      'UCP-Agent': fx.headers['ucp-agent'],
+      'Idempotency-Key': fx.headers['idempotency-key'],
+    };
+    expect((await verify(fx, { headers })).valid).toBe(true);
+  });
+
+  it('maps a duplicate covered component to a malformed result (not a throw)', async () => {
+    const fx = buildFixture();
+    const dupInput = fx.signature_input.replace('("@method"', '("@method" "@method"');
+    const result = await verify(fx, { signature_input: dupInput });
+    expect(result.valid).toBe(false);
+    expect(result.error_code).toBe(ErrorCodes.HTTP_SIGNATURE_MALFORMED);
+  });
+});
+
+describe('legacy Request-Signature path remains intact (no-fallback)', () => {
+  it('verifyUcpWebhookSignature still verifies a valid detached JWS (RFC 7797)', async () => {
+    const { publicKey, privateKey } = await jose.generateKeyPair('ES256', { extractable: true });
+    const body = new TextEncoder().encode(JSON.stringify({ hello: 'world' }));
+    const jws = await new jose.FlattenedSign(body)
+      .setProtectedHeader({ alg: 'ES256', kid: 'legacy-key', b64: false, crit: ['b64'] })
+      .sign(privateKey);
+    const detached = `${jws.protected}..${jws.signature}`;
+    const jwk = await jose.exportJWK(publicKey);
+    const profile: UcpProfile = {
+      version: '1.0',
+      business_id: 'merchant.example.com',
+      signing_keys: [
+        {
+          kty: 'EC',
+          crv: jwk.crv as UcpSigningKey['crv'],
+          kid: 'legacy-key',
+          x: jwk.x!,
+          y: jwk.y!,
+        },
+      ],
+    };
+
+    const result = await verifyUcpWebhookSignature({
+      signature_header: detached,
+      body_bytes: body,
+      profile_url: 'https://merchant.example.com/.well-known/ucp',
+      profile,
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('the RFC 9421 verifier does not accept a legacy detached JWS in the Signature header', async () => {
+    const fx = buildFixture();
+    const result = await verifyUcpHttpSignature({
+      signature_input: '',
+      signature: 'eyJhbGciOiJFUzI1NiJ9..AbCdEf',
+      method: fx.method,
+      url: fx.url,
+      headers: fx.headers,
+      body_bytes: fx.body_bytes,
+      profile: fx.profile,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error_code).toBe(ErrorCodes.HTTP_SIGNATURE_INPUT_MISSING);
+  });
+});

--- a/packages/mappings/ucp/tsconfig.json
+++ b/packages/mappings/ucp/tsconfig.json
@@ -8,5 +8,9 @@
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "tests"],
-  "references": [{ "path": "../../jwks-cache" }, { "path": "../../kernel" }]
+  "references": [
+    { "path": "../../http-signatures" },
+    { "path": "../../jwks-cache" },
+    { "path": "../../kernel" }
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1667,6 +1667,9 @@ importers:
       '@peac/adapter-core':
         specifier: workspace:*
         version: link:../../adapters/core
+      '@peac/http-signatures':
+        specifier: workspace:*
+        version: link:../../http-signatures
       '@peac/kernel':
         specifier: workspace:*
         version: link:../../kernel


### PR DESCRIPTION
## Summary

Adds an additive request-shaped UCP HTTP Message Signatures verifier for RFC 9421 signed requests and webhooks.

The verifier:
- derives ES256/ES384 from UCP signing keys;
- verifies RFC 9530 Content-Digest over raw body bytes;
- preserves exact `@signature-params` serialization for the UCP path;
- validates required UCP signed components and UCP-Agent profile binding;
- rejects malformed structured-field signature inputs fail-closed;
- keeps the legacy `Request-Signature` / detached-JWS helper exported.

Response signatures using `@status` are out of scope for this PR.

## Scope

- Adds `verifyUcpHttpSignature(...)`.
- Keeps `verifyUcpWebhookSignature(...)` exported and unchanged for the legacy detached-JWS path.
- Reuses `@peac/http-signatures` for shared RFC 9421 parser/base mechanics.
- Adds a workspace dependency edge from `@peac/mappings-ucp` to `@peac/http-signatures`.
- Does not add an external runtime dependency.
- Does not change schema, wire version, registries, receipt types, extension groups, signing envelope, PEAC core API, package versions, release state, or response-signature support.

## Verification

- `pnpm --filter '@peac/http-signatures' test`
- `pnpm --filter '@peac/mappings-ucp' test`
- `pnpm --filter '@peac/mappings-tap' test`
- `pnpm --filter '@peac/worker-core' test`
- `pnpm --filter '@peac/worker-shared' build`
- `pnpm typecheck:core`
- `pnpm conformance:test`
- `pnpm verify:no-widening`
- `pnpm verify:registries-schema`
- `pnpm verify:codegen-drift`
- `pnpm verify:release`
- `pnpm exec tsx scripts/extract-api-contract.ts --check`
- `bash scripts/ci/forbid-strings.sh`
- `git diff --check`
