### PR TITLE
chore(release): stamp v0.15.2 release state

### DIFF
--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable surface classification for PEAC Protocol workspace. CI fails if any workspace member is missing. See docs/PACKAGE_STATUS.md for human-readable view.",
   "version": "0.13.0",
-  "updated": "2026-06-11",
+  "updated": "2026-06-22",
   "states": {
     "default": "Current recommended path. Actively maintained, Wire 0.2 native.",
     "supported": "Actively maintained, published, production-ready. May not be on default quickstart path.",

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -2,7 +2,7 @@
 
 Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scripts/generate-surface-status.mjs`.
 
-**Version:** 0.13.0 | **Updated:** 2026-06-11
+**Version:** 0.13.0 | **Updated:** 2026-06-22
 
 ## Layer 1
 

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -4,7 +4,7 @@
   "version": "0.15.2",
   "wire_format_version": "0.2",
   "dist_tag": "latest",
-  "release_date": "2026-06-11",
+  "release_date": "2026-06-22",
   "metrics": {
     "tests": 11813,
     "test_files": 471,


### PR DESCRIPTION
## Summary

Stamps v0.15.2 release-state after the tag, npm publish, and promote-to-latest. Release-state metadata only.

## Scope

- `docs/releases/facts.json`: `release_date` -> `2026-06-22` (dist_tag was already `latest`).
- `REPO_SURFACE_STATUS.json` + `docs/SURFACE_STATUS.md`: regenerated surface-status.

No runtime, schema, wire format, registry, conformance, dependency, lockfile, or package export change.

## Release state (verified)

- npm `latest` = `0.15.2` across all 36 packages; `next` = `0.15.2`.
- Tag `v0.15.2` (signed) reachable from `origin/main`.
- GitHub Release `v0.15.2` finalized.
- `verify-release-closeout --version 0.15.2 --stage final`: 7 GREEN / 0 YELLOW / 0 RED.
- `verify:release`: 25/0.
