### PR TITLE
docs(spec): title error registry companion to match its role

### DIFF
--- a/docs/specs/ERRORS.md
+++ b/docs/specs/ERRORS.md
@@ -1,4 +1,4 @@
-# PEAC Error Registry
+# PEAC Error Registry Companion
 
 The complete, authoritative, machine-readable error registry is
 [`specs/kernel/errors.json`](../../specs/kernel/errors.json). Its top-level `version`


### PR DESCRIPTION
## Summary

Renames the `docs/specs/ERRORS.md` heading from "PEAC Error Registry" to
"PEAC Error Registry Companion" so the title matches the document's stated role.

PR #890 clarified that the complete, authoritative, machine-readable error
registry is `specs/kernel/errors.json` and that this Markdown file is a
human-readable companion. The old top-level heading still implied the Markdown
file itself was the registry. This one-line change aligns the heading with the
body.

## Scope

- Single heading line in `docs/specs/ERRORS.md`.
- File path is unchanged, so all existing links remain stable.
- No wire, schema, signing, registry, runtime, or version change. Docs-only.

## Validation

- Heading now reads "PEAC Error Registry Companion".
- `errors.json` remains the normative source; this file remains the companion.
- prettier clean; no hidden or bidirectional characters (pure ASCII).
