### PR TITLE
fix(cli): derive observation CLI version from package metadata

### DIFF
--- a/packages/cli/src/commands/observe-command.ts
+++ b/packages/cli/src/commands/observe-command.ts
@@ -21,6 +21,7 @@
 import { Command, Option } from 'commander';
 import { writeFileSync } from 'node:fs';
 import { CLI_LIMITS } from '../lib/cli-limits.js';
+import { getVersion } from '../lib/version.js';
 import {
   preflightOutputWritable,
   resolveProgramPath,
@@ -193,7 +194,7 @@ export async function runObserveCommand(
   const childEnv = io.childEnv ?? process.env;
   const captureEnv = io.captureEnv ?? process.env;
   const cwd = io.cwd ?? process.cwd();
-  const peacCliVersion = io.peacCliVersion ?? '0.14.1';
+  const peacCliVersion = io.peacCliVersion ?? getVersion();
 
   const failures = validateObserveOptions(opts, childArgv);
   if (failures.length > 0) {

--- a/packages/cli/src/commands/record-command.ts
+++ b/packages/cli/src/commands/record-command.ts
@@ -29,6 +29,7 @@ import { CLI_COMMAND_EXECUTION_TYPE, CLI_EXECUTION_EXTENSION_KEY } from '@peac/s
 import { issue, IssueError } from '@peac/protocol';
 import { generateKeypair } from '@peac/crypto';
 import { CLI_LIMITS } from '../lib/cli-limits.js';
+import { getVersion } from '../lib/version.js';
 import { runObservationCore, preflightOutputWritable } from '../lib/observation-pipeline.js';
 import { parseIntegerFlag, type ObserveCommandOptions } from './observe-command.js';
 import {
@@ -201,7 +202,7 @@ export async function runRecordCommand(
   const captureEnv = io.captureEnv ?? process.env;
   const issuerKeyEnv = io.issuerKeyEnv ?? process.env;
   const cwd = io.cwd ?? process.cwd();
-  const peacCliVersion = io.peacCliVersion ?? '0.14.1';
+  const peacCliVersion = io.peacCliVersion ?? getVersion();
 
   const failures = validateRecordOptions(opts, childArgv);
   if (failures.length > 0) {

--- a/packages/cli/tests/observe-command-wiring.test.ts
+++ b/packages/cli/tests/observe-command-wiring.test.ts
@@ -19,6 +19,7 @@ import {
   parseIntegerFlag,
 } from '../src/commands/observe-command';
 import { CliExecutionSchema } from '@peac/schema';
+import { getVersion } from '../src/lib/version';
 
 const NODE = process.execPath;
 
@@ -130,6 +131,15 @@ describe('observe command wiring: end-to-end smoke', () => {
     const record = JSON.parse(result.stdout.trim()) as Record<string, unknown>;
     expect(record.shell_mode).toBe(true);
     expect((record.command as { program: string }).program).toBe('sh');
+  }, 20_000);
+
+  it('emits peac_cli_version from the canonical getVersion(), not a hardcoded fallback', async () => {
+    const result = await runWiredObserveCommand(['--', NODE, '-e', 'process.stdout.write("ok")']);
+    expect(result.exitCode).toBe(0);
+    const record = JSON.parse(result.stdout.trim()) as Record<string, unknown>;
+    const platform = record.platform as Record<string, unknown>;
+    expect(platform.peac_cli_version).toBe(getVersion());
+    expect(platform.peac_cli_version).not.toBe('0.14.1');
   }, 20_000);
 });
 

--- a/packages/cli/tests/record-command-wiring.test.ts
+++ b/packages/cli/tests/record-command-wiring.test.ts
@@ -12,6 +12,7 @@ import { Command } from 'commander';
 import { recordCommand } from '../src/commands/record-command';
 import { decode } from '@peac/crypto';
 import { CLI_EXECUTION_EXTENSION_KEY } from '@peac/schema';
+import { getVersion } from '../src/lib/version';
 
 const NODE = process.execPath;
 
@@ -94,6 +95,11 @@ describe('record command wiring: end-to-end smoke', () => {
     const extensions = (payload as Record<string, unknown>).extensions as Record<string, unknown>;
     const ext = extensions[CLI_EXECUTION_EXTENSION_KEY] as Record<string, unknown>;
     expect(ext.type).toBe('org.peacprotocol/cli-command-execution');
+    // peac_cli_version comes from the canonical getVersion(), not a hardcoded fallback,
+    // and matches the observe command path (same version source).
+    const platform = ext.platform as Record<string, unknown>;
+    expect(platform.peac_cli_version).toBe(getVersion());
+    expect(platform.peac_cli_version).not.toBe('0.14.1');
   }, 20_000);
 
   it('keeps options before `--` as PEAC options and post-`--` tokens as child args', async () => {

--- a/tests/tooling/package-surface-audit.test.ts
+++ b/tests/tooling/package-surface-audit.test.ts
@@ -110,11 +110,11 @@ describe('publish-manifest surface audit', () => {
     expect(manifest.totalPackages).toBe(V0_13_1_TARGET_COUNT);
   });
 
-  it('manifest version is either current release (0.15.3) or target (0.16.0)', () => {
+  it('manifest version is either current release (0.16.0) or target (0.17.0)', () => {
     // Version stamping belongs to release prep. Accept either the current
     // released value or the next-release target to keep the gate robust
     // across the release lifecycle.
-    expect(['0.15.3', '0.16.0']).toContain(manifest.version);
+    expect(['0.16.0', '0.17.0']).toContain(manifest.version);
   });
 
   it('totalPackages field matches packages[] length', () => {


### PR DESCRIPTION
## Summary

The observe and record commands hardcoded `peacCliVersion ?? '0.14.1'`, embedded as `platform.peac_cli_version` in emitted records. That fallback was stale (last accurate at v0.14.1). This routes both commands through the canonical `getVersion()` helper (`packages/cli/src/lib/version.ts`), the same source already used by `samples`, `conformance`, and `--version`, so the emitted version no longer goes stale.

## Changes

- `packages/cli/src/commands/observe-command.ts` and `record-command.ts`: replace the hardcoded `'0.14.1'` fallback with `getVersion()`. Explicit `io.peacCliVersion` still overrides the default (test-injection behavior preserved).
- `packages/cli/tests/observe-command-wiring.test.ts` and `record-command-wiring.test.ts`: assert the emitted `platform.peac_cli_version` equals `getVersion()` and is no longer `'0.14.1'`, on both command paths (same source).
- `tests/tooling/package-surface-audit.test.ts`: advance the version allowlist from current `0.15.3` / target `0.16.0` to current `0.16.0` / target `0.17.0`.

## Scope

No wire/schema/signing/registry change. No release metadata or package-version change. No new dependencies. Post-release hygiene only.

## Validation

`@peac/cli` suite (287) and `package-surface-audit` pass; typecheck, prettier, `git diff --check`, forbidden-string and public-artifact gates pass.
