### PR TITLE
chore(release): stamp v0.16.0 release state

### DIFF
--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable surface classification for PEAC Protocol workspace. CI fails if any workspace member is missing. See docs/PACKAGE_STATUS.md for human-readable view.",
   "version": "0.13.0",
-  "updated": "2026-06-26",
+  "updated": "2026-06-28",
   "states": {
     "default": "Current recommended path. Actively maintained, Wire 0.2 native.",
     "supported": "Actively maintained, published, production-ready. May not be on default quickstart path.",

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -2,7 +2,7 @@
 
 Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scripts/generate-surface-status.mjs`.
 
-**Version:** 0.13.0 | **Updated:** 2026-06-26
+**Version:** 0.13.0 | **Updated:** 2026-06-28
 
 ## Layer 1
 

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -4,7 +4,7 @@
   "version": "0.16.0",
   "wire_format_version": "0.2",
   "dist_tag": "latest",
-  "release_date": "2026-06-26",
+  "release_date": "2026-06-28",
   "metrics": {
     "tests": 11974,
     "test_files": 478,


### PR DESCRIPTION
## Summary

Stamps the v0.16.0 post-publish release state: `release_date` and the surface-status `updated` date. The npm `latest` dist-tag, signed tag, and finalized GitHub Release are already in place; closeout `--stage final` reports 7 GREEN.

No code, schema, or version change.
