### PR TITLE
docs: community contribution surfaces

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,10 +1,19 @@
 # Contributing to PEAC Protocol
 
-Thank you for your interest in contributing to the PEAC Protocol! This document outlines how to contribute effectively to our modern enterprise monorepo.
+Thank you for your interest in contributing to the PEAC Protocol! This document outlines how to contribute effectively to the PEAC open protocol repository.
 
 ## Code of Conduct
 
 By participating in this project, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Where to start
+
+New here? A few good entry points:
+
+- **Good first issues:** browse issues labeled [`good first issue`](https://github.com/peacprotocol/peac/labels/good%20first%20issue) for small, well-scoped tasks.
+- **Run the examples first:** `pnpm demo:all` runs the start-here examples end to end; see [`examples/README.md`](../examples/README.md) for the curated set and [`docs/START_HERE.md`](../docs/START_HERE.md) for path-by-role guidance.
+- **Want an example that does not exist yet?** Open an [Example Request](https://github.com/peacprotocol/peac/issues/new?template=example_request.md).
+- **Questions or design discussion?** Use [Discussions](https://github.com/peacprotocol/peac/discussions) rather than an issue.
 
 ## Development Setup
 
@@ -104,7 +113,7 @@ perf(scope): optimize performance
 - Crawler operations: ≤ 35ms
 - API endpoints: documented SLOs
 
-## Enterprise CI/CD Pipeline
+## CI/CD validation pipeline
 
 Our 7-phase enterprise pipeline validates:
 
@@ -134,7 +143,7 @@ The project follows semantic versioning with development releases:
 - `0.9.12` for stable releases
 - Breaking changes documented
 
-### Branch Strategy
+### Branching workflow
 
 - Create release branches: `release/vX.X.X`
 - Feature branches: `feature/description`

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and usage help
+    url: https://github.com/peacprotocol/peac/discussions
+    about: Ask how to use PEAC, get integration help, or discuss design. Please use Discussions for questions rather than opening an issue.
+  - name: Contribution guide
+    url: https://github.com/peacprotocol/peac/blob/main/.github/CONTRIBUTING.md
+    about: Read the contributor workflow, testing expectations, and how to start.
+  - name: Security disclosure
+    url: https://github.com/peacprotocol/peac/security/policy
+    about: Report a security vulnerability privately. Do not open a public issue for security reports; see SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/example_request.md
+++ b/.github/ISSUE_TEMPLATE/example_request.md
@@ -1,0 +1,35 @@
+---
+name: Example Request
+about: Request a runnable integration example for an existing PEAC surface
+title: '[EXAMPLE] '
+labels: enhancement, documentation
+assignees: ''
+---
+
+## What integration do you want an example for?
+
+<!-- e.g. "MCP tool call with attached record", "x402 payment flow", "OTel span to signed record", "HTTP API gateway record export" -->
+
+## Surface / protocol
+
+<!-- Which surface or protocol does this involve? -->
+
+- [ ] MCP (tool calls, gateway)
+- [ ] HTTP API / middleware
+- [ ] Payments / commerce
+- [ ] A2A (agent-to-agent)
+- [ ] OpenTelemetry / correlation
+- [ ] Provisioning / lifecycle
+- [ ] Other (describe below)
+
+## Integration shape
+
+<!-- Roughly how should it work? Where does the record get issued, carried, and verified? -->
+
+## What does "done" look like?
+
+<!-- What should the example let a reader copy-paste and run, and what should they see? -->
+
+## Additional context
+
+<!-- Existing examples that are close, related issues, or links. The runnable examples live under examples/ (see examples/README.md). -->


### PR DESCRIPTION
Adds an issue-template chooser config, an example-request issue template, and a short "Where to start" section in CONTRIBUTING so new contributors can find good first issues, run examples, ask usage questions in Discussions, and request runnable integration examples.

Reuses the existing contributor, code-of-conduct, security, support, bug-report, and feature-request surfaces. No code, schema, wire format, registry, dependency, package export, or release-state change.
