### PR TITLE
docs: verification options and sample index

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -13,14 +13,14 @@ pnpm start
 
 ## Endpoints
 
-### `POST /api/v1/verify`
+### `POST /v1/verify`
 
-Verify a PEAC receipt.
+Verify a PEAC receipt. This is the canonical verify operation; see `packages/schema/openapi/verify.yaml` and [`docs/HOSTED_VERIFY_CONTRACT.md`](../../docs/HOSTED_VERIFY_CONTRACT.md).
 
 **Request:**
 
 ```bash
-curl -X POST http://localhost:3000/api/v1/verify \
+curl -X POST http://localhost:3000/v1/verify \
   -H "Content-Type: application/json" \
   -d '{"receipt": "eyJhbGciOiJFZERTQSIs..."}'
 ```
@@ -36,16 +36,18 @@ curl -X POST http://localhost:3000/api/v1/verify \
 
 **Success response (200):**
 
+The response body indicates the verified/failed state. See `packages/schema/openapi/verify.yaml` and [`docs/HOSTED_VERIFY_CONTRACT.md`](../../docs/HOSTED_VERIFY_CONTRACT.md) for the canonical schema.
+
 ```json
 {
-  "valid": true,
-  "claims": {
-    "iss": "https://sandbox.peacprotocol.org",
-    "aud": "https://example.com",
-    "iat": 1738756800,
-    "exp": 1738760400,
-    "rid": "receipt-id"
-  }
+  "verified": true,
+  "receipt_ref": "sha256:<hex>",
+  "claims": {},
+  "warnings": [],
+  "policy_binding": "verified",
+  "issuer": "https://example.com",
+  "kid": "key-1",
+  "wire_version": "0.2"
 }
 ```
 
@@ -53,14 +55,14 @@ curl -X POST http://localhost:3000/api/v1/verify \
 
 ```json
 {
-  "type": "https://www.peacprotocol.org/problems/invalid-jws-format",
-  "title": "Invalid JWS Format",
-  "status": 422,
-  "detail": "Receipt is not valid JWS compact serialization"
+  "type": "https://www.peacprotocol.org/problems/invalid-format",
+  "title": "Invalid Format",
+  "status": 400,
+  "detail": "Input is not a valid compact JWS."
 }
 ```
 
-All error responses use `Content-Type: application/problem+json`.
+All error responses use `Content-Type: application/problem+json` with kernel-canonical error codes (see [`docs/HOSTED_VERIFY_CONTRACT.md`](../../docs/HOSTED_VERIFY_CONTRACT.md)).
 
 ### `GET /health`
 
@@ -70,15 +72,15 @@ Health check endpoint.
 { "ok": true }
 ```
 
-### `POST /verify` (deprecated)
+### Deprecated aliases
 
-Legacy verify endpoint. Use `/api/v1/verify` instead.
+`POST /api/v1/verify` and `POST /verify` are deprecated compatibility aliases. They delegate in-process to `POST /v1/verify` and return the same response shape and status codes. New integrations MUST target `POST /v1/verify`. See [`docs/HOSTED_VERIFY_CONTRACT.md`](../../docs/HOSTED_VERIFY_CONTRACT.md) for the alias behavior and Sunset schedule.
 
 ## Rate Limits
 
 | Tier      | Limit         | Window   | Header      |
 | --------- | ------------- | -------- | ----------- |
-| Anonymous | 100 requests  | 1 minute | :           |
+| Anonymous | 100 requests  | 1 minute | none        |
 | API Key   | 1000 requests | 1 minute | `X-API-Key` |
 
 All responses include RFC 9333 rate limit headers:
@@ -89,13 +91,14 @@ All responses include RFC 9333 rate limit headers:
 
 ## HTTP Status Codes
 
-| Status | Meaning                                              |
-| ------ | ---------------------------------------------------- |
-| 200    | Verification complete                                |
-| 413    | Receipt too large (> 256 KB)                         |
-| 422    | Invalid receipt, untrusted issuer, or missing claims |
-| 429    | Rate limit exceeded                                  |
-| 500    | Internal server error                                |
+| Status | Meaning                                                                                  |
+| ------ | ---------------------------------------------------------------------------------------- |
+| 200    | Verification completed; response body indicates the result.                              |
+| 400    | Invalid request format.                                                                  |
+| 413    | Request body too large (receipt exceeds 256 KiB).                                        |
+| 422    | Verification or validation failure (signature invalid, claims invalid, policy mismatch). |
+| 429    | Rate limit exceeded.                                                                     |
+| 502    | Upstream resolution failure (JWKS fetch, issuer config fetch).                           |
 
 ## Security Headers
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -38,8 +38,9 @@ You have a receipt (JWS string) and want to verify it offline with a public key.
 
 1. Install: `pnpm add @peac/protocol @peac/crypto`
 2. Follow the [Agent Operator Quickstart](guides/quickstart-agent-operator.md) (5 minutes)
-3. See [examples/minimal](../examples/minimal/) for typed accessor helpers
-4. Self-host the reference verifier: recipes under [`surfaces/reference-verifier/`](../surfaces/reference-verifier/)
+3. Compare the CLI, browser, and self-host paths in [Verification options](guides/verification-options.md), and try them on the shipped records in the [Offline sample index](guides/offline-sample-index.md)
+4. See [examples/minimal](../examples/minimal/) for typed accessor helpers
+5. Self-host the reference verifier: recipes under [`surfaces/reference-verifier/`](../surfaces/reference-verifier/)
 
 Key packages: `@peac/protocol`, `@peac/crypto`.
 

--- a/docs/guides/offline-sample-index.md
+++ b/docs/guides/offline-sample-index.md
@@ -1,0 +1,49 @@
+# Offline sample index
+
+`@peac/cli` ships a set of sample records you can generate and verify offline with only a public key. They let you exercise the verification paths in [Verification options](verification-options.md) without trusting any hosted service: the valid records are expected to verify, and the invalid fixtures are expected to be rejected.
+
+## Generate the samples
+
+```bash
+pnpm dlx @peac/cli samples generate -o ./s
+```
+
+This writes the valid records under `./s/valid/`, the invalid rejection fixtures under `./s/invalid/`, and the single-key sandbox public key at `./s/bundles/sandbox-jwks.json`.
+
+## Valid records
+
+These verify offline against the sandbox key. Verify any of them with:
+
+```bash
+pnpm dlx @peac/cli verify ./s/valid/<id>.jws --public-key ./s/bundles/sandbox-jwks.json
+```
+
+| Record              | What it is                                                     |
+| ------------------- | -------------------------------------------------------------- |
+| `basic-record`      | Minimal valid signed interaction record.                       |
+| `full-record`       | Valid record with optional fields (subject, declared purpose). |
+| `mcp-tool-run`      | Valid record for an MCP tool run.                              |
+| `payment-event`     | Valid record for a payment event.                              |
+| `event-time-record` | Valid record carrying an event time (`occurred_at`).           |
+
+A valid record prints:
+
+```text
+Signature valid (offline).
+```
+
+## Invalid records
+
+These are intentionally invalid rejection fixtures. They demonstrate that verification fails closed; a verifier rejects them rather than accepting a bad record.
+
+| Record        | Why it is rejected                                  |
+| ------------- | --------------------------------------------------- |
+| `expired`     | Already expired.                                    |
+| `future-iat`  | Issuance time in the future (clock-skew violation). |
+| `missing-iss` | Missing the required issuer claim.                  |
+
+## Related
+
+- [`docs/guides/verification-options.md`](verification-options.md) — the three verification paths.
+- [`docs/VERIFY.md`](../VERIFY.md) — command-line and library verification walkthrough.
+- [`specs/conformance/samples/README.md`](../../specs/conformance/samples/README.md) — the canonical sample reference.

--- a/docs/guides/verification-options.md
+++ b/docs/guides/verification-options.md
@@ -1,0 +1,63 @@
+# Verification options
+
+A PEAC record is a signed JWS. Its signature can be verified offline with the issuer's public key; hosted verification may also perform issuer discovery and policy-binding checks depending on the request. This guide lays out the three verification paths that already ship in this repository, so you can pick the one that fits where verification happens. For the command-line and library walkthrough in depth, see [`docs/VERIFY.md`](../VERIFY.md).
+
+## The three paths
+
+| Path             | Where it runs              | Use it when                                                                   |
+| ---------------- | -------------------------- | ----------------------------------------------------------------------------- |
+| CLI offline      | A terminal, no network     | You want to verify a file locally or in CI.                                   |
+| Browser verifier | A static page, client-side | You want to paste or drop a record and verify it in a browser with no server. |
+| Self-host HTTP   | A container you run        | You want a verify endpoint other services can call.                           |
+
+### 1. CLI offline
+
+Generate the sample records and verify one with only the bundled public key:
+
+```bash
+pnpm dlx @peac/cli samples generate -o ./s
+pnpm dlx @peac/cli verify ./s/valid/basic-record.jws --public-key ./s/bundles/sandbox-jwks.json
+```
+
+Expected output:
+
+```text
+Signature valid (offline).
+```
+
+No network calls are made when `--public-key` is supplied. See [`docs/VERIFY.md`](../VERIFY.md) for the `verifyLocal()` library form and the issuer-discovery (network JWKS) path.
+
+### 2. Browser verifier
+
+[`apps/verifier/`](../../apps/verifier/) is a client-side browser verifier. All verification runs locally with `verifyLocal()` from `@peac/protocol`; no record is sent to any server. Add the trusted issuer public key to its trust store, then paste or drop a record.
+
+```bash
+# from apps/verifier/
+pnpm install
+pnpm dev
+# opens on http://localhost:5173
+```
+
+See [`apps/verifier/README.md`](../../apps/verifier/README.md) for the trust-store and build details.
+
+### 3. Self-host HTTP
+
+[`surfaces/reference-verifier/`](../../surfaces/reference-verifier/) packages the verify API ([`apps/api/`](../../apps/api/)) as a container you can run. The canonical verify operation is `POST /v1/verify`.
+
+```bash
+# from surfaces/reference-verifier/
+docker compose up -d
+curl -s http://localhost:3000/health
+```
+
+The canonical verify contract is [`packages/schema/openapi/verify.yaml`](../../packages/schema/openapi/verify.yaml); see [`docs/HOSTED_VERIFY_CONTRACT.md`](../HOSTED_VERIFY_CONTRACT.md) for the request/response shape, error catalog, and the deprecated `/api/v1/verify` and `/verify` aliases. These recipes are for local evaluation, CI smoke tests, and single-tenant self-hosting; multi-tenant hosted operation is out of scope.
+
+## Try it on sample records
+
+Every path above can verify the shipped sample records. See the [Offline sample index](offline-sample-index.md) for the full set of valid and invalid records and the one-liner to verify each offline.
+
+## Related
+
+- [`docs/VERIFY.md`](../VERIFY.md) — command-line and library verification walkthrough.
+- [`docs/guides/offline-sample-index.md`](offline-sample-index.md) — the shipped valid and invalid sample records.
+- [`docs/START_HERE.md`](../START_HERE.md) — entry path by role.

--- a/tests/tooling/entry-links-doc-truth.test.ts
+++ b/tests/tooling/entry-links-doc-truth.test.ts
@@ -42,6 +42,8 @@ const REQUIRED_DOCS = [
   'docs/TRY.md',
   'docs/VERIFY.md',
   'docs/guides/integration-patterns.md',
+  'docs/guides/verification-options.md',
+  'docs/guides/offline-sample-index.md',
 ];
 
 // The seven "Choose your path" table targets in the README (one table row


### PR DESCRIPTION
## Summary

Adds two docs-only verifier guides:

- `docs/guides/verification-options.md` compares the CLI offline, browser verifier, and self-host HTTP verification paths.
- `docs/guides/offline-sample-index.md` documents the shipped valid and invalid sample records and the offline verification one-liner.

Also links the guides from `docs/START_HERE.md` and adds both guides to entry-link doc-truth coverage.

## Verifier README drift repair

Repairs `apps/api/README.md` so it matches the verifier authority sources:

- canonical verify endpoint is `POST /v1/verify`
- `POST /api/v1/verify` and `POST /verify` are deprecated compatibility aliases
- success response shape uses `verified`, `receipt_ref`, `claims`, `warnings`, `policy_binding`, `issuer`, `kid`, and `wire_version`
- error example uses kernel-canonical `invalid-format`
- HTTP status table now documents `200`, `400`, `413`, `422`, `429`, and `502`
- anonymous rate-limit header is documented as `none`

## Scope

Documentation only.

Changed files:

- `apps/api/README.md`
- `docs/START_HERE.md`
- `docs/guides/offline-sample-index.md`
- `docs/guides/verification-options.md`
- `tests/tooling/entry-links-doc-truth.test.ts`