### PR TITLE
docs: update Smithery distribution pins

### DIFF
--- a/docs/case-studies/distribution-submissions.md
+++ b/docs/case-studies/distribution-submissions.md
@@ -25,7 +25,7 @@ Status tracking for every external listing or marketplace submission PEAC mainta
 
 ## Tag-time discipline
 
-At v0.12.13 tag time, every row above requires:
+At release tag time, every row above requires:
 
 - `prepared` at minimum, with a committed artifact under `surfaces/plugin-pack/`, `packages/mcp-server/smithery.yaml`, or equivalent local source.
 - Or `submitted`, with a submission URL, PR number, or review thread captured in the `Artifact reference` cell.

--- a/docs/guides/smithery-remote-mcp.md
+++ b/docs/guides/smithery-remote-mcp.md
@@ -19,7 +19,7 @@ truth.
 
 1. Provision your host to run:
    ```text
-   npx -y @peac/mcp-server@0.12.11 --issuer-key env:PEAC_ISSUER_KEY \
+   npx -y @peac/mcp-server@0.16.1 --issuer-key env:PEAC_ISSUER_KEY \
      --issuer-id https://your-service.example.com
    ```
    The pinned version tracks the canonical `smithery.yaml`; update


### PR DESCRIPTION
## Summary

- Refreshes the Smithery remote MCP guide's exact package pin to the current released `@peac/mcp-server` version (`0.12.11` -> `0.16.1`), matching `docs/releases/current.json`, `packages/mcp-server/smithery.yaml`, and the npm `latest` tag.
- Makes the distribution-submission tag-time rule release-agnostic ("At v0.12.13 tag time" -> "At release tag time").
