### PR TITLE
docs: refresh developer docs and metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 Agent-readable metadata for PEAC Protocol.
-Last reviewed: 2026-04-01
+Last reviewed: 2026-06-24
 
 ## Identity
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,5 +22,5 @@ keywords:
   - content-licensing
   - agent-protocols
 license: Apache-2.0
-version: '0.15.0'
-date-released: '2026-06-01'
+version: '0.15.2'
+date-released: '2026-06-22'

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ PEAC records those actions, decisions, and events as portable signed interaction
 [![npm downloads](https://img.shields.io/npm/dm/@peac/protocol?style=flat&color=brightgreen)](https://www.npmjs.com/package/@peac/protocol)
 [![CI Status](https://img.shields.io/github/actions/workflow/status/peacprotocol/peac/ci.yml?branch=main&label=CI&color=brightgreen)](https://github.com/peacprotocol/peac/actions/workflows/ci.yml)
 
+## Start fast
+
+- **Verify a sample offline:** [`docs/guides/offline-sample-index.md`](docs/guides/offline-sample-index.md)
+- **Compare verification paths:** [`docs/guides/verification-options.md`](docs/guides/verification-options.md)
+- **Wire PEAC into MCP, OpenTelemetry, or a gateway:** [`docs/guides/integration-patterns.md`](docs/guides/integration-patterns.md)
+- **Choose by role:** [`docs/START_HERE.md`](docs/START_HERE.md)
+
 ## What PEAC records
 
 PEAC is useful when a system does work and another party later needs to
@@ -83,18 +90,33 @@ scope: [`docs/WHAT-PEAC-STANDARDIZES.md`](docs/WHAT-PEAC-STANDARDIZES.md).
 
 ## Choose your path
 
-| If you...                                       | PEAC helps you...                                                                                                                      | Start here                                                                                                                              |
-| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| Run an API or metered service                   | issue signed records for requests, responses, usage, and policy-visible outcomes                                                       | [API Provider Quickstart](docs/guides/quickstart-api-provider.md)                                                                       |
-| Build MCP tools or agent workflows              | attach records to tool runs, command execution, handoffs, lifecycle events, and agent actions                                          | [MCP Integration Kit](integrator-kits/mcp/README.md) or `npx -y @peac/mcp-server`                                                       |
-| Build payment, gateway, or commerce flows       | preserve signed evidence around access, payment, settlement, mandate, gateway, and dispute events without operating the payment system | [MCP gateway records](docs/SOLUTIONS/mcp-gateway-receipts.md) or [Commerce evidence bundle](docs/SOLUTIONS/commerce-evidence-bundle.md) |
-| Track provisioning or resource lifecycle events | record catalog, provider-link, account, credential, budget, subscription, domain, deployment, and resource events                      | [Provisioning lifecycle records](docs/SOLUTIONS/verify-agent-provisioning.md)                                                           |
-| Need audit or review evidence                   | export portable records and bundles that can be referenced beside logs, traces, SIEMs, reports, and audit repositories                 | [Where PEAC fits](docs/WHERE-IT-FITS.md)                                                                                                |
-| Need to verify a record                         | verify a signed PEAC record with the issuer's public key or a self-hosted verifier                                                     | [Agent Operator Quickstart](docs/guides/quickstart-agent-operator.md)                                                                   |
+| If you...                                       | PEAC helps you...                                                                                                                      | Start here                                                                                                                                                                                         |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Run an API or metered service                   | issue signed records for requests, responses, usage, and policy-visible outcomes                                                       | [API Provider Quickstart](docs/guides/quickstart-api-provider.md)                                                                                                                                  |
+| Build MCP tools or agent workflows              | attach records to tool runs, command execution, handoffs, lifecycle events, and agent actions                                          | [MCP Integration Kit](integrator-kits/mcp/README.md), [Integration patterns guide](docs/guides/integration-patterns.md), or `npx -y @peac/mcp-server`                                              |
+| Build payment, gateway, or commerce flows       | preserve signed evidence around access, payment, settlement, mandate, gateway, and dispute events without operating the payment system | [MCP gateway records](docs/SOLUTIONS/mcp-gateway-receipts.md) or [Commerce evidence bundle](docs/SOLUTIONS/commerce-evidence-bundle.md)                                                            |
+| Track provisioning or resource lifecycle events | record catalog, provider-link, account, credential, budget, subscription, domain, deployment, and resource events                      | [Provisioning lifecycle records](docs/SOLUTIONS/verify-agent-provisioning.md)                                                                                                                      |
+| Need audit or review evidence                   | export portable records and bundles that can be referenced beside logs, traces, SIEMs, reports, and audit repositories                 | [Verification options](docs/guides/verification-options.md) or [Where PEAC fits](docs/WHERE-IT-FITS.md)                                                                                            |
+| Need to verify a record                         | verify a signed PEAC record with the issuer's public key or a self-hosted verifier                                                     | [Verification options](docs/guides/verification-options.md), [Offline sample index](docs/guides/offline-sample-index.md), or [Agent Operator Quickstart](docs/guides/quickstart-agent-operator.md) |
 
 Full path-by-role tree: [`docs/START_HERE.md`](docs/START_HERE.md).
 
-## Quickstart: verify one record
+## Quickstart: verify a sample offline
+
+```bash
+pnpm dlx @peac/cli samples generate -o ./s
+pnpm dlx @peac/cli verify ./s/valid/basic-record.jws --public-key ./s/bundles/sandbox-jwks.json
+```
+
+Expected:
+
+```text
+Signature valid (offline).
+```
+
+For browser and self-hosted verifier paths, see [`docs/guides/verification-options.md`](docs/guides/verification-options.md). For the full shipped sample set, see [`docs/guides/offline-sample-index.md`](docs/guides/offline-sample-index.md).
+
+## Quickstart: verify one record in code
 
 ```bash
 npm install @peac/protocol @peac/crypto
@@ -168,14 +190,16 @@ produced the log.
 PEAC is designed to be reviewed as protocol infrastructure, not as a
 hosted control plane.
 
-| Need                                      | Read                                                           |
-| ----------------------------------------- | -------------------------------------------------------------- |
-| Supported versions and disclosure process | [`SECURITY.md`](SECURITY.md)                                   |
-| Measured local verification baselines     | [`docs/SLO.md`](docs/SLO.md)                                   |
-| Stability classes and archived surfaces   | [`docs/STABILITY-CONTRACT.md`](docs/STABILITY-CONTRACT.md)     |
-| Compatibility and deprecation status      | [`docs/COMPATIBILITY_MATRIX.md`](docs/COMPATIBILITY_MATRIX.md) |
-| External standards references             | [`docs/STANDARDS_LEDGER.md`](docs/STANDARDS_LEDGER.md)         |
-| Release-line invariant snapshots          | [`docs/baselines/`](docs/baselines/)                           |
+| Need                                      | Read                                                                         |
+| ----------------------------------------- | ---------------------------------------------------------------------------- |
+| Supported versions and disclosure process | [`SECURITY.md`](SECURITY.md)                                                 |
+| Measured local verification baselines     | [`docs/SLO.md`](docs/SLO.md)                                                 |
+| Stability classes and archived surfaces   | [`docs/STABILITY-CONTRACT.md`](docs/STABILITY-CONTRACT.md)                   |
+| Compatibility and deprecation status      | [`docs/COMPATIBILITY_MATRIX.md`](docs/COMPATIBILITY_MATRIX.md)               |
+| External standards references             | [`docs/STANDARDS_LEDGER.md`](docs/STANDARDS_LEDGER.md)                       |
+| Release-line invariant snapshots          | [`docs/baselines/`](docs/baselines/)                                         |
+| Verification paths                        | [`docs/guides/verification-options.md`](docs/guides/verification-options.md) |
+| Offline sample records                    | [`docs/guides/offline-sample-index.md`](docs/guides/offline-sample-index.md) |
 
 The reference verifier is self-hostable. Verification can also be
 performed locally when the record and issuer public key are available.
@@ -309,6 +333,8 @@ Full doctrine: [`docs/specs/VERSIONING.md`](docs/specs/VERSIONING.md).
 ## Documentation
 
 - [Start Here](docs/START_HERE.md) — path by role.
+- [Integration patterns](docs/guides/integration-patterns.md) — MCP, OpenTelemetry, and gateway integration patterns using shipped surfaces.
+- [Verification options](docs/guides/verification-options.md), [Offline sample index](docs/guides/offline-sample-index.md) — verifier paths and sample records.
 - [How it works](docs/HOW-IT-WORKS.md), [Artifacts](docs/ARTIFACTS.md), [Where it fits](docs/WHERE-IT-FITS.md), [What PEAC standardizes](docs/WHAT-PEAC-STANDARDIZES.md).
 - [Use cases](docs/SOLUTIONS/) — practical recipes.
 - [Spec Index](docs/SPEC_INDEX.md) — normative specifications, including [Resource limits](docs/specs/RESOURCE-LIMITS.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-Last reviewed: 2026-06-01
+Last reviewed: 2026-06-24
 
 This is the canonical security policy for the PEAC Protocol. It describes
 how to report a vulnerability, which versions receive security fixes, what

--- a/integrator-kits/README.md
+++ b/integrator-kits/README.md
@@ -29,3 +29,7 @@ pnpm exec tsx scripts/conformance-harness.ts --adapter core --format pretty
 ```
 
 See the conformance harness documentation for full options.
+
+---
+
+_Last reviewed: 2026-06-24._

--- a/llms.txt
+++ b/llms.txt
@@ -2,8 +2,8 @@
 
 > Open standard for verifiable interaction records across agent, tool, API, MCP, and cross-runtime systems.
 > Portable signed records anyone can verify offline.
-> Current release: v0.15.0
-> Last reviewed: 2026-06-01
+> Current release: v0.15.2
+> Last reviewed: 2026-06-24
 
 ## What is PEAC
 
@@ -16,7 +16,8 @@ PEAC does not orchestrate protocols, control systems, or enforce behavior. It re
 ## Quick Start
 
 - Install the MCP server: `npx -y @peac/mcp-server`
-- Verify a record: start the MCP server, then call `peac_verify` with a JWS and public key
+- Verify offline from the CLI: `pnpm dlx @peac/cli samples generate -o ./s` then `pnpm dlx @peac/cli verify ./s/valid/basic-record.jws --public-key ./s/bundles/sandbox-jwks.json` (prints `Signature valid (offline).`)
+- Verify a record over MCP: start the MCP server, then call `peac_verify` with a JWS and public key
 - Issue a record: use `@peac/protocol` with `issue()` and an Ed25519 signing key
 - GitHub: https://github.com/peacprotocol/peac
 - Website: https://www.peacprotocol.org
@@ -46,6 +47,9 @@ PEAC does not orchestrate protocols, control systems, or enforce behavior. It re
 ## Documentation
 
 - Start Here: https://www.peacprotocol.org/start-here
+- Integration patterns: https://github.com/peacprotocol/peac/blob/main/docs/guides/integration-patterns.md
+- Verification options: https://github.com/peacprotocol/peac/blob/main/docs/guides/verification-options.md
+- Offline sample index: https://github.com/peacprotocol/peac/blob/main/docs/guides/offline-sample-index.md
 - Wire Format: https://www.peacprotocol.org/docs/architecture/wire-format
 - Package Layering: https://www.peacprotocol.org/docs/architecture/package-layering
 - Error Codes: https://www.peacprotocol.org/docs/reference/error-codes

--- a/sdks/README.md
+++ b/sdks/README.md
@@ -1,7 +1,7 @@
 # PEAC SDKs
 
 Language-specific client libraries for PEAC protocol integration.
-Last reviewed: 2026-04-01
+Last reviewed: 2026-06-24
 
 ## Structure
 

--- a/surfaces/README.md
+++ b/surfaces/README.md
@@ -34,3 +34,7 @@ Surfaces provide turnkey solutions for specific platforms:
 - Production-ready templates
 
 See [docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md) for full architecture.
+
+---
+
+_Last reviewed: 2026-06-24._


### PR DESCRIPTION
## Summary

Refreshes developer-facing documentation and root metadata so the repository front door reflects the current docs and release state.

README developer paths:

- Adds a `Start fast` section linking the integration patterns, verification options, and offline sample index guides, plus the Start Here index.
- Updates `Choose your path` and the reviewer table to point at the verification and integration guides.
- Splits the quickstart into a CLI-first offline-verification snippet and the in-code `verifyLocal()` snippet.
- Adds the new guides to the documentation list.

Root metadata:

- `CITATION.cff`: version and release date aligned to the current release.
- `llms.txt`: current-release line, review date, the offline CLI verification one-liner, and the new guide links.
- `SECURITY.md`, `AGENTS.md`, `sdks/README.md`: refreshed review dates.
- `integrator-kits/README.md`, `surfaces/README.md`: added a review-date footer.

## Scope

Documentation and metadata only. No code, schema, wire format, registry, dependency, package export, release-state, or version-stamp change.

## Validation

- `prettier --check`
- `forbid-strings`
- `git diff --check`
- `check-public-artifacts`
- `check-planning-leak`
- `entry-links-doc-truth`
- `readme-quickstart-doc-truth`
- `guard` with `PEAC_FAST=1`
- `verify:release`
- `extract-api-contract --check`
- `verify-doc-version-currency`
- `format:check`
- local doc-truth 26/26
- final hygiene 7/7
