### PR TITLE
feat(protocol): bounded replay guard for verified records

### DIFF
--- a/contracts/api/protocol.json
+++ b/contracts/api/protocol.json
@@ -1,7 +1,7 @@
 {
   "package": "@peac/protocol",
-  "version": "0.14.1",
-  "extracted_at": "2026-05-09",
+  "version": "0.15.3",
+  "extracted_at": "2026-06-28",
   "node_version": "v24.13.0",
   "value_exports": [
     {
@@ -94,6 +94,10 @@
     },
     {
       "name": "createEmptyReport",
+      "typeof": "static"
+    },
+    {
+      "name": "createReplayGuard",
       "typeof": "static"
     },
     {
@@ -318,6 +322,9 @@
     "PointerProfileResult",
     "PolicyBindingStatus",
     "ReasonCode",
+    "ReplayGuard",
+    "ReplayGuardOptions",
+    "ReplayGuardVerdict",
     "ResolveJWKSOptions",
     "ResultSeverity",
     "RevokedKeyInfo",
@@ -356,6 +363,6 @@
   "wire02_extension_keys": [],
   "legacy_extension_keys": [],
   "extension_schemas": [],
-  "total_value_exports": 70,
-  "total_type_exports": 64
+  "total_value_exports": 71,
+  "total_type_exports": 67
 }

--- a/docs/specs/REPLAY-GUARD-PROFILE.md
+++ b/docs/specs/REPLAY-GUARD-PROFILE.md
@@ -1,0 +1,53 @@
+# PEAC Bounded Replay Guard Profile
+
+**Status:** Informative
+**Package:** `@peac/protocol` (`createReplayGuard`)
+
+Optional online-acceptance guidance for bounded replay detection. This profile adds
+no normative requirement to the wire format and no field to any record.
+
+## Existing record invariant
+
+A PEAC record carries `(iss, jti)`; the pair is globally unique per issuer. This
+uniqueness is the durable basis for replay detection and is independent of any
+online policy.
+
+## Optional online replay defense
+
+An online consumer may, after verifying a record, apply a bounded replay guard:
+
+- Accept a record only if its `iat` is within a deployer-configured window
+  `[now - windowSeconds, now + maxClockSkew]`; otherwise treat it as outside the
+  acceptance window.
+- Within the window, treat a repeated `(iss, jti)` as a replay.
+- Bound the dedup store by both a maximum retained-entry count and a time-to-live
+  purge, so the store is finite and bounded against unbounded state growth.
+
+This is an acceptance policy, not a record property. The same record remains valid
+and offline-verifiable indefinitely outside any window; PEAC adds no `exp` to records
+and does not change the wire format. The reference implementation is the composable
+`createReplayGuard` helper in `@peac/protocol`, which returns a verdict
+(`fresh` / `replayed` / `outside-window`); the deployer chooses the response. The
+guard offers a verdict; it does not block, settle, authenticate, or enforce.
+
+## Finite-memory trade-off
+
+Under `maxEntries` pressure an older in-window key can be evicted. If that key appears
+again before it falls outside the time window, the reference in-memory guard may
+classify it as `fresh`. Deployers that require exact replay detection across the full
+window must size `maxEntries` for expected throughput, or use durable storage. Replay
+detection is therefore best-effort within the live set, not permanent replay
+prevention.
+
+## Clock handling
+
+The guard reads a clock in epoch seconds. Backward wall-clock movement (for example an
+NTP correction) is clamped to the last observed second so the bounded store stays
+correct. Entry expiry is a conservative upper bound on the latest time a record
+accepted now could still be replayed within the acceptance window.
+
+## Durable evidence vs online acceptance
+
+Offline and audit verification never apply a window: a record from years ago still
+verifies. The window and TTL are solely for live, online replay defense, where a
+deployer trades unbounded memory for a finite, time-bounded working set.

--- a/packages/protocol/__tests__/replay-guard.test.ts
+++ b/packages/protocol/__tests__/replay-guard.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest';
+import { generateKeypair } from '@peac/crypto';
+
+import { createReplayGuard, issueWire02, verifyLocal } from '../src/index.js';
+
+const rec = (iss: string, jti: string, iat: number) => ({ iss, jti, iat });
+
+describe('createReplayGuard', () => {
+  it('fresh on first sight, replayed on the second (same key)', () => {
+    const g = createReplayGuard({ windowSeconds: 3600, now: () => 1000 });
+    expect(g.check(rec('https://a', 'j1', 1000))).toBe('fresh');
+    expect(g.check(rec('https://a', 'j1', 1000))).toBe('replayed');
+  });
+
+  it('outside-window for iat too old, and the record is not stored', () => {
+    const t = 1000;
+    const g = createReplayGuard({
+      windowSeconds: 100,
+      maxClockSkewSeconds: 0,
+      maxEntries: 1,
+      now: () => t,
+    });
+    expect(g.check(rec('https://a', 'old', 800))).toBe('outside-window');
+    expect(g.check(rec('https://a', 'j1', 1000))).toBe('fresh'); // slot not consumed
+    expect(g.check(rec('https://a', 'j1', 1000))).toBe('replayed');
+  });
+
+  it('outside-window for iat too far in the future (> now + maxClockSkewSeconds)', () => {
+    const g = createReplayGuard({ windowSeconds: 100, maxClockSkewSeconds: 30, now: () => 1000 });
+    expect(g.check(rec('https://a', 'j1', 1031))).toBe('outside-window');
+  });
+
+  it('boundary now - windowSeconds is accepted (inclusive)', () => {
+    const g = createReplayGuard({ windowSeconds: 100, maxClockSkewSeconds: 0, now: () => 1000 });
+    expect(g.check(rec('https://a', 'j1', 900))).toBe('fresh');
+  });
+
+  it('boundary now + maxClockSkewSeconds is accepted (inclusive)', () => {
+    const g = createReplayGuard({ windowSeconds: 100, maxClockSkewSeconds: 30, now: () => 1000 });
+    expect(g.check(rec('https://a', 'j1', 1030))).toBe('fresh');
+  });
+
+  it('length-prefixed keys: (a, bc) and (ab, c) do not collide', () => {
+    const g = createReplayGuard({ windowSeconds: 3600, now: () => 1000 });
+    expect(g.check(rec('a', 'bc', 1000))).toBe('fresh');
+    expect(g.check(rec('ab', 'c', 1000))).toBe('fresh');
+  });
+
+  it('TTL purge removes expired entries; a later fresh insert does not retain them', () => {
+    let t = 1000;
+    const g = createReplayGuard({
+      windowSeconds: 100,
+      maxClockSkewSeconds: 0,
+      maxEntries: 10,
+      now: () => t,
+    });
+    expect(g.check(rec('i', 'j1', 1000))).toBe('fresh'); // expiresAt = 1000 + 100 + 0 = 1100
+    t = 1201; // past expiry
+    expect(g.check(rec('i', 'j2', 1201))).toBe('fresh'); // triggers purge of j1
+    expect(g.check(rec('i', 'j1', 1201))).toBe('fresh'); // j1 was purged -> fresh again
+  });
+
+  it('expired same-key followed by a fresh in-window record returns fresh', () => {
+    let t = 1000;
+    const g = createReplayGuard({ windowSeconds: 100, maxClockSkewSeconds: 0, now: () => t });
+    g.check(rec('i', 'j1', 1000));
+    t = 5000;
+    expect(g.check(rec('i', 'j1', 5000))).toBe('fresh'); // old entry purged; new one in-window
+  });
+
+  it('evicts the oldest retained entry past maxEntries', () => {
+    const g = createReplayGuard({ windowSeconds: 10_000, maxEntries: 2, now: () => 5000 });
+    expect(g.check(rec('i', 'j1', 5000))).toBe('fresh');
+    expect(g.check(rec('i', 'j2', 5000))).toBe('fresh');
+    expect(g.check(rec('i', 'j3', 5000))).toBe('fresh'); // evicts j1
+    expect(g.check(rec('i', 'j1', 5000))).toBe('fresh'); // j1 was evicted -> fresh again
+    expect(g.check(rec('i', 'j3', 5000))).toBe('replayed'); // j3 still present
+  });
+
+  it('a replay does not refresh recency or TTL', () => {
+    const g = createReplayGuard({ windowSeconds: 10_000, maxEntries: 2, now: () => 5000 });
+    g.check(rec('i', 'j1', 5000));
+    g.check(rec('i', 'j2', 5000));
+    g.check(rec('i', 'j1', 5000)); // replay j1 -> must not move it to newest
+    g.check(rec('i', 'j3', 5000)); // evicts oldest (j1)
+    expect(g.check(rec('i', 'j1', 5000))).toBe('fresh'); // j1 evicted, not refreshed
+  });
+
+  it('out-of-window record with the same key does not poison future in-window checks', () => {
+    const t = 1000;
+    const g = createReplayGuard({ windowSeconds: 100, maxClockSkewSeconds: 0, now: () => t });
+    expect(g.check(rec('i', 'j1', 800))).toBe('outside-window'); // not stored
+    expect(g.check(rec('i', 'j1', 1000))).toBe('fresh'); // now in-window -> fresh
+  });
+
+  it('injected clock drives window + TTL deterministically', () => {
+    let t = 1000;
+    const g = createReplayGuard({ windowSeconds: 100, maxClockSkewSeconds: 0, now: () => t });
+    expect(g.check(rec('i', 'j1', 1000))).toBe('fresh');
+    t = 2000;
+    expect(g.check(rec('i', 'j1', 1000))).toBe('outside-window'); // iat now too old
+  });
+
+  it('rejects invalid options at construction', () => {
+    expect(() => createReplayGuard({ windowSeconds: 0 })).toThrow();
+    expect(() => createReplayGuard({ windowSeconds: -1 })).toThrow();
+    expect(() => createReplayGuard({ windowSeconds: 1.5 })).toThrow();
+    expect(() => createReplayGuard({ windowSeconds: 10, maxEntries: 0 })).toThrow();
+    expect(() => createReplayGuard({ windowSeconds: 10, maxClockSkewSeconds: -1 })).toThrow();
+    // unsafe integers (beyond Number.MAX_SAFE_INTEGER) are rejected
+    expect(() => createReplayGuard({ windowSeconds: Number.MAX_SAFE_INTEGER + 1 })).toThrow();
+    expect(() =>
+      createReplayGuard({ windowSeconds: 10, maxEntries: Number.MAX_SAFE_INTEGER + 1 })
+    ).toThrow();
+    expect(() =>
+      createReplayGuard({ windowSeconds: 10, maxClockSkewSeconds: Number.MAX_SAFE_INTEGER + 1 })
+    ).toThrow();
+  });
+
+  it('fails closed on invalid runtime input and does not mutate state', () => {
+    const g = createReplayGuard({ windowSeconds: 100, maxEntries: 1, now: () => 1000 });
+    expect(() => g.check(rec('i', '', 1000))).toThrow(); // empty jti
+    expect(() => g.check(rec('', 'j1', 1000))).toThrow(); // empty iss
+    expect(() => g.check(rec('i', 'j1', Number.NaN))).toThrow(); // NaN iat
+    expect(() => g.check(rec('i', 'j1', Infinity))).toThrow(); // Infinity iat
+    expect(() => g.check(rec('i', 'j1', 1.5))).toThrow(); // fractional iat
+    expect(() => g.check(rec('i', 'j1', Number.MAX_SAFE_INTEGER + 1))).toThrow(); // unsafe iat
+    // store was not mutated by any failed call (the single slot is still free):
+    expect(g.check(rec('i', 'ok', 1000))).toBe('fresh');
+    expect(g.check(rec('i', 'ok', 1000))).toBe('replayed');
+  });
+
+  it('fails closed when now() returns a non-finite value', () => {
+    const g = createReplayGuard({ windowSeconds: 100, now: () => Number.NaN });
+    expect(() => g.check(rec('i', 'j1', 1000))).toThrow();
+  });
+
+  it('fails closed when now() returns an unsafe integer', () => {
+    const g = createReplayGuard({ windowSeconds: 100, now: () => Number.MAX_SAFE_INTEGER + 1 });
+    expect(() => g.check(rec('i', 'j1', 1000))).toThrow();
+  });
+
+  it('fails closed if expiry arithmetic exceeds the safe integer range, without storing the record', () => {
+    const t = Number.MAX_SAFE_INTEGER - 10;
+    const g = createReplayGuard({ windowSeconds: 100, maxClockSkewSeconds: 0, now: () => t });
+    // expiresAt = t + 100 exceeds MAX_SAFE_INTEGER -> throws before any store mutation.
+    expect(() => g.check(rec('i', 'j1', t))).toThrow();
+    // If j1 had been stored, a repeat check would short-circuit as 'replayed' before the
+    // expiry step; instead it throws again, proving the record was not stored.
+    expect(() => g.check(rec('i', 'j1', t))).toThrow();
+  });
+
+  it('clamps a backward clock to the last observed second', () => {
+    let t = 1000;
+    const g = createReplayGuard({ windowSeconds: 100, maxClockSkewSeconds: 0, now: () => t });
+    expect(g.check(rec('i', 'j1', 1000))).toBe('fresh');
+    t = 200; // wall clock jumps backward; guard clamps to 1000
+    // iat=1000 is still in-window relative to the clamped now (1000), and j1 is a replay:
+    expect(g.check(rec('i', 'j1', 1000))).toBe('replayed');
+    // a record at the regressed raw time is judged against the clamped now, so it is too old:
+    expect(g.check(rec('i', 'j2', 200))).toBe('outside-window');
+  });
+
+  it('conservative TTL: an older-iat entry is retained until the conservative horizon, but window-first still rejects it', () => {
+    let t = 1000;
+    const g = createReplayGuard({ windowSeconds: 100, maxClockSkewSeconds: 50, now: () => t });
+    // insert at t=1000 with an older in-window iat=960 -> expiresAt = 1000 + 100 + 50 = 1150
+    expect(g.check(rec('i', 'j1', 960))).toBe('fresh');
+    t = 1120; // past iat+window (1060) but before conservative expiry (1150): entry still retained
+    // window-first: a replay of j1 (iat 960) is now outside-window (960 < 1120 - 100), so it is
+    // rejected as outside-window regardless of still being retained:
+    expect(g.check(rec('i', 'j1', 960))).toBe('outside-window');
+  });
+});
+
+describe('createReplayGuard composition with verifyLocal', () => {
+  it('classifies a verified record as fresh, then replayed', async () => {
+    const { privateKey, publicKey } = await generateKeypair();
+    const { jws } = await issueWire02({
+      // Generic reverse-DNS type with no mapped extension group, so default-strict
+      // verifyLocal accepts it without an extension block.
+      iss: 'https://api.example.com',
+      kind: 'evidence',
+      type: 'org.example/replay-guard-smoke',
+      privateKey,
+      kid: '2026-03-07T00:00:00Z',
+      jti: 'replay-guard-smoke-1',
+    });
+
+    const result = await verifyLocal(jws, publicKey);
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+
+    const { iss, jti, iat } = result.claims;
+    // Generous window so the freshly-issued record (real iat) is in-window under the real clock.
+    const g = createReplayGuard({ windowSeconds: 86_400, maxClockSkewSeconds: 300 });
+    expect(g.check({ iss, jti, iat })).toBe('fresh');
+    expect(g.check({ iss, jti, iat })).toBe('replayed');
+  });
+});

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -46,6 +46,10 @@ export * from './ssrf-safe-fetch';
 export * from './transport-profiles';
 export * from './pointer-fetch';
 
+// Optional bounded replay guard for already-verified records (composable; not wired
+// into stateless verifyLocal). See docs/specs/REPLAY-GUARD-PROFILE.md.
+export * from './replay-guard';
+
 // Re-export crypto utilities for single-package quickstart
 export {
   base64urlDecode,

--- a/packages/protocol/src/replay-guard.ts
+++ b/packages/protocol/src/replay-guard.ts
@@ -1,0 +1,178 @@
+/**
+ * Optional, composable replay defense for online consumers of PEAC records.
+ *
+ * createReplayGuard() returns a stateful guard that classifies an already-verified
+ * record as 'fresh', 'replayed', or 'outside-window'. The store is bounded by both
+ * count (maxEntries) and time (a TTL purge plus an iat acceptance window), so
+ * it is finite and bounded against unbounded state growth. The dedup key is
+ * (iss, jti); iat gates the window. All timestamp/window values are safe integers
+ * (epoch seconds); unsafe-integer input fails closed.
+ *
+ * This is an online acceptance policy, not a record property: PEAC adds no exp to
+ * records, changes no wire bytes, and enforces nothing. The same record stays valid
+ * and offline-verifiable indefinitely outside any window. The guard returns a
+ * verdict; the deployer chooses the response. It is intentionally not wired into the
+ * stateless verifyLocal path.
+ *
+ * The clock (now) returns epoch seconds; backward movement (e.g. an NTP or manual
+ * wall-clock regression) is clamped internally to the last observed second, so the
+ * guard stays correct even if the clock goes backward. TTL entries expire at
+ * insertion-time + windowSeconds + maxClockSkewSeconds; with the clamped (monotonic)
+ * clock, expiry order equals insertion order and purge is O(number expired).
+ */
+
+/** Default future-skew tolerance for iat, in seconds (mirrors verifyLocal maxClockSkew). */
+const DEFAULT_MAX_CLOCK_SKEW_SECONDS = 300;
+/** Default upper bound on retained (iss,jti) entries. */
+const DEFAULT_MAX_ENTRIES = 100_000;
+
+export interface ReplayGuardOptions {
+  /**
+   * Accept only records whose iat is within [now - windowSeconds, now + maxClockSkewSeconds].
+   * Positive integer (seconds).
+   */
+  windowSeconds: number;
+  /** Allowed future skew for iat (seconds). Default 300. Non-negative integer. */
+  maxClockSkewSeconds?: number;
+  /** Upper bound on retained entries. Default 100_000. Positive integer. */
+  maxEntries?: number;
+  /**
+   * Injectable clock returning epoch seconds (tests/determinism). Backward movement
+   * is clamped internally to the last observed second. Default Math.floor(Date.now() / 1000).
+   */
+  now?: () => number;
+}
+
+export type ReplayGuardVerdict = 'fresh' | 'replayed' | 'outside-window';
+
+export interface ReplayGuard {
+  /** Classify a record that has already been verified (e.g. by verifyLocal). No I/O. */
+  check(record: { iss: string; jti: string; iat: number }): ReplayGuardVerdict;
+}
+
+/** Internal retained-entry shape (not exported). */
+interface ReplayEntry {
+  expiresAt: number;
+}
+
+function safeInteger(value: number, name: string): number {
+  // Use Number.isSafeInteger (not Number.isInteger) for all timestamp/window
+  // arithmetic: values beyond MAX_SAFE_INTEGER lose exactness, so the guard
+  // fails closed rather than computing imprecise window/TTL boundaries.
+  if (!Number.isSafeInteger(value)) {
+    throw new Error(`createReplayGuard: ${name} must be a safe integer`);
+  }
+  return value;
+}
+
+function positiveInt(value: number, name: string): number {
+  safeInteger(value, name);
+  if (value <= 0) {
+    throw new Error(`createReplayGuard: ${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function nonNegativeInt(value: number, name: string): number {
+  safeInteger(value, name);
+  if (value < 0) {
+    throw new Error(`createReplayGuard: ${name} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function nonEmptyString(value: string, name: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`createReplayGuard: ${name} must be a non-empty string`);
+  }
+  return value;
+}
+
+/**
+ * Create a bounded replay guard for already-verified records.
+ *
+ * @param options - window, optional max clock skew, optional entry cap, optional clock.
+ * @returns a guard whose `check(record)` returns 'fresh' | 'replayed' | 'outside-window'.
+ */
+export function createReplayGuard(options: ReplayGuardOptions): ReplayGuard {
+  const windowSeconds = positiveInt(options.windowSeconds, 'windowSeconds');
+  const maxClockSkewSeconds =
+    options.maxClockSkewSeconds === undefined
+      ? DEFAULT_MAX_CLOCK_SKEW_SECONDS
+      : nonNegativeInt(options.maxClockSkewSeconds, 'maxClockSkewSeconds');
+  const maxEntries =
+    options.maxEntries === undefined
+      ? DEFAULT_MAX_ENTRIES
+      : positiveInt(options.maxEntries, 'maxEntries');
+  const now = options.now ?? (() => Math.floor(Date.now() / 1000));
+
+  // Date.now() is a wall clock and can move backward (NTP / manual time changes);
+  // clamp to the last observed second so the insertion-order TTL purge stays correct
+  // even if the clock regresses. now() is validated (safe integer) here too.
+  let lastNow = Number.NEGATIVE_INFINITY;
+  const currentNow = (): number => {
+    const raw = safeInteger(now(), 'now()');
+    if (raw < lastNow) return lastNow;
+    lastNow = raw;
+    return raw;
+  };
+
+  // key -> entry. JS Map preserves insertion order. expiresAt is computed from the
+  // (clamped, monotonic) insertion-time clock, so the front of the map always holds
+  // the soonest-expiring entry: a front-scan that breaks on the first not-yet-expired
+  // entry is correct and O(number actually expired). A replay does not refresh the
+  // entry (no recency/TTL bump), so insertion order remains the eviction order.
+  const seen = new Map<string, ReplayEntry>();
+
+  // Length-prefixed key so (iss="a", jti="bc") cannot collide with (iss="ab", jti="c").
+  const keyOf = (iss: string, jti: string): string => `${iss.length}:${iss}${jti.length}:${jti}`;
+
+  const purgeExpired = (nowSeconds: number): void => {
+    for (const [key, entry] of seen) {
+      if (entry.expiresAt > nowSeconds) break;
+      seen.delete(key);
+    }
+  };
+
+  return {
+    check(record: { iss: string; jti: string; iat: number }): ReplayGuardVerdict {
+      // Fail closed on runtime misuse (plain-JS callers bypass the TS types). Validate
+      // the record before any state mutation so invalid input never changes the store.
+      const iat = safeInteger(record.iat, 'record.iat');
+      const iss = nonEmptyString(record.iss, 'record.iss');
+      const jti = nonEmptyString(record.jti, 'record.jti');
+      const t = currentNow(); // validates now() + clamps backward movement
+
+      // Time bound: drop entries that can no longer match within any window.
+      purgeExpired(t);
+
+      // Window first: out-of-window records never consume store capacity, and the
+      // verdict is unambiguous (reported outside-window without being recorded).
+      if (iat < t - windowSeconds || iat > t + maxClockSkewSeconds) {
+        return 'outside-window';
+      }
+
+      const key = keyOf(iss, jti);
+      if (seen.has(key)) {
+        return 'replayed';
+      }
+
+      // Conservative TTL: an upper bound on the latest time any record accepted now
+      // could still be replayed within the acceptance window. May retain older-iat
+      // entries slightly longer than their exact iat + windowSeconds horizon, but it
+      // preserves monotonic expiry order and keeps the store time-bounded (a stale
+      // entry re-checked short-circuits as outside-window before dedup regardless).
+      // Validate the expiry sum is a safe integer before any store mutation, so an
+      // overflow fails closed without evicting or inserting.
+      const expiresAt = safeInteger(t + windowSeconds + maxClockSkewSeconds, 'entry expiry');
+
+      // Count bound: apply the hard maxEntries cap before inserting.
+      if (seen.size >= maxEntries) {
+        const oldest = seen.keys().next().value;
+        if (oldest !== undefined) seen.delete(oldest);
+      }
+      seen.set(key, { expiresAt });
+      return 'fresh';
+    },
+  };
+}

--- a/tests/tooling/__snapshots__/api-contract.test.ts.snap
+++ b/tests/tooling/__snapshots__/api-contract.test.ts.snap
@@ -175,6 +175,7 @@ exports[`API contract: @peac/protocol > value exports match snapshot 1`] = `
   "createDefaultPolicy",
   "createDigest",
   "createEmptyReport",
+  "createReplayGuard",
   "createReportBuilder",
   "fetchDiscovery",
   "fetchIssuerConfig",

--- a/tests/tooling/protocol-public-surface-stable.test.ts
+++ b/tests/tooling/protocol-public-surface-stable.test.ts
@@ -47,6 +47,7 @@ const PROTOCOL_PUBLIC_EXPORT_BASELINE_PR_A = [
   'checkPolicyBinding',
   'clearJWKSCache',
   'clearKidThumbprints',
+  'createReplayGuard',
   'computeDocumentDigest',
   'computeJsonDocumentDigestJcs',
   'computeJwkThumbprint',


### PR DESCRIPTION
## Summary

Adds an optional, composable bounded replay guard, `createReplayGuard`, to `@peac/protocol`. It classifies an already-verified record as `fresh`, `replayed`, or `outside-window`, for online consumers that want bounded replay defense on top of offline verification.

This is an online acceptance policy, not a record property. It adds no field to any record, no `exp`, and no wire-format change. The same record remains valid and offline-verifiable indefinitely outside any window. The guard is intentionally not wired into the stateless `verifyLocal` path; the deployer composes it and chooses the response.

## Scope

- New: `packages/protocol/src/replay-guard.ts` (the helper) and `docs/specs/REPLAY-GUARD-PROFILE.md` (informative profile).
- Public API added: value `createReplayGuard`; types `ReplayGuardOptions`, `ReplayGuardVerdict`, `ReplayGuard`.
- Not changed: wire format, schemas, error registry, signing, CLI, Go SDK, conformance corpus, Node floor, dependencies.

## Behavior

- Dedup key is the existing `(iss, jti)` pair (length-prefixed so distinct issuer/jti splits cannot collide).
- `iat` is gated to `[now - windowSeconds, now + maxClockSkewSeconds]`; out-of-window records are reported `outside-window` and never stored.
- The store is bounded by both a maximum retained-entry count and a TTL purge, so it stays finite under load. The oldest retained entry is evicted past `maxEntries`; a replay does not refresh recency or TTL.
- Fail-closed: empty `iss`/`jti` and non-safe-integer `iat`/clock values throw before any state mutation.
- A backward wall-clock step (for example an NTP correction) is clamped to the last observed second so the insertion-order TTL purge stays correct. A replay does not refresh recency or TTL.

## Validation

- 20 unit tests plus a `verifyLocal` composition smoke test.
- Build, `typecheck:core`, full test suite, conformance, public-surface and api-contract gates, semantic-widening, codegen-drift, registries-schema, and forbidden-string gates all pass.
- API-contract snapshot regenerated for the new protocol exports.
