### PR TITLE
chore(security): patch undici advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
       "@protobufjs/utf8": "1.1.1",
       "defu": ">=6.1.5",
       "esbuild@<0.25.0": ">=0.25.0",
-      "undici@<6.24.0": ">=6.24.0",
+      "undici@<6.27.0": "6.27.0",
       "postcss@<8.5.10": ">=8.5.10",
       "form-data@<4.0.6": ">=4.0.6",
       "vite@<6.4.2": ">=8.0.16"
@@ -184,7 +184,7 @@
       "@protobufjs/utf8": "Defensive pin to 1.1.1 (fixes GHSA-q6x5-8v7m-xcrf in @protobufjs/utf8@<=1.1.0). protobufjs@8.0.2 no longer resolves the prior @protobufjs/* subtree in the current lockfile; this override prevents the vulnerable utf8 helper from re-entering through another transitive path. No published runtime package depends on it.",
       "defu": "Override to >=6.1.5 (fixes GHSA-737v-mqg7-c878 prototype pollution via __proto__ in defaults argument). Dev-only via wrangler -> @cloudflare/unenv-preset / unenv. Wrangler 3.x bundles defu 6.1.4; Wrangler 4 (latest) is a major bump deferred for separate review.",
       "esbuild@<0.25.0": "Range-scoped to <0.25.0 only (forces patched 0.25.0+, fixes GHSA-67mh-4wv8-2f99 dev-server CORS bypass). Dev-only via wrangler / @esbuild-plugins/node-globals-polyfill peer / @esbuild-plugins/node-modules-polyfill peer (all ship esbuild 0.17.19). Newer esbuild instances at 0.25.12+ already pulled by vitest/tsx are unaffected.",
-      "undici@<6.24.0": "Range-scoped to <6.24.0 only (forces patched 6.24.0+, fixes GHSA-4992-7rv2-5pvq CRLF injection via upgrade and GHSA-2mjp-6q6p-2qxm HTTP request/response smuggling). Dev-only via wrangler -> miniflare which bundles undici 5.29.0. @peac/net-node already uses undici 6.24.0+ (production path unaffected).",
+      "undici@<6.27.0": "Range-scoped to <6.27.0 only, pinned to exact 6.27.0 to stay on the undici v6 line (avoids floating to v7/v8). Fixes GHSA-vxpw-j846-p89q (WebSocket client DoS via fragment count bypass, affects 6.17.0..<6.27.0) and retains the prior GHSA-4992-7rv2-5pvq (CRLF injection) and GHSA-2mjp-6q6p-2qxm (request/response smuggling) patches from the earlier <6.24.0 floor. Prod path: apps/api -> @peac/resolver-http -> @peac/net-node, which now declares undici ^6.27.0 directly; also forces the dev wrangler -> miniflare undici onto the patched 6.27.0.",
       "postcss@<8.5.10": "Range-scoped to <8.5.10 only (forces patched 8.5.10+, fixes GHSA-qx2v-qp2m-jg93 XSS via unescaped </style> in CSS Stringify output). Dev-only via next 15.5.x (bundles postcss 8.4.31 internally) and vite. Workspace doesn't import postcss directly; affects build tooling only.",
       "form-data@<4.0.6": "Range-scoped to <4.0.6 only (forces patched 4.0.6+, fixes GHSA-hmw2-7cc7-3qxx CRLF injection via unescaped multipart field/filename). Dev-only via the supertest/superagent HTTP test client used by @peac/middleware-express tests; not in any published package.",
       "vite@<6.4.2": "Range-scoped to <6.4.2 only (forces patched, now floored at >=8.0.16, fixes GHSA-p9ff-h696-f583 arbitrary file read via dev server WebSocket, GHSA-4w7w-66w2-5vf9 path traversal in optimized deps .map handling, and GHSA-fx2h-pf6j-xcff server.fs.deny bypass on Windows alternate paths). Dev-only via vitest/@vitest/coverage-v8 and apps/verifier (internal app); pnpm resolves the override to vite 8.0.16; full test suite passes.",

--- a/packages/net/node/package.json
+++ b/packages/net/node/package.json
@@ -56,7 +56,7 @@
     "@peac/schema": "workspace:*",
     "ipaddr.js": "^2.3.0",
     "tldts": "^6.1.86",
-    "undici": "^6.24.0"
+    "undici": "^6.27.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ overrides:
   '@protobufjs/utf8': 1.1.1
   defu: '>=6.1.5'
   esbuild@<0.25.0: '>=0.25.0'
-  undici@<6.24.0: '>=6.24.0'
+  undici@<6.27.0: 6.27.0
   postcss@<8.5.10: '>=8.5.10'
   form-data@<4.0.6: '>=4.0.6'
   vite@<6.4.2: '>=8.0.16'
@@ -1804,8 +1804,8 @@ importers:
         specifier: ^6.1.86
         version: 6.1.86
       undici:
-        specifier: ^6.24.0
-        version: 6.24.0
+        specifier: ^6.27.0
+        version: 6.27.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.18.2
@@ -9324,7 +9324,7 @@ packages:
       exit-hook: 2.2.1
       glob-to-regexp: 0.4.1
       stoppable: 1.1.0
-      undici: 6.24.0
+      undici: 6.27.0
       workerd: 1.20250718.0
       ws: 8.18.0
       youch: 3.3.4
@@ -11174,8 +11174,8 @@ packages:
   /undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  /undici@6.24.0:
-    resolution: {integrity: sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==}
+  /undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
   /unenv@2.0.0-rc.14:


### PR DESCRIPTION
## Summary

Updates the undici dependency floor used by `@peac/net-node` to address the production dependency advisory `GHSA-vxpw-j846-p89q`.

The root pnpm override is also advanced from the prior `<6.24.0` guard to `<6.27.0`, keeping the fix on the undici v6 line.

## Scope

- Updates `@peac/net-node` from `undici ^6.24.0` to `^6.27.0`.
- Updates the root pnpm override to force vulnerable undici versions below `6.27.0` to `6.27.0`.
- Does not change runtime code, public APIs, package exports, schema, wire, registries, receipt types, signing envelope, or release state.

## Verification

- `node scripts/audit-gate.mjs`
- `pnpm audit --prod --audit-level high`
- `pnpm --filter '@peac/net-node' test`
- `pnpm --filter '@peac/cli' test`
- `pnpm --filter '@peac/resolver-http' test`
- `pnpm typecheck:core`
- `pnpm verify:release`
- `pnpm exec tsx scripts/extract-api-contract.ts --check`
- `bash scripts/ci/forbid-strings.sh`
- `git diff --check`
