### PR TITLE
docs: add try and verify guides

### DIFF
--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -8,6 +8,8 @@ PEAC helps API, MCP, agent, gateway, payment-adjacent, provisioning, runtime, an
 
 Pick the path that matches what you are building.
 
+New here? [Try PEAC in 5 minutes](TRY.md) or [verify a record](VERIFY.md).
+
 ## I run an API or HTTP service
 
 You want to issue signed receipts proving what terms applied and what happened on every response.

--- a/docs/TRY.md
+++ b/docs/TRY.md
@@ -1,0 +1,37 @@
+# Try PEAC in 5 minutes
+
+A PEAC record is portable signed evidence that another party can verify offline.
+This guide uses the PEAC CLI to generate sample records and verify one of them
+with nothing but a public key. No network access and no issuer discovery are
+required.
+
+## Generate and verify offline
+
+Run both commands in order. The first generates a set of sample records and a
+sandbox key set. The second verifies one record against that public key.
+
+```bash
+pnpm dlx @peac/cli samples generate -o ./s
+pnpm dlx @peac/cli verify ./s/valid/basic-record.jws --public-key ./s/bundles/sandbox-jwks.json
+```
+
+The expected output of the verify command is:
+
+```
+Signature valid (offline).
+```
+
+That confirms the record's signature checks out against the supplied key,
+without contacting any issuer.
+
+## What just happened
+
+- `samples generate` wrote sample records under `./s/valid/` and a sandbox key
+  set under `./s/bundles/sandbox-jwks.json`.
+- `verify --public-key` checked the record's signature against that key. Because
+  a key was supplied directly, the command did no network lookup.
+
+## Next steps
+
+- The same copy-paste walkthrough also appears in the README: [Try it in 5 minutes](../README.md#try-it-in-5-minutes).
+- Browse runnable flows under [examples](../examples/README.md).

--- a/docs/VERIFY.md
+++ b/docs/VERIFY.md
@@ -1,0 +1,57 @@
+# Verify a PEAC record
+
+In this quickstart, the record is carried as a compact JWS string. You can verify
+it offline with the issuer public key, either from the command line or from
+TypeScript. Neither path needs network access when the key is supplied directly.
+
+## Command line
+
+First generate the sample directory, then verify one record against the bundled
+sandbox key:
+
+```bash
+pnpm dlx @peac/cli samples generate -o ./s
+pnpm dlx @peac/cli verify ./s/valid/basic-record.jws --public-key ./s/bundles/sandbox-jwks.json
+```
+
+The expected verify output is:
+
+```
+Signature valid (offline).
+```
+
+For more on generating sample records, see [Try PEAC in 5 minutes](TRY.md).
+
+## Library
+
+In code, read the record from the `PEAC-Receipt` response header and verify it
+with `verifyLocal()`:
+
+```typescript
+import { verifyLocal } from '@peac/protocol';
+
+const recordJws = response.headers.get('PEAC-Receipt');
+
+if (!recordJws) {
+  throw new Error('Missing PEAC-Receipt header');
+}
+
+const result = await verifyLocal(recordJws, publicKey, {
+  issuer: 'https://api.example.com',
+});
+
+if (!result.valid) {
+  throw new Error(`${result.code}: ${result.message}`);
+}
+
+console.log(result.claims.iss, result.claims.kind, result.claims.type);
+```
+
+A successful result exposes the verified claims. A failed result carries a stable
+`code` and `message` so callers can fail closed.
+
+## Next steps
+
+- [Start Here](START_HERE.md#i-want-to-verify-a-receipt) walks through the verify path end to end.
+- [examples/minimal](../examples/minimal/) shows typed accessor helpers.
+- Self-host the [reference verifier](../surfaces/reference-verifier/).

--- a/tests/tooling/entry-links-doc-truth.test.ts
+++ b/tests/tooling/entry-links-doc-truth.test.ts
@@ -35,7 +35,13 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, '..', '..');
 
 // The primary entry documents whose relative links must resolve.
-const REQUIRED_DOCS = ['README.md', 'docs/START_HERE.md', 'examples/README.md'];
+const REQUIRED_DOCS = [
+  'README.md',
+  'docs/START_HERE.md',
+  'examples/README.md',
+  'docs/TRY.md',
+  'docs/VERIFY.md',
+];
 
 // The seven "Choose your path" table targets in the README (one table row
 // carries two links). Pinned independently of the generic scan.
@@ -230,5 +236,38 @@ describe('link parser handles Markdown durability cases', () => {
     expect(isInsideRepo(resolveTarget(startHerePath, '../../outside.md'))).toBe(false);
     // A normal in-repo link stays inside.
     expect(isInsideRepo(resolveTarget(startHerePath, '../examples/README.md'))).toBe(true);
+  });
+});
+
+describe('entry guides reuse the README quickstart snippet', () => {
+  // The exact public offline copy-paste the README promises a new developer.
+  // Source of truth: tests/tooling/readme-quickstart-doc-truth.test.ts, which
+  // locks these strings against the README and the shipped CLI. The entry
+  // guides must reuse them verbatim so the guides cannot drift from the README.
+  const GENERATE_CMD = 'pnpm dlx @peac/cli samples generate -o ./s';
+  const VERIFY_CMD =
+    'pnpm dlx @peac/cli verify ./s/valid/basic-record.jws --public-key ./s/bundles/sandbox-jwks.json';
+  const SUCCESS_LITERAL = 'Signature valid (offline).';
+
+  it('docs/TRY.md uses the offline one-liner (generate before verify) and the success literal', () => {
+    const try_ = readFileSync(join(REPO_ROOT, 'docs/TRY.md'), 'utf8');
+    const gen = try_.indexOf(GENERATE_CMD);
+    const verify = try_.indexOf(VERIFY_CMD);
+    expect(gen, 'docs/TRY.md must contain the generate command').toBeGreaterThan(-1);
+    expect(verify, 'docs/TRY.md must contain the verify command').toBeGreaterThan(-1);
+    expect(gen, 'generate must appear before verify in docs/TRY.md').toBeLessThan(verify);
+    expect(try_, 'docs/TRY.md must state the success literal').toContain(SUCCESS_LITERAL);
+  });
+
+  it('docs/VERIFY.md is self-contained: generate before verify, plus the success literal', () => {
+    // VERIFY.md must be independently copy-pasteable, so it includes the
+    // generate command before the verify command (not only the verify line).
+    const verifyDoc = readFileSync(join(REPO_ROOT, 'docs/VERIFY.md'), 'utf8');
+    const gen = verifyDoc.indexOf(GENERATE_CMD);
+    const verify = verifyDoc.indexOf(VERIFY_CMD);
+    expect(gen, 'docs/VERIFY.md must contain the generate command').toBeGreaterThan(-1);
+    expect(verify, 'docs/VERIFY.md must contain the verify command').toBeGreaterThan(-1);
+    expect(gen, 'generate must appear before verify in docs/VERIFY.md').toBeLessThan(verify);
+    expect(verifyDoc, 'docs/VERIFY.md must state the success literal').toContain(SUCCESS_LITERAL);
   });
 });


### PR DESCRIPTION
Adds two short entry guides, `docs/TRY.md` (Try PEAC in 5 minutes) and `docs/VERIFY.md` (Verify a PEAC record), that reuse the README's offline quickstart and verification snippets, plus a small pointer from the Start Here guide.

Extends the entry-document link test to cover the two new guides and to assert they reuse the exact README quickstart snippet (generate before verify, plus the success literal), so the guides cannot drift from the README.

No new commands, runtime behavior, schema, wire format, registry, conformance fixture, dependency, lockfile, package export, or release-state change.
