### PR TITLE
feat(x402): preserve settlement extensions for portable evidence

### DIFF
--- a/docs/specs/PAID-RESOURCE-EVIDENCE.md
+++ b/docs/specs/PAID-RESOURCE-EVIDENCE.md
@@ -52,9 +52,10 @@ preserved under `proofs.x402` using a privacy-hardened default:
   (`sha256:<64 lowercase hex>`, computed over the RFC 8785 JCS
   canonicalization of the `extensions` object), is added whenever a
   settlement `extensions` object is present.
-- The raw `extensions` bag itself is preserved verbatim under
-  `settlementExtensions` only when the caller opts in; it is omitted by
-  default.
+- The raw `extensions` bag is preserved under `settlementExtensions` only
+  when the caller opts in, as a canonical JSON clone (derived from the
+  bounded RFC 8785 JCS bytes, not the caller's original object reference or
+  byte serialization); it is omitted by default.
 
 `settlementExtensionsDigest` is an **integrity/correlation** handle, not
 anonymization: two records that preserve the same upstream settlement

--- a/docs/specs/PAID-RESOURCE-EVIDENCE.md
+++ b/docs/specs/PAID-RESOURCE-EVIDENCE.md
@@ -13,8 +13,9 @@ pattern is protocol-neutral, not x402-specific.
 
 A paid-resource interaction (an agent or client paying to access a resource
 behind a 402 challenge) produces several distinct artifacts: the offer terms
-the resource advertised, the signed receipt a facilitator or payer returned,
-and, optionally, upstream protocol-extension data attached to the settlement
+the resource advertised, the signed receipt or settlement artifact returned
+by the upstream payment flow, and, optionally, upstream protocol-extension
+data attached to the settlement
 response. PEAC records what happened without settling the payment, pricing
 the resource, or verifying the payment scheme's own invariants. This document
 describes the record composition and the privacy posture for the artifacts

--- a/docs/specs/PAID-RESOURCE-EVIDENCE.md
+++ b/docs/specs/PAID-RESOURCE-EVIDENCE.md
@@ -1,0 +1,119 @@
+# Paid Resource Evidence
+
+**Status:** Informative
+
+This document adds no normative requirement to the wire format and no field to
+any record. It describes how PEAC's existing record shape composes to carry
+evidence for a paid-resource interaction, using the x402 offer/receipt
+extension as the primary demonstrated binding. The same composition applies
+equally to other payment-observation profiles (paymentauth, MPP, UCP): the
+pattern is protocol-neutral, not x402-specific.
+
+## Purpose
+
+A paid-resource interaction (an agent or client paying to access a resource
+behind a 402 challenge) produces several distinct artifacts: the offer terms
+the resource advertised, the signed receipt a facilitator or payer returned,
+and, optionally, upstream protocol-extension data attached to the settlement
+response. PEAC records what happened without settling the payment, pricing
+the resource, or verifying the payment scheme's own invariants. This document
+describes the record composition and the privacy posture for the artifacts
+it preserves.
+
+## Record Composition
+
+A paid-resource record is the existing `org.peacprotocol/payment` record
+shape (see [COMMERCE-EVIDENCE.md](COMMERCE-EVIDENCE.md) for the commerce
+extension fields), optionally bound to an upstream artifact via
+`upstream_artifact_digest`. No new record type or extension group is
+introduced by this document; see [X402-PROFILE.md](X402-PROFILE.md) and
+[X402-V2-PROFILE.md](X402-V2-PROFILE.md) for the normative x402 mapping this
+document describes the evidence posture around.
+
+## Offer-Terms Digest (Verifier-Report-Only)
+
+A publisher's advertised offer terms may be bound into a verifier report via
+a digest, following the same document-binding pattern used for policy
+documents (see [DOCUMENT-BINDING.md](DOCUMENT-BINDING.md)). This binding is
+report-only: it surfaces in the verifier's output for the caller's own
+comparison and is never stamped into the signed record itself.
+
+## Payment-Artifact Preservation in Proofs
+
+Per the x402 offer/receipt profile (`peac-x402-offer-receipt/0.2`), the raw
+signed offer and signed receipt artifacts are preserved verbatim under
+`proofs.x402` (never mutated, never reconstructed). When a settlement
+response also carries upstream protocol-extension data (an `extensions` bag,
+which may embed a signed receipt via the offer-receipt extension, or
+unrelated sibling extensions this adapter does not interpret), that data is
+preserved under `proofs.x402` using a privacy-hardened default:
+
+- A stable content digest, `settlementExtensionsDigest`
+  (`sha256:<64 lowercase hex>`, computed over the RFC 8785 JCS
+  canonicalization of the `extensions` object), is added whenever a
+  settlement `extensions` object is present.
+- The raw `extensions` bag itself is preserved verbatim under
+  `settlementExtensions` only when the caller opts in; it is omitted by
+  default.
+
+`settlementExtensionsDigest` is an **integrity/correlation** handle, not
+anonymization: two records that preserve the same upstream settlement
+extensions share the same digest. It does not redact, hash away, or make
+unlinkable anything about the underlying data; it is a stable equality check
+a verifier can use to confirm two records reference the same settlement
+extension content without needing the raw bytes.
+
+## Privacy and Redaction
+
+The settlement `extensions` bag is upstream protocol-extension data and MAY
+carry payer- or resource-correlating material that the adapter does not
+otherwise interpret. Because of this, raw preservation is opt-in only
+(`preserveRawSettlementExtensions`); the default posture stores only the
+digest. Raw settlement headers or transport-level artifacts are never
+embedded in signed evidence, regardless of this opt-in: the preservation
+described here is scoped strictly to the settlement response body's
+`extensions` object, and only within the unsigned `proofs` bundle, never
+within signed record fields.
+
+## Idempotency and Replay
+
+A paid-resource record carries the same `(iss, jti)` uniqueness guarantee as
+any PEAC record. Deployers that need bounded online replay defense for
+paid-resource records can apply the same optional acceptance policy described
+in [REPLAY-GUARD-PROFILE.md](REPLAY-GUARD-PROFILE.md); that guidance is
+unchanged and unaffected by this document.
+
+## Issuer Roles
+
+The issuer of a paid-resource record is whichever party signs it (typically
+the resource server, gateway, or an intermediary observing the settlement).
+This document does not assign or require a specific issuer role; it
+describes the evidence shape once a record is issued, not who is authorized
+to issue it.
+
+## Non-Goals
+
+PEAC does not, through this evidence composition or any other:
+
+- Settle payments, execute transfers, or move funds.
+- Price resources or determine what should be charged.
+- Gate access to a resource or make an authorization decision.
+- Verify scheme-specific payment invariants (single-use, time bounds,
+  recipient binding, facilitator binding, or settled-vs-authorized amount
+  correctness). Those remain the responsibility of the upstream payment
+  protocol and its facilitator surfaces.
+- Detect bots or fraud.
+- Run a marketplace, checkout flow, or payment rail.
+- Claim any partnership, endorsement, or provider relationship with any
+  payment scheme, facilitator, or vendor.
+
+## Cross-References
+
+- [X402-PROFILE.md](X402-PROFILE.md) - normative x402 offer/receipt mapping
+- [X402-V2-PROFILE.md](X402-V2-PROFILE.md) - normative x402 v2 mapping
+- [COMMERCE-EVIDENCE.md](COMMERCE-EVIDENCE.md) - commerce extension fields
+  and rail neutrality
+- [DOCUMENT-BINDING.md](DOCUMENT-BINDING.md) - document digest and binding
+  helpers
+- [REPLAY-GUARD-PROFILE.md](REPLAY-GUARD-PROFILE.md) - optional online
+  replay defense

--- a/packages/adapters/x402/src/errors.ts
+++ b/packages/adapters/x402/src/errors.ts
@@ -15,6 +15,7 @@
  * - payload_*: Generic payload errors
  * - amount_*: Amount validation errors
  * - network_*: Network validation errors
+ * - settlement_extensions_*: Settlement `extensions` bag errors
  */
 export type X402ErrorCode =
   | 'offer_invalid_format'
@@ -42,7 +43,9 @@ export type X402ErrorCode =
   | 'jws_too_large'
   | 'jws_malformed'
   | 'jws_padded_base64url'
-  | 'jws_payload_not_object';
+  | 'jws_payload_not_object'
+  | 'settlement_extensions_invalid'
+  | 'settlement_extensions_too_large';
 
 /**
  * HTTP status mapping for error codes
@@ -74,6 +77,8 @@ const ERROR_HTTP_STATUS: Record<X402ErrorCode, number> = {
   jws_malformed: 400,
   jws_padded_base64url: 400,
   jws_payload_not_object: 400,
+  settlement_extensions_invalid: 400,
+  settlement_extensions_too_large: 400,
 };
 
 /**

--- a/packages/adapters/x402/src/index.ts
+++ b/packages/adapters/x402/src/index.ts
@@ -168,6 +168,15 @@ export type {
   X402SettlementOptions,
 } from './settlement.js';
 
+// Settlement extensions: signed-receipt extraction from the settlement
+// `extensions` bag (offer-receipt extension, upstream commit f2bbb5c).
+// Extraction only; does not verify signatures. See map.ts for how the
+// mapper preserves settlement extensions into proofs.x402.
+export {
+  extractSignedReceiptFromSettlement,
+  MAX_SETTLEMENT_EXTENSIONS_BYTES,
+} from './settlement-extensions.js';
+
 // x402 PR #1986 terms digest helpers (v0.12.14). Mapper-local convenience
 // over @peac/protocol/document-binding; digest is NEVER stamped into the
 // emitted record / envelope shape (verifier-report-only).

--- a/packages/adapters/x402/src/map.ts
+++ b/packages/adapters/x402/src/map.ts
@@ -8,14 +8,22 @@
  * Raw upstream artifacts are preserved as-is in proofs.
  */
 
+import { createHash } from 'node:crypto';
+
 import type { PeacEvidenceCarrier } from '@peac/kernel';
+import { HASH } from '@peac/kernel';
 import { computeReceiptRef } from '@peac/schema';
+import { canonicalize } from '@peac/crypto';
 
 import { X402Error } from './errors.js';
 import type { RawSignedOffer, RawSignedReceipt } from './raw.js';
 import { extractOfferPayload, extractReceiptPayload } from './raw.js';
 import { normalizeOfferPayload, normalizeReceiptPayload } from './normalize.js';
 import type { NormalizedV2Offer, NormalizedV2Receipt } from './normalize-v2.js';
+import {
+  extractSignedReceiptFromSettlement,
+  MAX_SETTLEMENT_EXTENSIONS_BYTES,
+} from './settlement-extensions.js';
 import type {
   X402OfferReceiptChallenge,
   X402SettlementResponse,
@@ -27,6 +35,85 @@ import type {
   AuthorizationResult,
 } from './types.js';
 import { X402_OFFER_RECEIPT_PROFILE } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Settlement extensions (proofs.x402), shared by V1 and V2 mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Applies settlement `extensions` (x402 protocol-extension passthrough
+ * data) to a PEAC record's `proofs.x402` bundle, in place.
+ *
+ * Privacy-hardened default: only a stable content digest
+ * (`settlementExtensionsDigest`) is added, computed over the RFC 8785 JCS
+ * canonicalization of `extensions`. The SAME canonical bytes are used for
+ * both the DoS bound and the digest (computed once), avoiding a
+ * bound/digest mismatch. The digest is byte-identical to
+ * `computeJsonDocumentDigestJcs(extensions)` from `@peac/protocol`; it is
+ * computed here via Node's synchronous `createHash` instead so that
+ * `toPeacRecord`/`toPeacRecordV2` remain synchronous public APIs.
+ *
+ * Raw `extensions` are preserved under `proofs.x402.settlementExtensions`
+ * ONLY when `preserveRaw` is true, and the preserved object is derived
+ * from the already-bounded canonical string (`JSON.parse(canonical)`),
+ * never the caller's live object reference, so later caller-side
+ * mutation of the input cannot alter the emitted record.
+ *
+ * Also enforces a receipt-consistency guard: if `extensions` embeds a
+ * signed receipt via the offer-receipt extension
+ * (`extensions["offer-receipt"].info.receipt`) that structurally differs
+ * from the receipt already present at `proofsX402.receipt`, the record
+ * would carry two conflicting receipts, so mapping fails closed instead.
+ *
+ * No-op (byte-identical output) when `extensions` is `undefined`.
+ *
+ * @throws X402Error `settlement_extensions_too_large` if the canonical
+ *   serialization exceeds `MAX_SETTLEMENT_EXTENSIONS_BYTES`.
+ * @throws X402Error `settlement_extensions_invalid` if `extensions`
+ *   embeds a receipt that conflicts with `proofsX402.receipt`, or if the
+ *   embedded offer-receipt extension is structurally malformed.
+ */
+function applySettlementExtensions(
+  proofsX402: X402PeacRecord['proofs']['x402'],
+  extensions: Record<string, unknown> | undefined,
+  preserveRaw: boolean
+): void {
+  if (extensions === undefined) {
+    return;
+  }
+
+  const canonical = canonicalize(extensions);
+  const byteLength = Buffer.byteLength(canonical, 'utf8');
+  if (byteLength > MAX_SETTLEMENT_EXTENSIONS_BYTES) {
+    throw new X402Error(
+      'settlement_extensions_too_large',
+      `Settlement extensions canonical serialization (${byteLength} bytes) exceeds the ${MAX_SETTLEMENT_EXTENSIONS_BYTES} byte limit`
+    );
+  }
+
+  // Reviewer addition: receipt-consistency guard. Reuses the same
+  // extraction path callers use standalone, so there is a single source
+  // of truth for the offer-receipt nesting walk.
+  const embeddedReceipt = extractSignedReceiptFromSettlement({ extensions });
+  if (
+    embeddedReceipt !== null &&
+    canonicalize(embeddedReceipt) !== canonicalize(proofsX402.receipt)
+  ) {
+    throw new X402Error(
+      'settlement_extensions_invalid',
+      'Settlement extensions embed a receipt that conflicts with proofs.x402.receipt'
+    );
+  }
+
+  const digestHex = createHash('sha256').update(canonical, 'utf8').digest('hex');
+  proofsX402.settlementExtensionsDigest = `${HASH.prefix}${digestHex}`;
+
+  if (preserveRaw) {
+    // Reviewer addition: derive the preserved object from the bounded
+    // canonical bytes (never the caller's object reference).
+    proofsX402.settlementExtensions = JSON.parse(canonical) as Record<string, unknown>;
+  }
+}
 
 /**
  * Options for record mapping
@@ -62,6 +149,21 @@ export interface ToPeacRecordOptions {
    * Maximum compact JWS byte length for payload extraction
    */
   maxCompactJwsBytes?: number;
+  /**
+   * Preserve the raw settlement `extensions` bag verbatim under
+   * `proofs.x402.settlementExtensions`, in addition to the always-on
+   * `settlementExtensionsDigest`. Default: false.
+   *
+   * Privacy note: the settlement `extensions` bag is upstream
+   * protocol-extension data (e.g. batch-settlement, or sibling
+   * extensions this adapter does not interpret) and MAY carry payer- or
+   * resource-correlating material. The digest-by-default posture avoids
+   * storing that raw material in the emitted PEAC record unless
+   * explicitly opted in. The preserved value is a clone derived from the
+   * bounded canonical (RFC 8785 JCS) bytes, never the caller's live
+   * object reference.
+   */
+  preserveRawSettlementExtensions?: boolean;
 }
 
 /**
@@ -182,13 +284,20 @@ export function toPeacRecord(
 
   hints.verification = verification;
 
+  const proofsX402: X402PeacRecord['proofs']['x402'] = {
+    offer, // exact raw artifact, never mutated
+    receipt, // exact raw artifact, never mutated
+  };
+  applySettlementExtensions(
+    proofsX402,
+    settlementResponse.extensions,
+    options?.preserveRawSettlementExtensions ?? false
+  );
+
   return {
     version: X402_OFFER_RECEIPT_PROFILE,
     proofs: {
-      x402: {
-        offer, // exact raw artifact, never mutated
-        receipt, // exact raw artifact, never mutated
-      },
+      x402: proofsX402,
     },
     evidence: {
       resourceUrl: offerPayload.resourceUrl,
@@ -226,6 +335,14 @@ export interface ToPeacRecordV2Options {
   cryptoResult?: CryptoResult;
   /** Signer authorization result */
   authorizationResult?: AuthorizationResult;
+  /**
+   * Preserve the raw settlement `extensions` bag verbatim under
+   * `proofs.x402.settlementExtensions`, in addition to the always-on
+   * `settlementExtensionsDigest`. Default: false. See
+   * `ToPeacRecordOptions.preserveRawSettlementExtensions` for the
+   * privacy rationale (identical semantics for V2).
+   */
+  preserveRawSettlementExtensions?: boolean;
 }
 
 /**
@@ -293,13 +410,20 @@ export function toPeacRecordV2(
 
   hints.verification = verification;
 
+  const proofsX402: X402PeacRecord['proofs']['x402'] = {
+    offer: rawOffer,
+    receipt: rawReceipt,
+  };
+  applySettlementExtensions(
+    proofsX402,
+    receipt.extensions,
+    options?.preserveRawSettlementExtensions ?? false
+  );
+
   return {
     version: X402_OFFER_RECEIPT_PROFILE,
     proofs: {
-      x402: {
-        offer: rawOffer,
-        receipt: rawReceipt,
-      },
+      x402: proofsX402,
     },
     evidence: {
       resourceUrl: offer.resource.url,

--- a/packages/adapters/x402/src/map.ts
+++ b/packages/adapters/x402/src/map.ts
@@ -115,9 +115,8 @@ function applySettlementExtensions(
     );
   }
 
-  // Reviewer addition: receipt-consistency guard. Reuses the same
-  // extraction path callers use standalone, so there is a single source
-  // of truth for the offer-receipt nesting walk.
+  // Enforce receipt consistency using the same extraction path exposed
+  // to callers, so the offer-receipt nesting walk has one source of truth.
   const embeddedReceipt = extractSignedReceiptFromSettlement({ extensions });
   if (
     embeddedReceipt !== null &&
@@ -133,8 +132,8 @@ function applySettlementExtensions(
   proofsX402.settlementExtensionsDigest = `${HASH.prefix}${digestHex}`;
 
   if (preserveRaw) {
-    // Reviewer addition: derive the preserved object from the bounded
-    // canonical bytes (never the caller's object reference).
+    // Derive the preserved object from the bounded canonical bytes,
+    // never the caller's live object reference.
     proofsX402.settlementExtensions = JSON.parse(canonical) as Record<string, unknown>;
   }
 }

--- a/packages/adapters/x402/src/map.ts
+++ b/packages/adapters/x402/src/map.ts
@@ -41,6 +41,29 @@ import { X402_OFFER_RECEIPT_PROFILE } from './types.js';
 // ---------------------------------------------------------------------------
 
 /**
+ * Canonicalize a settlement `extensions` object for bounding + digesting,
+ * converting any canonicalization failure into the stable adapter-local
+ * `settlement_extensions_invalid` error. A public JS caller could pass a
+ * value that is not JSON-canonicalizable (cyclic references, `BigInt`, or
+ * other non-JSON types); those must fail closed with a stable protocol
+ * code rather than leaking a raw `TypeError`/`RangeError`. The raw
+ * extension value is never included in the error message.
+ *
+ * Note: `undefined` object-member values are omitted by `canonicalize`
+ * (RFC 8785 / `JSON.stringify` semantics), not treated as an error.
+ */
+function canonicalizeSettlementExtensions(extensions: Record<string, unknown>): string {
+  try {
+    return canonicalize(extensions);
+  } catch {
+    throw new X402Error(
+      'settlement_extensions_invalid',
+      'Settlement extensions must be JSON-canonicalizable'
+    );
+  }
+}
+
+/**
  * Applies settlement `extensions` (x402 protocol-extension passthrough
  * data) to a PEAC record's `proofs.x402` bundle, in place.
  *
@@ -70,8 +93,9 @@ import { X402_OFFER_RECEIPT_PROFILE } from './types.js';
  * @throws X402Error `settlement_extensions_too_large` if the canonical
  *   serialization exceeds `MAX_SETTLEMENT_EXTENSIONS_BYTES`.
  * @throws X402Error `settlement_extensions_invalid` if `extensions`
- *   embeds a receipt that conflicts with `proofsX402.receipt`, or if the
- *   embedded offer-receipt extension is structurally malformed.
+ *   embeds a receipt that conflicts with `proofsX402.receipt`, if the
+ *   embedded offer-receipt extension is structurally malformed, or if
+ *   `extensions` is not JSON-canonicalizable.
  */
 function applySettlementExtensions(
   proofsX402: X402PeacRecord['proofs']['x402'],
@@ -82,7 +106,7 @@ function applySettlementExtensions(
     return;
   }
 
-  const canonical = canonicalize(extensions);
+  const canonical = canonicalizeSettlementExtensions(extensions);
   const byteLength = Buffer.byteLength(canonical, 'utf8');
   if (byteLength > MAX_SETTLEMENT_EXTENSIONS_BYTES) {
     throw new X402Error(
@@ -150,8 +174,8 @@ export interface ToPeacRecordOptions {
    */
   maxCompactJwsBytes?: number;
   /**
-   * Preserve the raw settlement `extensions` bag verbatim under
-   * `proofs.x402.settlementExtensions`, in addition to the always-on
+   * Preserve the raw settlement `extensions` bag as a canonical JSON
+   * clone under `proofs.x402.settlementExtensions`, in addition to the always-on
    * `settlementExtensionsDigest`. Default: false.
    *
    * Privacy note: the settlement `extensions` bag is upstream
@@ -336,8 +360,8 @@ export interface ToPeacRecordV2Options {
   /** Signer authorization result */
   authorizationResult?: AuthorizationResult;
   /**
-   * Preserve the raw settlement `extensions` bag verbatim under
-   * `proofs.x402.settlementExtensions`, in addition to the always-on
+   * Preserve the raw settlement `extensions` bag as a canonical JSON
+   * clone under `proofs.x402.settlementExtensions`, in addition to the always-on
    * `settlementExtensionsDigest`. Default: false. See
    * `ToPeacRecordOptions.preserveRawSettlementExtensions` for the
    * privacy rationale (identical semantics for V2).

--- a/packages/adapters/x402/src/normalize-v2.ts
+++ b/packages/adapters/x402/src/normalize-v2.ts
@@ -77,6 +77,16 @@ export interface NormalizedV2Receipt {
   resourceUrl: string;
   /** Receipt issuance timestamp in epoch seconds (caller-supplied from response timing) */
   issuedAt: number;
+  /**
+   * Upstream protocol-extensions data (optional), preserved verbatim from
+   * `RawV2SettlementResponseSuccess.extensions` when present.
+   *
+   * This is a raw/normalized pass-through only: no PEAC semantics are
+   * added here. The mapper (`map.ts` `toPeacRecordV2`) applies the
+   * privacy-hardened default (digest under `proofs.x402`, raw preservation
+   * opt-in) when building the emitted record.
+   */
+  extensions?: Record<string, unknown>;
 }
 
 // ---------------------------------------------------------------------------
@@ -154,5 +164,6 @@ export function normalizeV2Receipt(
     resourceUrl,
     issuedAt,
     ...(settlement.transaction && { transaction: settlement.transaction }),
+    ...(settlement.extensions !== undefined && { extensions: settlement.extensions }),
   };
 }

--- a/packages/adapters/x402/src/normalize-v2.ts
+++ b/packages/adapters/x402/src/normalize-v2.ts
@@ -78,8 +78,9 @@ export interface NormalizedV2Receipt {
   /** Receipt issuance timestamp in epoch seconds (caller-supplied from response timing) */
   issuedAt: number;
   /**
-   * Upstream protocol-extensions data (optional), preserved verbatim from
-   * `RawV2SettlementResponseSuccess.extensions` when present.
+   * Upstream protocol-extensions data (optional), carried through
+   * unchanged from `RawV2SettlementResponseSuccess.extensions` when
+   * present.
    *
    * This is a raw/normalized pass-through only: no PEAC semantics are
    * added here. The mapper (`map.ts` `toPeacRecordV2`) applies the

--- a/packages/adapters/x402/src/raw-v2.ts
+++ b/packages/adapters/x402/src/raw-v2.ts
@@ -145,6 +145,21 @@ export interface RawV2SettlementResponseSuccess {
   network: string;
   /** Payer address */
   payer: string;
+  /**
+   * Upstream protocol-extensions data (optional).
+   *
+   * Mirrors `SettleResponse.extensions?: Record<string, unknown>` from
+   * upstream x402-foundation/x402
+   * (`typescript/packages/core/src/types/facilitator.ts`), a generic
+   * protocol-extension passthrough field that pre-dates the offer-receipt
+   * extension (PR #1003). The "Signed Offers & Receipts" extension places
+   * a signed receipt at `extensions["offer-receipt"].info.receipt`
+   * (specs/extensions/extension-offer-and-receipt.md Section 5.1, pinned
+   * commit f2bbb5c); sibling extensions (e.g. batch-settlement) may use
+   * other keys under this same bag. Raw pass-through only: no PEAC
+   * semantics are added at this layer (see normalize-v2.ts / map.ts).
+   */
+  extensions?: Record<string, unknown>;
 }
 
 /**
@@ -162,6 +177,16 @@ export interface RawV2SettlementResponseFailure {
   network: string;
   /** Payer address */
   payer: string;
+  /**
+   * Upstream protocol-extensions data (optional).
+   *
+   * See `RawV2SettlementResponseSuccess.extensions` for the field's
+   * provenance and semantics. Present on the unified upstream
+   * `SettleResponse` shape regardless of `success`; PEAC's V2
+   * normalization (`normalizeV2Receipt`) only carries it forward on the
+   * success path, since failed settlements do not produce a receipt.
+   */
+  extensions?: Record<string, unknown>;
 }
 
 /** Discriminated union of V2 settlement response outcomes */

--- a/packages/adapters/x402/src/settlement-extensions.ts
+++ b/packages/adapters/x402/src/settlement-extensions.ts
@@ -99,7 +99,7 @@ function asSignedReceiptEnvelope(value: Record<string, unknown>): RawSignedRecei
 
   throw new X402Error(
     'settlement_extensions_invalid',
-    `Settlement offer-receipt receipt has an unrecognized format: ${JSON.stringify(format)}`
+    'Settlement offer-receipt receipt has an unrecognized format'
   );
 }
 

--- a/packages/adapters/x402/src/settlement-extensions.ts
+++ b/packages/adapters/x402/src/settlement-extensions.ts
@@ -1,0 +1,174 @@
+/**
+ * x402 settlement-extensions receipt extraction (Layer C convenience)
+ *
+ * Upstream x402's "Signed Offers & Receipts" extension places a signed
+ * receipt on the settlement/200 response at
+ * `extensions["offer-receipt"].info.receipt`
+ * (x402-foundation/x402 commit f2bbb5c,
+ * specs/extensions/extension-offer-and-receipt.md Section 5.1). This
+ * placement is identical for x402 v1 (`X402SettlementResponse.extensions`)
+ * and v2 (`NormalizedV2Receipt.extensions`, mirroring upstream
+ * `SettleResponse.extensions?: Record<string, unknown>` from
+ * `typescript/packages/core/src/types/facilitator.ts`).
+ *
+ * `extractSignedReceiptFromSettlement` narrows a settlement-shaped object
+ * down to the embedded signed receipt artifact, if present. It reuses
+ * `extractExtensionInfo` (raw.ts) for the documented challenge-side shape
+ * where `offers` is present (e.g. an empty array). A settlement response
+ * may also carry `extensions["offer-receipt"].info.receipt` with no
+ * `offers` key at all: there is nothing left to offer once payment has
+ * settled. `extractExtensionInfo` requires `offers` to be an array
+ * (challenge-side contract) and returns `null` when it is absent, so that
+ * settlement-only shape is narrowed to `.receipt` independently below.
+ * Structural validation (object-shape checks at each nesting level, and
+ * the signed-receipt envelope discriminant) is performed directly in this
+ * module so malformed input can fail closed with `settlement_extensions_invalid`;
+ * `extractExtensionInfo` returns `null` for any anomaly instead of
+ * throwing, which is the right default for its own challenge-side callers
+ * but not strict enough for this extraction path.
+ *
+ * This is extraction only: it does NOT verify the receipt's signature.
+ * Callers must verify the returned artifact with the appropriate
+ * x402/JWS/EIP-712 verifier.
+ */
+
+import { X402Error } from './errors.js';
+import { OFFER_RECEIPT, extractExtensionInfo, parseCompactJWS } from './raw.js';
+import type {
+  RawSignedReceipt,
+  RawJWSSignedReceipt,
+  RawEIP712SignedReceipt,
+  RawX402ExtensionInfo,
+} from './raw.js';
+
+/**
+ * Maximum bytes for the RFC 8785 (JCS) canonical serialization of a
+ * settlement `extensions` bag. Enforced by the mapper (`map.ts`) before
+ * digesting or preserving the raw bag (DoS bound); exported so callers
+ * share a single constant.
+ */
+export const MAX_SETTLEMENT_EXTENSIONS_BYTES = 256 * 1024;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Validate and narrow a raw `info.receipt` value to the `RawSignedReceipt`
+ * discriminated union (`RawJWSSignedReceipt | RawEIP712SignedReceipt`).
+ * Enforces the compact-JWS byte bound on the JWS branch via
+ * `parseCompactJWS` (the parsed result is discarded; only the raw compact
+ * JWS string is preserved, matching the challenge-side extraction
+ * discipline in raw.ts).
+ */
+function asSignedReceiptEnvelope(value: Record<string, unknown>): RawSignedReceipt {
+  const format = value.format;
+
+  if (format === 'jws') {
+    const signature = value.signature;
+    if (typeof signature !== 'string') {
+      throw new X402Error(
+        'settlement_extensions_invalid',
+        'Settlement offer-receipt JWS receipt is missing a signature string'
+      );
+    }
+    // Enforce the same compact-JWS byte bound as the challenge-side path.
+    // Throws jws_too_large / jws_malformed / jws_padded_base64url /
+    // jws_payload_not_object as appropriate; those codes propagate as-is.
+    parseCompactJWS(signature);
+    const receipt: RawJWSSignedReceipt = { format: 'jws', signature };
+    return receipt;
+  }
+
+  if (format === 'eip712') {
+    const signature = value.signature;
+    const payload = value.payload;
+    if (typeof signature !== 'string' || !isPlainObject(payload)) {
+      throw new X402Error(
+        'settlement_extensions_invalid',
+        'Settlement offer-receipt EIP-712 receipt is missing payload/signature'
+      );
+    }
+    const receipt: RawEIP712SignedReceipt = {
+      format: 'eip712',
+      payload: payload as unknown as RawEIP712SignedReceipt['payload'],
+      signature,
+    };
+    return receipt;
+  }
+
+  throw new X402Error(
+    'settlement_extensions_invalid',
+    `Settlement offer-receipt receipt has an unrecognized format: ${JSON.stringify(format)}`
+  );
+}
+
+/**
+ * Extracts a signed receipt artifact from an x402 settlement response.
+ * This helper does not verify the receipt signature; callers must verify
+ * the returned artifact with the appropriate x402/JWS/EIP-712 verifier.
+ */
+export function extractSignedReceiptFromSettlement(settlement: unknown): RawSignedReceipt | null {
+  if (!isPlainObject(settlement)) {
+    return null;
+  }
+
+  const extensions = settlement.extensions;
+  if (extensions === undefined) {
+    return null;
+  }
+  if (!isPlainObject(extensions)) {
+    throw new X402Error(
+      'settlement_extensions_invalid',
+      'settlement.extensions must be a JSON object'
+    );
+  }
+
+  const offerReceipt = extensions[OFFER_RECEIPT];
+  if (offerReceipt === undefined) {
+    return null;
+  }
+  if (!isPlainObject(offerReceipt)) {
+    throw new X402Error(
+      'settlement_extensions_invalid',
+      `settlement.extensions["${OFFER_RECEIPT}"] must be a JSON object`
+    );
+  }
+
+  const info = offerReceipt.info;
+  if (!isPlainObject(info)) {
+    throw new X402Error(
+      'settlement_extensions_invalid',
+      `settlement.extensions["${OFFER_RECEIPT}"].info must be a JSON object`
+    );
+  }
+
+  // Reuse the shared upstream nesting walk for the documented shape where
+  // `offers` is present (e.g. an empty array, matching the challenge-side
+  // contract). Fall back to an independent narrow-to-`.receipt` when
+  // `offers` is absent entirely (a settlement-only shape).
+  const extracted: RawX402ExtensionInfo | null = extractExtensionInfo(settlement);
+  const rawReceipt = extracted?.receipt ?? info.receipt;
+
+  if (rawReceipt === undefined) {
+    return null;
+  }
+  if (!isPlainObject(rawReceipt)) {
+    throw new X402Error(
+      'settlement_extensions_invalid',
+      `settlement.extensions["${OFFER_RECEIPT}"].info.receipt must be a JSON object`
+    );
+  }
+
+  // The x402 offer-receipt extension places receipts on settlement
+  // success (Section 5.1). A `success:false` settlement embedding a
+  // receipt fails closed instead of being silently preserved.
+  if (settlement.success === false) {
+    throw new X402Error(
+      'settlement_extensions_invalid',
+      'Settlement extensions embed a receipt on a failed (success:false) settlement'
+    );
+  }
+
+  return asSignedReceiptEnvelope(rawReceipt);
+}

--- a/packages/adapters/x402/src/types.ts
+++ b/packages/adapters/x402/src/types.ts
@@ -358,6 +358,23 @@ export interface X402PeacRecord {
     x402: {
       offer: RawSignedOffer;
       receipt: RawSignedReceipt;
+      /**
+       * Integrity/correlation digest over the settlement `extensions`
+       * bag (RFC 8785 JCS canonicalization + SHA-256,
+       * `sha256:<64 lowercase hex>`), present whenever the settlement
+       * response carried an `extensions` object. This is a stable
+       * equality handle, NOT anonymization: two records preserving the
+       * same upstream settlement extensions share this digest.
+       */
+      settlementExtensionsDigest?: string;
+      /**
+       * Raw settlement `extensions` bag, preserved verbatim ONLY when
+       * mapping was performed with `preserveRawSettlementExtensions:
+       * true` (default: omitted). May carry upstream protocol-extension
+       * data (e.g. payer- or resource-correlating material); never
+       * copied into signed `evidence`.
+       */
+      settlementExtensions?: Record<string, unknown>;
     };
   };
   /** Normalized evidence fields (extracted from signed payloads via Layer B) */

--- a/packages/adapters/x402/src/types.ts
+++ b/packages/adapters/x402/src/types.ts
@@ -368,8 +368,10 @@ export interface X402PeacRecord {
        */
       settlementExtensionsDigest?: string;
       /**
-       * Raw settlement `extensions` bag, preserved verbatim ONLY when
-       * mapping was performed with `preserveRawSettlementExtensions:
+       * Raw settlement `extensions` bag, preserved as a canonical JSON
+       * clone (derived from the bounded RFC 8785 JCS bytes, not the
+       * caller's original object reference or byte serialization) ONLY
+       * when mapping was performed with `preserveRawSettlementExtensions:
        * true` (default: omitted). May carry upstream protocol-extension
        * data (e.g. payer- or resource-correlating material); never
        * copied into signed `evidence`.

--- a/packages/adapters/x402/tests/map-v2.test.ts
+++ b/packages/adapters/x402/tests/map-v2.test.ts
@@ -39,12 +39,12 @@ const V2_RECEIPT: NormalizedV2Receipt = {
 
 const RAW_OFFER: RawSignedOffer = {
   format: 'jws',
-  compactJws: 'eyJ0eXAiOiJKV1QifQ.eyJ0ZXN0Ijp0cnVlfQ.c2lnbmF0dXJl',
+  signature: 'eyJ0eXAiOiJKV1QifQ.eyJ0ZXN0Ijp0cnVlfQ.c2lnbmF0dXJl',
 };
 
 const RAW_RECEIPT: RawSignedReceipt = {
   format: 'jws',
-  compactJws: 'eyJ0eXAiOiJKV1QifQ.eyJyZWNlaXB0Ijp0cnVlfQ.c2lnbmF0dXJl',
+  signature: 'eyJ0eXAiOiJKV1QifQ.eyJyZWNlaXB0Ijp0cnVlfQ.c2lnbmF0dXJl',
 };
 
 describe('toPeacRecordV2()', () => {
@@ -135,14 +135,6 @@ describe('toPeacRecordV2()', () => {
 // ---------------------------------------------------------------------------
 
 describe('toPeacRecordV2(): settlement extensions', () => {
-  // Properly-shaped RawJWSSignedReceipt (this file's top-level RAW_RECEIPT
-  // fixture uses a non-standard `compactJws` field name and is left as-is;
-  // these tests use a correctly-shaped fixture instead).
-  const VALID_RAW_RECEIPT: RawSignedReceipt = {
-    format: 'jws',
-    signature: 'eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJodHRwczovL2FwaS5leGFtcGxlLmNvbSJ9.c2lnbmF0dXJl',
-  };
-
   const EXTENSIONS_SIMPLE = { foo: 'bar' };
 
   function withExtensions(extensions: Record<string, unknown> | undefined): NormalizedV2Receipt {
@@ -154,19 +146,14 @@ describe('toPeacRecordV2(): settlement extensions', () => {
       V2_OFFER,
       withExtensions(EXTENSIONS_SIMPLE),
       RAW_OFFER,
-      VALID_RAW_RECEIPT
+      RAW_RECEIPT
     );
     expect(record.proofs.x402.settlementExtensionsDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
     expect(record.proofs.x402.settlementExtensions).toBeUndefined();
   });
 
   it('omits settlement extension keys entirely when extensions is absent', () => {
-    const record = toPeacRecordV2(
-      V2_OFFER,
-      withExtensions(undefined),
-      RAW_OFFER,
-      VALID_RAW_RECEIPT
-    );
+    const record = toPeacRecordV2(V2_OFFER, withExtensions(undefined), RAW_OFFER, RAW_RECEIPT);
     expect(record.proofs.x402.settlementExtensionsDigest).toBeUndefined();
     expect(record.proofs.x402.settlementExtensions).toBeUndefined();
   });
@@ -176,7 +163,7 @@ describe('toPeacRecordV2(): settlement extensions', () => {
       V2_OFFER,
       withExtensions(EXTENSIONS_SIMPLE),
       RAW_OFFER,
-      VALID_RAW_RECEIPT
+      RAW_RECEIPT
     );
     expect(record.evidence).not.toHaveProperty('settlementExtensions');
     expect(record.evidence).not.toHaveProperty('settlementExtensionsDigest');
@@ -184,15 +171,9 @@ describe('toPeacRecordV2(): settlement extensions', () => {
 
   it('adds raw only when preserveRawSettlementExtensions is true, as a clone of the caller input', () => {
     const extensions = { mutable: 'original' };
-    const record = toPeacRecordV2(
-      V2_OFFER,
-      withExtensions(extensions),
-      RAW_OFFER,
-      VALID_RAW_RECEIPT,
-      {
-        preserveRawSettlementExtensions: true,
-      }
-    );
+    const record = toPeacRecordV2(V2_OFFER, withExtensions(extensions), RAW_OFFER, RAW_RECEIPT, {
+      preserveRawSettlementExtensions: true,
+    });
     expect(record.proofs.x402.settlementExtensions).toEqual({ mutable: 'original' });
     expect(record.proofs.x402.settlementExtensions).not.toBe(extensions);
 
@@ -204,9 +185,9 @@ describe('toPeacRecordV2(): settlement extensions', () => {
 
   describe('receipt consistency guard', () => {
     it('allows a matching embedded receipt', () => {
-      const extensions = { 'offer-receipt': { info: { receipt: VALID_RAW_RECEIPT } } };
+      const extensions = { 'offer-receipt': { info: { receipt: RAW_RECEIPT } } };
       expect(() =>
-        toPeacRecordV2(V2_OFFER, withExtensions(extensions), RAW_OFFER, VALID_RAW_RECEIPT)
+        toPeacRecordV2(V2_OFFER, withExtensions(extensions), RAW_OFFER, RAW_RECEIPT)
       ).not.toThrow();
     });
 
@@ -217,7 +198,7 @@ describe('toPeacRecordV2(): settlement extensions', () => {
       };
       const extensions = { 'offer-receipt': { info: { receipt: conflicting } } };
       expect(() =>
-        toPeacRecordV2(V2_OFFER, withExtensions(extensions), RAW_OFFER, VALID_RAW_RECEIPT)
+        toPeacRecordV2(V2_OFFER, withExtensions(extensions), RAW_OFFER, RAW_RECEIPT)
       ).toThrow(X402Error);
     });
   });
@@ -228,7 +209,7 @@ describe('toPeacRecordV2(): settlement extensions', () => {
         V2_OFFER,
         withExtensions(EXTENSIONS_SIMPLE),
         RAW_OFFER,
-        VALID_RAW_RECEIPT
+        RAW_RECEIPT
       );
       expect(Object.keys(record.proofs.x402).sort()).toEqual(
         ['offer', 'receipt', 'settlementExtensionsDigest'].sort()

--- a/packages/adapters/x402/tests/map-v2.test.ts
+++ b/packages/adapters/x402/tests/map-v2.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { toPeacRecordV2 } from '../src/map.js';
+import { X402Error } from '../src/errors.js';
 import type { NormalizedV2Offer, NormalizedV2Receipt } from '../src/normalize-v2.js';
 import type { RawSignedOffer, RawSignedReceipt } from '../src/raw.js';
 import { X402_OFFER_RECEIPT_PROFILE } from '../src/types.js';
@@ -126,5 +127,112 @@ describe('toPeacRecordV2()', () => {
 
     expect(record.createdAt).toBeTruthy();
     expect(new Date(record.createdAt).getTime()).not.toBeNaN();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// settlement extensions (proofs.x402), V2
+// ---------------------------------------------------------------------------
+
+describe('toPeacRecordV2(): settlement extensions', () => {
+  // Properly-shaped RawJWSSignedReceipt (this file's top-level RAW_RECEIPT
+  // fixture uses a non-standard `compactJws` field name and is left as-is;
+  // these tests use a correctly-shaped fixture instead).
+  const VALID_RAW_RECEIPT: RawSignedReceipt = {
+    format: 'jws',
+    signature: 'eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJodHRwczovL2FwaS5leGFtcGxlLmNvbSJ9.c2lnbmF0dXJl',
+  };
+
+  const EXTENSIONS_SIMPLE = { foo: 'bar' };
+
+  function withExtensions(extensions: Record<string, unknown> | undefined): NormalizedV2Receipt {
+    return { ...V2_RECEIPT, extensions };
+  }
+
+  it('adds settlementExtensionsDigest by default, raw absent', () => {
+    const record = toPeacRecordV2(
+      V2_OFFER,
+      withExtensions(EXTENSIONS_SIMPLE),
+      RAW_OFFER,
+      VALID_RAW_RECEIPT
+    );
+    expect(record.proofs.x402.settlementExtensionsDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(record.proofs.x402.settlementExtensions).toBeUndefined();
+  });
+
+  it('omits settlement extension keys entirely when extensions is absent', () => {
+    const record = toPeacRecordV2(
+      V2_OFFER,
+      withExtensions(undefined),
+      RAW_OFFER,
+      VALID_RAW_RECEIPT
+    );
+    expect(record.proofs.x402.settlementExtensionsDigest).toBeUndefined();
+    expect(record.proofs.x402.settlementExtensions).toBeUndefined();
+  });
+
+  it('never places settlement extension data under evidence', () => {
+    const record = toPeacRecordV2(
+      V2_OFFER,
+      withExtensions(EXTENSIONS_SIMPLE),
+      RAW_OFFER,
+      VALID_RAW_RECEIPT
+    );
+    expect(record.evidence).not.toHaveProperty('settlementExtensions');
+    expect(record.evidence).not.toHaveProperty('settlementExtensionsDigest');
+  });
+
+  it('adds raw only when preserveRawSettlementExtensions is true, as a clone of the caller input', () => {
+    const extensions = { mutable: 'original' };
+    const record = toPeacRecordV2(
+      V2_OFFER,
+      withExtensions(extensions),
+      RAW_OFFER,
+      VALID_RAW_RECEIPT,
+      {
+        preserveRawSettlementExtensions: true,
+      }
+    );
+    expect(record.proofs.x402.settlementExtensions).toEqual({ mutable: 'original' });
+    expect(record.proofs.x402.settlementExtensions).not.toBe(extensions);
+
+    extensions.mutable = 'changed-after-mapping';
+    expect((record.proofs.x402.settlementExtensions as Record<string, unknown>).mutable).toBe(
+      'original'
+    );
+  });
+
+  describe('receipt consistency guard', () => {
+    it('allows a matching embedded receipt', () => {
+      const extensions = { 'offer-receipt': { info: { receipt: VALID_RAW_RECEIPT } } };
+      expect(() =>
+        toPeacRecordV2(V2_OFFER, withExtensions(extensions), RAW_OFFER, VALID_RAW_RECEIPT)
+      ).not.toThrow();
+    });
+
+    it('throws settlement_extensions_invalid when the embedded receipt conflicts with proofs.x402.receipt', () => {
+      const conflicting: RawSignedReceipt = {
+        format: 'jws',
+        signature: 'eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJodHRwczovL2FwaS5leGFtcGxlLmNvbSJ9.ZGlmZmVyZW50',
+      };
+      const extensions = { 'offer-receipt': { info: { receipt: conflicting } } };
+      expect(() =>
+        toPeacRecordV2(V2_OFFER, withExtensions(extensions), RAW_OFFER, VALID_RAW_RECEIPT)
+      ).toThrow(X402Error);
+    });
+  });
+
+  describe('serialization lock', () => {
+    it('proofs.x402 keys are exactly offer/receipt/settlementExtensionsDigest by default (camelCase)', () => {
+      const record = toPeacRecordV2(
+        V2_OFFER,
+        withExtensions(EXTENSIONS_SIMPLE),
+        RAW_OFFER,
+        VALID_RAW_RECEIPT
+      );
+      expect(Object.keys(record.proofs.x402).sort()).toEqual(
+        ['offer', 'receipt', 'settlementExtensionsDigest'].sort()
+      );
+    });
   });
 });

--- a/packages/adapters/x402/tests/map.test.ts
+++ b/packages/adapters/x402/tests/map.test.ts
@@ -345,4 +345,57 @@ describe('toPeacRecord: settlement extensions', () => {
       );
     });
   });
+
+  describe('canonicalization failures (JSON-canonicalizable guard)', () => {
+    it('throws settlement_extensions_invalid for a cyclic extensions object', () => {
+      const cyclic: Record<string, unknown> = {};
+      cyclic.self = cyclic;
+      expect(() => toPeacRecord(PAYMENT_REQUIRED_VALID, withExtensions(cyclic))).toThrow(X402Error);
+      try {
+        toPeacRecord(PAYMENT_REQUIRED_VALID, withExtensions(cyclic));
+        throw new Error('expected throw');
+      } catch (err) {
+        expect((err as X402Error).code).toBe('settlement_extensions_invalid');
+        // The raw extension value must not leak into the error message.
+        expect((err as X402Error).message).toBe(
+          'Settlement extensions must be JSON-canonicalizable'
+        );
+      }
+    });
+
+    it('throws settlement_extensions_invalid for a BigInt value inside extensions', () => {
+      const withBigInt = { amount: BigInt(1) } as unknown as Record<string, unknown>;
+      expect(() => toPeacRecord(PAYMENT_REQUIRED_VALID, withExtensions(withBigInt))).toThrow(
+        X402Error
+      );
+      try {
+        toPeacRecord(PAYMENT_REQUIRED_VALID, withExtensions(withBigInt));
+        throw new Error('expected throw');
+      } catch (err) {
+        expect((err as X402Error).code).toBe('settlement_extensions_invalid');
+      }
+    });
+
+    it('does not emit or partially populate a record when canonicalization fails', () => {
+      // toPeacRecord throws before returning; there is no partial record.
+      const cyclic: Record<string, unknown> = {};
+      cyclic.self = cyclic;
+      let record: unknown;
+      expect(() => {
+        record = toPeacRecord(PAYMENT_REQUIRED_VALID, withExtensions(cyclic));
+      }).toThrow(X402Error);
+      expect(record).toBeUndefined();
+    });
+
+    it('omits undefined object-member values per RFC 8785 / JSON.stringify (locked behavior, not an error)', () => {
+      // canonicalize drops undefined members (documented PROTOCOL DECISION),
+      // so { a: 1, b: undefined } digests identically to { a: 1 }.
+      const withUndefined = { a: 1, b: undefined } as Record<string, unknown>;
+      const recordU = toPeacRecord(PAYMENT_REQUIRED_VALID, withExtensions(withUndefined));
+      const recordPlain = toPeacRecord(PAYMENT_REQUIRED_VALID, withExtensions({ a: 1 }));
+      expect(recordU.proofs.x402.settlementExtensionsDigest).toBe(
+        recordPlain.proofs.x402.settlementExtensionsDigest
+      );
+    });
+  });
 });

--- a/packages/adapters/x402/tests/map.test.ts
+++ b/packages/adapters/x402/tests/map.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { toPeacRecord, X402Error, X402_OFFER_RECEIPT_PROFILE } from '../src/index.js';
+import { canonicalize } from '@peac/crypto';
+import { computeJsonDocumentDigestJcs } from '@peac/protocol';
+import {
+  toPeacRecord,
+  X402Error,
+  X402_OFFER_RECEIPT_PROFILE,
+  MAX_SETTLEMENT_EXTENSIONS_BYTES,
+} from '../src/index.js';
 import type {
   X402OfferReceiptChallenge,
   X402SettlementResponse,
@@ -183,6 +190,159 @@ describe('toPeacRecord', () => {
       };
       const record = toPeacRecord(PAYMENT_REQUIRED_VALID, sr);
       expect(record.evidence.transaction).toBeUndefined();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// settlement extensions (proofs.x402)
+// ---------------------------------------------------------------------------
+
+describe('toPeacRecord: settlement extensions', () => {
+  const EXTENSIONS_SIMPLE = { foo: 'bar', nested: { z: 1, a: 2 } };
+
+  function withExtensions(extensions: Record<string, unknown> | undefined): X402SettlementResponse {
+    return { ...SETTLEMENT_RESPONSE_VALID, extensions };
+  }
+
+  describe('default (digest-only, additive)', () => {
+    it('is byte-identical to the pre-existing shape when extensions is absent', () => {
+      const record = toPeacRecord(PAYMENT_REQUIRED_VALID, SETTLEMENT_RESPONSE_VALID);
+      expect(Object.keys(record.proofs.x402).sort()).toEqual(['offer', 'receipt']);
+      expect(record.proofs.x402.settlementExtensionsDigest).toBeUndefined();
+      expect(record.proofs.x402.settlementExtensions).toBeUndefined();
+    });
+
+    it('adds settlementExtensionsDigest and omits raw by default', () => {
+      const record = toPeacRecord(PAYMENT_REQUIRED_VALID, withExtensions(EXTENSIONS_SIMPLE));
+      expect(record.proofs.x402.settlementExtensionsDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
+      expect(record.proofs.x402.settlementExtensions).toBeUndefined();
+    });
+
+    it('matches computeJsonDocumentDigestJcs computed over the same extensions object', async () => {
+      const record = toPeacRecord(PAYMENT_REQUIRED_VALID, withExtensions(EXTENSIONS_SIMPLE));
+      const expected = await computeJsonDocumentDigestJcs(EXTENSIONS_SIMPLE);
+      expect(record.proofs.x402.settlementExtensionsDigest).toBe(expected);
+    });
+
+    it('digest is stable across key-order permutations (JCS canonicalization)', () => {
+      const a = { x: 1, y: 2, z: { b: 2, a: 1 } };
+      const b = { z: { a: 1, b: 2 }, y: 2, x: 1 };
+      const recordA = toPeacRecord(PAYMENT_REQUIRED_VALID, withExtensions(a));
+      const recordB = toPeacRecord(PAYMENT_REQUIRED_VALID, withExtensions(b));
+      expect(recordA.proofs.x402.settlementExtensionsDigest).toBe(
+        recordB.proofs.x402.settlementExtensionsDigest
+      );
+    });
+
+    it('never places settlement extension data under evidence', () => {
+      const record = toPeacRecord(PAYMENT_REQUIRED_VALID, withExtensions(EXTENSIONS_SIMPLE));
+      expect(record.evidence).not.toHaveProperty('settlementExtensions');
+      expect(record.evidence).not.toHaveProperty('settlementExtensionsDigest');
+    });
+  });
+
+  describe('DoS bound (UTF-8 bytes, not char count)', () => {
+    it('throws settlement_extensions_too_large when canonical bytes exceed the limit', () => {
+      const big = { blob: 'a'.repeat(MAX_SETTLEMENT_EXTENSIONS_BYTES + 100) };
+      expect(() => toPeacRecord(PAYMENT_REQUIRED_VALID, withExtensions(big))).toThrow(X402Error);
+      try {
+        toPeacRecord(PAYMENT_REQUIRED_VALID, withExtensions(big));
+        throw new Error('expected throw');
+      } catch (err) {
+        expect((err as X402Error).code).toBe('settlement_extensions_too_large');
+      }
+    });
+
+    it('uses UTF-8 byte length (not JS string length) for the bound: multi-byte payload over the boundary', () => {
+      // Each '€' (euro sign) is 1 UTF-16 code unit but 3 UTF-8 bytes.
+      const charCount = Math.floor(MAX_SETTLEMENT_EXTENSIONS_BYTES / 2);
+      const multiByte = { blob: '€'.repeat(charCount) };
+      const canonical = canonicalize(multiByte);
+      // Char length alone would be well under the byte limit...
+      expect(canonical.length).toBeLessThan(MAX_SETTLEMENT_EXTENSIONS_BYTES);
+      // ...but the UTF-8 byte length exceeds it.
+      expect(Buffer.byteLength(canonical, 'utf8')).toBeGreaterThan(MAX_SETTLEMENT_EXTENSIONS_BYTES);
+      expect(() => toPeacRecord(PAYMENT_REQUIRED_VALID, withExtensions(multiByte))).toThrow(
+        X402Error
+      );
+    });
+
+    it('accepts a multi-byte payload sized within the byte bound (boundary, not over it)', () => {
+      const charCount = Math.floor((MAX_SETTLEMENT_EXTENSIONS_BYTES - 100) / 3);
+      const multiByte = { blob: '€'.repeat(charCount) };
+      expect(() => toPeacRecord(PAYMENT_REQUIRED_VALID, withExtensions(multiByte))).not.toThrow();
+    });
+  });
+
+  describe('opt-in raw preservation', () => {
+    it('adds proofs.x402.settlementExtensions only when preserveRawSettlementExtensions is true', () => {
+      const withoutOptIn = toPeacRecord(PAYMENT_REQUIRED_VALID, withExtensions(EXTENSIONS_SIMPLE));
+      expect(withoutOptIn.proofs.x402.settlementExtensions).toBeUndefined();
+
+      const withOptIn = toPeacRecord(PAYMENT_REQUIRED_VALID, withExtensions(EXTENSIONS_SIMPLE), {
+        preserveRawSettlementExtensions: true,
+      });
+      expect(withOptIn.proofs.x402.settlementExtensions).toEqual(EXTENSIONS_SIMPLE);
+    });
+
+    it('preserves a clone derived from the bounded canonical bytes, not the caller object reference', () => {
+      const extensions = { mutable: 'original' };
+      const record = toPeacRecord(PAYMENT_REQUIRED_VALID, withExtensions(extensions), {
+        preserveRawSettlementExtensions: true,
+      });
+      expect(record.proofs.x402.settlementExtensions).not.toBe(extensions);
+      expect(record.proofs.x402.settlementExtensions).toEqual({ mutable: 'original' });
+
+      extensions.mutable = 'changed-after-mapping';
+      expect((record.proofs.x402.settlementExtensions as Record<string, unknown>).mutable).toBe(
+        'original'
+      );
+    });
+  });
+
+  describe('receipt consistency guard', () => {
+    it('allows a matching embedded receipt (no throw)', () => {
+      const sr = withExtensions({
+        'offer-receipt': { info: { receipt: SETTLEMENT_RESPONSE_VALID.receipt } },
+      });
+      expect(() => toPeacRecord(PAYMENT_REQUIRED_VALID, sr)).not.toThrow();
+    });
+
+    it('throws settlement_extensions_invalid when the embedded receipt conflicts with proofs.x402.receipt', () => {
+      const differentReceipt: RawEIP712SignedReceipt = {
+        format: 'eip712',
+        payload: { ...RECEIPT_PAYLOAD_VALID, payer: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' },
+        signature: SIG_EIP712,
+      };
+      const sr = withExtensions({
+        'offer-receipt': { info: { receipt: differentReceipt } },
+      });
+      expect(() => toPeacRecord(PAYMENT_REQUIRED_VALID, sr)).toThrow(X402Error);
+      try {
+        toPeacRecord(PAYMENT_REQUIRED_VALID, sr);
+        throw new Error('expected throw');
+      } catch (err) {
+        expect((err as X402Error).code).toBe('settlement_extensions_invalid');
+      }
+    });
+  });
+
+  describe('serialization lock', () => {
+    it('proofs.x402 keys are exactly offer/receipt/settlementExtensionsDigest by default (camelCase)', () => {
+      const record = toPeacRecord(PAYMENT_REQUIRED_VALID, withExtensions(EXTENSIONS_SIMPLE));
+      expect(Object.keys(record.proofs.x402).sort()).toEqual(
+        ['offer', 'receipt', 'settlementExtensionsDigest'].sort()
+      );
+    });
+
+    it('proofs.x402 keys additionally include settlementExtensions when opted in (camelCase)', () => {
+      const record = toPeacRecord(PAYMENT_REQUIRED_VALID, withExtensions(EXTENSIONS_SIMPLE), {
+        preserveRawSettlementExtensions: true,
+      });
+      expect(Object.keys(record.proofs.x402).sort()).toEqual(
+        ['offer', 'receipt', 'settlementExtensions', 'settlementExtensionsDigest'].sort()
+      );
     });
   });
 });

--- a/packages/adapters/x402/tests/normalize-v2.test.ts
+++ b/packages/adapters/x402/tests/normalize-v2.test.ts
@@ -170,4 +170,40 @@ describe('normalizeV2Receipt', () => {
       '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890'
     );
   });
+
+  // -------------------------------------------------------------------------
+  // extensions passthrough (settlement-extensions preservation)
+  // -------------------------------------------------------------------------
+
+  describe('extensions passthrough', () => {
+    it('preserves extensions verbatim on a successful settlement', () => {
+      const settlement: RawV2SettlementResponse = {
+        ...SUCCESS_SETTLEMENT,
+        extensions: { 'offer-receipt': { info: { offers: [] } } },
+      };
+      const result = normalizeV2Receipt(settlement, 'https://api.example.com/premium', 1711900000);
+      expect(result).not.toBeNull();
+      expect(result!.extensions).toEqual({ 'offer-receipt': { info: { offers: [] } } });
+    });
+
+    it('omits the extensions key entirely when absent (never synthesizes {})', () => {
+      const result = normalizeV2Receipt(
+        SUCCESS_SETTLEMENT,
+        'https://api.example.com/premium',
+        1711900000
+      );
+      expect(result).not.toBeNull();
+      expect(result!.extensions).toBeUndefined();
+      expect('extensions' in result!).toBe(false);
+    });
+
+    it('still returns null for a failed settlement even when extensions is present', () => {
+      const settlement: RawV2SettlementResponse = {
+        ...FAILED_SETTLEMENT,
+        extensions: { 'offer-receipt': { info: {} } },
+      };
+      const result = normalizeV2Receipt(settlement, 'https://api.example.com/premium', 1711900000);
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/packages/adapters/x402/tests/settlement-extensions.test.ts
+++ b/packages/adapters/x402/tests/settlement-extensions.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests for extractSignedReceiptFromSettlement() and
+ * MAX_SETTLEMENT_EXTENSIONS_BYTES (settlement-extensions.ts).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  extractSignedReceiptFromSettlement,
+  MAX_SETTLEMENT_EXTENSIONS_BYTES,
+  X402Error,
+} from '../src/index.js';
+import { RECEIPT_PAYLOAD_VALID, SIG_EIP712 } from './fixtures/index.js';
+
+// A structurally valid compact JWS (3 unpadded base64url segments; header
+// and payload both decode to plain JSON objects). Reused from
+// tests/carrier.test.ts's SAMPLE_JWS fixture pattern.
+const VALID_JWS = 'eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJodHRwczovL2FwaS5leGFtcGxlLmNvbSJ9.c2lnbmF0dXJl';
+
+describe('MAX_SETTLEMENT_EXTENSIONS_BYTES', () => {
+  it('is 256 KiB', () => {
+    expect(MAX_SETTLEMENT_EXTENSIONS_BYTES).toBe(256 * 1024);
+  });
+});
+
+describe('extractSignedReceiptFromSettlement', () => {
+  describe('happy paths', () => {
+    it('extracts a JWS-format receipt', () => {
+      const settlement = {
+        success: true,
+        extensions: {
+          'offer-receipt': {
+            info: {
+              receipt: { format: 'jws', signature: VALID_JWS },
+            },
+          },
+        },
+      };
+      expect(extractSignedReceiptFromSettlement(settlement)).toEqual({
+        format: 'jws',
+        signature: VALID_JWS,
+      });
+    });
+
+    it('extracts an EIP-712-format receipt', () => {
+      const settlement = {
+        success: true,
+        extensions: {
+          'offer-receipt': {
+            info: {
+              receipt: { format: 'eip712', payload: RECEIPT_PAYLOAD_VALID, signature: SIG_EIP712 },
+            },
+          },
+        },
+      };
+      expect(extractSignedReceiptFromSettlement(settlement)).toEqual({
+        format: 'eip712',
+        payload: RECEIPT_PAYLOAD_VALID,
+        signature: SIG_EIP712,
+      });
+    });
+
+    it('extracts a receipt when info carries no offers key at all (settlement-only shape)', () => {
+      const settlement = {
+        success: true,
+        extensions: {
+          'offer-receipt': {
+            info: { receipt: { format: 'jws', signature: VALID_JWS } },
+          },
+        },
+      };
+      expect(extractSignedReceiptFromSettlement(settlement)).not.toBeNull();
+    });
+
+    it('extracts a receipt when info carries an empty offers array (documented challenge-side shape)', () => {
+      const settlement = {
+        success: true,
+        extensions: {
+          'offer-receipt': {
+            info: { offers: [], receipt: { format: 'jws', signature: VALID_JWS } },
+          },
+        },
+      };
+      expect(extractSignedReceiptFromSettlement(settlement)).toEqual({
+        format: 'jws',
+        signature: VALID_JWS,
+      });
+    });
+
+    it('does not verify the returned artifact (extraction only)', () => {
+      // The signature is structurally valid but not cryptographically
+      // meaningful; the helper still returns it without attempting any
+      // verification.
+      const settlement = {
+        success: true,
+        extensions: {
+          'offer-receipt': { info: { receipt: { format: 'jws', signature: VALID_JWS } } },
+        },
+      };
+      const result = extractSignedReceiptFromSettlement(settlement);
+      expect(result).not.toBeNull();
+      expect(result).toEqual({ format: 'jws', signature: VALID_JWS });
+    });
+  });
+
+  describe('tolerant absence (returns null)', () => {
+    it('returns null for an absent/undefined settlement', () => {
+      expect(extractSignedReceiptFromSettlement(undefined)).toBeNull();
+    });
+
+    it('returns null for a non-object settlement', () => {
+      expect(extractSignedReceiptFromSettlement('not-an-object')).toBeNull();
+      expect(extractSignedReceiptFromSettlement(42)).toBeNull();
+      expect(extractSignedReceiptFromSettlement(null)).toBeNull();
+    });
+
+    it('returns null when extensions is absent', () => {
+      expect(extractSignedReceiptFromSettlement({ success: true })).toBeNull();
+    });
+
+    it('returns null when the offer-receipt extension key is absent', () => {
+      expect(
+        extractSignedReceiptFromSettlement({
+          success: true,
+          extensions: { 'some-other-extension': {} },
+        })
+      ).toBeNull();
+    });
+
+    it('returns null when info has no receipt field', () => {
+      expect(
+        extractSignedReceiptFromSettlement({
+          success: true,
+          extensions: { 'offer-receipt': { info: { offers: [] } } },
+        })
+      ).toBeNull();
+    });
+  });
+
+  describe('fail-closed malformed shapes', () => {
+    it('throws settlement_extensions_invalid when extensions is non-object', () => {
+      expect(() =>
+        extractSignedReceiptFromSettlement({ success: true, extensions: 'not-an-object' })
+      ).toThrow(X402Error);
+      try {
+        extractSignedReceiptFromSettlement({ success: true, extensions: 'not-an-object' });
+        throw new Error('expected throw');
+      } catch (err) {
+        expect((err as X402Error).code).toBe('settlement_extensions_invalid');
+      }
+    });
+
+    it('throws settlement_extensions_invalid when the offer-receipt extension is non-object', () => {
+      expect(() =>
+        extractSignedReceiptFromSettlement({
+          success: true,
+          extensions: { 'offer-receipt': 'not-an-object' },
+        })
+      ).toThrow(X402Error);
+    });
+
+    it('throws settlement_extensions_invalid when info is non-object', () => {
+      expect(() =>
+        extractSignedReceiptFromSettlement({
+          success: true,
+          extensions: { 'offer-receipt': { info: 42 } },
+        })
+      ).toThrow(X402Error);
+    });
+
+    it('throws settlement_extensions_invalid when the receipt has an unrecognized format', () => {
+      expect(() =>
+        extractSignedReceiptFromSettlement({
+          success: true,
+          extensions: {
+            'offer-receipt': { info: { receipt: { format: 'unknown', signature: 'x' } } },
+          },
+        })
+      ).toThrow(X402Error);
+    });
+
+    it('throws settlement_extensions_invalid when an EIP-712 receipt is missing its payload', () => {
+      expect(() =>
+        extractSignedReceiptFromSettlement({
+          success: true,
+          extensions: {
+            'offer-receipt': { info: { receipt: { format: 'eip712', signature: SIG_EIP712 } } },
+          },
+        })
+      ).toThrow(X402Error);
+    });
+  });
+
+  describe('receipt-on-failed-settlement guard', () => {
+    it('throws settlement_extensions_invalid when a receipt is embedded on success:false', () => {
+      const settlement = {
+        success: false,
+        extensions: {
+          'offer-receipt': { info: { receipt: { format: 'jws', signature: VALID_JWS } } },
+        },
+      };
+      expect(() => extractSignedReceiptFromSettlement(settlement)).toThrow(X402Error);
+      try {
+        extractSignedReceiptFromSettlement(settlement);
+        throw new Error('expected throw');
+      } catch (err) {
+        expect((err as X402Error).code).toBe('settlement_extensions_invalid');
+      }
+    });
+
+    it('does not throw when success is absent entirely (e.g. a V1-shaped settlement)', () => {
+      const settlement = {
+        extensions: {
+          'offer-receipt': { info: { receipt: { format: 'jws', signature: VALID_JWS } } },
+        },
+      };
+      expect(() => extractSignedReceiptFromSettlement(settlement)).not.toThrow();
+    });
+  });
+
+  describe('oversize JWS bound', () => {
+    it('throws jws_too_large (not settlement_extensions_invalid) for an oversized JWS signature', () => {
+      const oversized = 'x'.repeat(70_000);
+      const settlement = {
+        success: true,
+        extensions: {
+          'offer-receipt': { info: { receipt: { format: 'jws', signature: oversized } } },
+        },
+      };
+      try {
+        extractSignedReceiptFromSettlement(settlement);
+        throw new Error('expected throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(X402Error);
+        expect((err as X402Error).code).toBe('jws_too_large');
+      }
+    });
+  });
+});

--- a/packages/adapters/x402/tests/settlement.test.ts
+++ b/packages/adapters/x402/tests/settlement.test.ts
@@ -166,6 +166,21 @@ describe('fromX402SettlementObservation: rejection paths', () => {
   });
 });
 
+describe('fromX402SettlementObservation: settlement-extensions regression (finality guard untouched)', () => {
+  it('produces identical output whether or not an extensions-shaped field is present on the input', () => {
+    const base = input();
+    const withExtras = {
+      ...base,
+      extensions: { 'offer-receipt': { info: { offers: [] } } },
+    } as X402SettlementObservationInput;
+
+    const outBase = fromX402SettlementObservation(base);
+    const outWithExtras = fromX402SettlementObservation(withExtras);
+
+    expect(outWithExtras).toEqual(outBase);
+  });
+});
+
 describe('fromX402SettlementObservation: amount semantics (minor units)', () => {
   it('payment.amount is integer minor-unit value', () => {
     const out = fromX402SettlementObservation(input({ amount_minor: '99999' }));

--- a/specs/upstream/x402/type-snapshot.json
+++ b/specs/upstream/x402/type-snapshot.json
@@ -19,7 +19,7 @@
       "asset": { "type": "string", "required": true },
       "payTo": { "type": "string", "required": true },
       "amount": { "type": "string", "required": true },
-      "validUntil": { "type": "number", "required": true }
+      "validUntil": { "type": "number", "required": false }
     }
   },
   "receipt_payload": {


### PR DESCRIPTION
## Summary

Preserves x402 settlement `extensions` data inside portable PEAC records, additively and privacy-first.

- **Raw/normalized V2 types:** mirrors upstream's optional `SettleResponse.extensions?: Record<string, unknown>`
  onto `RawV2SettlementResponseSuccess`/`Failure` and `NormalizedV2Receipt`; `normalizeV2Receipt()` carries it
  forward only when present. Raw pass-through only, no semantics added at that layer.
- **Helper** `extractSignedReceiptFromSettlement(settlement): RawSignedReceipt | null` — narrows a settlement
  object to the signed receipt at `extensions["offer-receipt"].info.receipt`. Extraction only; it does not
  verify the signature. Absent extension returns `null`; a malformed extension, or a receipt embedded on a
  failed (`success:false`) settlement, fails closed.
- **Mapper:** the V1 and V2 mappers add `proofs.x402.settlementExtensionsDigest`
  (`sha256:<hex>` over the RFC 8785 JCS canonicalization of the `extensions` object) whenever settlement
  extensions are present. The raw `extensions` object is preserved under `proofs.x402.settlementExtensions`
  only with the opt-in `preserveRawSettlementExtensions` option, cloned from the bounded canonical bytes.
  A byte bound (`MAX_SETTLEMENT_EXTENSIONS_BYTES = 256 KiB`, UTF-8) is enforced over the same canonical bytes
  that are digested. A consistency guard rejects a settlement whose embedded receipt differs from the receipt
  already preserved at `proofs.x402.receipt`. Neither settlement key is ever copied into signed `evidence`.
- **Adapter-local errors** `settlement_extensions_invalid` and `settlement_extensions_too_large`.
- **Snapshot correction:** `specs/upstream/x402/type-snapshot.json` `offer_payload.validUntil` is marked
  optional (it is Optional in the upstream spec); a pre-existing local snapshot inaccuracy, corrected in its
  own commit.
- **Informative doc** `docs/specs/PAID-RESOURCE-EVIDENCE.md` describing the record composition and the
  privacy posture. Adds no normative requirement and no field.

`settlementExtensionsDigest` is an integrity/correlation handle (a stable equality check), not anonymization.

## Non-goals

- No settlement, pricing, access-gating, or scheme-invariant verification.
- No wire/schema/registry/receipt-type/extension-group/conformance change.
- No kernel `errors.json` change (kernel error count unchanged); adapter-local codes only.
- No package-version bump, no new dependency, no build-target change, no release work.
- No AP2 registry, and no pre-commit-hook, change.

## Validation

- `pnpm --filter @peac/adapter-x402 test` (281) and `build`
- `pnpm typecheck:core`
- `pnpm exec vitest run tests/tooling/repo-links-doc-truth.test.ts` (338)
- `pnpm exec vitest run tests/tooling` (1457)
- `pnpm verify:codegen-drift` and `pnpm verify:registries-schema`
- `pnpm exec tsx scripts/extract-api-contract.ts --check`
- `git diff --check` and `bash scripts/ci/forbid-strings.sh`
- `bash scripts/check-planning-leak.sh docs/specs/PAID-RESOURCE-EVIDENCE.md`
- `node scripts/check-public-artifacts.mjs --body-file docs/specs/PAID-RESOURCE-EVIDENCE.md`
