### PR TITLE
refactor(api): hide internal helper exports

### DIFF
--- a/packages/mappings/tap/src/helpers.ts
+++ b/packages/mappings/tap/src/helpers.ts
@@ -12,6 +12,7 @@
  *
  * @param headers - Headers-like object
  * @returns Record<string, string>
+ * @internal Package-internal helper; not part of the public API.
  */
 export function headersToRecord(
   headers:
@@ -37,6 +38,7 @@ export function headersToRecord(
  * @param headers - Headers as Record
  * @param name - Header name
  * @returns Header value or empty string
+ * @internal Package-internal helper; not part of the public API.
  */
 export function getHeader(headers: Record<string, string>, name: string): string {
   const lowerName = name.toLowerCase();

--- a/packages/mappings/tap/src/index.ts
+++ b/packages/mappings/tap/src/index.ts
@@ -28,9 +28,6 @@ export {
   isKnownTapTag,
 } from './validator.js';
 
-// Helpers
-export { headersToRecord, getHeader } from './helpers.js';
-
 // Keyid trust boundary (single source of truth for keyid -> issuer origin)
 export { issuerFromKeyid } from './keyid.js';
 

--- a/packages/rails/x402/src/helpers.ts
+++ b/packages/rails/x402/src/helpers.ts
@@ -144,7 +144,8 @@ export function isTestnet(networkId: string): boolean {
 }
 
 /**
- * Clear warned networks set (for testing)
+ * Clear warned networks set (for testing).
+ * @internal Package-internal test hook; not part of the public API.
  */
 export function _resetWarnedNetworks(): void {
   warnedNetworks.clear();

--- a/packages/rails/x402/src/index.ts
+++ b/packages/rails/x402/src/index.ts
@@ -13,7 +13,18 @@ import type { PaymentEvidence, PaymentSplit } from '@peac/schema';
 // Re-export types and constants for consumers
 export * from './constants';
 export * from './types';
-export * from './helpers';
+// Re-export the public helpers explicitly; the internal test reset hook
+// (_resetWarnedNetworks) is intentionally NOT part of the public API
+// (import it from './helpers' inside the package's own tests).
+export {
+  logUnknownNetworkWarning,
+  detectDialect,
+  resolveDialectFromInvoice,
+  normalizeNetworkId,
+  getNetworkLabel,
+  getHeaders,
+  isTestnet,
+} from './helpers';
 export * from './payment-headers';
 
 import type { X402Dialect } from './constants';

--- a/packages/rails/x402/tests/x402.test.ts
+++ b/packages/rails/x402/tests/x402.test.ts
@@ -18,7 +18,6 @@ import {
   normalizeNetworkId,
   getNetworkLabel,
   resolveDialectFromInvoice,
-  _resetWarnedNetworks,
   type X402Invoice,
   type X402Settlement,
   type X402WebhookEvent,
@@ -27,6 +26,7 @@ import {
   X402_HEADERS_V2,
   CAIP2_REGISTRY,
 } from '../src/index';
+import { _resetWarnedNetworks } from '../src/helpers';
 
 // =============================================================================
 // V1 TESTS (PRESERVED - ALL EXISTING BEHAVIOR)


### PR DESCRIPTION
## Summary

Removes internal helper utilities from package root barrels while keeping their internal source modules available for package-local tests and implementation code.

## Scope

- Stops exposing TAP header-normalization helpers from the TAP package root.
- Stops exposing the x402 test reset helper from the x402 package root.
- Keeps helper implementations unchanged.
- Does not change schemas, wire format, registries, release state, dependencies, or runtime protocol behavior.

## Verification

- `pnpm --filter '@peac/mappings-tap' test`
- `pnpm --filter '@peac/rails-x402' test`
- `pnpm --filter '@peac/worker-core' test`
- `pnpm --filter '@peac/worker-shared' test`
- `pnpm typecheck:core`
- `pnpm verify:release`
- `pnpm exec tsx scripts/extract-api-contract.ts --check`
- `bash scripts/ci/forbid-strings.sh`
- `git diff --check`
