### PR TITLE
chore(security): renew dev audit exceptions

### DIFF
--- a/security/audit-allowlist.json
+++ b/security/audit-allowlist.json
@@ -172,7 +172,7 @@
       "reason": "Vite dev server arbitrary file read (HIGH): dev-only via vitest@4.1.0 -> vite@6.4.1. Not exposed in production.",
       "why_not_exploitable": "Vite dev server is only used during local test runs via vitest. Not in published packages or production deployments.",
       "where_used": "root devDependency: @vitest/coverage-v8@4.1.0 -> vitest@4.1.0 -> vite@6.4.1",
-      "expires_at": "2026-07-06",
+      "expires_at": "2026-09-20",
       "remediation": "Update vite when vitest ships a fix or vite patches the dev server vulnerability",
       "issue_url": "https://github.com/advisories/GHSA-p9ff-h696-f583",
       "scope": "dev",
@@ -180,7 +180,7 @@
       "verified_by": "pnpm audit --prod shows no HIGH for vite; pnpm why vite confirms vitest-only path",
       "owner": "jithinraj",
       "added_at": "2026-04-07",
-      "reviewed_at": "2026-06-07"
+      "reviewed_at": "2026-06-22"
     },
     {
       "advisory_id": "GHSA-737v-mqg7-c878",
@@ -188,7 +188,7 @@
       "reason": "defu prototype pollution via __proto__ key (HIGH): dev-only transitive dependency. Not in published packages.",
       "why_not_exploitable": "defu is a transitive dev dependency used in build/test tooling. Not in published packages. No user-controlled input reaches defu in production.",
       "where_used": "transitive devDependency via build/test tooling",
-      "expires_at": "2026-07-06",
+      "expires_at": "2026-09-20",
       "remediation": "Update when upstream patches or when the consuming tool updates its dependency",
       "issue_url": "https://github.com/advisories/GHSA-737v-mqg7-c878",
       "scope": "dev",
@@ -196,7 +196,7 @@
       "verified_by": "pnpm audit --prod shows no HIGH for defu",
       "owner": "jithinraj",
       "added_at": "2026-04-07",
-      "reviewed_at": "2026-06-07"
+      "reviewed_at": "2026-06-22"
     },
     {
       "advisory_id": "GHSA-gv7w-rqvm-qjhr",


### PR DESCRIPTION
## Summary

Renews two dev-only audit allowlist entries that were within the strict release-check warning window, so `check-audit-exception-expiry.mjs --strict` passes.

## Scope

Only `security/audit-allowlist.json`.

This renews two dev-only audit allowlist entries that were inside the strict release-check warning window:

- `GHSA-p9ff-h696-f583`: Vite via Vitest / dev tooling
- `GHSA-737v-mqg7-c878`: defu via dev/build/test tooling

For both entries:

- `expires_at`: `2026-07-06` -> `2026-09-20`
- `reviewed_at`: `2026-06-07` -> `2026-06-22`

No dependency, lockfile, runtime, schema, wire format, registry, conformance fixture, package export, or release-state change.

## Validation

- `check-audit-exception-expiry.mjs --strict`: GREEN / exit 0
- `audit-gate.mjs`: OK
- `verify:release`: green
- API contract check: green
- forbid-strings, diff-check, and format-check: green
