### PR TITLE
test(content-signals): Content-Usage parameter-stripping behavior

### DIFF
--- a/packages/mappings/content-signals/src/content-usage.ts
+++ b/packages/mappings/content-signals/src/content-usage.ts
@@ -134,8 +134,19 @@ function parseSfDictionary(input: string): SfDictionaryMember[] {
 }
 
 /**
- * Strip SF parameters from a value or bare key.
- * Parameters start with ';' and are key=value or key pairs.
+ * Strip SF parameters from a value or bare key by truncating at the first ';'.
+ *
+ * This parser intentionally implements only the Content-Usage subset used by
+ * AIPREF tokens. It does not attempt full quoted-string delimiter handling.
+ * That is acceptable here because allow/deny decisions are produced only by
+ * bare `y` / `n` Tokens. Parameters on those tokens are stripped while
+ * preserving the decision; quoted Strings remain non-decision values and
+ * resolve to `unspecified`.
+ *
+ * Full RFC 9651 quoted-string delimiter handling would be a broader
+ * standards-correctness enhancement, not a security fix. The no-decision-flip
+ * invariant is locked by the parameter-stripping tests in
+ * tests/content-usage.test.ts.
  */
 function stripParams(s: string): string {
   const semiIdx = s.indexOf(';');

--- a/packages/mappings/content-signals/tests/content-usage.test.ts
+++ b/packages/mappings/content-signals/tests/content-usage.test.ts
@@ -225,3 +225,63 @@ describe('parseContentUsage', () => {
     expect(training?.raw_value).toBeDefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Parameter stripping (stripParams): locks the no-decision-flip invariant.
+//
+// stripParams() truncates a member value/key at the first ';'. These tests
+// characterize that behavior and prove it can never turn one AIPREF decision
+// (allow/deny) into another: allow/deny come only from a bare `y`/`n` Token.
+// Parameters on those tokens are stripped while preserving the decision;
+// quoted Strings remain non-decision values.
+// ---------------------------------------------------------------------------
+
+describe('parseContentUsage: parameter stripping (no decision flip)', () => {
+  const decisionFor = (header: string, purpose: string) =>
+    parseContentUsage(header).entries.find((e) => e.purpose === purpose)?.decision;
+
+  it('strips a parameter from a deny token', () => {
+    const result = parseContentUsage('train-ai=n;q=0.5');
+    expect(result.parsed[0].tokenValue).toBe('n');
+    expect(decisionFor('train-ai=n;q=0.5', 'ai-training')).toBe('deny');
+  });
+
+  it('keeps an allow token without parameters', () => {
+    expect(decisionFor('train-ai=y', 'ai-training')).toBe('allow');
+  });
+
+  it('strips a spaced parameter and preserves the token', () => {
+    expect(decisionFor('train-ai= y ; q=1', 'ai-training')).toBe('allow');
+  });
+
+  it('strips trailing/empty parameters and preserves the token', () => {
+    expect(decisionFor('train-ai=n;;;', 'ai-training')).toBe('deny');
+    expect(decisionFor('train-ai=n;', 'ai-training')).toBe('deny');
+  });
+
+  it('does not let a ";" inside a quoted String flip a decision', () => {
+    const result = parseContentUsage('train-ai="a;b"');
+    expect(result.parsed[0].valueType).toBe('string');
+    expect(result.parsed[0].tokenValue).toBeNull();
+    expect(decisionFor('train-ai="a;b"', 'ai-training')).toBeUndefined();
+  });
+
+  it('treats quoted "y"/"n" as unspecified (never allow/deny)', () => {
+    expect(decisionFor('train-ai="y"', 'ai-training')).toBeUndefined();
+    expect(decisionFor('search="n"', 'ai-search')).toBeUndefined();
+  });
+
+  it('routes an unknown key with parameters to extensions, not entries', () => {
+    const result = parseContentUsage('x-custom=n;q=1');
+    expect(result.extensions.some((m) => m.key === 'x-custom')).toBe(true);
+    expect(result.entries).toEqual([]);
+  });
+
+  it('does not flip a sibling decision when a bare key carries a parameter', () => {
+    expect(decisionFor('bots;foo=bar, train-ai=n', 'ai-training')).toBe('deny');
+  });
+
+  it('does not let a quoted decoy upgrade a later deny (last value wins)', () => {
+    expect(decisionFor('train-ai="allow";q=1, train-ai=n', 'ai-training')).toBe('deny');
+  });
+});


### PR DESCRIPTION
## Summary

Locks Content-Usage parameter-stripping behavior for AIPREF token values.

This adds characterization tests for parameterized tokens, quoted strings, unknown extension members, and malformed parameter edge cases. The tests confirm that parameter stripping preserves `y` / `n` token decisions and that quoted or unknown values remain non-decision values.

## Scope

- Adds tests for Content-Usage parameter-stripping behavior.
- Documents the no-decision-flip invariant in the parser helper.
- Does not change parser logic or valid Content-Usage behavior.
- Does not add public APIs, package exports, schema, wire, registry, release-state, or dependency changes.

## Verification

- `pnpm --filter '@peac/mappings-content-signals' test`
- `pnpm typecheck:core`
- `pnpm verify:release`
- `pnpm exec tsx scripts/extract-api-contract.ts --check`
- `bash scripts/ci/forbid-strings.sh`
- `git diff --check`
