### PR TITLE
test(tooling): lock receipt_ref SHA-256 boundary

### DIFF
--- a/packages/net/node/src/receipt-resolver.ts
+++ b/packages/net/node/src/receipt-resolver.ts
@@ -183,6 +183,10 @@ export async function resolveReceiptUrl(
  * @returns true if the JWS matches the receipt_ref
  */
 export function verifyReceiptRef(jws: string, receiptRef: string): boolean {
+  // Intentionally sync: this Node-only resolver helper mirrors
+  // @peac/schema.computeReceiptRef's sha256:<hex> contract without changing the
+  // exported verifyReceiptRef(...) API to async. Locked by the SHA-256 boundary
+  // test (tests/tooling/sha256-boundary-contract.test.ts).
   const hash = createHash('sha256').update(jws).digest('hex');
   const computed = `sha256:${hash}`;
   return computed === receiptRef;

--- a/tests/tooling/sha256-boundary-contract.test.ts
+++ b/tests/tooling/sha256-boundary-contract.test.ts
@@ -31,6 +31,7 @@ import { describe, it, expect } from 'vitest';
 
 import { sha256Hex } from '@peac/crypto';
 import { computeReceiptRef } from '@peac/schema';
+import { verifyReceiptRef } from '@peac/net-node';
 
 // Inputs intentionally include compact-JWS-shaped strings and non-JWS strings.
 // This parity test only requires byte-identical SHA-256 input handling across
@@ -63,5 +64,35 @@ describe('SHA-256 boundary contract: computeReceiptRef matches crypto.sha256Hex'
 
   it('sha256Hex itself never carries the reference prefix', async () => {
     expect((await sha256Hex(INPUTS[0])).startsWith('sha256:')).toBe(false);
+  });
+});
+
+// `@peac/net-node` `verifyReceiptRef` (Layer 5, Node-only) is a third SHA-256
+// site: it derives `sha256:<hex>` synchronously via `node:crypto` and compares it
+// to an expected receipt_ref. It stays sync by design (exported Node-only resolver
+// API). This block locks it to the same contract so the sync derivation can never
+// drift from the async `computeReceiptRef` / `sha256Hex` paths. The full invariant:
+//   receipt_ref = "sha256:" + lowercase_hex(SHA-256(UTF-8(compact_jws)))
+describe('SHA-256 boundary contract: net-node.verifyReceiptRef matches computeReceiptRef', () => {
+  it.each(INPUTS)(
+    'verifyReceiptRef(input, computeReceiptRef(input)) === true [len %#]',
+    async (input) => {
+      const ref = await computeReceiptRef(input);
+      expect(ref).toBe(`sha256:${await sha256Hex(input)}`);
+      expect(verifyReceiptRef(input, ref)).toBe(true);
+    }
+  );
+
+  it('verifyReceiptRef rejects a tampered JWS against the original ref', async () => {
+    const jws = INPUTS[0];
+    const ref = await computeReceiptRef(jws);
+    expect(verifyReceiptRef(`${jws}.tampered`, ref)).toBe(false);
+  });
+
+  it('verifyReceiptRef rejects a valid-shaped ref whose digest does not match', () => {
+    // Valid sha256:<64 lowercase hex> shape, but not the digest of any input:
+    // this proves a digest MISMATCH is rejected, not merely a malformed ref.
+    const wrongRef = 'sha256:0000000000000000000000000000000000000000000000000000000000000000';
+    expect(verifyReceiptRef(INPUTS[0], wrongRef)).toBe(false);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,6 +40,10 @@ export default defineConfig({
         find: '@peac/transport-grpc',
         replacement: resolve(__dirname, 'packages/transport/grpc/src/index.ts'),
       },
+      {
+        find: '@peac/net-node',
+        replacement: resolve(__dirname, 'packages/net/node/src/index.ts'),
+      },
     ],
   },
   server: {


### PR DESCRIPTION
## Summary

Extends the SHA-256 boundary test for PEAC receipt references to include the Node resolver verification path.

This locks the `sha256:<hex>` receipt reference invariant across schema, crypto, and net-node helpers without changing public APIs or runtime behavior.

## Scope

- Adds a root Vitest alias for `@peac/net-node` so the existing boundary test can import the Node resolver helper.
- Keeps `@peac/crypto` public API unchanged.
- Keeps `@peac/schema.computeReceiptRef(...)` async.
- Keeps `@peac/net-node.verifyReceiptRef(...)` sync.
- Does not change schema, wire, registries, receipt types, extension groups, signing envelope, package versions, dependencies, or release state.

## Verification

- `pnpm exec vitest run tests/tooling/sha256-boundary-contract.test.ts`
- `pnpm --filter '@peac/schema' test`
- `pnpm --filter '@peac/net-node' test`
- `pnpm --filter '@peac/crypto' test`
- `pnpm typecheck:core`
- `pnpm verify:release`
- `pnpm exec tsx scripts/extract-api-contract.ts --check`
- `bash scripts/ci/forbid-strings.sh`
- `git diff --check`
