### PR TITLE
refactor(mappings-ucp): reuse @peac/crypto base64url and JCS

### DIFF
--- a/packages/mappings/ucp/package.json
+++ b/packages/mappings/ucp/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "@peac/adapter-core": "workspace:*",
+    "@peac/crypto": "workspace:*",
     "@peac/http-signatures": "workspace:*",
     "@peac/kernel": "workspace:*",
     "@peac/schema": "workspace:*",

--- a/packages/mappings/ucp/src/evidence.ts
+++ b/packages/mappings/ucp/src/evidence.ts
@@ -23,7 +23,8 @@ import type {
   UcpSigningKey,
 } from './types.js';
 import { UCP_EVIDENCE_VERSION } from './types.js';
-import { sha256Hex, sha256Bytes, base64urlEncode, jcsCanonicalizeSync } from './util.js';
+import { base64urlEncode, canonicalize } from '@peac/crypto';
+import { sha256Hex, sha256Bytes } from './util.js';
 
 /**
  * Maximum body size to include as base64url in evidence (256KB).
@@ -257,7 +258,7 @@ export function createPayloadEvidence(
     jsonParseable = true;
 
     // JCS canonicalize
-    const canonicalized = jcsCanonicalizeSync(parsed);
+    const canonicalized = canonicalize(parsed);
     jcsSha256Hex = sha256Hex(new TextEncoder().encode(canonicalized));
 
     if (includeJcsText) {
@@ -308,7 +309,7 @@ export function createProfileSnapshot(
   fetchedAt: string
 ): ProfileSnapshot {
   // JCS canonicalize the profile
-  const canonicalized = jcsCanonicalizeSync(profile);
+  const canonicalized = canonicalize(profile);
   const profileJcsSha256Hex = sha256Hex(new TextEncoder().encode(canonicalized));
 
   // Compute JWK thumbprint (SHA-256 of JCS-canonicalized required members)
@@ -319,7 +320,7 @@ export function createProfileSnapshot(
     y: keyUsed.y,
   };
   const thumbprint = base64urlEncode(
-    sha256Bytes(new TextEncoder().encode(jcsCanonicalizeSync(thumbprintInput)))
+    sha256Bytes(new TextEncoder().encode(canonicalize(thumbprintInput)))
   );
 
   return {
@@ -330,6 +331,3 @@ export function createProfileSnapshot(
     key_jwk: keyUsed,
   };
 }
-
-// Re-export utilities for backwards compatibility
-export { sha256Hex, sha256Bytes, base64urlEncode, jcsCanonicalizeSync } from './util.js';

--- a/packages/mappings/ucp/src/util.ts
+++ b/packages/mappings/ucp/src/util.ts
@@ -1,12 +1,13 @@
 /**
  * @peac/mappings-ucp - Shared utilities
  *
- * Crypto and encoding helpers used by both verification and evidence generation.
- * Extracted to prevent architectural coupling between modules.
+ * SHA-256 helpers used by verification and evidence generation. base64url
+ * encoding and JCS canonicalization are reused from @peac/crypto directly at
+ * the call sites (verify.ts / evidence.ts); these SHA-256 helpers stay local
+ * and synchronous (node:crypto) pending the H3 sha256 sync/async consolidation.
  */
 
 import { createHash } from 'node:crypto';
-import { ErrorCodes, ucpError } from './errors.js';
 
 /**
  * SHA-256 hash as hex string.
@@ -20,97 +21,4 @@ export function sha256Hex(data: Uint8Array): string {
  */
 export function sha256Bytes(data: Uint8Array): Uint8Array {
   return new Uint8Array(createHash('sha256').update(data).digest());
-}
-
-/**
- * Convert base64 to base64url by replacing chars.
- */
-function base64ToBase64url(base64: string): string {
-  let result = '';
-  for (let i = 0; i < base64.length; i++) {
-    const c = base64.charCodeAt(i);
-    if (c === 43) {
-      // '+' -> '-'
-      result += '-';
-    } else if (c === 47) {
-      // '/' -> '_'
-      result += '_';
-    } else if (c === 61) {
-      // '=' padding - skip
-      break;
-    } else {
-      result += base64.charAt(i);
-    }
-  }
-  return result;
-}
-
-// Maximum size for base64url encoding (16MB - reasonable limit for webhook payloads)
-const MAX_ENCODE_SIZE = 16 * 1024 * 1024;
-
-/**
- * Base64url encode without padding.
- * Uses standard base64 + manual conversion for maximum portability.
- * Works with Node.js 12+ (does not require 'base64url' encoding from Node 15.7.0+).
- */
-export function base64urlEncode(data: Uint8Array): string {
-  // Safety check for unreasonably large input
-  if (data.length > MAX_ENCODE_SIZE) {
-    throw ucpError(
-      ErrorCodes.SIGNATURE_MALFORMED,
-      `Input too large for base64url encoding: ${data.length} bytes`
-    );
-  }
-
-  // Use Buffer in Node.js, then convert base64 to base64url
-  if (typeof Buffer !== 'undefined' && typeof Buffer.from === 'function') {
-    const base64 = Buffer.from(data).toString('base64');
-    return base64ToBase64url(base64);
-  }
-
-  // Fallback for non-Node environments (browsers)
-  // Build binary string with bounded iteration
-  const len = data.length;
-  let binary = '';
-  for (let i = 0; i < len; i++) {
-    binary += String.fromCharCode(data[i]);
-  }
-  const base64 = btoa(binary);
-  return base64ToBase64url(base64);
-}
-
-/**
- * JCS canonicalize (RFC 8785) - synchronous.
- * Produces deterministic JSON with sorted keys and no whitespace.
- */
-export function jcsCanonicalizeSync(obj: unknown): string {
-  if (obj === null) return 'null';
-  if (typeof obj === 'boolean') return obj ? 'true' : 'false';
-  if (typeof obj === 'number') {
-    if (!Number.isFinite(obj)) {
-      throw ucpError(
-        ErrorCodes.EVIDENCE_SERIALIZATION_FAILED,
-        'JCS does not support NaN or Infinity'
-      );
-    }
-    // Use ES6 number serialization (matches JSON.stringify for finite numbers)
-    return Object.is(obj, -0) ? '0' : String(obj);
-  }
-  if (typeof obj === 'string') return JSON.stringify(obj);
-  if (Array.isArray(obj)) {
-    return '[' + obj.map(jcsCanonicalizeSync).join(',') + ']';
-  }
-  if (typeof obj === 'object') {
-    const keys = Object.keys(obj as Record<string, unknown>).sort();
-    const pairs = keys
-      .filter((k) => (obj as Record<string, unknown>)[k] !== undefined)
-      .map(
-        (k) => JSON.stringify(k) + ':' + jcsCanonicalizeSync((obj as Record<string, unknown>)[k])
-      );
-    return '{' + pairs.join(',') + '}';
-  }
-  throw ucpError(
-    ErrorCodes.EVIDENCE_SERIALIZATION_FAILED,
-    `Cannot canonicalize type: ${typeof obj}`
-  );
 }

--- a/packages/mappings/ucp/src/verify.ts
+++ b/packages/mappings/ucp/src/verify.ts
@@ -32,7 +32,7 @@ import type {
   UcpSignatureAlgorithm,
 } from './types.js';
 import { ErrorCodes, ucpError, UcpError } from './errors.js';
-import { jcsCanonicalizeSync, base64urlEncode } from './util.js';
+import { base64urlEncode, canonicalize } from '@peac/crypto';
 
 /**
  * Supported ECDSA algorithms and their curve mappings.
@@ -217,6 +217,21 @@ function validateKeyForAlgorithm(key: UcpSigningKey, alg: UcpSignatureAlgorithm)
   }
 }
 
+// Preserve the legacy detached-JWS payload encode guard from the pre-H2 UCP
+// helper. This limit applies only to the deprecated Request-Signature path. The
+// current RFC 9421 verifier uses raw-body Content-Digest and is not changed by H2.
+const MAX_DETACHED_JWS_ENCODE_BYTES = 16 * 1024 * 1024;
+
+function encodeDetachedJwsPayload(payloadBytes: Uint8Array): string {
+  if (payloadBytes.length > MAX_DETACHED_JWS_ENCODE_BYTES) {
+    throw ucpError(
+      ErrorCodes.SIGNATURE_MALFORMED,
+      `Input too large for base64url encoding: ${payloadBytes.length} bytes`
+    );
+  }
+  return base64urlEncode(payloadBytes);
+}
+
 /**
  * Verify a detached JWS signature against payload bytes.
  *
@@ -254,7 +269,7 @@ async function verifyDetachedSignature(
     protected: parsed.protected_b64url,
     // For b64=false: pass raw bytes directly (jose handles RFC 7797 semantics)
     // For standard JWS: pass base64url-encoded string
-    payload: parsed.is_unencoded_payload ? payloadBytes : base64urlEncode(payloadBytes),
+    payload: parsed.is_unencoded_payload ? payloadBytes : encodeDetachedJwsPayload(payloadBytes),
     signature: parsed.signature_b64url,
   };
 
@@ -402,7 +417,7 @@ export async function verifyUcpWebhookSignature(
   try {
     const bodyText = new TextDecoder('utf-8').decode(body_bytes);
     const parsed_body = JSON.parse(bodyText);
-    const canonicalized = jcsCanonicalizeSync(parsed_body);
+    const canonicalized = canonicalize(parsed_body);
     const canonicalizedBytes = new TextEncoder().encode(canonicalized);
 
     const jcsValid = await verifyDetachedSignature(parsed, canonicalizedBytes, key);

--- a/packages/mappings/ucp/tests/crypto-parity.test.ts
+++ b/packages/mappings/ucp/tests/crypto-parity.test.ts
@@ -1,0 +1,131 @@
+/**
+ * H2 parity: prove the @peac/crypto helpers now used by @peac/mappings-ucp are
+ * byte-identical to the UCP-local helpers this PR removed.
+ *
+ * The `legacy*` functions below preserve the byte-output behavior of the pre-H2
+ * `@peac/mappings-ucp/src/util.ts` `base64urlEncode` and `jcsCanonicalizeSync`
+ * helpers. The old UCP encoder also had a 16 MB guard; that behavior is preserved
+ * in `verify.ts` at the detached-JWS call site, not in this byte-output parity
+ * helper. UCP feeds these helpers JSON.parse-derived values (webhook bodies,
+ * profile JSON) and small byte arrays (payloads, digests), so the corpora below
+ * reflect those inputs.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { base64urlEncode, canonicalize } from '@peac/crypto';
+
+// --- byte-output references for the removed UCP util.ts helpers ---
+
+function legacyBase64ToBase64url(base64: string): string {
+  let result = '';
+  for (let i = 0; i < base64.length; i++) {
+    const c = base64.charCodeAt(i);
+    if (c === 43) {
+      result += '-'; // '+' -> '-'
+    } else if (c === 47) {
+      result += '_'; // '/' -> '_'
+    } else if (c === 61) {
+      break; // '=' padding - skip
+    } else {
+      result += base64.charAt(i);
+    }
+  }
+  return result;
+}
+
+function legacyBase64urlEncode(data: Uint8Array): string {
+  const base64 = Buffer.from(data).toString('base64');
+  return legacyBase64ToBase64url(base64);
+}
+
+function legacyJcs(obj: unknown): string {
+  if (obj === null) return 'null';
+  if (typeof obj === 'boolean') return obj ? 'true' : 'false';
+  if (typeof obj === 'number') {
+    if (!Number.isFinite(obj)) {
+      throw new Error('JCS does not support NaN or Infinity');
+    }
+    return Object.is(obj, -0) ? '0' : String(obj);
+  }
+  if (typeof obj === 'string') return JSON.stringify(obj);
+  if (Array.isArray(obj)) {
+    return '[' + obj.map(legacyJcs).join(',') + ']';
+  }
+  if (typeof obj === 'object') {
+    const keys = Object.keys(obj as Record<string, unknown>).sort();
+    const pairs = keys
+      .filter((k) => (obj as Record<string, unknown>)[k] !== undefined)
+      .map((k) => JSON.stringify(k) + ':' + legacyJcs((obj as Record<string, unknown>)[k]));
+    return '{' + pairs.join(',') + '}';
+  }
+  throw new Error(`Cannot canonicalize type: ${typeof obj}`);
+}
+
+// Deterministic pseudo-random bytes (LCG; no Math.random for stable vectors).
+function lcgBytes(seed: number, length: number): Uint8Array {
+  let s = seed;
+  const out = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    s = (1103515245 * s + 12345) & 0x7fffffff;
+    out[i] = s & 0xff;
+  }
+  return out;
+}
+
+describe('H2 parity: @peac/crypto base64urlEncode matches the removed UCP helper', () => {
+  const vectors: Array<[string, Uint8Array]> = [
+    ['empty', new Uint8Array([])],
+    ['1 byte', new Uint8Array([0])],
+    ['2 bytes', new Uint8Array([0, 1])],
+    ['3 bytes', new Uint8Array([0, 1, 2])],
+    ['4 bytes', new Uint8Array([0, 1, 2, 3])],
+    ['high byte', new Uint8Array([255])],
+    ['tail 0x..', new Uint8Array([255, 254, 253])],
+    ['bytes 0..255', Uint8Array.from({ length: 256 }, (_, i) => i)],
+    ['lcg-199', lcgBytes(12345, 199)],
+    ['lcg-32 (digest-sized)', lcgBytes(67890, 32)],
+  ];
+  for (const [name, v] of vectors) {
+    it(`matches for ${name}`, () => {
+      expect(base64urlEncode(v)).toBe(legacyBase64urlEncode(v));
+    });
+  }
+});
+
+describe('H2 parity: @peac/crypto canonicalize matches the removed UCP JCS (JSON-parse-derived inputs)', () => {
+  const corpus: Array<[string, unknown]> = [
+    ['null', null],
+    ['true', true],
+    ['false', false],
+    ['int 0', 0],
+    ['int 42', 42],
+    ['negative', -1],
+    ['decimal', 3.14],
+    ['minus zero', -0],
+    ['large int', 123456789012345],
+    ['exponent form', 1e21],
+    ['empty string', ''],
+    ['ascii', 'hello'],
+    ['quotes', 'with "quotes" and \\ backslash'],
+    ['unicode', 'unicode: cafe ☕ 𝕏'],
+    ['control chars', 'tab\tnewline\n'],
+    ['empty array', []],
+    ['number array', [1, 2, 3]],
+    ['string array', ['a', 'b']],
+    ['object array', [{ a: 1 }, { b: 2 }]],
+    ['empty object', {}],
+    ['unsorted keys', { b: 2, a: 1 }],
+    ['three keys', { z: 1, a: 2, m: 3 }],
+    ['nested', { nested: { deep: { x: [1, { y: 2 }] } }, arr: [true, null, 'x'] }],
+    [
+      'ucp-order-ish',
+      JSON.parse('{"order":{"id":"o1","items":[{"p":9.99,"q":2}]},"ts":"2026-06-19T00:00:00Z"}'),
+    ],
+    ['jwk thumbprint shape', { crv: 'P-256', kty: 'EC', x: 'abc', y: 'def' }],
+  ];
+  for (const [name, value] of corpus) {
+    it(`matches for ${name}`, () => {
+      expect(canonicalize(value)).toBe(legacyJcs(value));
+    });
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1670,6 +1670,9 @@ importers:
       '@peac/adapter-core':
         specifier: workspace:*
         version: link:../../adapters/core
+      '@peac/crypto':
+        specifier: workspace:*
+        version: link:../../crypto
       '@peac/http-signatures':
         specifier: workspace:*
         version: link:../../http-signatures


### PR DESCRIPTION
## Summary

Reuses `@peac/crypto` for base64url encoding and JCS canonicalization inside `@peac/mappings-ucp`.

This removes duplicated encoding/canonicalization helpers while preserving byte-identical behavior for UCP JSON-derived inputs. The legacy detached-JWS payload encode-size guard remains enforced at the verifier call site.

SHA-256 helpers and `net/node` receipt-ref verification are intentionally unchanged because those involve sync/async API boundaries.

## Scope

- Adds an internal workspace dependency from `@peac/mappings-ucp` to `@peac/crypto`.
- Keeps the current RFC 9421 verifier untouched.
- Does not change schema, wire, registries, receipt types, extension groups, signing envelope, core API, package versions, release state, response `@status`, shared ECDSA verification, RFC 9530 helper behavior, or `rfc9421-proof`.

## Changes

- `verify.ts` / `evidence.ts`: base64url and JCS now come from `@peac/crypto`; `verify.ts` keeps a local 16 MB detached-JWS payload encode guard that size-checks then delegates to `@peac/crypto.base64urlEncode`.
- `util.ts`: trimmed to the sync SHA-256 helpers; removed the duplicated base64url and JCS implementations and a dead internal re-export.

## Validation

- `@peac/mappings-ucp` tests pass, including new parity tests asserting byte-identical base64url and JCS output for JSON-derived inputs.
- `typecheck:core`, release verification, API contract check, and lint all pass; no sentinel change.
