### PR TITLE
fix(http-signatures): enforce Structured Field byte-sequence parsing

### DIFF
--- a/packages/http-signatures/src/parser.ts
+++ b/packages/http-signatures/src/parser.ts
@@ -82,9 +82,11 @@ export function parseSignatureHeader(
     }
     seenLabels.add(label);
 
-    // The value MUST be a structured-field byte sequence (:base64:).
-    const match = value.match(/^:([A-Za-z0-9+/=_-]+):$/);
-    if (!match) {
+    // The value MUST be a Structured Field Byte Sequence (:base64:) using
+    // RFC 4648 Section 4 standard base64 (RFC 9651 Section 3.3.5), NOT
+    // base64url. Capture the inner value, then validate Structured Field base64.
+    const match = value.match(/^:([^:]*):$/);
+    if (!match || !isValidSfBase64(match[1])) {
       throw new HttpSignatureError(
         ErrorCodes.SIGNATURE_INPUT_MALFORMED,
         `Malformed Signature byte sequence for label "${label}"`
@@ -389,16 +391,44 @@ function parseParameters(paramsString: string): Record<string, string | number> 
   return params;
 }
 
+// Standard base64 alphabet (RFC 4648 Section 4), with optional terminal
+// padding only. Rejects base64url (`-`/`_`), whitespace, and any `=` that is
+// not part of trailing padding.
+const SF_BASE64_ALPHABET = /^[A-Za-z0-9+/]*={0,2}$/;
+// Canonical terminal padding when padding is present.
+const SF_BASE64_CANONICAL_PADDED =
+  /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
 /**
- * Decode base64 (standard or URL-safe) to bytes.
+ * Validate a Structured Field Byte Sequence value (RFC 9651 Section 3.3.5).
+ *
+ * Structured Field Byte Sequences use the RFC 4648 Section 4 base64 alphabet,
+ * not base64url. Per RFC 9651 parsing, absent padding may be synthesized on
+ * decode; characters outside the base64 alphabet remain invalid. So this
+ * accepts valid unpadded standard base64, but rejects base64url (`-`/`_`),
+ * misplaced/excess `=`, `length % 4 === 1`, whitespace, and the empty string
+ * (no behavior widening). Keep this separate from JOSE/JWS base64url handling.
+ */
+function isValidSfBase64(value: string): boolean {
+  if (value.length === 0) return false;
+  if (!SF_BASE64_ALPHABET.test(value)) return false;
+  if (value.includes('=')) {
+    // If padding is present, it must be canonical terminal padding.
+    return SF_BASE64_CANONICAL_PADDED.test(value);
+  }
+  // Absent padding is synthesized on decode; `length % 4 === 1` is unrepairable.
+  return value.length % 4 !== 1;
+}
+
+/**
+ * Decode an RFC 4648 Section 4 base64 string to bytes, synthesizing absent
+ * padding per RFC 9651 byte-sequence parsing. Callers MUST validate the input
+ * with {@link isValidSfBase64} first; this does not accept base64url.
  */
 function base64ToBytes(base64: string): Uint8Array {
-  // Handle URL-safe base64
-  const normalized = base64.replace(/-/g, '+').replace(/_/g, '/');
-
-  // Add padding if needed
-  const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), '=');
-
+  const padded = base64.includes('=')
+    ? base64
+    : base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=');
   const binary = atob(padded);
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) {

--- a/packages/http-signatures/tests/parser.test.ts
+++ b/packages/http-signatures/tests/parser.test.ts
@@ -65,6 +65,45 @@ describe('parseSignatureHeader', () => {
     expect(result.get('sig1')!.bytes).toEqual(new Uint8Array([97, 98, 99])); // "abc"
     expect(result.get('sig2')!.bytes).toEqual(new Uint8Array([100, 101, 102])); // "def"
   });
+
+  // The Signature value is a Structured Field Byte Sequence: the RFC 4648
+  // Section 4 base64 alphabet (RFC 9651 Section 3.3.5), NOT base64url. Per
+  // RFC 9651 parsing, absent padding is synthesized on decode, so valid
+  // unpadded standard base64 is accepted.
+  it('accepts valid standard base64, padded or unpadded', () => {
+    expect(parseSignatureHeader('sig1=:AAEC/w==:').get('sig1')!.bytes).toEqual(
+      new Uint8Array([0, 1, 2, 255])
+    );
+    expect(parseSignatureHeader('sig1=:YWJj:').get('sig1')!.bytes).toEqual(
+      new Uint8Array([97, 98, 99]) // "abc"
+    );
+    expect(parseSignatureHeader('sig1=:YWI:').get('sig1')!.bytes).toEqual(
+      new Uint8Array([97, 98]) // "ab", unpadded (RFC 9651 synthesizes padding)
+    );
+    expect(parseSignatureHeader('sig1=:YQ:').get('sig1')!.bytes).toEqual(
+      new Uint8Array([97]) // "a", unpadded
+    );
+  });
+
+  it('rejects base64url ("-" and "_") in the Signature value', () => {
+    for (const header of ['sig1=:ab-d:', 'sig1=:ab_d:']) {
+      expect(() => parseSignatureHeader(header)).toThrow(HttpSignatureError);
+    }
+  });
+
+  it('rejects malformed padding / length in the Signature value', () => {
+    const bad = [
+      'sig1=:YW==YWI=:', // padding in the middle
+      'sig1=:YQ===:', // too much padding
+      'sig1=:YWJjZ:', // length % 4 === 1 (unrepairable by synthesized padding)
+      'sig1=:Y:', // length % 4 === 1 (single char)
+      'sig1=:YW Jj:', // whitespace inside the byte sequence
+      'sig1=::', // empty byte sequence (no behavior widening)
+    ];
+    for (const header of bad) {
+      expect(() => parseSignatureHeader(header)).toThrow(HttpSignatureError);
+    }
+  });
 });
 
 describe('parseSignature', () => {

--- a/packages/mappings/ucp/src/http-signature.ts
+++ b/packages/mappings/ucp/src/http-signature.ts
@@ -124,16 +124,44 @@ function hasQueryString(url: string): boolean {
   }
 }
 
+// Standard base64 alphabet (RFC 4648 Section 4), with optional terminal
+// padding only (not base64url). Used by the RFC 9530 Content-Digest value.
+const SF_BASE64_ALPHABET = /^[A-Za-z0-9+/]*={0,2}$/;
+const SF_BASE64_CANONICAL_PADDED =
+  /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
 /**
- * Decode standard or URL-safe base64 to bytes. Returns null on failure.
+ * Validate a Structured Field Byte Sequence value (RFC 9651 Section 3.3.5).
+ *
+ * Uses the RFC 4648 Section 4 base64 alphabet, not base64url. Per RFC 9651
+ * parsing, absent padding may be synthesized on decode; characters outside the
+ * base64 alphabet remain invalid. Accepts valid unpadded standard base64;
+ * rejects base64url (`-`/`_`), misplaced/excess `=`, `length % 4 === 1`,
+ * whitespace, and the empty string. Keep separate from JOSE/JWS handling.
+ */
+function isValidSfBase64(value: string): boolean {
+  if (value.length === 0) return false;
+  if (!SF_BASE64_ALPHABET.test(value)) return false;
+  if (value.includes('=')) {
+    return SF_BASE64_CANONICAL_PADDED.test(value);
+  }
+  return value.length % 4 !== 1;
+}
+
+/**
+ * Decode an RFC 4648 Section 4 base64 string to bytes, synthesizing absent
+ * padding per RFC 9651 byte-sequence parsing. Returns null on failure. Callers
+ * validate the input with {@link isValidSfBase64} first; this does not accept
+ * base64url. Keep separate from JOSE/JWS handling.
  */
 function base64ToBytes(b64: string): Uint8Array | null {
   try {
+    const padded = b64.includes('=')
+      ? b64
+      : b64.padEnd(b64.length + ((4 - (b64.length % 4)) % 4), '=');
     if (typeof Buffer !== 'undefined' && typeof Buffer.from === 'function') {
-      return new Uint8Array(Buffer.from(b64, 'base64'));
+      return new Uint8Array(Buffer.from(padded, 'base64'));
     }
-    const normalized = b64.replace(/-/g, '+').replace(/_/g, '/');
-    const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), '=');
     const binary = atob(padded);
     const bytes = new Uint8Array(binary.length);
     for (let i = 0; i < binary.length; i++) {
@@ -183,8 +211,10 @@ function parseContentDigestStrict(headerValue: string): DigestParse {
         message: 'Content-Digest contains an empty member',
       };
     }
-    const match = member.match(/^([A-Za-z0-9-]+)=:([A-Za-z0-9+/=]+):$/);
-    if (!match) {
+    // The value is a Structured Field Byte Sequence (RFC 9651 Section 3.3.5):
+    // RFC 4648 Section 4 standard base64; absent padding may be synthesized during parsing.
+    const match = member.match(/^([A-Za-z0-9-]+)=:([^:]*):$/);
+    if (!match || !isValidSfBase64(match[2])) {
       return {
         ok: false,
         code: ErrorCodes.CONTENT_DIGEST_MALFORMED,

--- a/packages/mappings/ucp/tests/http-signature.test.ts
+++ b/packages/mappings/ucp/tests/http-signature.test.ts
@@ -488,6 +488,56 @@ describe('verifyUcpHttpSignature: Content-Digest', () => {
     expect((await verify(fx, { headers })).error_code).toBe(ErrorCodes.CONTENT_DIGEST_MALFORMED);
   });
 
+  // Structured Field Byte Sequences are RFC 4648 Section 4 base64, not
+  // base64url, and invalid padding is rejected (RFC 9651 Section 3.3.5).
+  it('rejects a base64url ("-"/"_") Content-Digest value', async () => {
+    const fx = buildFixture();
+    for (const bad of ['sha-256=:ab-d:', 'sha-256=:ab_d:']) {
+      const headers = { ...fx.headers, 'content-digest': bad };
+      expect((await verify(fx, { headers })).error_code).toBe(ErrorCodes.CONTENT_DIGEST_MALFORMED);
+    }
+  });
+
+  it('rejects non-canonical padding in a Content-Digest value', async () => {
+    const fx = buildFixture();
+    // padding in the middle, length % 4 === 1, and too much padding
+    for (const bad of ['sha-256=:YW==YWI=:', 'sha-256=:YWJjZ:', 'sha-256=:YQ===:']) {
+      const headers = { ...fx.headers, 'content-digest': bad };
+      expect((await verify(fx, { headers })).error_code).toBe(ErrorCodes.CONTENT_DIGEST_MALFORMED);
+    }
+  });
+
+  it('accepts a valid unpadded Content-Digest signed over the exact header', async () => {
+    const fx = buildFixture();
+    const body = fx.body_bytes!;
+    // SHA-256 base64 carries one '=' pad; strip it for a valid unpadded value
+    // (RFC 9651 synthesizes the absent padding on decode).
+    const unpadded = createHash('sha256').update(body).digest('base64').replace(/=+$/g, '');
+    const headers = { ...fx.headers, 'content-digest': `sha-256=:${unpadded}:` };
+
+    // Re-sign over the exact updated headers so the covered-component binding holds.
+    const paramsValue = fx.signature_input.slice('sig1='.length);
+    const signerParams: ParsedSignatureParams = {
+      keyid: fx.kid,
+      coveredComponents: fx.covered,
+      signatureParamsValue: paramsValue,
+    };
+    const base = buildSignatureBase({ method: fx.method, url: fx.url, headers }, signerParams, {
+      preferSerializedParams: true,
+    });
+    const sig = nodeSign('sha256', signatureBaseToBytes(base), {
+      key: fx.privateKey,
+      dsaEncoding: 'ieee-p1363',
+    });
+
+    const result = await verify(fx, {
+      headers,
+      signature: `sig1=:${sig.toString('base64')}:`,
+    });
+    expect(result.valid).toBe(true);
+    expect(result.content_digest_verified).toBe(true);
+  });
+
   it('rejects a Content-Digest without sha-256 (only sha-512)', async () => {
     const fx = buildFixture();
     const headers = { ...fx.headers, 'content-digest': 'sha-512=:dGVzdA==:' };


### PR DESCRIPTION
## Summary

Tightens Structured Field byte-sequence parsing for HTTP Message Signatures and UCP digest verification.

Structured Field Byte Sequences use the RFC 4648 Section 4 base64 alphabet, matching RFC 9651. URL-safe base64 variants are rejected for these fields; absent padding is handled according to the RFC 9651 parsing algorithm. JOSE/JWS base64url handling is unchanged.

## Scope

- Tightens `Signature` byte-sequence parsing in `@peac/http-signatures`.
- Tightens UCP `Content-Digest` byte-sequence parsing.
- Adds tests for base64url rejection, malformed padding rejection, and valid unpadded base64.
- Does not change JWS/base64url receipt handling.
- Does not change schemas, wire format, registries, release state, dependencies, or package exports.

## Verification

- `pnpm --filter '@peac/http-signatures' test`
- `pnpm --filter '@peac/mappings-ucp' test`
- `pnpm --filter '@peac/mappings-tap' test`
- `pnpm --filter '@peac/worker-core' test`
- `pnpm typecheck:core`
- `pnpm verify:release`
- `pnpm exec tsx scripts/extract-api-contract.ts --check`
- `bash scripts/ci/forbid-strings.sh`
- `git diff --check`
