### PR TITLE
test(tooling): example source gate to commerce examples

### DIFF
--- a/scripts/verify-example-source-gate.mjs
+++ b/scripts/verify-example-source-gate.mjs
@@ -2,105 +2,137 @@
 /**
  * verify-example-source-gate
  *
- * Repository check for the v0.14.2 provisioning-lifecycle PR 3 public
- * surface. Detects committed live-shaped secrets and retired public
- * vocabulary in the example, recipe, parity-corpus, and smoke/doc-truth
- * test files.
+ * Repository check for the provisioning-lifecycle and commerce example
+ * public surface. Detects committed live-shaped secrets, base64url-encoded
+ * payment credentials, and retired public vocabulary in the example,
+ * recipe, parity-corpus, and smoke/doc-truth test files.
  *
  * This is NOT a substitute for the recursive credential-material walker
  * in `@peac/schema/src/extensions/provisioning-lifecycle.ts`. The walker
  * enforces the no-credential-leak invariant at the protocol layer; this
- * script enforces the doctrine that public examples, recipes, parity
- * corpora, and smoke tests must not carry live token shapes or vendor-
- * named identifiers.
+ * script enforces the repository rule that public examples, recipes, parity
+ * corpora, and smoke tests must not carry live token shapes, decoded
+ * payment credentials, or vendor-named identifiers.
  *
- * Scoped paths (provisioning-lifecycle PR 3 surface only):
- *   examples/provisioning-lifecycle/
- *   examples/agent-provisioning-demo/
- *   docs/SOLUTIONS/verify-agent-provisioning.md
- *   specs/conformance/parity-corpus/provisioning-lifecycle/
- *   tests/solutions/
- *   tests/tooling/provisioning-recipe-doc-truth.test.ts
+ * Scanned surface:
+ *   - provisioning-lifecycle PR 3 surface (examples/recipe/parity/tests)
+ *   - the commerce example directories (x402 / paymentauth / ACP / Stripe /
+ *     commerce-evidence-bundle / commerce-mandate-records)
+ *
+ * Import-safe: `scanContent(text, options?)` is a pure function (no
+ * filesystem, console, or process access) so it can be unit-tested
+ * directly. The CLI behavior lives in `main()`, run only when this file
+ * is executed directly.
  *
  * Exit code 0 = clean; 1 = one or more findings or a missing required
  * target.
  */
 import { readFileSync, readdirSync } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(HERE, '..');
 
-/** Each target declares whether it is a file or a directory. The walker
- * is operation-first: file targets are read directly and directory
- * targets are enumerated directly. It does not classify paths before
- * reading them. Missing required targets surface as findings; missing
- * optional targets are silently skipped. */
-const SCAN_TARGETS = [
+/** Each target declares whether it is a file or a directory. File targets
+ * are read directly; directory targets are enumerated directly. Missing
+ * required targets surface as findings; missing optional targets are
+ * silently skipped. */
+export const SCAN_TARGETS = [
+  // provisioning-lifecycle PR 3 surface
   { path: 'examples/provisioning-lifecycle', kind: 'dir', required: true },
   { path: 'examples/agent-provisioning-demo', kind: 'dir', required: true },
   { path: 'docs/SOLUTIONS/verify-agent-provisioning.md', kind: 'file', required: true },
   { path: 'specs/conformance/parity-corpus/provisioning-lifecycle', kind: 'dir', required: true },
   { path: 'tests/solutions', kind: 'dir', required: true },
   { path: 'tests/tooling/provisioning-recipe-doc-truth.test.ts', kind: 'file', required: true },
+  // commerce example surface
+  { path: 'examples/stripe-spt-evidence', kind: 'dir', required: true },
+  { path: 'examples/stripe-x402-crypto', kind: 'dir', required: true },
+  { path: 'examples/paymentauth-evidence', kind: 'dir', required: true },
+  { path: 'examples/paymentauth-jsonrpc', kind: 'dir', required: true },
+  { path: 'examples/mpp-payment-attempt', kind: 'dir', required: true },
+  { path: 'examples/mpp-payment-record', kind: 'dir', required: true },
+  { path: 'examples/x402-dual-header-read', kind: 'dir', required: true },
+  { path: 'examples/x402-node-server', kind: 'dir', required: true },
+  { path: 'examples/x402-upto-evidence', kind: 'dir', required: true },
+  { path: 'examples/x402-weather-proof', kind: 'dir', required: true },
+  { path: 'examples/acp-delegated-checkout', kind: 'dir', required: true },
+  { path: 'examples/acp-session-lifecycle', kind: 'dir', required: true },
+  { path: 'examples/cf-policy-x402-terms', kind: 'dir', required: true },
+  { path: 'examples/commerce-evidence-bundle', kind: 'dir', required: true },
+  { path: 'examples/commerce-mandate-records', kind: 'dir', required: true },
 ];
 
-const SKIP_DIRS = new Set(['node_modules', '.turbo', 'out', 'dist']);
+/** Directory names that are never scanned (vendored or generated). */
+export const SKIP_DIRS = new Set(['node_modules', '.turbo', 'out', 'dist']);
+
+/** File suffixes that are never scanned (generated artifacts). */
+export const SKIP_FILE_SUFFIXES = ['.map'];
 
 const SELF_PATH_FRAGMENT = 'scripts/verify-example-source-gate.mjs';
 
-const FORBIDDEN_PATTERNS = [
-  {
-    name: 'aws-access-key',
-    pattern: /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/,
-    severity: 'live-secret',
-  },
-  {
-    name: 'stripe-secret-live',
-    pattern: /\bsk_live_[A-Za-z0-9]{20,}\b/,
-    severity: 'live-secret',
-  },
-  {
-    name: 'stripe-public-live',
-    pattern: /\bpk_live_[A-Za-z0-9]{20,}\b/,
-    severity: 'live-secret',
-  },
+/** Upper bound on the length of a base64url candidate token that the
+ * decode-and-inspect tier will attempt to decode. A token longer than
+ * this is treated as a non-secret blob and skipped, so a very long
+ * base64url-looking string cannot drive pathological decode/parse cost. */
+export const MAX_DECODE_CANDIDATE_LEN = 8192;
+
+/** Bounds on the decoded-JSON key walk (defense against pathological
+ * nesting or huge objects in the decode-and-inspect tier). */
+const MAX_KEY_WALK_DEPTH = 12;
+const MAX_KEY_WALK_NODES = 4096;
+
+/** Tier 1 (literal shapes) + tier 3 (retired vocabulary). Each pattern is
+ * matched per line; anchored where needed so demo values do not fire. */
+export const FORBIDDEN_PATTERNS = [
+  // --- tier 1: literal live-shaped secrets ---
+  { name: 'aws-access-key', pattern: /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/, severity: 'live-secret' },
+  { name: 'stripe-secret-live', pattern: /\bsk_live_[A-Za-z0-9]{20,}\b/, severity: 'live-secret' },
+  { name: 'stripe-public-live', pattern: /\bpk_live_[A-Za-z0-9]{20,}\b/, severity: 'live-secret' },
   {
     name: 'stripe-restricted-live',
     pattern: /\brk_live_[A-Za-z0-9]{20,}\b/,
     severity: 'live-secret',
   },
-  {
-    name: 'stripe-secret-test',
-    pattern: /\bsk_test_[A-Za-z0-9]{20,}\b/,
-    severity: 'live-secret',
-  },
-  {
-    name: 'stripe-public-test',
-    pattern: /\bpk_test_[A-Za-z0-9]{20,}\b/,
-    severity: 'live-secret',
-  },
-  {
-    name: 'webhook-secret',
-    pattern: /\bwhsec_[A-Za-z0-9]{20,}\b/,
-    severity: 'live-secret',
-  },
+  { name: 'stripe-secret-test', pattern: /\bsk_test_[A-Za-z0-9]{20,}\b/, severity: 'live-secret' },
+  { name: 'stripe-public-test', pattern: /\bpk_test_[A-Za-z0-9]{20,}\b/, severity: 'live-secret' },
+  { name: 'webhook-secret', pattern: /\bwhsec_[A-Za-z0-9]{20,}\b/, severity: 'live-secret' },
   {
     name: 'pem-private-key',
     pattern: /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
     severity: 'live-secret',
   },
-  {
-    name: 'github-token-classic',
-    pattern: /\bghp_[A-Za-z0-9]{36}\b/,
-    severity: 'live-secret',
-  },
+  { name: 'github-token-classic', pattern: /\bghp_[A-Za-z0-9]{36}\b/, severity: 'live-secret' },
   {
     name: 'github-token-fine-grained',
     pattern: /\bgithub_pat_[A-Za-z0-9_]{82}\b/,
     severity: 'live-secret',
   },
+  // JWK private scalar: a "d" member carrying a base64url value of key length.
+  // Ed25519/P-256 private scalars are ~43 base64url chars; require >= 40 so a
+  // short "d" field (e.g. a day-of-month) does not fire.
+  {
+    name: 'jwk-private-scalar',
+    pattern: /"d"\s*:\s*"[A-Za-z0-9_-]{40,}"/,
+    severity: 'live-secret',
+  },
+  // Bearer JWT: three base64url segments starting eyJ. `Bearer realm="..."`
+  // and other non-JWT Bearer challenges do not match (no eyJ header).
+  {
+    name: 'bearer-jwt',
+    pattern: /\bBearer\s+eyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}/,
+    severity: 'live-secret',
+  },
+  // Keyword-anchored private hex key: only fires when a secret keyword sits
+  // right before a 0x<64 hex> value, so a bare demo tx hash (0xdeadbeef...)
+  // with no keyword does NOT fire.
+  {
+    name: 'keyword-anchored-hex-key',
+    pattern: /\b(?:private_key|secret_key|mnemonic|seed_phrase)\b[\s"':=]{0,8}0x[0-9a-fA-F]{64}\b/i,
+    severity: 'live-secret',
+  },
+  // --- tier 3: retired public vocabulary ---
   {
     name: 'retired-old-dir-name',
     pattern: /\bstripe-projects-provisioning\b/,
@@ -111,41 +143,159 @@ const FORBIDDEN_PATTERNS = [
     pattern: /\bpayment_token_observation\b/,
     severity: 'retired-vocabulary',
   },
-  {
-    name: 'retired-vendor-secret',
-    pattern: /\bstripe_secret\b/,
-    severity: 'retired-vocabulary',
-  },
-  {
-    name: 'retired-vendor-token',
-    pattern: /\bcloudflare_token\b/,
-    severity: 'retired-vocabulary',
-  },
+  { name: 'retired-vendor-secret', pattern: /\bstripe_secret\b/, severity: 'retired-vocabulary' },
+  { name: 'retired-vendor-token', pattern: /\bcloudflare_token\b/, severity: 'retired-vocabulary' },
 ];
 
-const findings = [];
-const missingRequired = [];
+/** Decoded-JSON keys that indicate a raw (unredacted) payment credential.
+ * PEAC records carry `sha256:` digests, never these raw fields, so a base64url
+ * payload that decodes to an object holding any of these keys is a leak.
+ * Compared case-insensitively. */
+export const PAYMENT_CREDENTIAL_KEYS = new Set([
+  'pan',
+  'card_number',
+  'cardnumber',
+  'cvv',
+  'cvc',
+  'cvv2',
+  'account_number',
+  'accountnumber',
+  'iban',
+  'routing_number',
+  'sort_code',
+  'mnemonic',
+  'seed_phrase',
+  'private_key',
+  'secret_key',
+]);
 
-/** Operation-first directory walker.
- *
- * `readdirSync(path, { withFileTypes: true })` returns Dirent objects
- * whose `.isFile()` / `.isDirectory()` come from the directory entry
- * itself, so the walker classifies and reads in one step rather than
- * checking the path first and reading it second.
- *
- * If the directory is missing (`ENOENT`) or is unexpectedly a file
- * (`ENOTDIR`), the caller decides whether to treat that as a finding
- * (required target) or a silent skip (optional target). */
-function* walkDirOperationFirst(start) {
-  let entries;
-  try {
-    entries = readdirSync(start, { withFileTypes: true });
-  } catch (err) {
-    if (err && (err.code === 'ENOENT' || err.code === 'ENOTDIR')) {
-      throw err;
+/** Keys that indicate a raw (unredacted) Payment-Receipt embedded as a nested
+ * object, e.g. `{ "payment_receipt": { ... } }`. A PEAC record binds a receipt
+ * by digest or preserves it as a signed JWS string, so a decoded payload that
+ * carries a Payment-Receipt-family key whose VALUE is an object is a raw-receipt
+ * leak. Deliberately object-valued only: string reference fields such as
+ * `payment_receipt_digest` / `payment_receipt_jws` / `payment_receipt_id` are
+ * safe PEAC proof references and must NOT flag. Compared case-insensitively. */
+export const PAYMENT_RECEIPT_SHAPE_KEYS = new Set([
+  'payment_receipt',
+  'payment-receipt',
+  'paymentreceipt',
+  'payment_receipts',
+]);
+
+/** Build a log-safe preview of a matched value. Live-secret matches are never
+ * echoed in full (so a real committed secret cannot leak into CI logs); only a
+ * short prefix plus the length is shown. Retired-vocabulary matches are not
+ * secret material and are shown verbatim so the offending token is locatable. */
+export function safeMatchPreview(patternName, raw) {
+  if (!raw) return '<redacted>';
+  if (patternName.startsWith('retired-')) return raw;
+  return `${raw.slice(0, 8)}...<redacted:${raw.length}>`;
+}
+
+/** Candidate base64url run for the decode-and-inspect tier. */
+const BASE64URL_TOKEN_RE = /[A-Za-z0-9_-]{40,}/g;
+/** Pure-hex tokens (sha256 digests, 0x tx-hash bodies) are never base64url
+ * JSON, so they are skipped before any decode attempt. */
+const PURE_HEX_RE = /^[0-9a-fA-F]+$/;
+
+/** Recursively collect (bounded) the offending keys from a decoded JSON value:
+ * `credential` = lowercased keys intersecting PAYMENT_CREDENTIAL_KEYS;
+ * `receipt` = Payment-Receipt-family keys whose value is a nested object (a raw
+ * embedded receipt). A normal PEAC JWS payload (iss/type/pillars) and string
+ * digest/jws references produce neither. */
+function offendingDecodedKeys(value) {
+  const credential = new Set();
+  const receipt = new Set();
+  let nodes = 0;
+  const stack = [{ v: value, d: 0 }];
+  while (stack.length > 0) {
+    const { v, d } = stack.pop();
+    nodes += 1;
+    if (nodes > MAX_KEY_WALK_NODES || d > MAX_KEY_WALK_DEPTH) break;
+    if (v === null || typeof v !== 'object') continue;
+    if (Array.isArray(v)) {
+      for (const item of v) stack.push({ v: item, d: d + 1 });
+      continue;
     }
-    throw err;
+    for (const key of Object.keys(v)) {
+      const lower = key.toLowerCase();
+      if (PAYMENT_CREDENTIAL_KEYS.has(lower)) credential.add(lower);
+      if (PAYMENT_RECEIPT_SHAPE_KEYS.has(lower) && v[key] !== null && typeof v[key] === 'object') {
+        receipt.add(lower);
+      }
+      stack.push({ v: v[key], d: d + 1 });
+    }
   }
+  return { credential, receipt };
+}
+
+/**
+ * Pure scanner. Takes file text and returns an array of findings; performs
+ * no filesystem reads, no console writes, no process mutation.
+ *
+ * @param {string} text
+ * @param {{ maxDecodeCandidateLen?: number }} [options]
+ * @returns {Array<{ line: number, pattern: string, severity: string, match: string }>}
+ */
+export function scanContent(text, options = {}) {
+  const maxDecodeLen = options.maxDecodeCandidateLen ?? MAX_DECODE_CANDIDATE_LEN;
+  const findings = [];
+  const lines = text.split('\n');
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const lineNo = i + 1;
+
+    // tier 1 + tier 3: literal / anchored shapes
+    for (const { name, pattern, severity } of FORBIDDEN_PATTERNS) {
+      const m = line.match(pattern);
+      if (m) {
+        findings.push({
+          line: lineNo,
+          pattern: name,
+          severity,
+          match: safeMatchPreview(name, m[0]),
+        });
+      }
+    }
+
+    // tier 2: decode-and-inspect base64url runs for raw payment credentials
+    BASE64URL_TOKEN_RE.lastIndex = 0;
+    let tok;
+    while ((tok = BASE64URL_TOKEN_RE.exec(line)) !== null) {
+      const raw = tok[0];
+      if (raw.length > maxDecodeLen) continue; // bounded: skip pathological blobs
+      if (PURE_HEX_RE.test(raw)) continue; // sha256 hex / 0x tx-hash body
+      const before = line.slice(Math.max(0, tok.index - 7), tok.index);
+      if (before.endsWith('sha256:')) continue; // explicit digest prefix guard
+      let decoded;
+      try {
+        decoded = JSON.parse(Buffer.from(raw, 'base64url').toString('utf8'));
+      } catch {
+        continue; // not base64url JSON (e.g. a JWS signature segment)
+      }
+      const { credential, receipt } = offendingDecodedKeys(decoded);
+      const offending = [...new Set([...credential, ...receipt])];
+      if (offending.length > 0) {
+        // key NAMES only, never decoded values -> no credential material logged
+        findings.push({
+          line: lineNo,
+          pattern: 'decoded-payment-credential',
+          severity: 'live-secret',
+          match: `base64url json keys: ${offending.sort().join(', ')}`,
+        });
+      }
+    }
+  }
+
+  return findings;
+}
+
+/** Operation-first directory walker: classifies via Dirent and reads in one
+ * step. Throws ENOENT/ENOTDIR up to the caller, which decides finding vs skip. */
+function* walkDirOperationFirst(start) {
+  const entries = readdirSync(start, { withFileTypes: true });
   for (const ent of entries) {
     if (SKIP_DIRS.has(ent.name)) continue;
     const child = join(start, ent.name);
@@ -153,9 +303,7 @@ function* walkDirOperationFirst(start) {
       try {
         yield* walkDirOperationFirst(child);
       } catch (err) {
-        if (err && (err.code === 'ENOENT' || err.code === 'ENOTDIR')) {
-          continue;
-        }
+        if (err && (err.code === 'ENOENT' || err.code === 'ENOTDIR')) continue;
         throw err;
       }
     } else if (ent.isFile()) {
@@ -164,87 +312,89 @@ function* walkDirOperationFirst(start) {
   }
 }
 
-function scanFile(file) {
-  if (file.endsWith(SELF_PATH_FRAGMENT)) return;
+function shouldSkipFile(file) {
+  if (file.endsWith(SELF_PATH_FRAGMENT)) return true;
+  return SKIP_FILE_SUFFIXES.some((suffix) => file.endsWith(suffix));
+}
+
+/** Read one file and map pure findings onto repo-relative locations. */
+function scanFileInto(file, findings) {
+  if (shouldSkipFile(file)) return;
   let content;
   try {
     content = readFileSync(file, 'utf8');
   } catch (err) {
-    if (err && err.code === 'ENOENT') {
-      return;
-    }
+    if (err && err.code === 'ENOENT') return;
     throw err;
   }
-  const lines = content.split('\n');
-  for (const { name, pattern, severity } of FORBIDDEN_PATTERNS) {
-    for (let i = 0; i < lines.length; i += 1) {
-      const m = lines[i].match(pattern);
-      if (m) {
-        findings.push({
-          file: relative(REPO_ROOT, file),
-          line: i + 1,
-          pattern: name,
-          severity,
-          match: m[0],
-        });
-      }
-    }
+  for (const f of scanContent(content)) {
+    findings.push({ file: relative(REPO_ROOT, file), ...f });
   }
 }
 
-for (const target of SCAN_TARGETS) {
-  const full = join(REPO_ROOT, target.path);
-  if (target.kind === 'file') {
-    try {
-      scanFile(full);
-    } catch (err) {
-      if (err && err.code === 'ENOENT') {
-        if (target.required) {
-          missingRequired.push(target.path);
-        }
-        continue;
-      }
-      throw err;
-    }
-  } else if (target.kind === 'dir') {
-    try {
-      for (const file of walkDirOperationFirst(full)) {
-        scanFile(file);
-      }
-    } catch (err) {
-      if (err && (err.code === 'ENOENT' || err.code === 'ENOTDIR')) {
-        if (target.required) {
-          missingRequired.push(target.path);
-        }
-        continue;
-      }
-      throw err;
-    }
-  }
-}
+/** CLI entrypoint. Owns all filesystem, console, and process interaction. */
+export function main() {
+  const findings = [];
+  const missingRequired = [];
 
-if (missingRequired.length > 0) {
-  console.error('verify-example-source-gate: FAIL (required targets missing)');
+  for (const target of SCAN_TARGETS) {
+    const full = join(REPO_ROOT, target.path);
+    if (target.kind === 'file') {
+      try {
+        scanFileInto(full, findings);
+      } catch (err) {
+        if (err && err.code === 'ENOENT') {
+          if (target.required) missingRequired.push(target.path);
+          continue;
+        }
+        throw err;
+      }
+    } else if (target.kind === 'dir') {
+      try {
+        for (const file of walkDirOperationFirst(full)) {
+          scanFileInto(file, findings);
+        }
+      } catch (err) {
+        if (err && (err.code === 'ENOENT' || err.code === 'ENOTDIR')) {
+          if (target.required) missingRequired.push(target.path);
+          continue;
+        }
+        throw err;
+      }
+    }
+  }
+
+  if (missingRequired.length > 0) {
+    console.error('verify-example-source-gate: FAIL (required targets missing)');
+    console.error('');
+    for (const p of missingRequired) {
+      console.error(`  MISSING: ${p}`);
+    }
+    console.error('');
+    process.exit(1);
+  }
+
+  if (findings.length === 0) {
+    console.log(
+      'verify-example-source-gate: clean (0 findings across provisioning + commerce surface)'
+    );
+    process.exit(0);
+  }
+
+  console.error('verify-example-source-gate: FAIL');
   console.error('');
-  for (const p of missingRequired) {
-    console.error(`  MISSING: ${p}`);
+  for (const f of findings) {
+    console.error(
+      `  ${f.severity.toUpperCase()}: ${f.file}:${f.line}: pattern=${f.pattern} match=${JSON.stringify(f.match)}`
+    );
   }
   console.error('');
+  console.error(`${findings.length} finding(s)`);
   process.exit(1);
 }
 
-if (findings.length === 0) {
-  console.log('verify-example-source-gate: clean (0 findings across PR 3 surface)');
-  process.exit(0);
+const invokedDirectly =
+  Boolean(process.argv[1]) && pathToFileURL(process.argv[1]).href === import.meta.url;
+if (invokedDirectly) {
+  main();
 }
-
-console.error('verify-example-source-gate: FAIL');
-console.error('');
-for (const f of findings) {
-  console.error(
-    `  ${f.severity.toUpperCase()}: ${f.file}:${f.line}: pattern=${f.pattern} match=${JSON.stringify(f.match)}`
-  );
-}
-console.error('');
-console.error(`${findings.length} finding(s)`);
-process.exit(1);

--- a/tests/tooling/verify-example-source-gate.test.ts
+++ b/tests/tooling/verify-example-source-gate.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Unit gate for scripts/verify-example-source-gate.mjs.
+ *
+ * Exercises the pure `scanContent()` scanner directly (no filesystem): the
+ * positive detectors (live-shaped secrets, JWK private scalars, bearer JWTs,
+ * keyword-anchored hex keys, base64url-encoded payment credentials) and the
+ * locked false-positive traps (sha256 digests, non-JWT Bearer challenges,
+ * `pi_...` placeholders, demo tx hashes, PEAC JWS payload segments, and very
+ * long non-secret tokens).
+ *
+ * Importing the module must be side-effect-free: `main()` runs only when the
+ * script is invoked directly, so this test never touches the repo tree.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  scanContent,
+  SCAN_TARGETS,
+  PAYMENT_CREDENTIAL_KEYS,
+  MAX_DECODE_CANDIDATE_LEN,
+} from '../../scripts/verify-example-source-gate.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = resolve(__dirname, '..', '..', 'scripts', 'verify-example-source-gate.mjs');
+
+/** base64url-encode a JSON value (matches how examples inline encoded payloads). */
+function b64urlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), 'utf8').toString('base64url');
+}
+
+const patternsOf = (text: string): string[] => scanContent(text).map((f) => f.pattern);
+
+describe('scanContent - purity and shape', () => {
+  it('returns an array and never throws on empty or benign text', () => {
+    expect(scanContent('')).toEqual([]);
+    expect(scanContent('const amount = 100; // just a comment\n')).toEqual([]);
+  });
+
+  it('does not mutate its input string', () => {
+    const input = 'harmless line\n';
+    const copy = String(input);
+    scanContent(input);
+    expect(input).toBe(copy);
+  });
+
+  it('reports 1-indexed line numbers', () => {
+    // build the live-key value at runtime so the scanned text is contiguous
+    // while this source file holds no contiguous secret literal
+    const skLive = 'sk_live_' + 'x'.repeat(24);
+    const text = ['line one', 'const k = "' + skLive + '";'].join('\n');
+    const findings = scanContent(text);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].line).toBe(2);
+  });
+});
+
+describe('scanContent - positive detectors (must flag)', () => {
+  it('flags a live-shaped Stripe secret key', () => {
+    const skLive = 'sk_live_' + 'a'.repeat(24);
+    const text = 'const key = "' + skLive + '";';
+    expect(patternsOf(text)).toContain('stripe-secret-live');
+  });
+
+  it('flags a JWK private scalar ("d")', () => {
+    const text = `{ "kty": "OKP", "crv": "Ed25519", "d": "${'A'.repeat(43)}" }`;
+    expect(patternsOf(text)).toContain('jwk-private-scalar');
+  });
+
+  it('flags a bearer JWT', () => {
+    const jwt = ['eyJ' + 'a'.repeat(8), 'b'.repeat(10), 'c'.repeat(10)].join('.');
+    expect(patternsOf(`Authorization: Bearer ${jwt}`)).toContain('bearer-jwt');
+  });
+
+  it('flags a keyword-anchored private hex key', () => {
+    const text = `secret_key = 0x${'a'.repeat(64)}`;
+    expect(patternsOf(text)).toContain('keyword-anchored-hex-key');
+  });
+
+  it('flags a base64url payload carrying raw payment credential fields', () => {
+    const blob = b64urlJson({ pan: '4111111111111111', cvv: '123', brand: 'visa' });
+    const findings = scanContent(`const payload = "${blob}";`);
+    expect(findings.map((f) => f.pattern)).toContain('decoded-payment-credential');
+    const cred = findings.find((f) => f.pattern === 'decoded-payment-credential');
+    expect(cred?.match).toContain('cvv');
+    expect(cred?.match).toContain('pan');
+  });
+
+  it('flags a base64url payload matching a raw Payment-Receipt shape (nested credentials)', () => {
+    const blob = b64urlJson({
+      payment_receipt: { account_number: '000123456789', routing_number: '021000021' },
+    });
+    const patterns = patternsOf(`receipt = "${blob}"`);
+    expect(patterns).toContain('decoded-payment-credential');
+  });
+
+  it('flags a raw Payment-Receipt shape even with NO credential keys (object-valued)', () => {
+    const blob = b64urlJson({
+      payment_receipt: { amount_minor: 100, currency: 'USD', transaction_id: 'txn_abc123' },
+    });
+    const hit = scanContent(`receipt = "${blob}"`).find(
+      (f) => f.pattern === 'decoded-payment-credential'
+    );
+    expect(hit).toBeDefined();
+    expect(hit?.match).toContain('payment_receipt');
+  });
+
+  it('does NOT flag a string payment_receipt_digest reference (safe PEAC proof field)', () => {
+    // a PEAC record legitimately binds a receipt by digest / signed-JWS string;
+    // these are object-key-shaped but string-valued -> must not fire
+    const blob = b64urlJson({
+      type: 'org.peacprotocol/payment',
+      proofs: {
+        payment_receipt_digest: 'sha256:' + 'a'.repeat(64),
+        payment_receipt_jws: 'eyJhbGc',
+      },
+    });
+    expect(scanContent(`rec = "${blob}"`)).toEqual([]);
+  });
+});
+
+describe('scanContent - locked false-positive traps (must NOT flag)', () => {
+  it('does not flag a sha256 digest', () => {
+    expect(scanContent(`digest: sha256:${'a'.repeat(64)}`)).toEqual([]);
+  });
+
+  it('does not flag a non-JWT Bearer challenge', () => {
+    expect(scanContent('WWW-Authenticate: Bearer realm="payment", error="invalid_token"')).toEqual(
+      []
+    );
+  });
+
+  it('does not flag a pi_ placeholder id', () => {
+    expect(scanContent('const id = "pi_3QxYz1234567890abc";')).toEqual([]);
+  });
+
+  it('does not flag a demo 0x transaction hash', () => {
+    const txHash = '0x' + 'deadbeef'.repeat(8);
+    expect(scanContent(`tx_hash: "${txHash}"`)).toEqual([]);
+  });
+
+  it('does not flag a PEAC JWS payload segment', () => {
+    const payload = b64urlJson({
+      iss: 'https://issuer.example',
+      sub: 'agent-1',
+      type: 'org.peacprotocol/payment',
+      pillars: ['Commerce'],
+      iat: 1700000000,
+      jti: '018f...uuid',
+    });
+    // full compact JWS shape: header.payload.signature
+    const jws = ['eyJhbGciOiJFZERTQSJ9', payload, 'c'.repeat(86)].join('.');
+    expect(scanContent(`receipt: "${jws}"`)).toEqual([]);
+  });
+
+  it('does not flag (or blow up on) a very long non-secret token', () => {
+    // >MAX_DECODE_CANDIDATE_LEN, non-hex so it exercises the length bound,
+    // not the pure-hex guard.
+    const longToken = 'Zz9_'.repeat(6000); // 24000 chars, well over the bound
+    expect(longToken.length).toBeGreaterThan(MAX_DECODE_CANDIDATE_LEN);
+    const start = Date.now();
+    const findings = scanContent(`blob = "${longToken}"`);
+    expect(findings).toEqual([]);
+    // sanity: the bound keeps this cheap (no per-token decode of a huge blob)
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+});
+
+describe('scanContent - output redaction (no secret material in findings)', () => {
+  it('redacts a literal live-secret match (never echoes the full key)', () => {
+    const skLive = 'sk_live_' + 'a'.repeat(24);
+    const [finding] = scanContent('const key = "' + skLive + '";');
+    expect(finding.pattern).toBe('stripe-secret-live');
+    expect(finding.match).not.toContain(skLive);
+    expect(finding.match).toContain('<redacted');
+  });
+
+  it('redacts a JWK private scalar match', () => {
+    const d = 'A'.repeat(43);
+    const [finding] = scanContent(`{ "kty": "OKP", "d": "${d}" }`);
+    expect(finding.pattern).toBe('jwk-private-scalar');
+    expect(finding.match).not.toContain(d);
+    expect(finding.match).toContain('<redacted');
+  });
+
+  it('reports decoded credential KEY NAMES only, never the values', () => {
+    const blob = b64urlJson({ pan: '4111111111111111', cvv: '123' });
+    const finding = scanContent(`payload="${blob}"`).find(
+      (f) => f.pattern === 'decoded-payment-credential'
+    );
+    expect(finding?.match).toContain('pan');
+    expect(finding?.match).not.toContain('4111111111111111');
+    expect(finding?.match).not.toContain('123');
+  });
+
+  it('shows retired-vocabulary matches verbatim (not secret material)', () => {
+    const [finding] = scanContent('const x = "stripe_secret";');
+    expect(finding.pattern).toBe('retired-vendor-secret');
+    expect(finding.match).toBe('stripe_secret');
+  });
+});
+
+describe('CLI', () => {
+  it('runs as a CLI and reports clean (import guard keeps main() off on import)', () => {
+    const out = execFileSync(process.execPath, [SCRIPT], { encoding: 'utf8' });
+    expect(out).toContain('verify-example-source-gate: clean');
+  });
+});
+
+describe('module exports', () => {
+  it('scans both the provisioning and commerce example surface', () => {
+    const paths = SCAN_TARGETS.map((t: { path: string }) => t.path);
+    expect(paths).toContain('examples/provisioning-lifecycle');
+    expect(paths).toContain('examples/stripe-spt-evidence');
+    expect(paths).toContain('examples/commerce-evidence-bundle');
+    // every commerce target is required (fail-closed)
+    const commerce = SCAN_TARGETS.filter((t: { path: string }) => t.path.startsWith('examples/'));
+    expect(commerce.every((t: { required: boolean }) => t.required)).toBe(true);
+  });
+
+  it('exposes the payment-credential key set used by decode-and-inspect', () => {
+    expect(PAYMENT_CREDENTIAL_KEYS.has('pan')).toBe(true);
+    expect(PAYMENT_CREDENTIAL_KEYS.has('account_number')).toBe(true);
+    expect(PAYMENT_CREDENTIAL_KEYS.has('iss')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Extends the example source/secret gate to cover commerce examples and makes the scanner import-safe and unit-testable.

## Changes

- Refactors `scripts/verify-example-source-gate.mjs` so CLI behavior runs only through `main()`.
- Exports a pure `scanContent(text, options?)` helper for unit tests.
- Extends required scan coverage to the commerce example directories.
- Skips generated/vendor output consistently (`dist/`, `.turbo/`, `node_modules/`, `out/`, `.map`).
- Adds context-aware detectors for:
  - live-shaped secret keys,
  - private JWK scalar fields,
  - bearer JWTs,
  - keyword-anchored private hex keys,
  - bounded base64url JSON payload inspection for payment credentials or raw object-valued Payment-Receipt shapes.
- Redacts live-secret matches in scanner output so CI logs do not echo raw secret material.
- Adds tests for positive detections, false-positive traps, output redaction, receipt-shape handling, bounded decode behavior, and CLI execution.

## Non-goals

- No product code change.
- No protocol wire-format change.
- No schema, registry, receipt-type, extension-group, signing, conformance, or API-contract change.
- No new dependencies.
- No public docs or release metadata change.

## Validation

- `node scripts/verify-example-source-gate.mjs`
- `pnpm exec vitest run tests/tooling/verify-example-source-gate.test.ts`
- `pnpm exec vitest run tests/tooling`
- `pnpm typecheck:core`
- `git diff --check`
- `pnpm exec prettier --check scripts/verify-example-source-gate.mjs tests/tooling/verify-example-source-gate.test.ts`
- `node scripts/check-public-artifacts.mjs`
- `bash scripts/check-planning-leak.sh scripts/verify-example-source-gate.mjs`
- `bash scripts/check-planning-leak.sh tests/tooling/verify-example-source-gate.test.ts`
