### PR TITLE
chore(security): refresh dev dependency overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,8 @@
       "undici@<6.27.0": "6.27.0",
       "postcss@<8.5.10": ">=8.5.10",
       "form-data@<4.0.6": ">=4.0.6",
-      "vite@<6.4.2": ">=8.0.16"
+      "vite@<6.4.2": ">=8.0.16",
+      "ws@>=8.0.0 <8.21.0": "8.21.0"
     },
     "overridesComments": {
       "minimatch": "Cross-major pin to 10.2.4: typescript-estree requires ^9.0.4 but 9.x has no patch for GHSA-3ppc-4f35-3m26. minimatch 10.x is API-compatible (same globbing interface). 10.2.4 patches GHSA-7r86-cg39-jmmj and GHSA-23c5-xmqv-rm74 (ReDoS). Drops Node 18 (fine: repo baseline is >=22.0.0). Lint verified clean.",
@@ -189,6 +190,7 @@
       "postcss@<8.5.10": "Range-scoped to <8.5.10 only (forces patched 8.5.10+, fixes GHSA-qx2v-qp2m-jg93 XSS via unescaped </style> in CSS Stringify output). Dev-only via next 15.5.x (bundles postcss 8.4.31 internally) and vite. Workspace doesn't import postcss directly; affects build tooling only.",
       "form-data@<4.0.6": "Range-scoped to <4.0.6 only (forces patched 4.0.6+, fixes GHSA-hmw2-7cc7-3qxx CRLF injection via unescaped multipart field/filename). Dev-only via the supertest/superagent HTTP test client used by @peac/middleware-express tests; not in any published package.",
       "vite@<6.4.2": "Range-scoped to <6.4.2 only (forces patched, now floored at >=8.0.16, fixes GHSA-p9ff-h696-f583 arbitrary file read via dev server WebSocket, GHSA-4w7w-66w2-5vf9 path traversal in optimized deps .map handling, and GHSA-fx2h-pf6j-xcff server.fs.deny bypass on Windows alternate paths). Dev-only via vitest/@vitest/coverage-v8 and apps/verifier (internal app); pnpm resolves the override to vite 8.0.16; full test suite passes.",
+      "ws@>=8.0.0 <8.21.0": "Range-scoped to the v8 line below 8.21.0 only, pinned to exact 8.21.0 (the fixed v8 release). Fixes CVE-2026-48779 / GHSA-96hv-2xvq-fx4p (memory-exhaustion DoS from tiny fragments/data chunks) by resolving ws v8 to the patched 8.21.0 line. Dev/examples-only: resolves via dev wrangler -> miniflare -> ws and examples/erc8004-feedback -> isows; not in any published package. Exact pin (not a >= bound) keeps the lockfile diff narrow and stays on the v8 line.",
       "hono": "Bumped to >=4.12.25 to pull patches for CVE-2026-44455 (bodyLimit() bypass for chunked / unknown-length requests), CVE-2026-44456 (hono/jsx unvalidated JSX tag names), CVE-2026-44457 (CSS declaration injection via Style Object Values in JSX SSR), CVE-2026-44458 (Cache Middleware ignores Vary: Authorization / Vary: Cookie), CVE-2026-44459 (improper validation of NumericDate JWT claims), and GHSA-88fw-hqm2-52qc (CORS Middleware reflects any Origin, patched in 4.12.25). Prod dep via apps/api, apps/sandbox-issuer, packages/mcp-server, packages/server.",
       "fast-uri@<3.1.2": "Range-scoped to <3.1.2 only (forces patched 3.1.2+, fixes CVE-2026-6321 path traversal via percent-encoded dot segments and CVE-2026-6322 host confusion via percent-encoded authority delimiters). Transitive prod dep via ajv / ajv-formats (in @peac/protocol, @peac/receipts, apps/api) and @modelcontextprotocol/sdk (in @peac/mcp-server).",
       "ip-address@<=10.1.0": "Range-scoped to <=10.1.0 only (forces patched 10.1.1+, fixes CVE-2026-42338 XSS in Address6 HTML-emitting methods). Transitive prod dep via @modelcontextprotocol/sdk -> express-rate-limit."

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,7 @@ overrides:
   postcss@<8.5.10: '>=8.5.10'
   form-data@<4.0.6: '>=4.0.6'
   vite@<6.4.2: '>=8.0.16'
+  ws@>=8.0.0 <8.21.0: 8.21.0
 
 importers:
 
@@ -8387,12 +8388,12 @@ packages:
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  /isows@1.0.7(ws@8.18.3):
+  /isows@1.0.7(ws@8.21.0):
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
-      ws: '*'
+      ws: 8.21.0
     dependencies:
-      ws: 8.18.3
+      ws: 8.21.0
     dev: false
 
   /istanbul-lib-coverage@3.2.2:
@@ -9335,7 +9336,7 @@ packages:
       stoppable: 1.1.0
       undici: 6.27.0
       workerd: 1.20250718.0
-      ws: 8.18.0
+      ws: 8.21.0
       youch: 3.3.4
       zod: 4.3.6
     transitivePeerDependencies:
@@ -11328,10 +11329,10 @@ packages:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.3)
-      isows: 1.0.7(ws@8.18.3)
+      isows: 1.0.7(ws@8.21.0)
       ox: 0.12.1(typescript@5.9.3)
       typescript: 5.9.3
-      ws: 8.18.3
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -11592,8 +11593,8 @@ packages:
       signal-exit: 4.1.0
     dev: true
 
-  /ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+  /ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -11603,20 +11604,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-    dev: true
-
-  /ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-    dev: false
 
   /xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}

--- a/sdks/go/middleware/gin/go.mod
+++ b/sdks/go/middleware/gin/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
-	github.com/quic-go/quic-go v0.59.0 // indirect
+	github.com/quic-go/quic-go v0.59.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect

--- a/sdks/go/middleware/gin/go.sum
+++ b/sdks/go/middleware/gin/go.sum
@@ -49,8 +49,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
-github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=
-github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
+github.com/quic-go/quic-go v0.59.1 h1:0Gmua0HW1Tv7ANR7hUYwRyD0MG5OJfgvYSZasGZzBic=
+github.com/quic-go/quic-go v0.59.1/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/security/audit-allowlist.json
+++ b/security/audit-allowlist.json
@@ -219,22 +219,6 @@
       "owner": "jithinraj",
       "added_at": "2026-06-13",
       "reviewed_at": "2026-06-13"
-    },
-    {
-      "advisory_id": "GHSA-96hv-2xvq-fx4p",
-      "package": "ws",
-      "reason": "ws memory-exhaustion DoS from tiny fragments/data chunks (HIGH, GHSA-96hv-2xvq-fx4p). ws >=8.0.0 <8.21.0; resolved 8.18.0 via the Cloudflare Workers local dev simulator (wrangler -> miniflare) and 8.18.3 via the erc8004-feedback example. No published @peac/* package depends on ws.",
-      "why_not_exploitable": "ws is used only by miniflare (the local Cloudflare Workers simulator) during development and by one example. It is not in any published package and processes no untrusted production traffic (prod audit shows no high). Patched in ws >= 8.21.0; wrangler 3.x pins the transitive ws version.",
-      "where_used": "surfaces/workers/cloudflare devDependency: wrangler@3.114.17 -> miniflare -> ws@8.18.0; examples/erc8004-feedback -> viem -> ws@8.18.3",
-      "expires_at": "2026-09-13",
-      "remediation": "Adopt ws >= 8.21.0 when wrangler/miniflare bump their transitive ws, or evaluate wrangler 4.x.",
-      "issue_url": "https://github.com/advisories/GHSA-96hv-2xvq-fx4p",
-      "scope": "dev",
-      "dependency_chain": ["wrangler@3.114.17", "miniflare", "ws@8.18.0"],
-      "verified_by": "pnpm audit --prod shows no high advisories; pnpm why ws confirms the wrangler/miniflare dev path and the erc8004-feedback example path.",
-      "owner": "jithinraj",
-      "added_at": "2026-06-16",
-      "reviewed_at": "2026-06-16"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Refreshes narrow dev/example dependency overrides for advisories that have fixed versions available.

- Pins `ws` v8 below `8.21.0` to `8.21.0`.
- Updates the Gin Go middleware example from `quic-go v0.59.0` to `v0.59.1`.
- Removes the now-obsolete `ws` audit allowlist entry after the override eliminates the advisory from audit output.

## Scope

Security-maintenance only.

No schema, wire format, registry, package export, release-state, version, README, or CHANGELOG change. No v0.15.3 release change.

## Validation

- audit gate default
- audit gate strict
- prettier
- git diff --check
- guard
- verify:release
- extract-api-contract
- format:check
- local doc-truth 26/26
- final hygiene 7/7
