### PR TITLE
docs(ucp): make HTTP Message Signatures the primary verifier path

### DIFF
--- a/docs/specs/COMMERCE-EVIDENCE.md
+++ b/docs/specs/COMMERCE-EVIDENCE.md
@@ -82,6 +82,7 @@ HTTP `Payment` authentication scheme, aligned with the active Internet-Draft `dr
 - **Approach**: order-vs-payment separation; order state distinct from payment state
 - **Package**: `@peac/mappings-ucp`
 - **Boundary**: `payment_state_source` marker distinguishes `explicit` from `derived_order_fallback`
+- **Signing model**: the current UCP signing model is RFC 9421 HTTP Message Signatures (`Signature-Input` / `Signature`) with an RFC 9530 `Content-Digest` computed over the raw request body bytes (no JSON canonicalization), verified by `verifyUcpHttpSignature`. The algorithm is resolved from the signing key curve (ES256 for P-256, ES384 for P-384); UCP omits `alg` from `Signature-Input`. PEAC observes and binds the UCP signature facts (covered components, `Content-Digest`, `keyid`, and any signed `UCP-Agent` profile); it does not assert UCP conformance or re-sign UCP messages. The earlier `Request-Signature` detached JWS (RFC 7797) path remains available, deprecated, as `verifyUcpWebhookSignature`; the two schemes never silently fall back to each other.
 
 ## Cross-Ecosystem Evidence
 

--- a/examples/ucp-webhook-express/README.md
+++ b/examples/ucp-webhook-express/README.md
@@ -99,4 +99,3 @@ Earlier UCP integrations used a `Request-Signature` detached JWS (RFC 7797). Tha
 - `@peac/mappings-ucp` - UCP to PEAC mapping and signature verification
 - `@peac/crypto` - Demo key generation and JWS receipt signing
 - `@peac/http-signatures` - RFC 9421 signature-base construction (demo signer)
-- `@peac/audit` - Dispute bundle creation (legacy compatibility path)

--- a/examples/ucp-webhook-express/README.md
+++ b/examples/ucp-webhook-express/README.md
@@ -1,12 +1,15 @@
 # UCP Webhook Express Example
 
-This example demonstrates how to receive and process Google Universal Commerce Protocol (UCP) order webhooks using Express.js.
+This example demonstrates how to receive and verify Universal Commerce Protocol (UCP) order webhooks using Express.js, then issue a PEAC receipt for the observed order.
+
+It verifies the current UCP signing model: RFC 9421 HTTP Message Signatures (`Signature-Input` / `Signature`) with an RFC 9530 `Content-Digest` over the raw request body bytes.
 
 ## Features
 
-- Webhook signature verification (raw-first, JCS fallback)
-- UCP order to PEAC receipt mapping
-- Dispute evidence generation for offline verification
+- RFC 9421 HTTP Message Signature verification (`verifyUcpHttpSignature`)
+- RFC 9530 `Content-Digest` binding over the raw request body bytes
+- Signed `UCP-Agent` profile binding (the verifier returns the bound `signer_profile_url`)
+- UCP order to PEAC receipt mapping and signed receipt issuance
 
 ## Quick Start
 
@@ -23,22 +26,27 @@ pnpm run demo
 
 ## How It Works
 
-1. **Webhook Reception**: The server receives POST requests at `/webhooks/ucp/orders` with a `Request-Signature` header containing a detached JWS.
+1. **Webhook Reception**: The server receives POST requests at `/webhooks/ucp/orders` carrying RFC 9421 `Signature-Input` and `Signature` headers, an RFC 9530 `Content-Digest`, and a `UCP-Agent` profile.
 
-2. **Signature Verification**: The `@peac/mappings-ucp` package verifies the signature:
-   - First tries raw request body bytes
-   - Falls back to JCS-canonicalized body if raw fails
-   - Records all verification attempts for debugging
+2. **Signature Verification**: The `@peac/mappings-ucp` package verifies the request with `verifyUcpHttpSignature`:
+   - Resolves the signing key by `keyid` against the supplied `/.well-known/ucp` profile
+   - Derives the algorithm from the key curve (ES256 for P-256, ES384 for P-384); UCP does not put `alg` in `Signature-Input`
+   - Verifies the `Content-Digest` over the raw body bytes (no JSON canonicalization)
+   - Enforces the required signed-component set and, via `expected_profile_url`, binds the signed `UCP-Agent` profile to the expected signer (`SIGNER_PROFILE_URL`)
 
 3. **Receipt Mapping**: UCP order data is mapped to PEAC receipt claims:
    - Amounts in minor units (cents)
    - Extensions use `dev.ucp/*` namespace
    - Order status derived from line item fulfillment
 
-4. **Evidence Creation**: Dispute evidence is created for offline verification:
-   - Full signature header preserved
-   - Both raw and JCS payload hashes stored
-   - Profile snapshot for key rotation scenarios
+4. **Receipt Issuance**: The example verifies the UCP signature, maps the observed order, and issues a PEAC receipt for that observation. It rejects failed signatures before mapping. PEAC does not authenticate, authorize, settle, or execute the order.
+
+The demo also sends a tampered body with the original signature to show that the `Content-Digest` binding rejects it.
+
+## Two URLs in this example
+
+- `PUBLIC_URL` (default `https://platform.example.com`) is the **receiver** endpoint. UCP signs the `@authority` and `@path` derived components over this canonical public request URL, so the demo signs and verifies against it even though the local server listens on `http://localhost`. In production, derive the public URL from your deployment configuration (for example, behind a TLS-terminating proxy), never from caller-controlled `Host` headers.
+- `SIGNER_PROFILE_URL` (default `https://demo.business.example.com/.well-known/ucp`) is the **signer** identity profile carried in the signed `UCP-Agent` header. The server passes it as `expected_profile_url` so the verifier binds the signature to that known signer.
 
 ## API Endpoints
 
@@ -49,7 +57,11 @@ Receives UCP order webhooks.
 **Headers:**
 
 - `Content-Type: application/json`
-- `Request-Signature: <detached-jws>`
+- `Content-Digest: sha-256=:<base64>:`
+- `Idempotency-Key: <key>`
+- `UCP-Agent: profile="https://.../.well-known/ucp"`
+- `Signature-Input: sig1=("@method" "@authority" "@path" "content-digest" "content-type" "idempotency-key" "ucp-agent");keyid="<kid>"`
+- `Signature: sig1=:<base64>:`
 
 **Response (success):**
 
@@ -71,16 +83,20 @@ Health check endpoint.
 
 Mock UCP profile (for demo purposes).
 
+## Legacy compatibility (deprecated)
+
+Earlier UCP integrations used a `Request-Signature` detached JWS (RFC 7797). That path remains available in `@peac/mappings-ucp` as `verifyUcpWebhookSignature` (with the dispute-evidence helper `createUcpDisputeEvidence`) for backward compatibility and is deprecated; new integrations should use `verifyUcpHttpSignature`. There is no silent fallback between the two schemes.
+
 ## Production Considerations
 
 1. **Key Management**: Load signing keys from secure storage (HSM, KMS, etc.)
-2. **Profile Fetching**: Fetch and cache business UCP profiles with TTL
-3. **Evidence Storage**: Persist evidence YAML to database for dispute bundles
-4. **Rate Limiting**: Add rate limiting for webhook endpoints
-5. **Idempotency**: Track processed webhooks to prevent duplicates
+2. **Profile Fetching**: Fetch and cache business UCP profiles with TTL over an SSRF-safe, host-allowlisted path; pass the resolved profile to the verifier (it performs no network I/O)
+3. **Rate Limiting**: Add rate limiting for webhook endpoints
+4. **Idempotency**: Track processed webhooks to prevent duplicates
 
 ## Related Packages
 
-- `@peac/mappings-ucp` - UCP to PEAC mapping
-- `@peac/protocol` - Receipt signing
-- `@peac/audit` - Dispute bundle creation
+- `@peac/mappings-ucp` - UCP to PEAC mapping and signature verification
+- `@peac/crypto` - Demo key generation and JWS receipt signing
+- `@peac/http-signatures` - RFC 9421 signature-base construction (demo signer)
+- `@peac/audit` - Dispute bundle creation (legacy compatibility path)

--- a/examples/ucp-webhook-express/demo.ts
+++ b/examples/ucp-webhook-express/demo.ts
@@ -37,6 +37,7 @@ const UCP_AGENT = `profile="${SIGNER_PROFILE_URL}"`;
 
 // Demo EC keypair (P-256 curve for ES256). In production this is the signer's key,
 // published as a JWK in their /.well-known/ucp profile (public x/y only).
+// Demo-only keypair. Do not reuse this private key outside this example.
 const DEMO_PRIVATE_KEY = crypto.createPrivateKey({
   key: {
     kty: 'EC',

--- a/examples/ucp-webhook-express/demo.ts
+++ b/examples/ucp-webhook-express/demo.ts
@@ -1,60 +1,120 @@
 /**
  * UCP Webhook Demo Script
  *
- * Sends a mock UCP order webhook to the local server.
- * Demonstrates signature verification and receipt issuance.
+ * Sends a mock UCP order webhook to the local server, signed with the current UCP
+ * signing model: an RFC 9421 HTTP Message Signature (`Signature-Input` /
+ * `Signature`) plus an RFC 9530 `Content-Digest` over the raw body bytes.
+ * Demonstrates signature verification and receipt issuance, then a tamper case.
  *
  * Prerequisites:
  * 1. Start the server: pnpm start
  * 2. Run this demo: pnpm demo
+ *
+ * The signature base is built with `@peac/http-signatures` (the same RFC 9421
+ * mechanics the verifier uses), so the signer and verifier cannot drift. PEAC
+ * verifies the result with `verifyUcpHttpSignature`.
  */
 
 import * as crypto from 'node:crypto';
+import {
+  buildSignatureBase,
+  signatureBaseToBytes,
+  type ParsedSignatureParams,
+  type SignatureRequest,
+} from '@peac/http-signatures';
 
-// Server configuration
+// Transport address of the local server (HTTP). The signature is computed over
+// the canonical PUBLIC_URL below, matching what the server verifies against.
 const SERVER_URL = process.env.SERVER_URL || 'http://localhost:3000';
+const PUBLIC_URL = process.env.PUBLIC_URL || 'https://platform.example.com';
+const WEBHOOK_PATH = '/webhooks/ucp/orders';
 
-// Demo EC keypair (P-256 curve for ES256)
-// In production, this would be the business's signing key
+const KID = 'demo-key-001';
+const IDEMPOTENCY_KEY = 'demo-idem-001';
+// Signer identity profile, bound by the verifier via expected_profile_url.
+const SIGNER_PROFILE_URL = 'https://demo.business.example.com/.well-known/ucp';
+const UCP_AGENT = `profile="${SIGNER_PROFILE_URL}"`;
+
+// Demo EC keypair (P-256 curve for ES256). In production this is the signer's key,
+// published as a JWK in their /.well-known/ucp profile (public x/y only).
 const DEMO_PRIVATE_KEY = crypto.createPrivateKey({
   key: {
     kty: 'EC',
     crv: 'P-256',
-    x: 'WbbYvAT6hxoZn-zSA7h3JXQlTFGPMCx2MxZ2SjCNrYo',
-    y: 'JWYUg4z0JJyIOl2lKN3JCB6HWBGtS-31X7WQWFZ7OTI',
-    d: 'uFZ3pQlcyf4oCK2I9qZm9r3vJ9hCfTX2_F3yVl5QYQI',
+    x: '1r5jSqODThl8JfPN0o7y6T24x3GsQvv30byrvCGR-Bs',
+    y: 'tnZaWtpX8uUi511v2QFFLY8rzSPhFqGKyd-tOvJoM4k',
+    d: 'QdOJRxCr_fsTKG2fno__oWWOIuXQnFyPMz4XiHoYMUw',
   },
   format: 'jwk',
 });
 
+// Covered components for a UCP request POST with a body. Order is significant: it
+// is the order serialized into Signature-Input and reflected in the signature base.
+const COVERED_COMPONENTS = [
+  '@method',
+  '@authority',
+  '@path',
+  'content-digest',
+  'content-type',
+  'idempotency-key',
+  'ucp-agent',
+] as const;
+
 /**
- * Create a detached JWS signature for UCP webhook
+ * Compute an RFC 9530 Content-Digest header value over raw bytes (sha-256).
  */
-function signDetachedJws(payload: Buffer, kid: string): string {
-  // Create protected header
-  const header = {
-    alg: 'ES256',
-    kid,
+function contentDigest(body: Buffer): string {
+  const digest = crypto.createHash('sha256').update(body).digest('base64');
+  return `sha-256=:${digest}:`;
+}
+
+/**
+ * Sign a UCP request with an RFC 9421 HTTP Message Signature. Returns the headers
+ * to send alongside the body: Signature-Input, Signature, and Content-Digest.
+ *
+ * The signature base is built with `@peac/http-signatures` buildSignatureBase
+ * (preferSerializedParams), the exact mechanics the verifier uses, so the signed
+ * value cannot drift from what is verified. UCP omits `alg`/`created`.
+ */
+function signUcpRequest(body: Buffer): Record<string, string> {
+  const digest = contentDigest(body);
+  const request: SignatureRequest = {
+    method: 'POST',
+    url: `${PUBLIC_URL}${WEBHOOK_PATH}`,
+    headers: {
+      'content-digest': digest,
+      'content-type': 'application/json',
+      'idempotency-key': IDEMPOTENCY_KEY,
+      'ucp-agent': UCP_AGENT,
+    },
   };
 
-  const headerB64 = Buffer.from(JSON.stringify(header)).toString('base64url');
-  const payloadB64 = payload.toString('base64url');
+  // Serialized Signature-Input value (inner list + parameters; UCP omits alg/created).
+  const innerList = COVERED_COMPONENTS.map((c) => `"${c}"`).join(' ');
+  const signatureParamsValue = `(${innerList});keyid="${KID}"`;
 
-  // Create signing input
-  const signingInput = `${headerB64}.${payloadB64}`;
+  const params: ParsedSignatureParams = {
+    keyid: KID,
+    coveredComponents: [...COVERED_COMPONENTS],
+    signatureParamsValue,
+  };
 
-  // Sign with ES256
-  // IMPORTANT: Use 'ieee-p1363' dsaEncoding for JWS-compatible signatures
-  // Default is 'der' which produces DER-encoded signatures, but JWS ES256/384/512
-  // requires raw R||S concatenation (IEEE P1363 format)
-  const signature = crypto.sign('sha256', Buffer.from(signingInput), {
+  const base = buildSignatureBase(request, params, { preferSerializedParams: true });
+
+  // ES256 raw (r||s, IEEE P1363) signature, base64 byte-sequence per RFC 8941.
+  const signatureBytes = crypto.sign('sha256', signatureBaseToBytes(base), {
     key: DEMO_PRIVATE_KEY,
     dsaEncoding: 'ieee-p1363',
   });
-  const signatureB64 = signature.toString('base64url');
 
-  // Return detached JWS (empty payload section)
-  return `${headerB64}..${signatureB64}`;
+  return {
+    'Content-Type': 'application/json',
+    'Content-Digest': digest,
+    'Idempotency-Key': IDEMPOTENCY_KEY,
+    'UCP-Agent': UCP_AGENT,
+    'Signature-Input': `sig1=${signatureParamsValue}`,
+    Signature: `sig1=:${signatureBytes.toString('base64')}:`,
+  };
 }
 
 /**
@@ -128,24 +188,22 @@ async function main() {
   );
   console.log('');
 
-  // Sign the payload
-  console.log('2. Signing payload with ES256 (detached JWS)');
-  const signature = signDetachedJws(payloadBytes, 'demo-key-001');
-  console.log('   Request-Signature:', signature.substring(0, 50) + '...');
+  // Sign the payload (RFC 9421 HTTP Message Signature + RFC 9530 Content-Digest)
+  console.log('2. Signing request with ES256 (RFC 9421 HTTP Message Signature)');
+  const signedHeaders = signUcpRequest(payloadBytes);
+  console.log('   Content-Digest:', signedHeaders['Content-Digest']);
+  console.log('   Signature-Input:', signedHeaders['Signature-Input']);
   console.log('');
 
   // Send webhook
-  console.log('3. Sending webhook to server');
-  console.log('   URL:', `${SERVER_URL}/webhooks/ucp/orders`);
+  console.log('3. Sending signed webhook to server');
+  console.log('   URL:', `${SERVER_URL}${WEBHOOK_PATH}`);
   console.log('');
 
   try {
-    const response = await fetch(`${SERVER_URL}/webhooks/ucp/orders`, {
+    const response = await fetch(`${SERVER_URL}${WEBHOOK_PATH}`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Request-Signature': signature,
-      },
+      headers: signedHeaders,
       body: payloadJson,
     });
 
@@ -157,7 +215,7 @@ async function main() {
     console.log('');
 
     if (response.ok) {
-      console.log('SUCCESS: Webhook processed and PEAC receipt issued');
+      console.log('SUCCESS: Webhook verified and PEAC receipt issued');
       console.log('');
       console.log('Receipt details:');
       console.log('  ID:', result.receipt_id);
@@ -167,12 +225,39 @@ async function main() {
       console.log('ERROR: Webhook processing failed');
       console.log('  Code:', result.error);
       console.log('  Message:', result.message);
+      return;
     }
   } catch (error) {
     console.error('ERROR: Failed to send webhook');
     console.error(error);
     console.log('');
     console.log('Make sure the server is running: pnpm start');
+    return;
+  }
+
+  // Tamper case: reuse the valid signature/digest but mutate the body. The
+  // Content-Digest no longer matches the raw bytes, so the server rejects it.
+  console.log('');
+  console.log('5. Tamper check: resending with a mutated body and the same signature');
+  const tamperedPayload = payloadJson.replace('order_demo_12345', 'order_TAMPERED');
+  try {
+    const signedHeaders = signUcpRequest(payloadBytes); // signature/digest of the ORIGINAL body
+    const response = await fetch(`${SERVER_URL}${WEBHOOK_PATH}`, {
+      method: 'POST',
+      headers: signedHeaders,
+      body: tamperedPayload,
+    });
+    const result = await response.json();
+    console.log('   Status:', response.status);
+    console.log('   Code:', result.error);
+    if (!response.ok) {
+      console.log('EXPECTED: tampered body rejected (Content-Digest binds the raw bytes)');
+    } else {
+      console.log('UNEXPECTED: tampered body was accepted');
+    }
+  } catch (error) {
+    console.error('ERROR: Failed to send tamper request');
+    console.error(error);
   }
 }
 

--- a/examples/ucp-webhook-express/package.json
+++ b/examples/ucp-webhook-express/package.json
@@ -11,11 +11,11 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@peac/audit": "workspace:*",
     "@peac/crypto": "workspace:*",
     "@peac/http-signatures": "workspace:*",
     "@peac/mappings-ucp": "workspace:*",
-    "express": "^4.22.1"
+    "express": "^4.22.1",
+    "express-rate-limit": "^8.2.2"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/examples/ucp-webhook-express/package.json
+++ b/examples/ucp-webhook-express/package.json
@@ -2,7 +2,7 @@
   "name": "@peac/example-ucp-webhook-express",
   "version": "0.0.0",
   "private": true,
-  "description": "PEAC UCP webhook example - verify signatures, issue receipts, create dispute evidence",
+  "description": "PEAC UCP webhook example - verify HTTP Message Signatures and issue receipts",
   "type": "module",
   "scripts": {
     "start": "tsx server.ts",
@@ -13,6 +13,7 @@
   "dependencies": {
     "@peac/audit": "workspace:*",
     "@peac/crypto": "workspace:*",
+    "@peac/http-signatures": "workspace:*",
     "@peac/mappings-ucp": "workspace:*",
     "express": "^4.22.1"
   },

--- a/examples/ucp-webhook-express/server.ts
+++ b/examples/ucp-webhook-express/server.ts
@@ -20,7 +20,8 @@
  */
 
 import express from 'express';
-import type { Request, Response } from 'express';
+import type { Request, RequestHandler, Response } from 'express';
+import { rateLimit } from 'express-rate-limit';
 import { verifyUcpHttpSignature, mapUcpOrderToReceipt, ErrorHttpStatus } from '@peac/mappings-ucp';
 import type { UcpOrder, UcpProfile } from '@peac/mappings-ucp';
 import { generateKeypair, sign } from '@peac/crypto';
@@ -96,6 +97,17 @@ const MOCK_PROFILE: UcpProfile = {
 
 const app = express();
 
+// Rate limiter for the webhook endpoint. The handler verifies signatures and
+// issues receipts, so cap requests per client to blunt brute-force and abuse.
+// Cast bridges a types-only skew: express-rate-limit v8 ships Express 5 core
+// types, while this example pins Express 4; the middleware is runtime-compatible.
+const webhookLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  limit: 100, // per IP per window
+  standardHeaders: 'draft-7', // RateLimit-* response headers
+  legacyHeaders: false,
+}) as unknown as RequestHandler;
+
 // Raw body parser for webhook signature verification
 app.use('/webhooks', express.raw({ type: 'application/json' }));
 
@@ -137,7 +149,7 @@ function firstHeader(value: string | string[] | undefined): string | undefined {
  * current UCP signing model (RFC 9421 HTTP Message Signatures), then issues a
  * PEAC receipt for the observed order.
  */
-app.post(WEBHOOK_PATH, async (req: Request, res: Response) => {
+app.post(WEBHOOK_PATH, webhookLimiter, async (req: Request, res: Response) => {
   // Convert body to Buffer using helper (breaks taint tracking)
   const bodyBytes = toBuffer(req.body);
   if (bodyBytes === null) {

--- a/examples/ucp-webhook-express/server.ts
+++ b/examples/ucp-webhook-express/server.ts
@@ -3,20 +3,25 @@
  *
  * This example demonstrates:
  * 1. Receiving UCP order webhooks
- * 2. Verifying webhook signatures (raw-first, JCS fallback)
+ * 2. Verifying the current UCP signing model: RFC 9421 HTTP Message Signatures
+ *    (`Signature-Input` / `Signature`) with an RFC 9530 `Content-Digest` over the
+ *    raw request body bytes
  * 3. Mapping UCP orders to PEAC receipts
- * 4. Creating dispute evidence for offline verification
+ * 4. Issuing a signed PEAC receipt for the observed order
+ *
+ * PEAC can record and bind the facts of UCP signature verification. This example
+ * rejects failed or absent UCP signatures before mapping the order; it does not
+ * authenticate, authorize, settle, or execute the order.
+ *
+ * The earlier `Request-Signature` detached JWS (RFC 7797) scheme is deprecated;
+ * see the "Legacy compatibility" section of the README for `verifyUcpWebhookSignature`.
  *
  * Run with: pnpm start
  */
 
 import express from 'express';
 import type { Request, Response } from 'express';
-import {
-  mapUcpOrderToReceipt,
-  createUcpDisputeEvidence,
-  ErrorHttpStatus,
-} from '@peac/mappings-ucp';
+import { verifyUcpHttpSignature, mapUcpOrderToReceipt, ErrorHttpStatus } from '@peac/mappings-ucp';
 import type { UcpOrder, UcpProfile } from '@peac/mappings-ucp';
 import { generateKeypair, sign } from '@peac/crypto';
 
@@ -50,10 +55,30 @@ const PORT = process.env.PORT || 3000;
 const ISSUER = process.env.ISSUER || 'https://platform.example.com';
 const CURRENCY = process.env.CURRENCY || 'USD';
 
+/**
+ * Canonical public HTTPS URL this endpoint is reachable at. UCP signs the
+ * `@authority` / `@path` derived components over the canonical request URL, so
+ * verification MUST use that URL, not the raw socket address. In this local demo
+ * the server listens on http://localhost but is addressed as PUBLIC_URL; behind a
+ * TLS-terminating proxy in production you would derive the public URL from your
+ * deployment configuration (never from caller-controlled Host headers).
+ */
+const PUBLIC_URL = process.env.PUBLIC_URL || 'https://platform.example.com';
+const WEBHOOK_PATH = '/webhooks/ucp/orders';
+
+/**
+ * Expected signer identity profile. This is the signer's `/.well-known/ucp`
+ * profile URL (distinct from PUBLIC_URL, which is the receiver endpoint). When
+ * passed as `expected_profile_url`, the verifier requires a signed `UCP-Agent`
+ * whose profile equals this value, binding the signature to a known signer.
+ */
+const SIGNER_PROFILE_URL = 'https://demo.business.example.com/.well-known/ucp';
+
 // In production, load from secure storage
 let signingKeypair: { privateKey: Uint8Array; publicKey: Uint8Array } | undefined;
 
-// Mock UCP profile for demo (in production, this is fetched from /.well-known/ucp)
+// Mock UCP profile for demo (in production, this is fetched from /.well-known/ucp
+// over an SSRF-safe, host-allowlisted path and passed to the verifier).
 const MOCK_PROFILE: UcpProfile = {
   version: '2026-01-11',
   business_id: 'demo_business',
@@ -62,8 +87,8 @@ const MOCK_PROFILE: UcpProfile = {
       kty: 'EC',
       crv: 'P-256',
       kid: 'demo-key-001',
-      x: 'WbbYvAT6hxoZn-zSA7h3JXQlTFGPMCx2MxZ2SjCNrYo',
-      y: 'JWYUg4z0JJyIOl2lKN3JCB6HWBGtS-31X7WQWFZ7OTI',
+      x: '1r5jSqODThl8JfPN0o7y6T24x3GsQvv30byrvCGR-Bs',
+      y: 'tnZaWtpX8uUi511v2QFFLY8rzSPhFqGKyd-tOvJoM4k',
       alg: 'ES256',
     },
   ],
@@ -96,23 +121,23 @@ function toBuffer(body: unknown): Buffer | null {
 }
 
 /**
+ * Read the first value of a possibly-repeated header.
+ */
+function firstHeader(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return value;
+}
+
+/**
  * UCP Order Webhook Endpoint
  *
- * Receives order events from UCP-compliant businesses.
- * Verifies the signature and issues a PEAC receipt.
+ * Receives order events from UCP-compliant businesses and verifies them with the
+ * current UCP signing model (RFC 9421 HTTP Message Signatures), then issues a
+ * PEAC receipt for the observed order.
  */
-app.post('/webhooks/ucp/orders', async (req: Request, res: Response) => {
-  // Handle header that may be string or array (if sent multiple times)
-  const rawSignatureHeader = req.headers['request-signature'];
-  let signatureHeader: string | undefined;
-  if (Array.isArray(rawSignatureHeader)) {
-    signatureHeader = rawSignatureHeader[0];
-  } else if (typeof rawSignatureHeader === 'string') {
-    signatureHeader = rawSignatureHeader;
-  } else {
-    signatureHeader = undefined;
-  }
-
+app.post(WEBHOOK_PATH, async (req: Request, res: Response) => {
   // Convert body to Buffer using helper (breaks taint tracking)
   const bodyBytes = toBuffer(req.body);
   if (bodyBytes === null) {
@@ -122,61 +147,69 @@ app.post('/webhooks/ucp/orders', async (req: Request, res: Response) => {
     });
   }
 
-  // Safely get content length for logging
-  const contentLength = bodyBytes.byteLength;
-
   console.log('Received UCP webhook');
-  console.log('  Content-Length:', sanitizeForLog(contentLength));
-  console.log('  Request-Signature:', signatureHeader ? 'present' : 'missing');
+  console.log('  Content-Length:', sanitizeForLog(bodyBytes.byteLength));
+  console.log(
+    '  Signature-Input:',
+    firstHeader(req.headers['signature-input']) ? 'present' : 'missing'
+  );
 
-  // Check for signature header
-  if (!signatureHeader) {
-    console.log('  Error: Missing Request-Signature header');
-    return res.status(400).json({
-      error: 'E_UCP_SIGNATURE_MISSING',
-      message: 'Request-Signature header is required',
-    });
+  // Collect the signed request components the verifier needs (case-insensitive).
+  const headers: Record<string, string> = {};
+  for (const name of ['content-type', 'content-digest', 'idempotency-key', 'ucp-agent']) {
+    const value = firstHeader(req.headers[name]);
+    if (value !== undefined) {
+      headers[name] = value;
+    }
   }
 
-  const receivedAt = new Date().toISOString();
-  const profileFetchedAt = receivedAt; // In production, track actual fetch time
-
   try {
-    // Create dispute evidence (includes signature verification)
-    const evidence = await createUcpDisputeEvidence({
-      signature_header: signatureHeader,
-      body_bytes: new Uint8Array(bodyBytes),
+    // Verify the RFC 9421 signature. The profile is supplied here (no network
+    // I/O happens inside the verifier); `url` is the canonical public URL the
+    // signer signed over, not the raw socket address.
+    const result = await verifyUcpHttpSignature({
+      signature_input: firstHeader(req.headers['signature-input']) ?? '',
+      signature: firstHeader(req.headers['signature']) ?? '',
       method: 'POST',
-      path: '/webhooks/ucp/orders',
-      received_at: receivedAt,
-      profile_url: 'https://demo.business.example.com/.well-known/ucp',
-      profile_fetched_at: profileFetchedAt,
-      profile: MOCK_PROFILE, // In production, fetch from profile_url
+      url: `${PUBLIC_URL}${WEBHOOK_PATH}`,
+      headers,
+      body_bytes: new Uint8Array(bodyBytes),
+      profile: MOCK_PROFILE, // In production, resolve from the signer's /.well-known/ucp
+      expected_profile_url: SIGNER_PROFILE_URL, // bind the signed UCP-Agent to a known signer
     });
 
-    console.log('  Signature verification:', evidence.signature_valid ? 'PASSED' : 'FAILED');
-    console.log('  Verification mode:', evidence.verification.mode_used || 'none');
+    console.log('  Signature verification:', result.valid ? 'PASSED' : 'FAILED');
 
-    if (!evidence.signature_valid) {
-      console.log('  Error:', evidence.verification.error_code);
-      console.log('  Attempts:', evidence.verification.attempts);
+    if (!result.valid) {
+      console.log('  Error:', result.error_code);
 
-      const httpStatus = evidence.verification.error_code
-        ? ErrorHttpStatus[evidence.verification.error_code as keyof typeof ErrorHttpStatus] || 401
+      const httpStatus = result.error_code
+        ? ErrorHttpStatus[result.error_code as keyof typeof ErrorHttpStatus] || 401
         : 401;
 
       return res.status(httpStatus).json({
-        error: evidence.verification.error_code,
-        message: evidence.verification.error_message,
-        attempts: evidence.verification.attempts,
+        error: result.error_code,
+        message: result.error_message,
       });
     }
 
-    // Parse the webhook payload
-    const payload = JSON.parse(bodyBytes.toString()) as {
-      event_type: string;
-      order: UcpOrder;
-    };
+    console.log('  Algorithm:', result.alg);
+    console.log('  Content-Digest verified:', result.content_digest_verified ? 'yes' : 'n/a');
+    if (result.signer_profile_url) {
+      console.log('  Signer profile:', sanitizeForLog(result.signer_profile_url));
+    }
+
+    // Parse the webhook payload. The body is signature- and digest-verified at
+    // this point, so a parse failure means malformed JSON (client error -> 400).
+    let payload: { event_type: string; order: UcpOrder };
+    try {
+      payload = JSON.parse(bodyBytes.toString());
+    } catch {
+      return res.status(400).json({
+        error: 'E_UCP_PAYLOAD_NOT_JSON',
+        message: 'Request body is not valid JSON',
+      });
+    }
 
     console.log('  Event type:', sanitizeForLog(payload.event_type));
     console.log('  Order ID:', sanitizeForLog(payload.order.id));
@@ -187,7 +220,7 @@ app.post('/webhooks/ucp/orders', async (req: Request, res: Response) => {
       issuer: ISSUER,
       subject: `buyer:${payload.order.checkout_id || 'unknown'}`,
       currency: CURRENCY,
-      issued_at: receivedAt,
+      issued_at: new Date().toISOString(),
     });
 
     console.log('  Receipt claims mapped');
@@ -207,10 +240,6 @@ app.post('/webhooks/ucp/orders', async (req: Request, res: Response) => {
 
     console.log('  Receipt issued:', claims.jti);
 
-    // Store evidence for potential disputes (in production, persist to database)
-    console.log('  Evidence YAML stored for dispute bundle');
-    // evidence.evidence_yaml can be passed to createDisputeBundle()
-
     // Respond with receipt info
     res.status(200).json({
       status: 'processed',
@@ -220,7 +249,10 @@ app.post('/webhooks/ucp/orders', async (req: Request, res: Response) => {
       order_id: payload.order.id,
     });
   } catch (error) {
-    console.error('  Error processing webhook:', error);
+    console.error(
+      '  Error processing webhook:',
+      sanitizeForLog(error instanceof Error ? error.message : 'unknown error')
+    );
     res.status(500).json({
       error: 'E_INTERNAL',
       message: 'Failed to process webhook',
@@ -247,7 +279,7 @@ app.listen(PORT, () => {
   console.log(`UCP Webhook Example Server running on port ${PORT}`);
   console.log('');
   console.log('Endpoints:');
-  console.log(`  POST http://localhost:${PORT}/webhooks/ucp/orders - Receive UCP order webhooks`);
+  console.log(`  POST http://localhost:${PORT}${WEBHOOK_PATH} - Receive UCP order webhooks`);
   console.log(`  GET  http://localhost:${PORT}/health - Health check`);
   console.log(`  GET  http://localhost:${PORT}/.well-known/ucp - Mock UCP profile`);
   console.log('');

--- a/packages/http-signatures/src/parser.ts
+++ b/packages/http-signatures/src/parser.ts
@@ -349,9 +349,15 @@ function parseInnerList(content: string): string[] {
 /**
  * Parse parameters from ;key=value;key2=value2 format.
  */
+
+// The closed set of RFC 9421 signature parameters consumed by callers. Only these
+// names are stored, so a caller-controlled parameter name from the header is never
+// written to an arbitrary (or prototype-polluting) property. Unknown parameters are
+// ignored, which is already how the consumer treats them.
+const ALLOWED_PARAMS = new Set(['keyid', 'alg', 'created', 'expires', 'nonce', 'tag']);
+
 function parseParameters(paramsString: string): Record<string, string | number> {
-  // Null-prototype map so a caller-controlled parameter name can never reach
-  // Object.prototype, defense in depth alongside the explicit key guard below.
+  // Null-prototype map, defense in depth alongside the allowlist guard below.
   const params: Record<string, string | number> = Object.create(null);
 
   // Split by semicolon
@@ -361,11 +367,9 @@ function parseParameters(paramsString: string): Record<string, string | number> 
     const [key, value] = splitKeyValue(part.trim());
     if (!key) continue;
 
-    // Never write a prototype-polluting property name from caller-controlled
-    // header input. Legitimate RFC 9421 parameters (created, expires, nonce,
-    // keyid, alg, tag) are never these, so skipping them changes nothing for
-    // valid input and is the only consumer-visible effect.
-    if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
+    // Only store known RFC 9421 parameters; the write target is constrained to a
+    // constant allowlist rather than caller-controlled input.
+    if (!ALLOWED_PARAMS.has(key)) continue;
 
     // Parse value - could be integer, string, or token
     if (!value) {

--- a/packages/http-signatures/src/parser.ts
+++ b/packages/http-signatures/src/parser.ts
@@ -350,7 +350,9 @@ function parseInnerList(content: string): string[] {
  * Parse parameters from ;key=value;key2=value2 format.
  */
 function parseParameters(paramsString: string): Record<string, string | number> {
-  const params: Record<string, string | number> = {};
+  // Null-prototype map so a caller-controlled parameter name can never reach
+  // Object.prototype, defense in depth alongside the explicit key guard below.
+  const params: Record<string, string | number> = Object.create(null);
 
   // Split by semicolon
   const parts = paramsString.split(';').filter((p) => p.trim());
@@ -358,6 +360,12 @@ function parseParameters(paramsString: string): Record<string, string | number> 
   for (const part of parts) {
     const [key, value] = splitKeyValue(part.trim());
     if (!key) continue;
+
+    // Never write a prototype-polluting property name from caller-controlled
+    // header input. Legitimate RFC 9421 parameters (created, expires, nonce,
+    // keyid, alg, tag) are never these, so skipping them changes nothing for
+    // valid input and is the only consumer-visible effect.
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
 
     // Parse value - could be integer, string, or token
     if (!value) {

--- a/packages/mappings/ucp/README.md
+++ b/packages/mappings/ucp/README.md
@@ -10,7 +10,7 @@ pnpm add @peac/mappings-ucp
 
 ## What It Does
 
-`@peac/mappings-ucp` maps UCP order data to PEAC receipt claims, verifies UCP webhook signatures using detached JWS (RFC 7797), and generates structured dispute evidence bundles. Order state is kept distinct from payment state: the `payment_state_source` field marks whether payment status was explicitly provided or derived from order fulfillment, so downstream consumers can distinguish observed payment evidence from inferred status.
+`@peac/mappings-ucp` maps UCP order data to PEAC receipt claims, verifies UCP request and webhook signatures, and generates structured dispute evidence bundles. The current UCP signing model is RFC 9421 HTTP Message Signatures (`Signature-Input` / `Signature` with an RFC 9530 `Content-Digest` over the raw body bytes), verified by `verifyUcpHttpSignature`. The earlier `Request-Signature` detached JWS (RFC 7797) path remains available for backward compatibility, deprecated, via `verifyUcpWebhookSignature`; the two schemes never silently fall back to each other. Order state is kept distinct from payment state: the `payment_state_source` field marks whether payment status was explicitly provided or derived from order fulfillment, so downstream consumers can distinguish observed payment evidence from inferred status.
 
 ## How Do I Use It?
 
@@ -18,6 +18,7 @@ pnpm add @peac/mappings-ucp
 
 ```typescript
 import { mapUcpOrderToReceipt } from '@peac/mappings-ucp';
+import { sign } from '@peac/crypto';
 
 const claims = mapUcpOrderToReceipt({
   order: ucpOrder,
@@ -26,15 +27,64 @@ const claims = mapUcpOrderToReceipt({
   currency: 'USD',
 });
 
-// Sign with @peac/protocol
-const receipt = await issue(claims, privateKey, kid);
+// Sign the mapped claims into a JWS receipt (Ed25519 private key + kid)
+const receiptJws = await sign(claims, privateKey, kid);
 ```
 
-### Verify a UCP webhook signature
+### Verify a UCP request or webhook signature (RFC 9421)
+
+`verifyUcpHttpSignature` is the current signing model. It verifies the RFC 9421
+`Signature-Input` / `Signature` and, when a body is present, an RFC 9530
+`Content-Digest` over the raw request body bytes. The algorithm (ES256 for P-256,
+ES384 for P-384) is resolved from the signing key's curve; UCP does not put `alg`
+in `Signature-Input`. The UCP party profile is resolved by the caller (SSRF-safe,
+host-allowlisted) and passed in; this function performs no network I/O.
+
+The verifier parses a signed `UCP-Agent` header and returns its profile as
+`signer_profile_url`. When you supply `expected_profile_url`, it also binds that
+signed profile to the expected signer: the `UCP-Agent` component MUST be signed
+and its profile MUST equal the expected URL, or verification fails. An unsigned
+component is never trusted.
+
+```typescript
+import { verifyUcpHttpSignature } from '@peac/mappings-ucp';
+
+const result = await verifyUcpHttpSignature({
+  signature_input: req.headers['signature-input'],
+  signature: req.headers['signature'],
+  method: 'POST',
+  url: 'https://platform.example.com/webhooks/ucp/orders',
+  headers: {
+    'content-type': req.headers['content-type'],
+    'content-digest': req.headers['content-digest'],
+    'idempotency-key': req.headers['idempotency-key'],
+    'ucp-agent': req.headers['ucp-agent'],
+  },
+  body_bytes: rawBody,
+  profile: ucpProfile, // the /.well-known/ucp document, resolved by the caller
+  expected_profile_url: 'https://business.example.com/.well-known/ucp', // bind the signer
+});
+
+if (result.valid) {
+  // Signature verified and Content-Digest bound the raw body; proceed with mapping.
+  // result.signer_profile_url is the bound UCP-Agent profile.
+}
+```
+
+This verifier covers request-shaped UCP signatures; UCP response signatures use
+`@status` and are a separate component model, out of scope here.
+
+### Legacy: verify a Request-Signature detached JWS (deprecated)
+
+Earlier UCP integrations used a `Request-Signature` detached JWS (RFC 7797). That
+path remains exported as `verifyUcpWebhookSignature` for backward compatibility
+and is deprecated; new integrations should use `verifyUcpHttpSignature`. There is
+no silent fallback between the two schemes: the caller selects one explicitly.
 
 ```typescript
 import { verifyUcpWebhookSignature } from '@peac/mappings-ucp';
 
+// Deprecated: legacy Request-Signature / RFC 7797 path.
 const result = await verifyUcpWebhookSignature({
   signature_header: req.headers['request-signature'],
   body_bytes: rawBody,
@@ -85,14 +135,14 @@ const extracted = adapter.extract(webhookPayload);
 
 - `@peac/kernel` (Layer 0): Evidence carrier types and constants
 - `@peac/schema` (Layer 1): Receipt schemas and carrier validation
-- `@peac/protocol` (Layer 3): Sign mapped claims into receipts with `issue()`
+- `@peac/crypto` (Layer 2): Sign mapped receipt claims into JWS receipts with `sign()`
 
 ## For Agent Developers
 
 If you are building an AI agent that interacts with UCP-based commerce platforms:
 
 - Use `mapUcpOrderToReceipt()` to produce signed evidence of order observations
-- Use `verifyUcpWebhookSignature()` to validate incoming webhook authenticity before mapping
+- Use `verifyUcpHttpSignature()` to verify the RFC 9421 signature on incoming UCP requests and webhooks before mapping (the legacy `verifyUcpWebhookSignature()` covers the deprecated `Request-Signature` path)
 - Order status reflects fulfillment state; payment status requires explicit `payment_state` when the upstream source provides it
 - See the [llms.txt](https://github.com/peacprotocol/peac/blob/main/llms.txt) for a concise protocol overview
 

--- a/packages/mappings/ucp/package.json
+++ b/packages/mappings/ucp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@peac/mappings-ucp",
   "version": "0.15.1",
-  "description": "Google Universal Commerce Protocol (UCP) mapping to PEAC receipts and dispute evidence",
+  "description": "Universal Commerce Protocol (UCP) mapping to PEAC receipts and dispute evidence",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/mappings/ucp/src/bundle.ts
+++ b/packages/mappings/ucp/src/bundle.ts
@@ -6,6 +6,11 @@
  *
  * Evidence is stored in policy/policy.yaml with a hardened schema
  * that cannot be misinterpreted as executable policy.
+ *
+ * Note: these helpers verify the legacy `Request-Signature` detached JWS
+ * (RFC 7797) path via `verifyUcpWebhookSignature`. The current UCP signing model
+ * is RFC 9421 HTTP Message Signatures (`verifyUcpHttpSignature`); a request-shaped
+ * dispute-evidence helper for that path is not yet provided here.
  */
 
 import type {

--- a/packages/mappings/ucp/src/index.ts
+++ b/packages/mappings/ucp/src/index.ts
@@ -18,17 +18,26 @@
  *
  * @example
  * ```ts
- * import {
- *   verifyUcpWebhookSignature,
- *   mapUcpOrderToReceipt,
- *   createUcpDisputeEvidence,
- * } from '@peac/mappings-ucp';
+ * import { verifyUcpHttpSignature, mapUcpOrderToReceipt } from '@peac/mappings-ucp';
+ * import { sign } from '@peac/crypto';
  *
- * // Verify webhook signature
- * const result = await verifyUcpWebhookSignature({
- *   signature_header: req.headers['request-signature'],
+ * // Verify the current UCP signing model (RFC 9421 HTTP Message Signature).
+ * // The /.well-known/ucp profile is resolved by the caller (SSRF-safe) and
+ * // passed in; this function performs no network I/O.
+ * const result = await verifyUcpHttpSignature({
+ *   signature_input: req.headers['signature-input'],
+ *   signature: req.headers['signature'],
+ *   method: 'POST',
+ *   url: 'https://platform.example.com/webhooks/ucp/orders',
+ *   headers: {
+ *     'content-type': req.headers['content-type'],
+ *     'content-digest': req.headers['content-digest'],
+ *     'idempotency-key': req.headers['idempotency-key'],
+ *     'ucp-agent': req.headers['ucp-agent'],
+ *   },
  *   body_bytes: rawBody,
- *   profile_url: 'https://business.example.com/.well-known/ucp',
+ *   profile: ucpProfile,
+ *   expected_profile_url: 'https://business.example.com/.well-known/ucp', // bind the signer
  * });
  *
  * if (result.valid) {
@@ -40,8 +49,8 @@
  *     currency: 'USD',
  *   });
  *
- *   // Sign with @peac/protocol
- *   const receipt = await issue(claims, privateKey, kid);
+ *   // Sign the mapped claims into a JWS receipt
+ *   const receiptJws = await sign(claims, privateKey, kid);
  * }
  * ```
  */

--- a/packages/mappings/ucp/src/mapper.ts
+++ b/packages/mappings/ucp/src/mapper.ts
@@ -117,6 +117,8 @@ function paymentStateToStatus(state: UcpPaymentState): 'completed' | 'pending' {
  *
  * @example
  * ```ts
+ * import { sign } from '@peac/crypto';
+ *
  * const claims = mapUcpOrderToReceipt({
  *   order: ucpOrder,
  *   issuer: 'https://merchant.example.com',
@@ -124,8 +126,8 @@ function paymentStateToStatus(state: UcpPaymentState): 'completed' | 'pending' {
  *   currency: 'USD',
  * });
  *
- * // Sign with @peac/protocol
- * const receipt = await issue(claims, privateKey, kid);
+ * // Sign the mapped claims into a JWS receipt (Ed25519 private key + kid)
+ * const receiptJws = await sign(claims, privateKey, kid);
  * ```
  */
 export function mapUcpOrderToReceipt(options: MapUcpOrderOptions): MappedReceiptClaims {

--- a/packages/mappings/ucp/src/types.ts
+++ b/packages/mappings/ucp/src/types.ts
@@ -1,8 +1,15 @@
 /**
  * @peac/mappings-ucp - Type definitions
  *
- * Google Universal Commerce Protocol (UCP) types and evidence schema.
- * UCP webhooks use detached JWS (RFC 7797) with ES256/ES384/ES512.
+ * Universal Commerce Protocol (UCP) types and evidence schema.
+ *
+ * The current UCP signing model is RFC 9421 HTTP Message Signatures
+ * (`Signature-Input` / `Signature` with an RFC 9530 `Content-Digest` over the
+ * raw body bytes; ES256 for P-256, ES384 for P-384), modeled by the
+ * `VerifyUcpHttpSignature*` types and verified by `verifyUcpHttpSignature`.
+ * The detached JWS (RFC 7797) `Request-Signature` types below model the legacy,
+ * deprecated `verifyUcpWebhookSignature` path; the two never silently fall back
+ * to each other.
  */
 
 /**

--- a/packages/mappings/ucp/src/verify.ts
+++ b/packages/mappings/ucp/src/verify.ts
@@ -1,5 +1,11 @@
 /**
- * @peac/mappings-ucp - Webhook signature verification
+ * @peac/mappings-ucp - Legacy webhook signature verification (deprecated)
+ *
+ * This module verifies the legacy UCP `Request-Signature` detached JWS (RFC 7797)
+ * scheme. The current UCP signing model is RFC 9421 HTTP Message Signatures; use
+ * `verifyUcpHttpSignature` from `./http-signature.js` for new integrations. These
+ * exports remain for backward compatibility and never silently fall back to (or
+ * from) the RFC 9421 path.
  *
  * Verifies UCP webhook signatures using detached JWS (RFC 7797).
  * Supports ES256, ES384, ES512 algorithms with ECDSA keys.
@@ -46,6 +52,10 @@ const UNDERSTOOD_CRIT_PARAMS = new Set(['b64']);
 /**
  * Parse a detached JWS from the Request-Signature header.
  * Format: <protected>..<signature> (empty payload section)
+ *
+ * @deprecated Part of the legacy UCP `Request-Signature` (RFC 7797) path. The
+ * current UCP signing model is RFC 9421 HTTP Message Signatures; prefer
+ * `verifyUcpHttpSignature`. Retained for backward compatibility.
  */
 export function parseDetachedJws(headerValue: string): ParsedDetachedJws {
   const trimmed = headerValue.trim();
@@ -260,7 +270,12 @@ async function verifyDetachedSignature(
 }
 
 /**
- * Verify a UCP webhook signature.
+ * Verify a UCP webhook signature (legacy `Request-Signature` / RFC 7797 path).
+ *
+ * @deprecated The current UCP signing model is RFC 9421 HTTP Message Signatures;
+ * use `verifyUcpHttpSignature` for new integrations. This legacy detached-JWS
+ * path remains exported for backward compatibility and never silently falls back
+ * to (or from) the RFC 9421 path.
  *
  * Strategy: raw-first, JCS fallback
  * 1. Parse the detached JWS from Request-Signature header

--- a/packages/privacy/README.md
+++ b/packages/privacy/README.md
@@ -17,9 +17,9 @@ pnpm add @peac/privacy
 ### Issue a privacy-tagged receipt
 
 ```typescript
-import { issueWire02 } from '@peac/protocol';
+import { issue } from '@peac/protocol';
 
-const receipt = await issueWire02({
+const receipt = await issue({
   iss: 'https://issuer.example.com',
   kind: 'evidence',
   type: 'org.peacprotocol/privacy',

--- a/packages/receipts/README.md
+++ b/packages/receipts/README.md
@@ -12,6 +12,8 @@ pnpm add @peac/receipts
 
 `@peac/receipts` provides a fluent `ReceiptBuilder` for constructing valid PEAC receipts, validation functions for conditional field enforcement (such as payment fields for HTTP 402), and content negotiation support for JSON and CBOR serialization. It operates on the receipt payload structure before signing.
 
+> Note: `ReceiptBuilder` constructs the Wire 0.1 receipt payload model (`peac-receipt/0.1`, with the crawler/AIPREF fields shown below). The current stable signed-record format is Wire 0.2 (`interaction-record+jwt`); issue those records with `issue()` from [`@peac/protocol`](https://www.npmjs.com/package/@peac/protocol).
+
 ## How Do I Use It?
 
 ### Build a receipt with the fluent builder

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -836,9 +836,6 @@ importers:
 
   examples/ucp-webhook-express:
     dependencies:
-      '@peac/audit':
-        specifier: workspace:*
-        version: link:../../packages/audit
       '@peac/crypto':
         specifier: workspace:*
         version: link:../../packages/crypto
@@ -851,6 +848,9 @@ importers:
       express:
         specifier: ^4.22.1
         version: 4.22.1
+      express-rate-limit:
+        specifier: '>=8.2.2'
+        version: 8.3.0(express@4.22.1)
     devDependencies:
       '@types/express':
         specifier: ^4.17.21
@@ -7665,6 +7665,16 @@ packages:
       jest-mock: 30.2.0
       jest-util: 30.2.0
     dev: true
+
+  /express-rate-limit@8.3.0(express@4.22.1):
+    resolution: {integrity: sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+    dependencies:
+      express: 4.22.1
+      ip-address: 10.2.0
+    dev: false
 
   /express-rate-limit@8.3.0(express@5.2.1):
     resolution: {integrity: sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -842,6 +842,9 @@ importers:
       '@peac/crypto':
         specifier: workspace:*
         version: link:../../packages/crypto
+      '@peac/http-signatures':
+        specifier: workspace:*
+        version: link:../../packages/http-signatures
       '@peac/mappings-ucp':
         specifier: workspace:*
         version: link:../../packages/mappings/ucp


### PR DESCRIPTION
## Summary

Updates the UCP package docs and the Express example so RFC 9421 HTTP Message Signatures are the primary documented verification path, while keeping the legacy `Request-Signature` / detached-JWS path documented as deprecated compatibility. Docs and example only; no protocol surface change.

This PR:

- leads with `verifyUcpHttpSignature(...)` in the README, the `index.ts` example, and the `types.ts` / `bundle.ts` JSDoc;
- marks `verifyUcpWebhookSignature` and `parseDetachedJws` `@deprecated` (retained and working; no silent fallback);
- updates the Express example to sign and verify a request-shaped UCP webhook with RFC 9421 and an RFC 9530 `Content-Digest` over the raw body bytes;
- binds the signed `UCP-Agent` profile via `expected_profile_url`;
- reuses `@peac/http-signatures` for signature-base construction in the demo signer;
- fixes stale receipt-signing snippets to use the supported `@peac/crypto` `sign(...)` path for mapped UCP receipt claims;
- documents the UCP signing model in `docs/specs/COMMERCE-EVIDENCE.md`;
- uses vendor-neutral "Universal Commerce Protocol (UCP)" naming;
- fixes `@peac/receipts` (Wire 0.2 pointer) and `@peac/privacy` (`issue()`) README slips.

Response signatures using `@status` remain out of scope.

## Scope

Docs and example only. No verifier behavior, schema, wire, registry, receipt type, extension group, signing envelope, core API, package version, or release-state change. The example adds one workspace dependency (`@peac/http-signatures`).

## Validation

- `@peac/mappings-ucp` tests: 150 passed
- example typecheck and live run: a valid RFC 9421 request verifies (ES256, Content-Digest verified, signed UCP-Agent profile bound); a tampered body is rejected with `E_UCP_CONTENT_DIGEST_MISMATCH`
- `typecheck:core`, `verify:release` (build_targets 106), `format:check`, `verify:no-widening`, `verify:codegen-drift`, `verify:registries-schema`, `gate:fast`, API contract check (27 stable), and forbid-strings all pass
