### PR TITLE
feat(examples): records for open-model inference calls

### DIFF
--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -9,7 +9,7 @@
     "tests": 11813,
     "test_files": 471,
     "published_packages": 36,
-    "build_targets": 106,
+    "build_targets": 107,
     "conformance_requirement_ids": 290,
     "conformance_sections": 32
   },

--- a/examples/open-model-inference-records/.gitignore
+++ b/examples/open-model-inference-records/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+out/
+.env*
+*.log
+*private*key*
+*secret*

--- a/examples/open-model-inference-records/README.md
+++ b/examples/open-model-inference-records/README.md
@@ -1,0 +1,91 @@
+# Records for open-model inference calls
+
+> **Outcome:** Issue a portable signed PEAC record for an open-model inference call and verify it offline, without exposing the prompt or the response. The record binds digests of the request and the response through an inference observation manifest, so a downstream reviewer can verify what was reported across organizational and runtime boundaries.
+>
+> **Audience:** Someone running an open model (locally or behind an OpenAI-compatible endpoint) who wants a portable, tamper-evident record of model use.
+>
+> **Time:** About 5 minutes from a clean clone.
+
+## The problem
+
+Open models are often strong on creation transparency: documented weights, training data, and methods. Once a model is deployed and used, the operational question is different: which model answered, through which provider, under what policy, with what request and response, and can that be verified later without sharing the raw prompt or output?
+
+PEAC records what an open-model inference call reported. It binds digests of the request and response into one signed record, verifiable offline.
+
+## What PEAC records (and what it does not)
+
+PEAC models the inference call as the existing `org.peacprotocol/agent-action-invoked-observed` record. The model identity, provider, and request/response digests are carried through an **inference observation manifest** whose digest is bound into the record's existing `upstream_artifact_digest` field. No new receipt type, extension group, schema field, wire format, signing envelope, or public API is introduced.
+
+| Record field               | Value                                        | Notes                                                                         |
+| -------------------------- | -------------------------------------------- | ----------------------------------------------------------------------------- |
+| `agent_ref`                | `urn:peac:agent:inference-client`            | the caller/agent (opaque ref)                                                 |
+| `action_ref`               | `urn:peac:model:open-model-sample`           | model invocation identity (opaque ref)                                        |
+| `caller_ref`               | `urn:peac:provider:local-openai-compatible`  | provider/deployment descriptor (opaque ref)                                   |
+| `upstream_artifact_ref`    | `urn:peac:inference-manifest:offline-sample` | opaque ref to the manifest                                                    |
+| `upstream_artifact_digest` | `sha256:<hex>`                               | digest of the inference observation manifest; binds both request and response |
+| `policy_ref`               | `https://issuer.example/usage-policy`        | optional usage/deployment policy reference                                    |
+| `observed_at`              | timestamp                                    | reported time of the call                                                     |
+
+The inference observation manifest is plain JSON the example builds; it contains only opaque refs and `sha256:<hex>` digests:
+
+```json
+{
+  "model_ref": "urn:peac:model:open-model-sample",
+  "provider_ref": "urn:peac:provider:local-openai-compatible",
+  "request_digest": "sha256:<hex>",
+  "response_digest": "sha256:<hex>",
+  "policy_ref": "https://issuer.example/usage-policy",
+  "observed_at": "2026-01-15T10:00:00Z"
+}
+```
+
+PEAC does **not** serve models, route requests, enforce policy, certify compliance, or imply adoption or endorsement by any model project or provider. The raw prompt and raw response are never placed in the manifest, the record, or any output file.
+
+## Run it (offline sample, no network)
+
+From the repository root:
+
+```bash
+pnpm install
+pnpm --filter @peac/example-open-model-inference-records demo:write
+```
+
+This writes the public key, the manifest, and the records under `out/`:
+
+- `out/pubkey.json` — a public Ed25519 JWK (no private key is ever written to disk)
+- `out/manifest.json` — the inference observation manifest (refs and digests only)
+- `out/valid/inference-record.jws` — the signed record
+- `out/tampered/inference-record.jws` — a record whose payload was altered after signing
+
+## Verify offline
+
+```bash
+peac verify examples/open-model-inference-records/out/valid/inference-record.jws \
+  --public-key examples/open-model-inference-records/out/pubkey.json
+# -> Signature valid (offline).
+```
+
+## Tamper beat
+
+```bash
+peac verify examples/open-model-inference-records/out/tampered/inference-record.jws \
+  --public-key examples/open-model-inference-records/out/pubkey.json
+# -> Verification failed (exit 1), code E_INVALID_SIGNATURE
+```
+
+A second, content-level check: if a value behind the manifest changes after signing, the recomputed manifest digest no longer matches the digest bound in the record, so the binding is detectably broken even when the signature itself still parses.
+
+## Other input modes
+
+The same flow applies to a real endpoint. Point at a local OpenAI-compatible server (for example a `/v1/chat/completions` endpoint), compute the request and response digests with the same JSON canonicalization, and feed them into the manifest. The example ships the deterministic offline sample so the demo and test require no network; the local and hosted modes are documented in `fixtures/` as input descriptors.
+
+## What this proves (and what it does not)
+
+- Proves: a portable, offline-verifiable record that a specific open model, through a specific provider, under a referenced policy, reported a request and a response with the given digests at the given time.
+- Does not prove: anything about the content of the prompt or output (only their digests travel), nor that the deployment is compliant with any framework, nor any relationship with a model project or provider.
+
+---
+
+This is an independent PEAC-side worked example. A real open model it maps to is, for example, `swiss-ai/Apertus-*`; naming it here is illustrative and does not imply adoption, endorsement, partnership, or support by that project.[^1]
+
+[^1]: Inclusion of a real open-model name is descriptive only. PEAC records model use; it does not serve, certify, or endorse any model.

--- a/examples/open-model-inference-records/demo.ts
+++ b/examples/open-model-inference-records/demo.ts
@@ -1,0 +1,273 @@
+/**
+ * Open-model inference records: in-process demo.
+ *
+ * Issues a signed PEAC record for an open-model inference call and verifies it
+ * offline, by reusing the existing `org.peacprotocol/agent-action-invoked-observed`
+ * record and binding an "inference observation manifest" digest through the
+ * existing `upstream_artifact_digest` field. No new receipt type, extension group,
+ * schema field, wire, signing, or public API is introduced.
+ *
+ * The manifest carries only opaque refs and `sha256:<hex>` digests. Raw prompt,
+ * raw response, secrets, headers, API keys, user data, and logs are never placed
+ * in the manifest, the record, or any output file.
+ *
+ * Boundary: PEAC records what an open-model inference call reported. PEAC does not
+ * serve models, route requests, enforce policy, certify compliance, or imply
+ * adoption or endorsement by any model project or provider.
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { generateKeypair, base64urlEncode, jcsHash } from '@peac/crypto';
+import { issue, verifyLocal } from '@peac/protocol';
+import { AGENT_ACTION_EXTENSION_KEY, validateAgentAction } from '@peac/schema';
+
+const ISSUER = 'https://issuer.example';
+const KID = 'open-model-demo-key-1';
+const RECORD_TYPE = 'org.peacprotocol/agent-action-invoked-observed';
+
+/**
+ * A generic, vendor-neutral request/response pair used for the offline sample.
+ * These stand in for the real request and response bodies; only their digests are
+ * bound into the manifest, so the exact wire shape does not matter here. The
+ * placeholder content strings are scanned out by the no-leak test to prove the
+ * raw bodies never reach the record or the manifest.
+ */
+const SAMPLE_REQUEST = {
+  model: 'open-model-sample',
+  input: '<<prompt>>',
+} as const;
+
+const SAMPLE_RESPONSE = {
+  id: 'cmpl-offline-sample',
+  output: '<<answer>>',
+} as const;
+
+/** The inference observation manifest: refs + digests only. Never raw I/O. */
+export interface InferenceObservationManifest {
+  model_ref: string;
+  provider_ref: string;
+  request_digest: string;
+  response_digest: string;
+  policy_ref?: string;
+  policy_digest?: string;
+  observed_at: string;
+}
+
+export interface InferenceDemoResult {
+  ok: boolean;
+  signatureValid: boolean;
+  /** manifest.request_digest equals the recomputed request digest. */
+  requestDigestMatches: boolean;
+  /** manifest.response_digest equals the recomputed response digest. */
+  responseDigestMatches: boolean;
+  /** record.upstream_artifact_digest equals the recomputed manifest digest. */
+  manifestDigestMatches: boolean;
+  /** true if any raw prompt/response string appears in the record ext or manifest. */
+  rawIoLeak: boolean;
+  /** the signed record (compact JWS) and the manifest, for the writer scripts. */
+  jws: string;
+  manifest: InferenceObservationManifest;
+  publicKeyB64u: string;
+  /** a CLI `--public-key`-compatible bare Ed25519 public JWK. */
+  publicJwk: { kty: 'OKP'; crv: 'Ed25519'; x: string };
+  tamper?: {
+    /** content tamper: signature still verifies, but the manifest digest no longer matches. */
+    signatureStillValid: boolean;
+    manifestDigestMatchesAfterTamper: boolean;
+    /** payload tamper: signature fails. */
+    payloadTamperValid: boolean;
+    payloadTamperCode?: string;
+  };
+}
+
+/** Build the agent-action-invoked-observed extension that binds the manifest digest. */
+function buildExtension(manifest: InferenceObservationManifest, manifestDigest: string) {
+  return {
+    event_kind: 'agent-action-invoked-observed' as const,
+    agent_ref: 'urn:peac:agent:inference-client',
+    action_ref: manifest.model_ref,
+    observed_at: manifest.observed_at,
+    caller_ref: manifest.provider_ref,
+    upstream_artifact_ref: 'urn:peac:inference-manifest:offline-sample',
+    upstream_artifact_digest: manifestDigest,
+    policy_ref: manifest.policy_ref,
+  };
+}
+
+/** Flip a byte of the JWS payload, keeping the signature, so verification fails. */
+function tamperPayload(jws: string): string {
+  const [header, payload, signature] = jws.split('.');
+  const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as Record<
+    string,
+    unknown
+  >;
+  decoded.iss = 'https://attacker.example.com';
+  const reEncoded = Buffer.from(JSON.stringify(decoded), 'utf8').toString('base64url');
+  return `${header}.${reEncoded}.${signature}`;
+}
+
+export interface RunOptions {
+  /** also produce the tamper beats. */
+  tamper?: boolean;
+  /** suppress console output. */
+  quiet?: boolean;
+}
+
+export async function runInferenceDemo(opts: RunOptions = {}): Promise<InferenceDemoResult> {
+  const { tamper = false, quiet = false } = opts;
+  const log = (m: string) => {
+    if (!quiet) console.log(m);
+  };
+
+  const { privateKey, publicKey } = await generateKeypair();
+
+  // Offline-sample mode: deterministic request/response, no network.
+  const requestDigest = `sha256:${await jcsHash(SAMPLE_REQUEST)}`;
+  const responseDigest = `sha256:${await jcsHash(SAMPLE_RESPONSE)}`;
+
+  const manifest: InferenceObservationManifest = {
+    model_ref: 'urn:peac:model:open-model-sample',
+    provider_ref: 'urn:peac:provider:local-openai-compatible',
+    request_digest: requestDigest,
+    response_digest: responseDigest,
+    policy_ref: 'https://issuer.example/usage-policy',
+    observed_at: '2026-01-15T10:00:00Z',
+  };
+  const manifestDigest = `sha256:${await jcsHash(manifest)}`;
+
+  const ext = buildExtension(manifest, manifestDigest);
+  const validation = validateAgentAction(ext);
+  if (!validation.ok) {
+    const detail = validation.errors.map((e) => `${e.code}: ${e.message}`).join('; ');
+    throw new Error(`agent-action extension validation failed: ${detail}`);
+  }
+
+  // occurred_at is the issuance time (must be ~now; verifyLocal rejects future
+  // timestamps). observed_at, carried in the manifest + extension, is the reported
+  // event time and stays independent of issuance.
+  const occurredAt = new Date(Math.floor(Date.now() / 1000) * 1000).toISOString();
+  const { jws } = await issue({
+    iss: ISSUER,
+    kind: 'evidence',
+    type: RECORD_TYPE,
+    pillars: ['provenance'],
+    occurred_at: occurredAt,
+    privateKey,
+    kid: KID,
+    extensions: { [AGENT_ACTION_EXTENSION_KEY]: ext },
+  });
+
+  const verify = await verifyLocal(jws, publicKey);
+  log(`[issue]  record signed (${jws.length} bytes); offline verify: ${verify.valid}`);
+
+  // Digest checks: recompute and compare to the bound values.
+  const requestDigestMatches =
+    `sha256:${await jcsHash(SAMPLE_REQUEST)}` === manifest.request_digest;
+  const responseDigestMatches =
+    `sha256:${await jcsHash(SAMPLE_RESPONSE)}` === manifest.response_digest;
+  const manifestDigestMatches =
+    `sha256:${await jcsHash(manifest)}` === ext.upstream_artifact_digest;
+
+  // No-leak scan: the raw prompt/answer must not appear in the record ext or manifest.
+  const surfaces = JSON.stringify(ext) + JSON.stringify(manifest);
+  const rawIoLeak = surfaces.includes('<<prompt>>') || surfaces.includes('<<answer>>');
+
+  const publicKeyB64u = base64urlEncode(publicKey);
+  const publicJwk = { kty: 'OKP' as const, crv: 'Ed25519' as const, x: publicKeyB64u };
+
+  const result: InferenceDemoResult = {
+    ok: verify.valid === true && manifestDigestMatches && !rawIoLeak,
+    signatureValid: verify.valid === true,
+    requestDigestMatches,
+    responseDigestMatches,
+    manifestDigestMatches,
+    rawIoLeak,
+    jws,
+    manifest,
+    publicKeyB64u,
+    publicJwk,
+  };
+
+  if (tamper) {
+    // Content tamper: change a recorded value AFTER signing -> manifest digest mismatch.
+    const tamperedManifest: InferenceObservationManifest = {
+      ...manifest,
+      response_digest: `sha256:${'0'.repeat(64)}`,
+    };
+    const reVerify = await verifyLocal(jws, publicKey);
+    const manifestDigestMatchesAfterTamper =
+      `sha256:${await jcsHash(tamperedManifest)}` === ext.upstream_artifact_digest;
+
+    // Payload tamper: flip the record payload, keep the signature -> verification fails.
+    const tamperedJws = tamperPayload(jws);
+    const tamperedVerify = await verifyLocal(tamperedJws, publicKey);
+
+    result.tamper = {
+      signatureStillValid: reVerify.valid === true,
+      manifestDigestMatchesAfterTamper,
+      payloadTamperValid: tamperedVerify.valid === true,
+      payloadTamperCode: tamperedVerify.valid ? undefined : tamperedVerify.code,
+    };
+    log(
+      `[tamper] payload tamper verify: ${result.tamper.payloadTamperValid} (${result.tamper.payloadTamperCode ?? 'n/a'}); ` +
+        `manifest digest after content tamper matches: ${result.tamper.manifestDigestMatchesAfterTamper}`
+    );
+  }
+
+  return result;
+}
+
+/**
+ * Write the demo outputs to `out/` for the README walkthrough and the CLI command.
+ * Only PUBLIC material is written: the public-key JWK, the manifest (refs + digests),
+ * and the valid + tampered records as individual compact-JWS files. No private key
+ * is ever written to disk.
+ */
+export async function writeOutputs(outDir: string): Promise<void> {
+  const result = await runInferenceDemo({ tamper: true, quiet: true });
+  mkdirSync(join(outDir, 'valid'), { recursive: true });
+  mkdirSync(join(outDir, 'tampered'), { recursive: true });
+
+  // CLI `--public-key`-compatible bare Ed25519 public JWK (no private `d`).
+  writeFileSync(join(outDir, 'pubkey.json'), JSON.stringify(result.publicJwk, null, 2) + '\n');
+  writeFileSync(join(outDir, 'manifest.json'), JSON.stringify(result.manifest, null, 2) + '\n');
+  writeFileSync(join(outDir, 'valid', 'inference-record.jws'), result.jws + '\n');
+
+  // A separate tampered record (payload flipped, signature kept) for the tamper beat.
+  const tamperedJws = (() => {
+    const [header, payload, signature] = result.jws.split('.');
+    const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as Record<
+      string,
+      unknown
+    >;
+    decoded.iss = 'https://attacker.example.com';
+    const reEncoded = Buffer.from(JSON.stringify(decoded), 'utf8').toString('base64url');
+    return `${header}.${reEncoded}.${signature}`;
+  })();
+  writeFileSync(join(outDir, 'tampered', 'inference-record.jws'), tamperedJws + '\n');
+}
+
+// Run as a script: `tsx demo.ts` (print summary) or `tsx demo.ts --write` (write out/).
+const isMain = (() => {
+  try {
+    return process.argv[1] === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
+})();
+
+if (isMain) {
+  const write = process.argv.includes('--write');
+  const here = dirname(fileURLToPath(import.meta.url));
+  if (write) {
+    await writeOutputs(join(here, 'out'));
+    console.log('Wrote out/pubkey.json, out/manifest.json, out/valid/*.jws, out/tampered/*.jws');
+  } else {
+    const r = await runInferenceDemo({ tamper: true });
+    console.log(
+      JSON.stringify({ ok: r.ok, signatureValid: r.signatureValid, tamper: r.tamper }, null, 2)
+    );
+  }
+}

--- a/examples/open-model-inference-records/fixtures/01-self-hosted-openai-compatible.json
+++ b/examples/open-model-inference-records/fixtures/01-self-hosted-openai-compatible.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Input descriptor (NOT a signed record). Describes a local OpenAI-compatible inference call whose request and response digests are bound into the inference observation manifest. Raw prompt and response are never placed in the manifest or the record.",
+  "mode": "local-openai-compatible",
+  "endpoint": "http://localhost:8000/v1/chat/completions",
+  "model_ref": "urn:peac:model:open-model-sample",
+  "provider_ref": "urn:peac:provider:local-openai-compatible",
+  "policy_ref": "https://issuer.example/usage-policy"
+}

--- a/examples/open-model-inference-records/fixtures/02-hosted-openai-compatible.json
+++ b/examples/open-model-inference-records/fixtures/02-hosted-openai-compatible.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Input descriptor (NOT a signed record). Describes a hosted OpenAI-compatible inference call. README-only; not exercised in CI (no network in tests).",
+  "mode": "hosted-openai-compatible",
+  "endpoint": "https://api.example/v1/chat/completions",
+  "model_ref": "urn:peac:model:open-model-sample",
+  "provider_ref": "urn:peac:provider:hosted-openai-compatible",
+  "policy_ref": "https://issuer.example/usage-policy"
+}

--- a/examples/open-model-inference-records/fixtures/03-offline-sample.json
+++ b/examples/open-model-inference-records/fixtures/03-offline-sample.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Input descriptor (NOT a signed record). The deterministic, no-network mode the demo and the test exercise. The demo builds request/response digests from a fixed sample pair and binds them through the inference observation manifest.",
+  "mode": "offline-sample",
+  "endpoint": null,
+  "model_ref": "urn:peac:model:open-model-sample",
+  "provider_ref": "urn:peac:provider:local-openai-compatible",
+  "policy_ref": "https://issuer.example/usage-policy"
+}

--- a/examples/open-model-inference-records/package.json
+++ b/examples/open-model-inference-records/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@peac/example-open-model-inference-records",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Records for open-model inference calls: bind an inference observation manifest digest into a signed agent-action record and verify it offline.",
+  "type": "module",
+  "scripts": {
+    "demo": "tsx demo.ts",
+    "demo:write": "tsx demo.ts --write",
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@peac/crypto": "workspace:*",
+    "@peac/protocol": "workspace:*",
+    "@peac/schema": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/examples/open-model-inference-records/tsconfig.json
+++ b/examples/open-model-inference-records/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -607,6 +607,25 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
 
+  examples/open-model-inference-records:
+    dependencies:
+      '@peac/crypto':
+        specifier: workspace:*
+        version: link:../../packages/crypto
+      '@peac/protocol':
+        specifier: workspace:*
+        version: link:../../packages/protocol
+      '@peac/schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+    devDependencies:
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+
   examples/openclaw-capture:
     dependencies:
       '@peac/adapter-openclaw':

--- a/tests/tooling/open-model-inference-records-example.test.ts
+++ b/tests/tooling/open-model-inference-records-example.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Runtime smoke test for examples/open-model-inference-records.
+ *
+ * The example is a public, copy-paste artifact, so its end-to-end behavior is
+ * gated here, not just its types. This imports the demo's exported
+ * runInferenceDemo() in-process (vitest aliases @peac/* to source, so no build
+ * or example install is required) and asserts:
+ *   - the record verifies offline and the manifest digest binds
+ *   - request and response digests each match their recomputed value
+ *   - tampering is detected two independent ways (manifest-digest mismatch after
+ *     a content change, and an invalid Ed25519 signature after a payload change)
+ *   - no raw prompt/response strings reach the record extension or the manifest
+ *   - the public key the example emits is CLI `--public-key`-compatible
+ *   - a top-level model_ref / request_digest / response_digest is rejected by the
+ *     strict agent-action extension (so the manifest indirection is the only path)
+ *
+ * No network, no subprocess.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { jwkToPublicKeyBytes, base64urlDecode } from '@peac/crypto';
+import { verifyLocal } from '@peac/protocol';
+import { AGENT_ACTION_EXTENSION_KEY, validateAgentAction } from '@peac/schema';
+import { runInferenceDemo } from '../../examples/open-model-inference-records/demo';
+
+describe('open-model-inference-records example', () => {
+  it('issues an inference record that verifies offline and binds the manifest digest', async () => {
+    const r = await runInferenceDemo({ quiet: true });
+    expect(r.ok).toBe(true);
+    expect(r.signatureValid).toBe(true);
+    expect(r.requestDigestMatches).toBe(true);
+    expect(r.responseDigestMatches).toBe(true);
+    expect(r.manifestDigestMatches).toBe(true);
+    expect(r.rawIoLeak).toBe(false);
+  });
+
+  it('binds only refs and sha256 digests in the manifest (no raw I/O)', async () => {
+    const r = await runInferenceDemo({ quiet: true });
+    const manifestJson = JSON.stringify(r.manifest);
+    expect(manifestJson).not.toContain('<<prompt>>');
+    expect(manifestJson).not.toContain('<<answer>>');
+    expect(r.manifest.request_digest).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(r.manifest.response_digest).toMatch(/^sha256:[a-f0-9]{64}$/);
+    // No private key material anywhere in the result surfaces.
+    expect(JSON.stringify(r.publicJwk)).not.toContain('"d"');
+  });
+
+  it('detects tampering two independent ways', async () => {
+    const r = await runInferenceDemo({ tamper: true, quiet: true });
+    // Content tamper: the signature still verifies, but the bound manifest digest no longer matches.
+    expect(r.tamper?.signatureStillValid).toBe(true);
+    expect(r.tamper?.manifestDigestMatchesAfterTamper).toBe(false);
+    // Payload tamper: the signature fails with the stable code.
+    expect(r.tamper?.payloadTamperValid).toBe(false);
+    expect(r.tamper?.payloadTamperCode).toBe('E_INVALID_SIGNATURE');
+  });
+
+  it('emits a CLI --public-key-compatible bare Ed25519 JWK that verifies the record', async () => {
+    const r = await runInferenceDemo({ quiet: true });
+    // The CLI's parsePublicKey path uses jwkToPublicKeyBytes; the emitted JWK must parse.
+    const keyBytes = jwkToPublicKeyBytes(r.publicJwk);
+    expect(keyBytes).toHaveLength(32);
+    // And it must verify the same record the README tells users to verify.
+    const viaJwk = await verifyLocal(r.jws, keyBytes);
+    expect(viaJwk.valid).toBe(true);
+    // The x value round-trips to the same 32 bytes as the raw public key.
+    expect(base64urlDecode(r.publicJwk.x)).toHaveLength(32);
+  });
+
+  it('rejects a naive top-level model_ref / request_digest / response_digest (strict extension)', () => {
+    // The agent-action extension is .strict(); the inference fields must live in the
+    // manifest (bound via upstream_artifact_digest), never as top-level record keys.
+    const bad = {
+      event_kind: 'agent-action-invoked-observed',
+      agent_ref: 'urn:peac:agent:inference-client',
+      action_ref: 'urn:peac:model:open-model-sample',
+      observed_at: '2026-06-26T10:00:00Z',
+      model_ref: 'urn:peac:model:open-model-sample',
+      request_digest: `sha256:${'0'.repeat(64)}`,
+      response_digest: `sha256:${'0'.repeat(64)}`,
+    };
+    const result = validateAgentAction(bad);
+    expect(result.ok).toBe(false);
+  });
+
+  it('uses the existing agent-action extension key and an existing type URI', async () => {
+    expect(AGENT_ACTION_EXTENSION_KEY).toBe('org.peacprotocol/agent-action');
+    const r = await runInferenceDemo({ quiet: true });
+    // action_ref carries the generic model id; never a vendor model id.
+    expect(r.manifest.model_ref).toBe('urn:peac:model:open-model-sample');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a runnable example that issues a portable signed PEAC record for an open-model inference call and verifies it offline. It reuses the existing `org.peacprotocol/agent-action-invoked-observed` record and binds an inference observation manifest digest through the existing `upstream_artifact_digest` field. No new receipt type, extension group, schema field, wire format, signing envelope, or public API is introduced.

## Scope

- New private example workspace `examples/open-model-inference-records/` (`private: true`, not published).
- New runtime smoke test `tests/tooling/open-model-inference-records-example.test.ts`.
- `docs/releases/facts.json` `build_targets` 106 -> 107 (the new example is a turbo build target).

Explicitly unchanged: no schema, registry, extension group, type URI, wire format, signing, public API, exported function, CLI command, or error code. `published_packages` stays 36; structural sentinels unchanged.

## What it records (and what it does not)

The model identity, provider, and request/response digests are carried in an inference observation manifest (plain JSON: opaque refs and `sha256:<hex>` digests only). The record binds the manifest digest, so both request and response are tamper-evident in one portable record. Raw prompt, raw response, secrets, headers, keys, user data, and logs are never placed in the manifest, the record, or any output file. No private key is written to disk.

PEAC records what an open-model inference call reported. It does not serve models, route requests, enforce policy, certify compliance, or imply adoption or endorsement by any model project or provider.

## How to verify

```bash
pnpm install
pnpm --filter @peac/example-open-model-inference-records demo:write
peac verify examples/open-model-inference-records/out/valid/inference-record.jws \
  --public-key examples/open-model-inference-records/out/pubkey.json
# -> Signature valid (offline).
peac verify examples/open-model-inference-records/out/tampered/inference-record.jws \
  --public-key examples/open-model-inference-records/out/pubkey.json
# -> Verification failed (exit 1), code E_INVALID_SIGNATURE
```

## Validation

- `tests/tooling/open-model-inference-records-example.test.ts` passes (offline verify; manifest-digest binding; payload-tamper detection via `E_INVALID_SIGNATURE`; content-tamper detection via manifest-digest mismatch; no raw I/O in the record or manifest; the emitted public-key JWK verifies the record; and a top-level `model_ref`/`request_digest`/`response_digest` is rejected by the strict extension).
- Example builds and typechecks; lint, format, `typecheck:core`, the package-surface and workspace-boundary audits, and the source-to-test import guard all pass.
- Offline CLI verification of the exact README commands confirmed.
