### PR TITLE
chore: stamp v0.15.3 release state

### DIFF
--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable surface classification for PEAC Protocol workspace. CI fails if any workspace member is missing. See docs/PACKAGE_STATUS.md for human-readable view.",
   "version": "0.13.0",
-  "updated": "2026-06-22",
+  "updated": "2026-06-26",
   "states": {
     "default": "Current recommended path. Actively maintained, Wire 0.2 native.",
     "supported": "Actively maintained, published, production-ready. May not be on default quickstart path.",

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -2,7 +2,7 @@
 
 Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scripts/generate-surface-status.mjs`.
 
-**Version:** 0.13.0 | **Updated:** 2026-06-22
+**Version:** 0.13.0 | **Updated:** 2026-06-26
 
 ## Layer 1
 

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -4,7 +4,7 @@
   "version": "0.15.3",
   "wire_format_version": "0.2",
   "dist_tag": "latest",
-  "release_date": "2026-06-22",
+  "release_date": "2026-06-26",
   "metrics": {
     "tests": 11863,
     "test_files": 475,


### PR DESCRIPTION
## Summary

Stamps the post-publish release state for the latest patch release. Updates the
release date in `docs/releases/facts.json` to the actual publish date and refreshes
the derived repository-surface status. No functional change.

## Scope

- `docs/releases/facts.json`: `release_date` -> actual publish date (`dist_tag`
  already `latest`).
- `REPO_SURFACE_STATUS.json` + derived `docs/SURFACE_STATUS.md`: refreshed `updated`
  date.

## Not changed

No schema, registry, wire format, signing, public API, CLI, package-set, or version
change. Stamp-only.
