### PR TITLE
docs: clarify repo-local demo prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,17 @@ Practical recipes under [`docs/SOLUTIONS/`](docs/SOLUTIONS/):
   pnpm dlx @peac/cli verify ./s/valid/basic-record.jws --public-key ./s/bundles/sandbox-jwks.json
   ```
 - Start the MCP server: `npx -y @peac/mcp-server`.
+
+The `pnpm dlx @peac/cli ...` and `npx ...` commands above run without cloning this repository. The examples below are repo-local: clone the repository first, then run:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm build
+pnpm demo:all
+```
+
+`pnpm demo:all` runs the start-here examples end to end. The individual commands below are optional targeted demos you can run after that setup.
+
 - Run the minimal example: `pnpm --filter @peac/example-minimal demo`.
 - Run the MCP gateway records example:
   ```bash


### PR DESCRIPTION
## Summary

Clarifies the README "Try it in 5 minutes" path by separating standalone commands from repo-local examples.

The `pnpm dlx @peac/cli ...` and `npx -y @peac/mcp-server` commands can run without cloning this repository. The repo-local example commands now point readers to the required setup first:

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm demo:all`

The existing individual `pnpm --filter @peac/example-* ...` commands remain as optional targeted demos after that setup.

## Scope

Documentation only. One file changed: `README.md`.

No code, schema, wire format, registry, dependency, package export, release-state, or package-script change.

## Validation

- `prettier --check README.md`
- `forbid-strings`
- `git diff --check`
- `check-public-artifacts`
- `pnpm demo:all`
- `guard` with `PEAC_FAST=1`
- `verify:release`
- `extract-api-contract --check`
- `format:check`
- README quickstart/doc-truth gates
