### PR TITLE
examples: paid resource and MCP paid tool records

### DIFF
--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -9,7 +9,7 @@
     "tests": 11975,
     "test_files": 478,
     "published_packages": 36,
-    "build_targets": 107,
+    "build_targets": 109,
     "conformance_requirement_ids": 290,
     "conformance_sections": 32
   },

--- a/examples/mcp-paid-tool-records/README.md
+++ b/examples/mcp-paid-tool-records/README.md
@@ -1,0 +1,61 @@
+# MCP Paid Tool Records
+
+**Outcome:** a portable, offline-verifiable `org.peacprotocol/payment` record that binds a specific MCP tool call (name, a digest of its arguments, and a digest of its result) to the x402 settlement that paid for it, carried directly in the tool result's `_meta`.
+
+**Audience:** MCP tool authors and integrators who charge for individual tool calls via x402 and need evidence of which call a settlement paid for, portable outside their own server.
+
+**Time:** 5 minutes.
+
+A priced MCP tool call triggers an x402 payment challenge; once the caller pays, the settlement is observed via the "Signed Offers and Receipts" extension (upstream `x402-foundation/x402` commit `f2bbb5c`, `extensions["offer-receipt"]`, body path via `extractSignedReceiptFromSettlement`). This example binds that settlement to the specific tool call it paid for: the tool name, a digest of the tool call arguments (never the raw arguments), and a digest of the returned tool result (never the raw result) are bound into a signed `org.peacprotocol/payment` record, carried in the MCP tool result's `_meta`, and verified offline directly from that `_meta` carrier.
+
+Before issuing the record, the offer is verified against the accepted payment terms and the receipt is checked for consistency with the offer (`verifyOffer` / `verifyOfferReceiptConsistency`, reused from `@peac/adapter-x402`); a mismatched offer or receipt refuses issuance.
+
+## Where this fits (no duplication)
+
+- [`x402-paid-resource-records`](../x402-paid-resource-records/) - the general signed-record composition example for a settled x402 offer/receipt pair, with full offer term-matching, offer/receipt consistency, and dual-channel (header + body) settlement observation.
+- [`mcp-gateway-receipts`](../mcp-gateway-receipts/) - **gateway-side**: a gateway signs policy decisions (allow/deny) for a whole fleet of tools, independent of payment.
+- **`mcp-paid-tool-records` (this example)** - **tool-call-side composition**: the record is issued by (or on behalf of) the one specific paid tool, at the point that tool call completes, binding the tool call itself (name + argument digest + result digest) to its settlement. Not gateway mediation, and not the general x402 record-composition example: it is the narrower "this exact call, this exact settlement" binding.
+
+## What it shows
+
+1. A priced tool call (`market_data.premium_quote`) triggers an x402 challenge (a signed offer, `extensions["offer-receipt"].info.offers`). Only the tool name and a digest of the arguments are ever logged, never the raw arguments.
+2. The caller pays; the settlement is observed via the offer-receipt extension body (`extractSignedReceiptFromSettlement`). `verifyOffer` confirms the offer matches the accepted payment terms and `verifyOfferReceiptConsistency` confirms the receipt is consistent with the offer (same resource, same network, issued within the offer's validity window); either check failing refuses issuance. Issuance also refuses to proceed on offer-only data (no observed settlement artifact).
+3. PEAC issues a signed `org.peacprotocol/payment` record:
+   - the registered `org.peacprotocol/commerce` extension carries `payment_rail = x402`, `amount_minor`, `currency`, `asset`, `reference` (the on-chain transaction reference), `env`, `event = settlement`;
+   - an example-local `com.example/mcp_paid_tool` extension binds `tool_name`, `tool_args_digest` (an RFC 8785 JCS digest of the tool call arguments via `computeJsonDocumentDigestJcs`, never the raw arguments), and `tool_result_digest` (a digest of the returned tool result's `content`/`structuredContent`, never the raw result), plus three receipt digests that distinguish the signed artifact from the normalized payload (mirroring the x402 paid-resource example):
+     - `signed_receipt_artifact_digest`: digest of the signed upstream receipt artifact (the `RawSignedReceipt` observed in the settlement).
+     - `settlement_receipt_payload_digest`: digest of the normalized receipt payload (field-level audit, not the artifact identity).
+     - `upstream_artifact_digest`: equal to `signed_receipt_artifact_digest` (the signed artifact is the upstream artifact this call paid for, mirroring `org.peacprotocol/agent-action`'s `upstream_artifact_digest` field).
+4. The record is attached to the MCP tool result via the top-level `_meta` carrier keys (`org.peacprotocol/receipt_ref`, `org.peacprotocol/receipt_jws`), the same carrier contract `mcp-gateway-receipts` and `mpp-payment-record` use.
+5. Verification reads the record back out of `_meta` (not from a value the demo already had in hand) and verifies it offline with only the issuer public key. The counterparty independently re-derives the tool-args digest, the tool-result digest, and the settlement-receipt digest from the same raw materials it separately received, and confirms they still match what is bound in the record.
+6. Two independent tamper checks: altering the returned tool result after signing breaks the tool-result digest re-bind (signature still verifies); tampering with the `_meta`-carried record payload fails verification (`E_INVALID_SIGNATURE`).
+
+## Redaction and binding
+
+The tool call arguments, the returned tool result, and the raw settlement receipt JWS artifact are never inlined into the signed record or into `_meta`: only their sha256 digests are bound. The `_meta` carrier legitimately contains the PEAC receipt JWS itself (`org.peacprotocol/receipt_jws`) by design; that is the record being carried, not a leak.
+
+## Non-goals
+
+- Not a payment rail: PEAC does not move funds or decide pricing.
+- Not a gate: PEAC does not decide whether to run the tool or return its result.
+- Not a scheme verifier: x402 scheme-specific invariants remain the facilitator's and the upstream x402 scheme's responsibility; see [`docs/compatibility/x402-scheme-coverage.md`](../../docs/compatibility/x402-scheme-coverage.md).
+
+## Run
+
+```bash
+pnpm install
+pnpm --filter @peac/example-mcp-paid-tool-records demo           # full flow
+pnpm --filter @peac/example-mcp-paid-tool-records demo:tamper    # tamper checks
+```
+
+No network, no external services. This demo generates two ephemeral local keypairs: one simulating the x402 facilitator's signing key (for the offer/receipt JWS artifacts) and one for the PEAC record issuer.
+
+## Reused building blocks (no new protocol surface)
+
+This example adds no new receipt type, extension group, schema field, wire version, signing envelope, or package API. It composes existing packages:
+
+- `@peac/adapter-x402` - `extractExtensionInfo`, `verifyOffer`, `verifyOfferReceiptConsistency`, `extractOfferPayload`, `normalizeOfferPayload`, `extractSignedReceiptFromSettlement`, `extractReceiptPayload`, `normalizeReceiptPayload`
+- `@peac/protocol` - `issue`, `verifyLocal`, `computeJsonDocumentDigestJcs`
+- `@peac/mappings-mcp` - `attachReceiptToMeta`, `extractReceiptFromMetaAsync`
+- `@peac/crypto` - `generateKeypair`, `sign`
+- `@peac/schema` - `computeReceiptRef`

--- a/examples/mcp-paid-tool-records/demo.ts
+++ b/examples/mcp-paid-tool-records/demo.ts
@@ -1,0 +1,574 @@
+/**
+ * MCP Paid Tool Records Example
+ *
+ * A priced MCP tool call triggers an x402 payment challenge; once the caller
+ * pays, the settlement is observed via the offer-receipt extension (upstream
+ * x402-foundation/x402 commit f2bbb5c, `extensions["offer-receipt"]`, body
+ * path via `extractSignedReceiptFromSettlement`). This example binds that
+ * settlement to the specific tool call it paid for: the tool name, a digest
+ * of the tool call arguments (never the raw arguments), and a digest of the
+ * returned tool result (never the raw result) are bound into a signed
+ * org.peacprotocol/payment record, carried in the MCP tool result's `_meta`,
+ * and verified offline directly from that `_meta` carrier.
+ *
+ * Before issuing the record, the offer is verified against the accepted
+ * payment terms and the receipt is checked for consistency with the offer
+ * (`verifyOffer` / `verifyOfferReceiptConsistency`, reused from
+ * `@peac/adapter-x402`); a mismatched offer or receipt refuses issuance.
+ *
+ * This is tool-call composition, not gateway mediation: the record is issued
+ * by (or on behalf of) the specific paid tool, at the point the tool call
+ * completes. Compare with examples/mcp-gateway-receipts, which signs
+ * gateway-mediated policy decisions for a whole fleet of tools regardless of
+ * payment.
+ *
+ * Boundaries (PEAC does not become a payment rail):
+ * - PEAC records and verifies; it does not settle, price, or gate the tool call.
+ * - PEAC does not verify x402 scheme-specific invariants; see
+ *   docs/compatibility/x402-scheme-coverage.md.
+ * - The raw settlement receipt JWS artifact, the raw tool call arguments, and
+ *   the raw tool result are sensitive. The record binds each by sha256
+ *   digest; it never inlines the raw artifact, the raw arguments, or the raw
+ *   result into the signed payload or _meta (nor are the raw arguments ever
+ *   logged).
+ *
+ * Record type / extensions used here:
+ * - Registered record type org.peacprotocol/payment.
+ * - Registered extension group org.peacprotocol/commerce carries
+ *   payment_rail = x402, amount_minor, currency, asset, env, event.
+ * - com.example/mcp_paid_tool is a well-formed but unregistered example-local
+ *   extension group carrying observational overflow (record_role, tool_name,
+ *   tool_args_digest, tool_result_digest, signed_receipt_artifact_digest,
+ *   settlement_receipt_payload_digest, upstream_artifact_digest,
+ *   redaction_applied).
+ *
+ * No network, no external services. This demo generates two ephemeral local
+ * keypairs: one simulating the x402 facilitator's signing key (for the
+ * offer/receipt JWS artifacts) and one for the PEAC record issuer.
+ *
+ * Run:
+ *   pnpm demo               full flow (record, carry in _meta, verify offline)
+ *   pnpm demo:tamper        tamper checks (signature tamper + result digest mismatch)
+ */
+
+import { issue, verifyLocal, computeJsonDocumentDigestJcs } from '@peac/protocol';
+import { generateKeypair, sign as signJws } from '@peac/crypto';
+import { attachReceiptToMeta, extractReceiptFromMetaAsync } from '@peac/mappings-mcp';
+import { computeReceiptRef } from '@peac/schema';
+import type { JsonValue } from '@peac/kernel';
+import {
+  extractExtensionInfo,
+  extractOfferPayload,
+  extractReceiptPayload,
+  normalizeOfferPayload,
+  normalizeReceiptPayload,
+  extractSignedReceiptFromSettlement,
+  verifyOffer,
+  verifyOfferReceiptConsistency,
+  type AcceptEntry,
+  type RawOfferPayload,
+  type RawReceiptPayload,
+  type RawSignedOffer,
+  type RawSignedReceipt,
+  type NormalizedReceiptPayload,
+} from '@peac/adapter-x402';
+
+// Configuration (issuer = the service that observed the settlement and records it)
+const ISSUER_URL = 'https://api.example.com';
+const KID = 'record-key-2026';
+const FACILITATOR_KID = 'x402-facilitator-key-2026';
+const COMMERCE_EXT = 'org.peacprotocol/commerce';
+const TOOL_EXT = 'com.example/mcp_paid_tool';
+
+const TOOL_NAME = 'market_data.premium_quote';
+const TOOL_RESOURCE = 'https://api.example.com/v1/tools/market_data.premium_quote';
+const TOOL_ARGS = { symbol: 'ACME', depth: 'full' } as const;
+
+const NETWORK = 'eip155:8453'; // Base mainnet (CAIP-2)
+const ASSET = 'USDC';
+const PAY_TO = '0x9e2d35Cc6634C0532925a3b844Bc9e7595f19aa1';
+const PAYER = '0x1230456789abcdef1234567890abcdef12345678';
+const TRANSACTION = '0xfeedface1234567890abcdef1234567890abcdef1234567890abcdef1234ab';
+const AMOUNT = '500000'; // $0.50 in USDC minor units (6 decimals)
+const SCHEME = 'exact';
+
+const ACCEPTS: AcceptEntry[] = [
+  { network: NETWORK, asset: ASSET, payTo: PAY_TO, amount: AMOUNT, scheme: SCHEME },
+];
+
+/** Canonical, deterministic digest document for the settlement receipt. */
+function receiptDocument(
+  receipt: NormalizedReceiptPayload
+): Record<string, string | number | null> {
+  return {
+    version: receipt.version,
+    network: receipt.network,
+    resourceUrl: receipt.resourceUrl,
+    payer: receipt.payer,
+    issuedAt: receipt.issuedAt,
+    transaction: receipt.transaction ?? null,
+  };
+}
+
+/** Decode a compact JWS without verifying (leak-check helper). */
+function decodeJws(jws: string): { header: unknown; payload: unknown } {
+  const [header, payload] = jws.split('.');
+  return {
+    header: JSON.parse(Buffer.from(header, 'base64url').toString('utf8')),
+    payload: JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')),
+  };
+}
+
+/** Modify one payload claim while keeping the original signature (tamper helper). */
+function tamperPayload(jws: string): string {
+  const [header, payload, signature] = jws.split('.');
+  const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as Record<
+    string,
+    unknown
+  >;
+  decoded.iss = 'https://attacker.example.com';
+  const reEncoded = Buffer.from(JSON.stringify(decoded), 'utf8').toString('base64url');
+  return `${header}.${reEncoded}.${signature}`;
+}
+
+export interface ToolPaymentFixtures {
+  /** Raw x402 402 challenge body for the priced tool call. */
+  challengeBody: unknown;
+  /** Raw x402 settlement response body (offer-receipt extension body path). */
+  settlementBody: unknown;
+}
+
+/**
+ * Build a signed x402 offer (the tool call's payment challenge) and a signed
+ * x402 receipt (the settlement), ephemeral Ed25519 JWS artifacts simulating
+ * the facilitator's signing key, wrapped in the upstream offer-receipt
+ * extension wire shape.
+ */
+export async function buildToolPaymentFixtures(
+  facilitatorPrivateKey: Uint8Array
+): Promise<ToolPaymentFixtures> {
+  const now = Math.floor(Date.now() / 1000);
+
+  const offerPayload: RawOfferPayload = {
+    version: 1,
+    resourceUrl: TOOL_RESOURCE,
+    scheme: SCHEME,
+    network: NETWORK,
+    asset: ASSET,
+    payTo: PAY_TO,
+    amount: AMOUNT,
+    validUntil: now + 3600,
+  };
+  const offerJws = await signJws(offerPayload, facilitatorPrivateKey, FACILITATOR_KID);
+  const signedOffer: RawSignedOffer = { format: 'jws', signature: offerJws };
+
+  const receiptPayload: RawReceiptPayload = {
+    version: 1,
+    network: NETWORK,
+    resourceUrl: TOOL_RESOURCE,
+    payer: PAYER,
+    issuedAt: now,
+    transaction: TRANSACTION,
+  };
+  const receiptJws = await signJws(receiptPayload, facilitatorPrivateKey, FACILITATOR_KID);
+  const signedReceipt: RawSignedReceipt = { format: 'jws', signature: receiptJws };
+
+  const challengeBody = {
+    resourceUrl: TOOL_RESOURCE,
+    extensions: { 'offer-receipt': { info: { offers: [signedOffer] } } },
+  };
+  const settlementBody = {
+    success: true,
+    resourceUrl: TOOL_RESOURCE,
+    extensions: { 'offer-receipt': { info: { receipt: signedReceipt } } },
+  };
+
+  return { challengeBody, settlementBody };
+}
+
+/** The MCP tool result content this call returned, as bound by tool_result_digest (excludes _meta and raw args). */
+export interface ToolCallResultForDigest {
+  content: unknown;
+  structuredContent?: Record<string, unknown> | null;
+}
+
+export interface ToolPaymentRecordResult {
+  jws: string;
+  toolArgsDigest: string;
+  toolResultDigest: string;
+  signedReceiptArtifactDigest: string;
+  settlementReceiptPayloadDigest: string;
+  upstreamArtifactDigest: string;
+  amountMinor: string;
+  currency: string;
+}
+
+/**
+ * Observe a settled x402 payment for a priced MCP tool call and issue a
+ * signed PEAC payment record (record type org.peacprotocol/payment) binding
+ * the tool name, a digest of the tool call arguments (never the raw
+ * arguments), and a digest of the returned tool result (never the raw
+ * result) to the settlement.
+ *
+ * Verifies the offer against the accepted payment terms and checks the
+ * receipt is consistent with the offer (same resource, same network,
+ * issued within the offer's validity window) before issuing; a mismatched
+ * offer or receipt throws rather than producing a record. Also refuses to
+ * issue without an observed settlement artifact: a settlement body with no
+ * offer-receipt receipt throws rather than producing a record from
+ * offer-only data.
+ */
+export async function recordPaidToolCall(
+  toolName: string,
+  toolArgs: Record<string, unknown>,
+  toolResult: ToolCallResultForDigest,
+  challengeBody: unknown,
+  settlementBody: unknown,
+  issuerPrivateKey: Uint8Array
+): Promise<ToolPaymentRecordResult> {
+  const info = extractExtensionInfo(challengeBody);
+  if (!info || info.offers.length === 0) {
+    throw new Error('no x402 payment challenge found for this tool call');
+  }
+  const offer = info.offers[0];
+
+  const offerVerification = verifyOffer(offer, ACCEPTS);
+  if (!offerVerification.valid) {
+    throw new Error(
+      `x402 offer failed term-matching verification: ${offerVerification.errors.map((e) => e.code).join(', ')}`
+    );
+  }
+  const normOffer = normalizeOfferPayload(extractOfferPayload(offer));
+
+  const settledReceipt = extractSignedReceiptFromSettlement(settlementBody);
+  if (!settledReceipt) {
+    throw new Error(
+      'refusing to record a paid tool call without an observed settlement artifact (offer-only data is not settlement evidence)'
+    );
+  }
+  const normReceipt = normalizeReceiptPayload(extractReceiptPayload(settledReceipt));
+
+  const consistency = verifyOfferReceiptConsistency(normOffer, normReceipt);
+  if (!consistency.valid) {
+    throw new Error(
+      `offer and receipt are inconsistent: ${consistency.errors.map((e) => e.code).join(', ')}`
+    );
+  }
+
+  const toolArgsDigest = await computeJsonDocumentDigestJcs(toolArgs as unknown as JsonValue);
+  const toolResultDigest = await computeJsonDocumentDigestJcs({
+    content: toolResult.content,
+    structuredContent: toolResult.structuredContent ?? null,
+  } as unknown as JsonValue);
+  // signed_receipt_artifact_digest binds the signed receipt artifact itself
+  // (the RawSignedReceipt envelope observed in the settlement), not just the
+  // normalized receipt payload; this is the upstream artifact identity for
+  // disputes and audits.
+  const signedReceiptArtifactDigest = await computeJsonDocumentDigestJcs(
+    settledReceipt as unknown as JsonValue
+  );
+  // settlement_receipt_payload_digest binds the normalized receipt payload
+  // (useful for field-level audit, but not the signed-artifact identity).
+  const settlementReceiptPayloadDigest = await computeJsonDocumentDigestJcs(
+    receiptDocument(normReceipt) as unknown as JsonValue
+  );
+
+  const commerce: Record<string, string> = {
+    payment_rail: 'x402',
+    amount_minor: normOffer.amount,
+    currency: normOffer.asset,
+    asset: normOffer.asset,
+    env: 'test',
+    event: 'settlement',
+  };
+  if (normReceipt.transaction) commerce.reference = normReceipt.transaction;
+
+  const toolExt: Record<string, string> = {
+    record_role: 'paid-tool-call',
+    tool_name: toolName,
+    tool_args_digest: toolArgsDigest,
+    tool_result_digest: toolResultDigest,
+    signed_receipt_artifact_digest: signedReceiptArtifactDigest,
+    settlement_receipt_payload_digest: settlementReceiptPayloadDigest,
+    // upstream_artifact_digest binds the signed settlement receipt artifact
+    // this tool call paid for (equal to signed_receipt_artifact_digest;
+    // mirrors org.peacprotocol/agent-action's upstream_artifact_digest field).
+    upstream_artifact_digest: signedReceiptArtifactDigest,
+    redaction_applied: 'true',
+  };
+
+  const { jws } = await issue({
+    iss: ISSUER_URL,
+    kind: 'evidence',
+    type: 'org.peacprotocol/payment',
+    pillars: ['commerce'],
+    occurred_at: new Date(normReceipt.issuedAt * 1000).toISOString(),
+    extensions: {
+      [COMMERCE_EXT]: commerce,
+      [TOOL_EXT]: toolExt,
+    },
+    privateKey: issuerPrivateKey,
+    kid: KID,
+  });
+
+  return {
+    jws,
+    toolArgsDigest,
+    toolResultDigest,
+    signedReceiptArtifactDigest,
+    settlementReceiptPayloadDigest,
+    upstreamArtifactDigest: signedReceiptArtifactDigest,
+    amountMinor: normOffer.amount,
+    currency: commerce.currency,
+  };
+}
+
+/** MCP CallToolResult-shaped response with a top-level _meta carrier. */
+interface McpToolCallResult {
+  content: Array<{ type: 'text'; text: string }>;
+  structuredContent?: Record<string, unknown>;
+  _meta?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface ToolDemoResult {
+  ok: boolean;
+  signatureValid: boolean;
+  toolArgsDigestMatches: boolean;
+  toolResultDigestMatches: boolean;
+  signedReceiptArtifactDigestMatches: boolean;
+  settlementReceiptPayloadDigestMatches: boolean;
+  upstreamArtifactDigestMatches: boolean;
+  /** true if the raw tool call arguments or the raw settlement receipt JWS leaked anywhere. */
+  rawLeak: boolean;
+  receiptInMeta: boolean;
+  metaReceiptVerifies: boolean;
+  warnings: string[];
+  tamper?: {
+    payloadTamperValid: boolean;
+    payloadTamperCode?: string;
+    /** content tamper: signature still verifies, but the re-derived tool-result digest no longer matches. */
+    toolResultDigestMatchesAfterTamper: boolean;
+  };
+}
+
+export interface RunOptions {
+  tamper?: boolean;
+  quiet?: boolean;
+}
+
+/**
+ * Run the full MCP paid-tool-call demo and return a structured result.
+ * Prints a stage report unless quiet. Importing this module runs nothing;
+ * only the guarded main() at the bottom invokes it when run directly.
+ */
+export async function runDemo(opts: RunOptions = {}): Promise<ToolDemoResult> {
+  const { tamper = false, quiet = false } = opts;
+  const log = quiet ? () => undefined : (msg = '') => console.log(msg);
+
+  const { privateKey: facilitatorPrivateKey } = await generateKeypair();
+  const { privateKey: issuerPrivateKey, publicKey: issuerPublicKey } = await generateKeypair();
+
+  log('\n=== PEAC MCP Paid Tool Records Demo ===\n');
+  // Never logs the raw tool call arguments: only the tool name and a digest.
+  const toolArgsDigestPreview = await computeJsonDocumentDigestJcs(
+    TOOL_ARGS as unknown as JsonValue
+  );
+  log(
+    `1. Priced tool call: ${TOOL_NAME} (tool_args_digest = ${toolArgsDigestPreview.slice(0, 27)}...) triggers an x402 challenge.`
+  );
+
+  const { challengeBody, settlementBody } = await buildToolPaymentFixtures(facilitatorPrivateKey);
+  log('2. Caller pays; settlement observed via the offer-receipt extension body path.');
+
+  const failed = (): ToolDemoResult => ({
+    ok: false,
+    signatureValid: false,
+    toolArgsDigestMatches: false,
+    toolResultDigestMatches: false,
+    signedReceiptArtifactDigestMatches: false,
+    settlementReceiptPayloadDigestMatches: false,
+    upstreamArtifactDigestMatches: false,
+    rawLeak: false,
+    receiptInMeta: false,
+    metaReceiptVerifies: false,
+    warnings: [],
+  });
+
+  // Build the MCP tool result the call actually returns (content +
+  // structuredContent) before issuing the record, so tool_result_digest can
+  // bind the result the record is issued for.
+  const baseResult: McpToolCallResult = {
+    content: [{ type: 'text', text: `${TOOL_NAME} completed (paid).` }],
+    structuredContent: { symbol: TOOL_ARGS.symbol, price: '198.42' },
+  };
+
+  const rec = await recordPaidToolCall(
+    TOOL_NAME,
+    TOOL_ARGS,
+    { content: baseResult.content, structuredContent: baseResult.structuredContent },
+    challengeBody,
+    settlementBody,
+    issuerPrivateKey
+  );
+  log(
+    '\n3. PEAC records a signed org.peacprotocol/payment record (tool call + result bound by digest):'
+  );
+  log(`   tool_name                         = ${TOOL_NAME}`);
+  log(`   tool_args_digest                  = ${rec.toolArgsDigest.slice(0, 27)}...`);
+  log(`   tool_result_digest                = ${rec.toolResultDigest.slice(0, 27)}...`);
+  log(`   signed_receipt_artifact_digest    = ${rec.signedReceiptArtifactDigest.slice(0, 27)}...`);
+  log(
+    `   settlement_receipt_payload_digest = ${rec.settlementReceiptPayloadDigest.slice(0, 27)}...`
+  );
+  log(`   upstream_artifact_digest          = ${rec.upstreamArtifactDigest.slice(0, 27)}...`);
+
+  // 4. Carry the record in the MCP tool result's _meta.
+  const withReceipt = attachReceiptToMeta(baseResult, {
+    receipt_ref: await computeReceiptRef(rec.jws),
+    receipt_jws: rec.jws,
+  }) as McpToolCallResult;
+  log('\n4. Record attached via top-level _meta carrier keys.');
+
+  // 5. Verify offline directly from the _meta carrier (not from rec.jws).
+  const extracted = await extractReceiptFromMetaAsync(withReceipt);
+  const metaJws = extracted?.receipts[0]?.receipt_jws;
+  const receiptInMeta = Boolean(metaJws);
+  const verifyResult = metaJws
+    ? await verifyLocal(metaJws, issuerPublicKey, { issuer: ISSUER_URL })
+    : { valid: false as const };
+  if (!verifyResult.valid) {
+    if (!metaJws) console.error('4. No receipt found in _meta.');
+    else console.error(`5. Offline verification FAILED`);
+    return failed();
+  }
+  const exts = verifyResult.claims.extensions as Record<string, Record<string, string>> | undefined;
+  const toolExt = exts?.[TOOL_EXT];
+  const warnings = verifyResult.warnings.map((w) => w.code);
+
+  // The counterparty independently re-derives the tool-args digest, the
+  // tool-result digest (from the same returned content/structuredContent),
+  // and the settlement-receipt digest from the same raw materials it
+  // separately received, and confirms they still match what is bound in
+  // the record.
+  const reToolArgsDigest = await computeJsonDocumentDigestJcs(TOOL_ARGS as unknown as JsonValue);
+  const reToolResultDigest = await computeJsonDocumentDigestJcs({
+    content: baseResult.content,
+    structuredContent: baseResult.structuredContent ?? null,
+  } as unknown as JsonValue);
+  const reSettledReceipt = extractSignedReceiptFromSettlement(settlementBody)!;
+  const reNormReceipt = normalizeReceiptPayload(extractReceiptPayload(reSettledReceipt));
+  const reSignedReceiptArtifactDigest = await computeJsonDocumentDigestJcs(
+    reSettledReceipt as unknown as JsonValue
+  );
+  const reSettlementReceiptPayloadDigest = await computeJsonDocumentDigestJcs(
+    receiptDocument(reNormReceipt) as unknown as JsonValue
+  );
+  const toolArgsDigestMatches = reToolArgsDigest === toolExt?.tool_args_digest;
+  const toolResultDigestMatches = reToolResultDigest === toolExt?.tool_result_digest;
+  const signedReceiptArtifactDigestMatches =
+    reSignedReceiptArtifactDigest === toolExt?.signed_receipt_artifact_digest;
+  const settlementReceiptPayloadDigestMatches =
+    reSettlementReceiptPayloadDigest === toolExt?.settlement_receipt_payload_digest;
+  // upstream_artifact_digest binds the signed receipt artifact (not the
+  // normalized payload); it must equal signed_receipt_artifact_digest.
+  const upstreamArtifactDigestMatches =
+    reSignedReceiptArtifactDigest === toolExt?.upstream_artifact_digest;
+
+  // Redaction invariant: raw tool args and the raw settlement receipt JWS
+  // must not appear anywhere in the signed payload or the _meta carrier.
+  const payloadStr = JSON.stringify(decodeJws(metaJws!).payload);
+  const metaStr = JSON.stringify(withReceipt._meta);
+  const rawLeak =
+    payloadStr.includes(JSON.stringify(TOOL_ARGS)) ||
+    metaStr.includes(JSON.stringify(TOOL_ARGS)) ||
+    payloadStr.includes(reSettledReceipt.signature) ||
+    metaStr.includes(reSettledReceipt.signature);
+
+  log('\n5. Counterparty verification (offline, from the _meta carrier, public key only):');
+  log(`   signature valid = ${verifyResult.valid}`);
+  log(`   tool_name = ${TOOL_NAME}, amount = ${rec.amountMinor} ${rec.currency}`);
+  log(`   tool args digest re-binds                 = ${toolArgsDigestMatches}`);
+  log(`   tool result digest re-binds               = ${toolResultDigestMatches}`);
+  log(`   signed receipt artifact digest re-binds   = ${signedReceiptArtifactDigestMatches}`);
+  log(`   settlement receipt payload digest re-binds= ${settlementReceiptPayloadDigestMatches}`);
+  log(`   upstream artifact digest = signed receipt = ${upstreamArtifactDigestMatches}`);
+  log(`   raw tool args / raw settlement receipt present = ${rawLeak} (expected false)`);
+  if (warnings.length > 0) log(`   informational warnings: ${warnings.join(', ')}`);
+
+  const result: ToolDemoResult = {
+    ok: true,
+    signatureValid: verifyResult.valid === true,
+    toolArgsDigestMatches,
+    toolResultDigestMatches,
+    signedReceiptArtifactDigestMatches,
+    settlementReceiptPayloadDigestMatches,
+    upstreamArtifactDigestMatches,
+    rawLeak,
+    receiptInMeta,
+    metaReceiptVerifies: verifyResult.valid === true,
+    warnings,
+  };
+
+  if (tamper) {
+    // Content tamper: alter the returned tool result AFTER signing -> the
+    // re-derived tool-result digest no longer matches the digest bound in
+    // the record (the _meta-carried signature still verifies on the
+    // original result).
+    const tamperedResult = {
+      content: baseResult.content,
+      structuredContent: { ...baseResult.structuredContent, price: '999.99' },
+    };
+    const tamperedResultDigest = await computeJsonDocumentDigestJcs(
+      tamperedResult as unknown as JsonValue
+    );
+    const toolResultDigestMatchesAfterTamper = tamperedResultDigest === toolExt?.tool_result_digest;
+
+    // Payload tamper: modify the _meta-carried record payload, keep the signature -> invalid signature.
+    const tamperedJws = tamperPayload(metaJws!);
+    const tamperedVerify = await verifyLocal(tamperedJws, issuerPublicKey, { issuer: ISSUER_URL });
+    log('\n6. Tamper checks:');
+    log(
+      `   content tamper: tool result digest still matches = ${toolResultDigestMatchesAfterTamper} (expected false)`
+    );
+    log(`   payload tamper: signature valid = ${tamperedVerify.valid} (expected false)`);
+    if (!tamperedVerify.valid) log(`   payload tamper: code = ${tamperedVerify.code}`);
+    result.tamper = {
+      payloadTamperValid: tamperedVerify.valid === true,
+      payloadTamperCode: tamperedVerify.valid ? undefined : tamperedVerify.code,
+      toolResultDigestMatchesAfterTamper,
+    };
+  }
+
+  result.ok =
+    result.signatureValid &&
+    result.receiptInMeta &&
+    result.metaReceiptVerifies &&
+    result.toolArgsDigestMatches &&
+    result.toolResultDigestMatches &&
+    result.signedReceiptArtifactDigestMatches &&
+    result.settlementReceiptPayloadDigestMatches &&
+    result.upstreamArtifactDigestMatches &&
+    !result.rawLeak &&
+    (!tamper ||
+      (!result.tamper!.payloadTamperValid &&
+        result.tamper!.payloadTamperCode === 'E_INVALID_SIGNATURE' &&
+        !result.tamper!.toolResultDigestMatchesAfterTamper));
+
+  if (result.ok) log('\n=== Demo Complete ===\n');
+  return result;
+}
+
+async function main(): Promise<void> {
+  const result = await runDemo({ tamper: process.argv.includes('--tamper') });
+  if (!result.ok) process.exitCode = 1;
+}
+
+// Run only when executed directly (pnpm demo), not when imported by a test.
+const invokedDirectly = process.argv[1] !== undefined && /demo\.ts$/.test(process.argv[1]);
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error('Demo failed:', err);
+    process.exitCode = 1;
+  });
+}

--- a/examples/mcp-paid-tool-records/package.json
+++ b/examples/mcp-paid-tool-records/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@peac/example-mcp-paid-tool-records",
+  "version": "0.0.0",
+  "private": true,
+  "description": "PEAC example: bind a priced MCP tool call to a settled x402 payment as a portable signed payment record (org.peacprotocol/payment), carried in the tool result's _meta and verified offline",
+  "type": "module",
+  "scripts": {
+    "demo": "tsx demo.ts",
+    "demo:tamper": "tsx demo.ts --tamper",
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@peac/adapter-x402": "workspace:*",
+    "@peac/crypto": "workspace:*",
+    "@peac/kernel": "workspace:*",
+    "@peac/mappings-mcp": "workspace:*",
+    "@peac/protocol": "workspace:*",
+    "@peac/schema": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/examples/mcp-paid-tool-records/tsconfig.json
+++ b/examples/mcp-paid-tool-records/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true
+  },
+  "include": ["*.ts"]
+}

--- a/examples/x402-paid-resource-records/README.md
+++ b/examples/x402-paid-resource-records/README.md
@@ -1,0 +1,61 @@
+# x402 Paid Resource Records
+
+**Outcome:** a portable, offline-verifiable `org.peacprotocol/payment` record for a settled x402 offer/receipt pair, works behind any gateway or CDN that fronts x402.
+
+**Audience:** teams charging for access to an API or MCP tool behind x402 who need evidence of what settled that survives independently of their own logs.
+
+**Time:** 5 minutes.
+
+A resource server behind x402 challenges payment for a resource with a signed offer and, once payment settles, returns a signed receipt (the "Signed Offers and Receipts" extension, upstream `x402-foundation/x402` commit `f2bbb5c`, `extensions["offer-receipt"]`). `@peac/adapter-x402` verifies the offer against accept terms and checks offer/receipt consistency, but does not itself produce a portable, independently verifiable record of what settled.
+
+This example composes that record: PEAC observes the settled offer/receipt pair and issues a signed `org.peacprotocol/payment` record that a customer, auditor, counterparty, or dispute system can verify offline, with only the issuer public key.
+
+PEAC records and verifies. It does not settle, price, or gate access, and it does not verify x402 scheme-specific invariants (single-use, time bounds, recipient/facilitator binding, on-chain finality); see [`docs/compatibility/x402-scheme-coverage.md`](../../docs/compatibility/x402-scheme-coverage.md) for that boundary.
+
+## Where this fits (no duplication)
+
+- [`x402-weather-proof`](../x402-weather-proof/) - the offer/receipt verification walkthrough (term-matching, consistency, unsigned evidence mapping via `toPeacRecord`).
+- [`x402-upto-evidence`](../x402-upto-evidence/) - settlement-proof extraction from response headers, mapped to unsigned commerce evidence.
+- **`x402-paid-resource-records` (this example)** - the signed-record composition example: **sign** an `org.peacprotocol/payment` record from a settled offer/receipt pair, **verify it offline**, and detect both a signature tamper and a settlement-receipt digest mismatch.
+
+It reuses `@peac/adapter-x402`'s existing verification and mapping functions (`extractExtensionInfo`, `verifyOffer`, `verifyOfferReceiptConsistency`, `extractSettlementProofFromHeaders`, `extractSignedReceiptFromSettlement`, `toPeacRecord`) rather than re-implementing offer/receipt handling.
+
+## What it shows
+
+1. A resource server returns a 402 challenge carrying a signed x402 offer (`extensions["offer-receipt"].info.offers`).
+2. The client pays; the settlement is observed via **both** channels a real deployment might expose: the `PAYMENT-RESPONSE` response header (`extractSettlementProofFromHeaders`) and the offer-receipt extension body (`extractSignedReceiptFromSettlement`, the settlement-extensions body path). The demo checks the two channels report the same artifact (dual-channel consistency); if they disagree, the record is never issued (fail closed).
+3. `verifyOffer` and `verifyOfferReceiptConsistency` confirm the offer matches the accepted terms and the receipt is consistent with the offer (same resource, same network, issued within the offer's validity window).
+4. PEAC issues a signed `org.peacprotocol/payment` record:
+   - the registered `org.peacprotocol/commerce` extension carries `payment_rail = x402`, `amount_minor`, `currency`, `asset`, `reference` (the on-chain transaction reference), `env`, `event = settlement`;
+   - an example-local `com.example/paid_resource` extension carries `network` and `scheme` (x402 concepts with no home in `org.peacprotocol/commerce`, which is `.strict()` and has no `network` field) plus five digests: `offer_terms_digest` (an RFC 8785 JCS digest of the normalized offer terms), `signed_offer_artifact_digest` and `signed_receipt_artifact_digest` (digests of the signed offer/receipt artifacts themselves, via `computeJsonDocumentDigestJcs`), `settlement_header_digest` (a digest over the header-observed proof's `source` and `raw_value`, never the raw header value itself), and `settlement_receipt_payload_digest` (a digest of the normalized settlement receipt payload), plus `upstream_artifact_digest` (equal to `signed_receipt_artifact_digest`, binding the settlement receipt artifact this record was derived from, mirroring the naming already used by `org.peacprotocol/agent-action`'s `upstream_artifact_digest` field).
+5. The record is verified offline with only the issuer public key. The counterparty independently re-derives the offer terms, the signed offer/receipt artifacts, the header-observed proof, and the settlement receipt payload from the same raw materials it separately received, and confirms every digest still matches what is bound in the record; it does not just trust the issuer's arithmetic.
+6. Two independent tamper checks: altering the settlement receipt content after digesting breaks the digest re-bind (signature still verifies); tampering with the signed record payload breaks the signature (`E_INVALID_SIGNATURE`).
+
+## Redaction and binding
+
+The raw signed offer/receipt JWS artifacts and the raw `PAYMENT-RESPONSE` header value are upstream x402 material. The record binds them by digest; it never inlines the raw artifacts, the raw header value, or the unsigned `toPeacRecord()` evidence mapping (which does preserve the raw artifacts, for local audit use) into the signed payload.
+
+## Non-goals
+
+- Not a payment rail: PEAC does not move funds or decide pricing.
+- Not a gate: PEAC does not decide whether to grant access to the resource.
+- Not a scheme verifier: single-use, time-bound, and recipient/facilitator-binding invariants remain the facilitator's and the upstream x402 scheme's responsibility.
+
+## Run
+
+```bash
+pnpm install
+pnpm --filter @peac/example-x402-paid-resource-records demo           # full flow
+pnpm --filter @peac/example-x402-paid-resource-records demo:tamper    # tamper checks
+```
+
+No network, no external services. This demo generates two ephemeral local keypairs: one simulating the x402 facilitator's signing key (for the offer/receipt JWS artifacts) and one for the PEAC record issuer. Production issuers should use stable issuer-controlled signing keys.
+
+## Reused building blocks (no new protocol surface)
+
+This example adds no new receipt type, extension group, schema field, wire version, signing envelope, or package API. It composes existing packages:
+
+- `@peac/adapter-x402` - `extractExtensionInfo`, `verifyOffer`, `verifyOfferReceiptConsistency`, `extractSettlementProofFromHeaders`, `extractSignedReceiptFromSettlement`, `toPeacRecord`, `normalizeOfferPayload`, `normalizeReceiptPayload`, `extractOfferPayload`, `extractReceiptPayload`, `OFFER_RECEIPT`, `MAX_SETTLEMENT_EXTENSIONS_BYTES`
+- `@peac/protocol` - `issue`, `verifyLocal`, `computeJsonDocumentDigestJcs`
+- `@peac/crypto` - `generateKeypair`, `sign`
+- `@peac/schema` - `computeReceiptRef`

--- a/examples/x402-paid-resource-records/demo.ts
+++ b/examples/x402-paid-resource-records/demo.ts
@@ -1,0 +1,661 @@
+/**
+ * x402 Paid Resource Records Example (signed-record composition example)
+ *
+ * A resource server behind x402 challenges payment for a resource with a
+ * signed offer, and returns a signed receipt once payment settles (the
+ * "Signed Offers and Receipts" extension, upstream x402-foundation/x402
+ * commit f2bbb5c, `extensions["offer-receipt"]`). @peac/adapter-x402
+ * verifies the offer against accept terms and checks offer/receipt
+ * consistency, but does not itself produce a portable, independently
+ * verifiable record of what settled. This example composes that record:
+ * PEAC observes the settled offer/receipt pair and issues a signed
+ * org.peacprotocol/payment record that a customer, auditor, counterparty,
+ * or dispute system can verify offline with only the issuer public key,
+ * works behind any gateway or CDN that fronts x402.
+ *
+ * Boundaries (PEAC does not become a payment rail):
+ * - PEAC records and verifies; it does not settle, price, or gate access.
+ * - PEAC does not verify x402 scheme-specific invariants (single-use,
+ *   time bounds, recipient/facilitator binding, on-chain finality); see
+ *   docs/compatibility/x402-scheme-coverage.md for that boundary.
+ * - The raw signed offer/receipt JWS artifacts and the raw settlement
+ *   header value are sensitive upstream material. The record binds them
+ *   by sha256 digest; it never inlines the raw artifacts or the raw
+ *   header value into the signed payload.
+ * - The settlement is observed via two independent channels (a response
+ *   header and the offer-receipt body). If the two channels disagree on
+ *   what settled, the record is never issued (fail closed).
+ *
+ * Record type / extensions used here:
+ * - Registered record type org.peacprotocol/payment.
+ * - Registered extension group org.peacprotocol/commerce carries
+ *   payment_rail = x402, amount_minor, currency, asset, env, event.
+ * - com.example/paid_resource is a well-formed but unregistered
+ *   example-local extension group carrying observational overflow
+ *   (record_role, resource, network, scheme, offer_terms_digest,
+ *   signed_offer_artifact_digest, signed_receipt_artifact_digest,
+ *   settlement_header_digest, settlement_receipt_payload_digest,
+ *   upstream_artifact_digest, settlement_extensions_digest,
+ *   redaction_applied). Verification preserves it and surfaces an
+ *   informational unknown_extension_preserved warning.
+ *
+ * `network` is intentionally NOT part of org.peacprotocol/commerce:
+ * CommerceExtensionSchema is `.strict()` and has no `network` field, so
+ * network lives in the example-local extension instead (issuing a record
+ * that put it in commerce would fail schema validation; see the
+ * "strict-extension rejection" test in the smoke test).
+ *
+ * No network, no external services. This demo generates two ephemeral
+ * local keypairs: one simulating the x402 facilitator's signing key (for
+ * the offer/receipt JWS artifacts) and one for the PEAC record issuer.
+ * Production issuers should use stable issuer-controlled signing keys.
+ *
+ * Run:
+ *   pnpm demo               full flow (record, verify offline, dual-channel observation)
+ *   pnpm demo:tamper        tamper checks (signature tamper + content digest mismatch)
+ */
+
+import { issue, verifyLocal, computeJsonDocumentDigestJcs } from '@peac/protocol';
+import { generateKeypair, sign as signJws } from '@peac/crypto';
+import { computeReceiptRef } from '@peac/schema';
+import type { JsonValue } from '@peac/kernel';
+import {
+  OFFER_RECEIPT,
+  extractExtensionInfo,
+  extractOfferPayload,
+  extractReceiptPayload,
+  normalizeOfferPayload,
+  normalizeReceiptPayload,
+  verifyOffer,
+  verifyOfferReceiptConsistency,
+  extractSettlementProofFromHeaders,
+  extractSignedReceiptFromSettlement,
+  toPeacRecord,
+  MAX_SETTLEMENT_EXTENSIONS_BYTES,
+  type AcceptEntry,
+  type RawOfferPayload,
+  type RawReceiptPayload,
+  type RawSignedOffer,
+  type RawSignedReceipt,
+  type NormalizedOfferPayload,
+  type NormalizedReceiptPayload,
+  type X402OfferReceiptChallenge,
+  type X402SettlementResponse,
+  type HeaderBag,
+} from '@peac/adapter-x402';
+
+// Configuration (issuer = the service that observed the settlement and records it)
+const ISSUER_URL = 'https://api.example.com';
+const KID = 'record-key-2026';
+const FACILITATOR_KID = 'x402-facilitator-key-2026';
+const COMMERCE_EXT = 'org.peacprotocol/commerce';
+const X402_EXT = 'com.example/paid_resource';
+
+const RESOURCE_URL = 'https://api.example.com/v1/market-data/quote';
+const NETWORK = 'eip155:8453'; // Base mainnet (CAIP-2), matches upstream x402 examples
+const ASSET = 'USDC';
+const PAY_TO = '0x742d35Cc6634C0532925a3b844Bc9e7595f1e123';
+const PAYER = '0xabc1234567890abcdef1234567890abcdef123456';
+const TRANSACTION = '0xdeadbeef1234567890abcdef1234567890abcdef1234567890abcdef12345678';
+const AMOUNT = '250000'; // $0.25 in USDC minor units (6 decimals)
+const SCHEME = 'exact';
+
+const ACCEPTS: AcceptEntry[] = [
+  { network: NETWORK, asset: ASSET, payTo: PAY_TO, amount: AMOUNT, scheme: SCHEME },
+];
+
+/**
+ * Canonical, deterministic digest document for the offer terms: an explicit
+ * plain-JSON shape (optional fields normalized to null) so the digest is
+ * stable and cross-language-safe, mirroring challengeBindingForDigest in
+ * examples/mpp-payment-record.
+ */
+function offerTermsDocument(offer: NormalizedOfferPayload): Record<string, string | number | null> {
+  return {
+    version: offer.version,
+    resourceUrl: offer.resourceUrl,
+    scheme: offer.scheme,
+    network: offer.network,
+    asset: offer.asset,
+    payTo: offer.payTo,
+    amount: offer.amount,
+    validUntil: offer.validUntil ?? null,
+  };
+}
+
+/** Canonical, deterministic digest document for the settlement receipt. */
+function receiptDocument(
+  receipt: NormalizedReceiptPayload
+): Record<string, string | number | null> {
+  return {
+    version: receipt.version,
+    network: receipt.network,
+    resourceUrl: receipt.resourceUrl,
+    payer: receipt.payer,
+    issuedAt: receipt.issuedAt,
+    transaction: receipt.transaction ?? null,
+  };
+}
+
+/** Decode a compact JWS without verifying (display / leak-check helper). */
+function decodeJws(jws: string): { header: unknown; payload: unknown } {
+  const [header, payload] = jws.split('.');
+  return {
+    header: JSON.parse(Buffer.from(header, 'base64url').toString('utf8')),
+    payload: JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')),
+  };
+}
+
+/** Modify one payload claim while keeping the original signature (tamper helper). */
+function tamperPayload(jws: string): string {
+  const [header, payload, signature] = jws.split('.');
+  const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as Record<
+    string,
+    unknown
+  >;
+  decoded.iss = 'https://attacker.example.com';
+  const reEncoded = Buffer.from(JSON.stringify(decoded), 'utf8').toString('base64url');
+  return `${header}.${reEncoded}.${signature}`;
+}
+
+export interface X402Fixtures {
+  /** Raw upstream 402 challenge body (extensions["offer-receipt"].info.offers). */
+  challengeBody: unknown;
+  /** Raw upstream settlement response body (extensions["offer-receipt"].info.receipt). */
+  settlementBody: unknown;
+  /** Response headers carrying the same settlement proof independently. */
+  settlementHeaders: HeaderBag;
+}
+
+/**
+ * Build a signed x402 offer and a signed x402 receipt (ephemeral Ed25519 JWS
+ * artifacts, simulating the facilitator's signing key) and wrap them into
+ * the upstream wire shapes: a 402 challenge body and a settlement response
+ * body (both offer-receipt extension), plus a settlement response header
+ * carrying the same receipt artifact independently.
+ */
+export async function buildX402Fixtures(facilitatorPrivateKey: Uint8Array): Promise<X402Fixtures> {
+  const now = Math.floor(Date.now() / 1000);
+
+  const offerPayload: RawOfferPayload = {
+    version: 1,
+    resourceUrl: RESOURCE_URL,
+    scheme: SCHEME,
+    network: NETWORK,
+    asset: ASSET,
+    payTo: PAY_TO,
+    amount: AMOUNT,
+    validUntil: now + 3600,
+  };
+  const offerJws = await signJws(offerPayload, facilitatorPrivateKey, FACILITATOR_KID);
+  const signedOffer: RawSignedOffer = { format: 'jws', signature: offerJws, acceptIndex: 0 };
+
+  const receiptPayload: RawReceiptPayload = {
+    version: 1,
+    network: NETWORK,
+    resourceUrl: RESOURCE_URL,
+    payer: PAYER,
+    issuedAt: now,
+    transaction: TRANSACTION,
+  };
+  const receiptJws = await signJws(receiptPayload, facilitatorPrivateKey, FACILITATOR_KID);
+  const signedReceipt: RawSignedReceipt = { format: 'jws', signature: receiptJws };
+
+  const challengeBody = {
+    accepts: ACCEPTS,
+    resourceUrl: RESOURCE_URL,
+    extensions: { [OFFER_RECEIPT]: { info: { offers: [signedOffer] } } },
+  };
+
+  const settlementBody = {
+    success: true,
+    resourceUrl: RESOURCE_URL,
+    extensions: { [OFFER_RECEIPT]: { info: { receipt: signedReceipt } } },
+  };
+
+  // The same settlement receipt artifact, observed independently via a
+  // response header (dual-channel: header path and offer-receipt body path).
+  const settlementHeaders: HeaderBag = { 'PAYMENT-RESPONSE': receiptJws };
+
+  return { challengeBody, settlementBody, settlementHeaders };
+}
+
+export interface X402RecordResult {
+  jws: string;
+  receiptRef: string;
+  network: string;
+  asset: string;
+  amountMinor: string;
+  currency: string;
+  offerTermsDigest: string;
+  /** Digest over the signed offer artifact itself (the RawSignedOffer envelope), not just its normalized terms. */
+  signedOfferArtifactDigest: string;
+  /** Digest over the signed receipt artifact extracted from the settlement body (the RawSignedReceipt envelope). */
+  signedReceiptArtifactDigest: string;
+  /** Digest over a minimal { source, raw_value } document for the header-observed settlement proof. */
+  settlementHeaderDigest: string;
+  /** Digest over the normalized settlement receipt payload (not the signed artifact itself). */
+  settlementReceiptPayloadDigest: string;
+  upstreamArtifactDigest: string;
+  settlementExtensionsDigest?: string;
+  dualChannelConsistent: boolean;
+}
+
+/**
+ * Observe a settled x402 offer/receipt pair (via BOTH the settlement
+ * response header and the offer-receipt extension body) and issue a signed
+ * PEAC payment record (record type org.peacprotocol/payment).
+ *
+ * Refuses to issue without an observed settlement artifact: a challenge
+ * with no offer, or a settlement body/headers with no receipt, throws
+ * rather than producing a record from offer-only data.
+ */
+export async function recordX402Settlement(
+  challengeBody: unknown,
+  settlementHeaders: HeaderBag,
+  settlementBody: unknown,
+  issuerPrivateKey: Uint8Array
+): Promise<X402RecordResult> {
+  const info = extractExtensionInfo(challengeBody);
+  if (!info || info.offers.length === 0) {
+    throw new Error('no x402 offer found in the 402 challenge body');
+  }
+  const offer = info.offers[0];
+
+  const offerVerification = verifyOffer(offer, ACCEPTS);
+  if (!offerVerification.valid) {
+    throw new Error(
+      `x402 offer failed term-matching verification: ${offerVerification.errors.map((e) => e.code).join(', ')}`
+    );
+  }
+
+  // Body path (the offer-receipt extension embedded in the settlement
+  // response body). This is the primary source of the settled receipt.
+  const bodyReceipt = extractSignedReceiptFromSettlement(settlementBody);
+  if (!bodyReceipt) {
+    throw new Error(
+      'refusing to record a paid-resource event without an observed settlement artifact (offer-only data is not settlement evidence)'
+    );
+  }
+
+  // Header path: the same settlement proof, observed independently via
+  // response headers (dual-header precedence: PEAC-Receipt > PAYMENT-RESPONSE > X-PAYMENT-RESPONSE).
+  const headerProofs = extractSettlementProofFromHeaders(settlementHeaders);
+  const headerProof = headerProofs[0];
+  if (!headerProof) {
+    throw new Error(
+      'refusing to record a paid-resource event without a header-observed settlement proof'
+    );
+  }
+  // Dual-channel consistency: the header-observed raw artifact and the
+  // body-extracted receipt's own signature segment must agree. If a gateway
+  // reported different settlement artifacts on the two channels, that is a
+  // sign of a compromised or misconfigured intermediary: PEAC refuses to
+  // issue a record rather than picking one channel and hiding the mismatch.
+  if (headerProof.raw_value !== bodyReceipt.signature) {
+    throw new Error('settlement header and body receipt differ');
+  }
+  const dualChannelConsistent = true;
+
+  const normOffer = normalizeOfferPayload(extractOfferPayload(offer));
+  const normReceipt = normalizeReceiptPayload(extractReceiptPayload(bodyReceipt));
+
+  const consistency = verifyOfferReceiptConsistency(normOffer, normReceipt);
+  if (!consistency.valid) {
+    throw new Error(
+      `offer and receipt are inconsistent: ${consistency.errors.map((e) => e.code).join(', ')}`
+    );
+  }
+
+  const paymentRequired: X402OfferReceiptChallenge = {
+    accepts: ACCEPTS,
+    offers: [offer],
+    resourceUrl: RESOURCE_URL,
+  };
+  const settlementBodyObj = settlementBody as { extensions?: Record<string, unknown> };
+  const settlementResponse: X402SettlementResponse = {
+    receipt: bodyReceipt,
+    resourceUrl: RESOURCE_URL,
+    extensions: settlementBodyObj.extensions,
+  };
+  // Local, unsigned evidence mapping (proof preservation discipline): raw
+  // offer/receipt live here only, never in the signed record below. Digest
+  // preserved by default (preserveRawSettlementExtensions: false).
+  const mapped = toPeacRecord(paymentRequired, settlementResponse, {
+    offerVerification,
+    consistencyVerification: consistency,
+  });
+
+  const offerTermsDigest = await computeJsonDocumentDigestJcs(
+    offerTermsDocument(normOffer) as unknown as JsonValue
+  );
+  // signed_offer_artifact_digest binds the signed offer artifact itself
+  // (the RawSignedOffer envelope, e.g. { format: 'jws', signature,
+  // acceptIndex }), not just its normalized terms.
+  const signedOfferArtifactDigest = await computeJsonDocumentDigestJcs(
+    offer as unknown as JsonValue
+  );
+  // signed_receipt_artifact_digest binds the signed receipt artifact
+  // extracted from the settlement body (the RawSignedReceipt envelope).
+  const signedReceiptArtifactDigest = await computeJsonDocumentDigestJcs(
+    bodyReceipt as unknown as JsonValue
+  );
+  // settlement_header_digest binds a minimal digest document over the
+  // header-observed proof (source + raw value); the raw header value
+  // itself is never inlined into the signed record.
+  const settlementHeaderDigest = await computeJsonDocumentDigestJcs({
+    source: headerProof.source,
+    raw_value: headerProof.raw_value,
+  } as unknown as JsonValue);
+  const settlementReceiptPayloadDigest = await computeJsonDocumentDigestJcs(
+    receiptDocument(normReceipt) as unknown as JsonValue
+  );
+  // upstream_artifact_digest binds the settlement receipt artifact this
+  // record was derived from: the generic "artifact this record was derived
+  // from" name (mirroring the naming convention already used by
+  // org.peacprotocol/agent-action's upstream_artifact_digest field), equal
+  // to the signed receipt artifact digest (not the normalized payload digest).
+  const upstreamArtifactDigest = signedReceiptArtifactDigest;
+
+  const commerce: Record<string, string> = {
+    payment_rail: 'x402',
+    amount_minor: normOffer.amount,
+    currency: normOffer.asset,
+    asset: normOffer.asset,
+    env: 'test',
+    event: 'settlement',
+  };
+  if (normReceipt.transaction) commerce.reference = normReceipt.transaction;
+
+  const x402Ext: Record<string, string> = {
+    record_role: 'paid-resource-record',
+    resource: normOffer.resourceUrl,
+    network: normOffer.network,
+    scheme: normOffer.scheme,
+    offer_terms_digest: offerTermsDigest,
+    signed_offer_artifact_digest: signedOfferArtifactDigest,
+    signed_receipt_artifact_digest: signedReceiptArtifactDigest,
+    settlement_header_digest: settlementHeaderDigest,
+    settlement_receipt_payload_digest: settlementReceiptPayloadDigest,
+    upstream_artifact_digest: upstreamArtifactDigest,
+    redaction_applied: 'true',
+  };
+  if (mapped.proofs.x402.settlementExtensionsDigest) {
+    x402Ext.settlement_extensions_digest = mapped.proofs.x402.settlementExtensionsDigest;
+  }
+
+  const { jws } = await issue({
+    iss: ISSUER_URL,
+    kind: 'evidence',
+    type: 'org.peacprotocol/payment',
+    pillars: ['commerce'],
+    occurred_at: new Date(normReceipt.issuedAt * 1000).toISOString(),
+    extensions: {
+      [COMMERCE_EXT]: commerce,
+      [X402_EXT]: x402Ext,
+    },
+    privateKey: issuerPrivateKey,
+    kid: KID,
+  });
+
+  return {
+    jws,
+    receiptRef: await computeReceiptRef(jws),
+    network: normOffer.network,
+    asset: normOffer.asset,
+    amountMinor: normOffer.amount,
+    currency: commerce.currency,
+    offerTermsDigest,
+    signedOfferArtifactDigest,
+    signedReceiptArtifactDigest,
+    settlementHeaderDigest,
+    settlementReceiptPayloadDigest,
+    upstreamArtifactDigest,
+    settlementExtensionsDigest: mapped.proofs.x402.settlementExtensionsDigest,
+    dualChannelConsistent,
+  };
+}
+
+export interface X402DemoResult {
+  ok: boolean;
+  receiptRef: string;
+  signatureValid: boolean;
+  network?: string;
+  asset?: string;
+  amountMinor?: string;
+  currency?: string;
+  dualChannelConsistent: boolean;
+  offerTermsDigestMatches: boolean;
+  signedOfferArtifactDigestMatches: boolean;
+  signedReceiptArtifactDigestMatches: boolean;
+  settlementHeaderDigestMatches: boolean;
+  settlementReceiptPayloadDigestMatches: boolean;
+  upstreamArtifactDigestMatches: boolean;
+  /** True if any raw offer/receipt JWS or raw settlement header value leaked into the signed payload. */
+  rawArtifactLeak: boolean;
+  warnings: string[];
+  tamper?: {
+    payloadTamperValid: boolean;
+    payloadTamperCode?: string;
+    /** content tamper: signature still verifies, but the re-derived digest no longer matches. */
+    settlementReceiptPayloadDigestMatchesAfterTamper: boolean;
+  };
+}
+
+export interface RunOptions {
+  tamper?: boolean;
+  quiet?: boolean;
+}
+
+/**
+ * Run the full x402 paid-resource demo and return a structured result.
+ * Prints a stage report unless quiet. Importing this module runs nothing;
+ * only the guarded main() at the bottom invokes it when run directly.
+ */
+export async function runDemo(opts: RunOptions = {}): Promise<X402DemoResult> {
+  const { tamper = false, quiet = false } = opts;
+  const log = quiet ? () => undefined : (msg = '') => console.log(msg);
+
+  const { privateKey: facilitatorPrivateKey } = await generateKeypair();
+  const { privateKey: issuerPrivateKey, publicKey: issuerPublicKey } = await generateKeypair();
+
+  log('\n=== PEAC x402 Paid Resource Records Demo ===\n');
+
+  const { challengeBody, settlementBody, settlementHeaders } =
+    await buildX402Fixtures(facilitatorPrivateKey);
+  log(
+    '1. Resource server returns a 402 challenge with a signed x402 offer (offer-receipt extension).'
+  );
+  log(
+    `2. Client pays; settlement observed via BOTH the response header AND the offer-receipt body ` +
+      `(extensions bag bounded at ${MAX_SETTLEMENT_EXTENSIONS_BYTES} bytes).`
+  );
+
+  const failed = (partial: Partial<X402DemoResult> = {}): X402DemoResult => ({
+    ok: false,
+    receiptRef: '',
+    signatureValid: false,
+    dualChannelConsistent: false,
+    offerTermsDigestMatches: false,
+    signedOfferArtifactDigestMatches: false,
+    signedReceiptArtifactDigestMatches: false,
+    settlementHeaderDigestMatches: false,
+    settlementReceiptPayloadDigestMatches: false,
+    upstreamArtifactDigestMatches: false,
+    rawArtifactLeak: false,
+    warnings: [],
+    ...partial,
+  });
+
+  const rec = await recordX402Settlement(
+    challengeBody,
+    settlementHeaders,
+    settlementBody,
+    issuerPrivateKey
+  );
+  log(
+    '\n3. PEAC records a signed org.peacprotocol/payment record (raw offer/receipt bound by digest):'
+  );
+  log(`   receipt_ref                        = ${rec.receiptRef.slice(0, 27)}...`);
+  log(`   offer_terms_digest                 = ${rec.offerTermsDigest.slice(0, 27)}...`);
+  log(`   signed_offer_artifact_digest       = ${rec.signedOfferArtifactDigest.slice(0, 27)}...`);
+  log(`   signed_receipt_artifact_digest     = ${rec.signedReceiptArtifactDigest.slice(0, 27)}...`);
+  log(`   settlement_header_digest          = ${rec.settlementHeaderDigest.slice(0, 27)}...`);
+  log(
+    `   settlement_receipt_payload_digest  = ${rec.settlementReceiptPayloadDigest.slice(0, 27)}...`
+  );
+  log(`   upstream_artifact_digest           = ${rec.upstreamArtifactDigest.slice(0, 27)}...`);
+  log(`   dual-channel consistent            = ${rec.dualChannelConsistent}`);
+
+  // 4. Counterparty verifies offline with only the issuer public key.
+  const verifyResult = await verifyLocal(rec.jws, issuerPublicKey, { issuer: ISSUER_URL });
+  if (!verifyResult.valid) {
+    console.error(`4. Offline verification FAILED: ${verifyResult.code} ${verifyResult.message}`);
+    return failed({ receiptRef: rec.receiptRef });
+  }
+  const exts = verifyResult.claims.extensions as Record<string, Record<string, string>> | undefined;
+  const x402Ext = exts?.[X402_EXT];
+  const warnings = verifyResult.warnings.map((w) => w.code);
+
+  // The counterparty separately re-derives the offer/receipt from the same
+  // raw materials it independently received, and re-checks the digests
+  // bound in the record (it does not just trust the issuer's arithmetic).
+  const reInfo = extractExtensionInfo(challengeBody);
+  const reRawOffer = reInfo!.offers[0];
+  const reOffer = normalizeOfferPayload(extractOfferPayload(reRawOffer));
+  const reBodyReceipt = extractSignedReceiptFromSettlement(settlementBody)!;
+  const reReceipt = normalizeReceiptPayload(extractReceiptPayload(reBodyReceipt));
+  const reHeaderProof = extractSettlementProofFromHeaders(settlementHeaders)[0];
+  const reOfferTermsDigest = await computeJsonDocumentDigestJcs(
+    offerTermsDocument(reOffer) as unknown as JsonValue
+  );
+  const reSignedOfferArtifactDigest = await computeJsonDocumentDigestJcs(
+    reRawOffer as unknown as JsonValue
+  );
+  const reSignedReceiptArtifactDigest = await computeJsonDocumentDigestJcs(
+    reBodyReceipt as unknown as JsonValue
+  );
+  const reSettlementHeaderDigest = await computeJsonDocumentDigestJcs({
+    source: reHeaderProof.source,
+    raw_value: reHeaderProof.raw_value,
+  } as unknown as JsonValue);
+  const reSettlementReceiptPayloadDigest = await computeJsonDocumentDigestJcs(
+    receiptDocument(reReceipt) as unknown as JsonValue
+  );
+  const offerTermsDigestMatches = reOfferTermsDigest === x402Ext?.offer_terms_digest;
+  const signedOfferArtifactDigestMatches =
+    reSignedOfferArtifactDigest === x402Ext?.signed_offer_artifact_digest;
+  const signedReceiptArtifactDigestMatches =
+    reSignedReceiptArtifactDigest === x402Ext?.signed_receipt_artifact_digest;
+  const settlementHeaderDigestMatches =
+    reSettlementHeaderDigest === x402Ext?.settlement_header_digest;
+  const settlementReceiptPayloadDigestMatches =
+    reSettlementReceiptPayloadDigest === x402Ext?.settlement_receipt_payload_digest;
+  const upstreamArtifactDigestMatches =
+    reSignedReceiptArtifactDigest === x402Ext?.upstream_artifact_digest;
+
+  // Redaction invariant: the raw offer/receipt JWS artifacts and the raw
+  // settlement header value must not be in the signed payload.
+  const payloadStr = JSON.stringify(decodeJws(rec.jws).payload);
+  const rawArtifactLeak =
+    payloadStr.includes(reInfo!.offers[0].signature) ||
+    payloadStr.includes(reBodyReceipt.signature) ||
+    payloadStr.includes(String((settlementHeaders as Record<string, string>)['PAYMENT-RESPONSE']));
+
+  log('\n4. Counterparty verification (offline, public key only):');
+  log(`   signature valid = ${verifyResult.valid}`);
+  log(
+    `   payment_rail = x402, amount = ${rec.amountMinor} ${rec.currency}, network = ${rec.network}`
+  );
+  log(`   offer terms digest re-binds                 = ${offerTermsDigestMatches}`);
+  log(`   signed offer artifact digest re-binds       = ${signedOfferArtifactDigestMatches}`);
+  log(`   signed receipt artifact digest re-binds     = ${signedReceiptArtifactDigestMatches}`);
+  log(`   settlement header digest re-binds           = ${settlementHeaderDigestMatches}`);
+  log(`   settlement receipt payload digest re-binds  = ${settlementReceiptPayloadDigestMatches}`);
+  log(`   upstream artifact digest re-binds           = ${upstreamArtifactDigestMatches}`);
+  log(`   raw offer/receipt/header present in record = ${rawArtifactLeak} (expected false)`);
+  if (warnings.length > 0) log(`   informational warnings: ${warnings.join(', ')}`);
+
+  const result: X402DemoResult = {
+    ok: true,
+    receiptRef: rec.receiptRef,
+    signatureValid: verifyResult.valid === true,
+    network: rec.network,
+    asset: rec.asset,
+    amountMinor: rec.amountMinor,
+    currency: rec.currency,
+    dualChannelConsistent: rec.dualChannelConsistent,
+    offerTermsDigestMatches,
+    signedOfferArtifactDigestMatches,
+    signedReceiptArtifactDigestMatches,
+    settlementHeaderDigestMatches,
+    settlementReceiptPayloadDigestMatches,
+    upstreamArtifactDigestMatches,
+    rawArtifactLeak,
+    warnings,
+  };
+
+  if (tamper) {
+    // Content tamper: alter the settlement receipt AFTER digesting -> the
+    // re-computed digest no longer matches the digest bound in the record.
+    const tamperedReceipt: NormalizedReceiptPayload = {
+      ...reReceipt,
+      transaction: `0x${'f'.repeat(64)}`,
+    };
+    const tamperedDigest = await computeJsonDocumentDigestJcs(
+      receiptDocument(tamperedReceipt) as unknown as JsonValue
+    );
+    const settlementReceiptPayloadDigestMatchesAfterTamper =
+      tamperedDigest === x402Ext?.settlement_receipt_payload_digest;
+
+    // Payload tamper: flip a claim in the signed record, keep the signature -> invalid signature.
+    const tamperedJws = tamperPayload(rec.jws);
+    const tamperedVerify = await verifyLocal(tamperedJws, issuerPublicKey, { issuer: ISSUER_URL });
+
+    log('\n5. Tamper checks:');
+    log(
+      `   content tamper: settlement receipt payload digest still matches = ${settlementReceiptPayloadDigestMatchesAfterTamper} (expected false)`
+    );
+    log(`   payload tamper: signature valid = ${tamperedVerify.valid} (expected false)`);
+    if (!tamperedVerify.valid) log(`   payload tamper: code = ${tamperedVerify.code}`);
+
+    result.tamper = {
+      payloadTamperValid: tamperedVerify.valid === true,
+      payloadTamperCode: tamperedVerify.valid ? undefined : tamperedVerify.code,
+      settlementReceiptPayloadDigestMatchesAfterTamper,
+    };
+  }
+
+  // Verdict: every check the demo makes must hold.
+  result.ok =
+    result.signatureValid &&
+    result.dualChannelConsistent &&
+    result.offerTermsDigestMatches &&
+    result.signedOfferArtifactDigestMatches &&
+    result.signedReceiptArtifactDigestMatches &&
+    result.settlementHeaderDigestMatches &&
+    result.settlementReceiptPayloadDigestMatches &&
+    result.upstreamArtifactDigestMatches &&
+    !result.rawArtifactLeak &&
+    (!tamper ||
+      (!result.tamper!.payloadTamperValid &&
+        result.tamper!.payloadTamperCode === 'E_INVALID_SIGNATURE' &&
+        !result.tamper!.settlementReceiptPayloadDigestMatchesAfterTamper));
+
+  if (result.ok) log('\n=== Demo Complete ===\n');
+  return result;
+}
+
+async function main(): Promise<void> {
+  const result = await runDemo({ tamper: process.argv.includes('--tamper') });
+  if (!result.ok) process.exitCode = 1;
+}
+
+// Run only when executed directly (pnpm demo), not when imported by a test.
+const invokedDirectly = process.argv[1] !== undefined && /demo\.ts$/.test(process.argv[1]);
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error('Demo failed:', err);
+    process.exitCode = 1;
+  });
+}

--- a/examples/x402-paid-resource-records/package.json
+++ b/examples/x402-paid-resource-records/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@peac/example-x402-paid-resource-records",
+  "version": "0.0.0",
+  "private": true,
+  "description": "PEAC example: record an x402 offer/receipt settlement (offer-receipt extension) as a portable signed payment record (org.peacprotocol/payment) with offline verification, dual-channel settlement observation, and digest-mismatch detection",
+  "type": "module",
+  "scripts": {
+    "demo": "tsx demo.ts",
+    "demo:tamper": "tsx demo.ts --tamper",
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@peac/adapter-x402": "workspace:*",
+    "@peac/crypto": "workspace:*",
+    "@peac/kernel": "workspace:*",
+    "@peac/protocol": "workspace:*",
+    "@peac/schema": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/examples/x402-paid-resource-records/tsconfig.json
+++ b/examples/x402-paid-resource-records/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true
+  },
+  "include": ["*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -528,6 +528,34 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
 
+  examples/mcp-paid-tool-records:
+    dependencies:
+      '@peac/adapter-x402':
+        specifier: workspace:*
+        version: link:../../packages/adapters/x402
+      '@peac/crypto':
+        specifier: workspace:*
+        version: link:../../packages/crypto
+      '@peac/kernel':
+        specifier: workspace:*
+        version: link:../../packages/kernel
+      '@peac/mappings-mcp':
+        specifier: workspace:*
+        version: link:../../packages/mappings/mcp
+      '@peac/protocol':
+        specifier: workspace:*
+        version: link:../../packages/protocol
+      '@peac/schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+    devDependencies:
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+
   examples/mcp-tool-call:
     dependencies:
       '@peac/crypto':
@@ -931,6 +959,31 @@ importers:
       '@peac/crypto':
         specifier: workspace:*
         version: link:../../packages/crypto
+      '@peac/protocol':
+        specifier: workspace:*
+        version: link:../../packages/protocol
+      '@peac/schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+    devDependencies:
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+
+  examples/x402-paid-resource-records:
+    dependencies:
+      '@peac/adapter-x402':
+        specifier: workspace:*
+        version: link:../../packages/adapters/x402
+      '@peac/crypto':
+        specifier: workspace:*
+        version: link:../../packages/crypto
+      '@peac/kernel':
+        specifier: workspace:*
+        version: link:../../packages/kernel
       '@peac/protocol':
         specifier: workspace:*
         version: link:../../packages/protocol

--- a/scripts/verify-example-source-gate.mjs
+++ b/scripts/verify-example-source-gate.mjs
@@ -62,6 +62,8 @@ export const SCAN_TARGETS = [
   { path: 'examples/cf-policy-x402-terms', kind: 'dir', required: true },
   { path: 'examples/commerce-evidence-bundle', kind: 'dir', required: true },
   { path: 'examples/commerce-mandate-records', kind: 'dir', required: true },
+  { path: 'examples/x402-paid-resource-records', kind: 'dir', required: true },
+  { path: 'examples/mcp-paid-tool-records', kind: 'dir', required: true },
 ];
 
 /** Directory names that are never scanned (vendored or generated). */

--- a/tests/tooling/mcp-paid-tool-records-example.test.ts
+++ b/tests/tooling/mcp-paid-tool-records-example.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Runtime smoke test for examples/mcp-paid-tool-records.
+ *
+ * The example is a public, copy-paste artifact, so its end-to-end behavior is
+ * gated here, not just its types. This imports the demo's exported runDemo(),
+ * recordPaidToolCall(), and buildToolPaymentFixtures() in-process (vitest
+ * aliases @peac/* to source, so no build or example install is required) and
+ * asserts:
+ *   - the signed org.peacprotocol/payment record, read back out of the MCP
+ *     _meta carrier, verifies offline and its tool-args, tool-result, and
+ *     settlement-receipt digests re-bind
+ *   - a mismatched settlement receipt (wrong resource) fails offer/receipt
+ *     consistency verification and refuses issuance
+ *   - the raw tool call arguments are never logged, and the raw tool call
+ *     arguments, the raw tool result, and the raw settlement receipt JWS
+ *     artifact are never embedded in the signed payload or in _meta (the
+ *     carried receipt JWS itself is expected there, not a leak)
+ *   - tampering with the returned tool result after signing breaks the
+ *     tool-result digest re-bind, independent of the signature tamper
+ *   - tampering with the _meta-carried record payload fails with E_INVALID_SIGNATURE
+ *   - issuance refuses to proceed without an observed settlement artifact
+ *   - the commerce extension is strict: network has no home there
+ *
+ * No network, no subprocess.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { generateKeypair, sign as signJws } from '@peac/crypto';
+import { issue } from '@peac/protocol';
+import { computeReceiptRef } from '@peac/schema';
+import { attachReceiptToMeta } from '@peac/mappings-mcp';
+import { extractSignedReceiptFromSettlement } from '@peac/adapter-x402';
+import {
+  runDemo,
+  recordPaidToolCall,
+  buildToolPaymentFixtures,
+} from '../../examples/mcp-paid-tool-records/demo';
+
+function decodePayload(jws: string): Record<string, unknown> {
+  return JSON.parse(Buffer.from(jws.split('.')[1], 'base64url').toString('utf8'));
+}
+
+describe('mcp-paid-tool-records example', () => {
+  it('records, carries in _meta, verifies offline, and re-binds the tool-args, tool-result, and settlement digests', async () => {
+    const r = await runDemo({ quiet: true });
+    expect(r.signatureValid).toBe(true);
+    expect(r.receiptInMeta).toBe(true);
+    expect(r.metaReceiptVerifies).toBe(true);
+    expect(r.toolArgsDigestMatches).toBe(true);
+    expect(r.toolResultDigestMatches).toBe(true);
+    expect(r.signedReceiptArtifactDigestMatches).toBe(true);
+    expect(r.settlementReceiptPayloadDigestMatches).toBe(true);
+    expect(r.upstreamArtifactDigestMatches).toBe(true);
+    expect(r.ok).toBe(true);
+  });
+
+  it('binds payment_rail = x402 and the tool_name / tool_args_digest / tool_result_digest', async () => {
+    const { privateKey: facilitatorPrivateKey } = await generateKeypair();
+    const { privateKey: issuerPrivateKey } = await generateKeypair();
+    const { challengeBody, settlementBody } = await buildToolPaymentFixtures(facilitatorPrivateKey);
+    const toolArgs = { symbol: 'ACME', depth: 'full' };
+    const toolResult = {
+      content: [{ type: 'text', text: 'market_data.premium_quote completed (paid).' }],
+      structuredContent: { symbol: 'ACME', price: '198.42' },
+    };
+    const rec = await recordPaidToolCall(
+      'market_data.premium_quote',
+      toolArgs,
+      toolResult,
+      challengeBody,
+      settlementBody,
+      issuerPrivateKey
+    );
+    const exts = decodePayload(rec.jws).extensions as Record<string, Record<string, unknown>>;
+    expect(exts['org.peacprotocol/commerce'].payment_rail).toBe('x402');
+    expect(exts['org.peacprotocol/commerce'].amount_minor).toBe('500000');
+    // network has no home in the strict org.peacprotocol/commerce schema.
+    expect(exts['org.peacprotocol/commerce'].network).toBeUndefined();
+    expect(exts['com.example/mcp_paid_tool'].tool_name).toBe('market_data.premium_quote');
+    expect(exts['com.example/mcp_paid_tool'].tool_args_digest).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(exts['com.example/mcp_paid_tool'].tool_result_digest).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(exts['com.example/mcp_paid_tool'].signed_receipt_artifact_digest).toMatch(
+      /^sha256:[a-f0-9]{64}$/
+    );
+    expect(exts['com.example/mcp_paid_tool'].settlement_receipt_payload_digest).toMatch(
+      /^sha256:[a-f0-9]{64}$/
+    );
+    // upstream_artifact_digest binds the SIGNED receipt artifact, not the normalized payload.
+    expect(exts['com.example/mcp_paid_tool'].upstream_artifact_digest).toBe(
+      rec.signedReceiptArtifactDigest
+    );
+    expect(exts['com.example/mcp_paid_tool'].upstream_artifact_digest).not.toBe(
+      rec.settlementReceiptPayloadDigest
+    );
+  });
+
+  it('never logs the raw tool arguments; only the tool name and a digest', async () => {
+    const lines: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((msg?: unknown) => {
+      lines.push(String(msg ?? ''));
+    });
+    try {
+      await runDemo({ quiet: false });
+    } finally {
+      spy.mockRestore();
+    }
+    const out = lines.join('\n');
+    expect(out).not.toContain('ACME');
+    expect(out).not.toContain('full');
+    // A compact JWS or a base64url token is a long unbroken base64url run;
+    // the demo only ever prints short sliced digest previews.
+    expect(out).not.toMatch(/[A-Za-z0-9_-]{80,}/);
+  });
+
+  it('never embeds the raw tool arguments or the raw settlement receipt JWS in the signed payload or _meta', async () => {
+    const r = await runDemo({ quiet: true });
+    expect(r.rawLeak).toBe(false);
+  });
+
+  it('never embeds the raw tool call arguments, the raw tool result, or the raw settlement receipt JWS in the signed payload or _meta (the carried receipt JWS itself is expected there, not a leak)', async () => {
+    const { privateKey: facilitatorPrivateKey } = await generateKeypair();
+    const { privateKey: issuerPrivateKey } = await generateKeypair();
+    const { challengeBody, settlementBody } = await buildToolPaymentFixtures(facilitatorPrivateKey);
+    const toolArgs = { symbol: 'ACME', depth: 'full' };
+    const toolResult = {
+      content: [{ type: 'text' as const, text: 'market_data.premium_quote completed (paid).' }],
+      structuredContent: { symbol: 'ACME', price: '198.42' },
+    };
+    const rec = await recordPaidToolCall(
+      'market_data.premium_quote',
+      toolArgs,
+      toolResult,
+      challengeBody,
+      settlementBody,
+      issuerPrivateKey
+    );
+    const withReceipt = attachReceiptToMeta(
+      { ...toolResult },
+      { receipt_ref: await computeReceiptRef(rec.jws), receipt_jws: rec.jws }
+    ) as { _meta?: Record<string, unknown> };
+    const settledReceipt = extractSignedReceiptFromSettlement(settlementBody)!;
+
+    const payloadStr = JSON.stringify(decodePayload(rec.jws));
+    const metaStr = JSON.stringify(withReceipt._meta);
+
+    expect(payloadStr).not.toContain('ACME');
+    expect(payloadStr).not.toContain('full');
+    expect(payloadStr).not.toContain(settledReceipt.signature);
+    expect(metaStr).not.toContain('ACME');
+    expect(metaStr).not.toContain('full');
+    expect(metaStr).not.toContain(settledReceipt.signature);
+    // The _meta carrier legitimately contains the PEAC receipt JWS itself
+    // (org.peacprotocol/receipt_jws) by design; that is not a leak.
+    expect(metaStr).toContain(rec.jws);
+  });
+
+  it('detects a tool-result content tamper as a digest mismatch, independent of the signature tamper', async () => {
+    const r = await runDemo({ tamper: true, quiet: true });
+    expect(r.tamper?.toolResultDigestMatchesAfterTamper).toBe(false);
+  });
+
+  it('detects _meta-carried record tampering with an invalid signature', async () => {
+    const r = await runDemo({ tamper: true, quiet: true });
+    expect(r.tamper?.payloadTamperValid).toBe(false);
+    expect(r.tamper?.payloadTamperCode).toBe('E_INVALID_SIGNATURE');
+  });
+
+  it('reports an overall ok verdict with tamper checks enabled', async () => {
+    const r = await runDemo({ tamper: true, quiet: true });
+    expect(r.ok).toBe(true);
+  });
+
+  it('refuses to record a paid tool call without an observed settlement artifact', async () => {
+    const { privateKey: facilitatorPrivateKey } = await generateKeypair();
+    const { privateKey: issuerPrivateKey } = await generateKeypair();
+    const { challengeBody } = await buildToolPaymentFixtures(facilitatorPrivateKey);
+    const offerOnlySettlementBody = {
+      success: true,
+      resourceUrl: 'https://api.example.com/v1/tools/market_data.premium_quote',
+    };
+    await expect(
+      recordPaidToolCall(
+        'market_data.premium_quote',
+        { symbol: 'ACME' },
+        { content: [], structuredContent: {} },
+        challengeBody,
+        offerOnlySettlementBody,
+        issuerPrivateKey
+      )
+    ).rejects.toThrow(/settlement artifact/);
+  });
+
+  it('refuses to record when there is no x402 payment challenge for the tool call', async () => {
+    const { privateKey: facilitatorPrivateKey } = await generateKeypair();
+    const { privateKey: issuerPrivateKey } = await generateKeypair();
+    const { settlementBody } = await buildToolPaymentFixtures(facilitatorPrivateKey);
+    const noOfferChallenge = {
+      resourceUrl: 'https://api.example.com/v1/tools/market_data.premium_quote',
+    };
+    await expect(
+      recordPaidToolCall(
+        'market_data.premium_quote',
+        { symbol: 'ACME' },
+        { content: [], structuredContent: {} },
+        noOfferChallenge,
+        settlementBody,
+        issuerPrivateKey
+      )
+    ).rejects.toThrow(/no x402 payment challenge/);
+  });
+
+  it('refuses to record when the settlement receipt resource does not match the offer (mismatched resource; consistency check)', async () => {
+    const { privateKey: facilitatorPrivateKey } = await generateKeypair();
+    const { privateKey: issuerPrivateKey } = await generateKeypair();
+    const { challengeBody } = await buildToolPaymentFixtures(facilitatorPrivateKey);
+
+    // A settlement receipt for a DIFFERENT resource than the offer: passes
+    // wire validation but fails offer/receipt consistency
+    // (receipt_resource_mismatch).
+    const mismatchedReceiptJws = await signJws(
+      {
+        version: 1,
+        network: 'eip155:8453',
+        resourceUrl: 'https://api.example.com/v1/tools/other-tool',
+        payer: '0x1230456789abcdef1234567890abcdef12345678',
+        issuedAt: Math.floor(Date.now() / 1000),
+        transaction: '0xfeedface1234567890abcdef1234567890abcdef1234567890abcdef1234ab',
+      },
+      facilitatorPrivateKey,
+      'x402-facilitator-key-2026'
+    );
+    const mismatchedSettlementBody = {
+      success: true,
+      resourceUrl: 'https://api.example.com/v1/tools/market_data.premium_quote',
+      extensions: {
+        'offer-receipt': { info: { receipt: { format: 'jws', signature: mismatchedReceiptJws } } },
+      },
+    };
+
+    await expect(
+      recordPaidToolCall(
+        'market_data.premium_quote',
+        { symbol: 'ACME' },
+        { content: [], structuredContent: {} },
+        challengeBody,
+        mismatchedSettlementBody,
+        issuerPrivateKey
+      )
+    ).rejects.toThrow(/offer and receipt are inconsistent/);
+  });
+
+  it('rejects a naive commerce extension carrying network (strict schema; network has no commerce field)', async () => {
+    const { privateKey } = await generateKeypair();
+    await expect(
+      issue({
+        iss: 'https://api.example.com',
+        kind: 'evidence',
+        type: 'org.peacprotocol/payment',
+        pillars: ['commerce'],
+        extensions: {
+          'org.peacprotocol/commerce': {
+            payment_rail: 'x402',
+            amount_minor: '500000',
+            currency: 'USDC',
+            network: 'eip155:8453',
+          },
+        },
+        privateKey,
+        kid: 'record-key-2026',
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/tests/tooling/x402-paid-resource-records-example.test.ts
+++ b/tests/tooling/x402-paid-resource-records-example.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Runtime smoke test for examples/x402-paid-resource-records.
+ *
+ * The example is a public, copy-paste artifact, so its end-to-end behavior is
+ * gated here, not just its types. This imports the demo's exported runDemo(),
+ * recordX402Settlement(), and buildX402Fixtures() in-process (vitest aliases
+ * @peac/* to source, so no build or example install is required) and asserts:
+ *   - the signed org.peacprotocol/payment record verifies offline and its
+ *     offer-terms, signed-offer-artifact, signed-receipt-artifact,
+ *     settlement-header, settlement-receipt-payload, and upstream-artifact
+ *     digests all re-bind
+ *   - the settlement is observed via both the header path and the
+ *     offer-receipt body path, and the two channels are dual-channel consistent
+ *   - a dual-channel mismatch (the header and body report different
+ *     settlement artifacts) is rejected before issuance (fail closed)
+ *   - the raw x402 offer/receipt JWS artifacts and the raw settlement header
+ *     value are never logged or embedded in the signed payload
+ *   - tampering with the record payload fails with E_INVALID_SIGNATURE, and
+ *     tampering with the settlement receipt content after digesting breaks
+ *     the digest re-bind
+ *   - issuance refuses to proceed without an observed settlement artifact
+ *     (offer-only data is not settlement evidence)
+ *   - the commerce extension is strict: putting `network` inside
+ *     org.peacprotocol/commerce (instead of the example-local extension)
+ *     is rejected by issue()
+ *
+ * No network, no subprocess.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { generateKeypair, sign as signJws } from '@peac/crypto';
+import { issue } from '@peac/protocol';
+import { extractExtensionInfo, extractSignedReceiptFromSettlement } from '@peac/adapter-x402';
+import {
+  runDemo,
+  recordX402Settlement,
+  buildX402Fixtures,
+} from '../../examples/x402-paid-resource-records/demo';
+
+function decodePayload(jws: string): Record<string, unknown> {
+  return JSON.parse(Buffer.from(jws.split('.')[1], 'base64url').toString('utf8'));
+}
+
+describe('x402-paid-resource-records example', () => {
+  it('records, verifies offline, and re-binds the offer/settlement digests', async () => {
+    const r = await runDemo({ quiet: true });
+    expect(r.signatureValid).toBe(true);
+    expect(r.dualChannelConsistent).toBe(true);
+    expect(r.offerTermsDigestMatches).toBe(true);
+    expect(r.signedOfferArtifactDigestMatches).toBe(true);
+    expect(r.signedReceiptArtifactDigestMatches).toBe(true);
+    expect(r.settlementHeaderDigestMatches).toBe(true);
+    expect(r.settlementReceiptPayloadDigestMatches).toBe(true);
+    expect(r.upstreamArtifactDigestMatches).toBe(true);
+    expect(r.ok).toBe(true);
+  });
+
+  it('binds payment_rail = x402 and the settled amount/currency/network', async () => {
+    const { privateKey: facilitatorPrivateKey } = await generateKeypair();
+    const { privateKey: issuerPrivateKey } = await generateKeypair();
+    const { challengeBody, settlementBody, settlementHeaders } =
+      await buildX402Fixtures(facilitatorPrivateKey);
+    const rec = await recordX402Settlement(
+      challengeBody,
+      settlementHeaders,
+      settlementBody,
+      issuerPrivateKey
+    );
+    const exts = decodePayload(rec.jws).extensions as Record<string, Record<string, unknown>>;
+    expect(exts['org.peacprotocol/commerce'].payment_rail).toBe('x402');
+    expect(exts['org.peacprotocol/commerce'].amount_minor).toBe('250000');
+    expect(exts['org.peacprotocol/commerce'].currency).toBe('USDC');
+    expect(exts['org.peacprotocol/commerce'].env).toBe('test');
+    // network has no home in the strict org.peacprotocol/commerce schema.
+    expect(exts['org.peacprotocol/commerce'].network).toBeUndefined();
+    expect(exts['com.example/paid_resource'].network).toBe('eip155:8453');
+    expect(exts['com.example/paid_resource'].offer_terms_digest).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(exts['com.example/paid_resource'].signed_offer_artifact_digest).toMatch(
+      /^sha256:[a-f0-9]{64}$/
+    );
+    expect(exts['com.example/paid_resource'].signed_receipt_artifact_digest).toMatch(
+      /^sha256:[a-f0-9]{64}$/
+    );
+    expect(exts['com.example/paid_resource'].settlement_header_digest).toMatch(
+      /^sha256:[a-f0-9]{64}$/
+    );
+    expect(exts['com.example/paid_resource'].settlement_receipt_payload_digest).toMatch(
+      /^sha256:[a-f0-9]{64}$/
+    );
+    expect(exts['com.example/paid_resource'].upstream_artifact_digest).toBe(
+      exts['com.example/paid_resource'].signed_receipt_artifact_digest
+    );
+  });
+
+  it('never logs the raw x402 offer/receipt JWS or the raw settlement header', async () => {
+    const lines: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((msg?: unknown) => {
+      lines.push(String(msg ?? ''));
+    });
+    try {
+      await runDemo({ quiet: false });
+    } finally {
+      spy.mockRestore();
+    }
+    const out = lines.join('\n');
+    // A compact JWS or a base64url token is a long unbroken base64url run;
+    // the demo only ever prints short sliced digest previews.
+    expect(out).not.toMatch(/[A-Za-z0-9_-]{80,}/);
+  });
+
+  it('never embeds the raw offer/receipt JWS or the raw settlement header in the signed payload', async () => {
+    const r = await runDemo({ quiet: true });
+    expect(r.rawArtifactLeak).toBe(false);
+  });
+
+  it('never embeds the known raw signed-offer JWS, signed-receipt JWS, or settlement header value in the signed record payload, and carries every digest field', async () => {
+    const { privateKey: facilitatorPrivateKey } = await generateKeypair();
+    const { privateKey: issuerPrivateKey } = await generateKeypair();
+    const { challengeBody, settlementBody, settlementHeaders } =
+      await buildX402Fixtures(facilitatorPrivateKey);
+    const rec = await recordX402Settlement(
+      challengeBody,
+      settlementHeaders,
+      settlementBody,
+      issuerPrivateKey
+    );
+
+    const offerSignature = extractExtensionInfo(challengeBody)!.offers[0].signature;
+    const receiptSignature = extractSignedReceiptFromSettlement(settlementBody)!.signature;
+    const headerRawValue = String(
+      (settlementHeaders as Record<string, string>)['PAYMENT-RESPONSE']
+    );
+
+    const payload = decodePayload(rec.jws);
+    const payloadStr = JSON.stringify(payload);
+    expect(payloadStr).not.toContain(offerSignature);
+    expect(payloadStr).not.toContain(receiptSignature);
+    expect(payloadStr).not.toContain(headerRawValue);
+
+    const ext = (payload.extensions as Record<string, Record<string, unknown>>)[
+      'com.example/paid_resource'
+    ];
+    expect(ext.offer_terms_digest).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(ext.signed_offer_artifact_digest).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(ext.signed_receipt_artifact_digest).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(ext.settlement_header_digest).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(ext.settlement_receipt_payload_digest).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(ext.upstream_artifact_digest).toBe(ext.signed_receipt_artifact_digest);
+  });
+
+  it('refuses to record when the settlement header and body receipt artifacts disagree (dual-channel mismatch)', async () => {
+    const { privateKey: facilitatorPrivateKey } = await generateKeypair();
+    const { privateKey: issuerPrivateKey } = await generateKeypair();
+    const { challengeBody, settlementBody, settlementHeaders } =
+      await buildX402Fixtures(facilitatorPrivateKey);
+
+    // A different, otherwise well-formed settlement receipt JWS (same
+    // facilitator key, different transaction), standing in for a gateway
+    // that reported a different settlement artifact on the header channel
+    // than on the offer-receipt body channel.
+    const otherReceiptJws = await signJws(
+      {
+        version: 1,
+        network: 'eip155:8453',
+        resourceUrl: 'https://api.example.com/v1/market-data/quote',
+        payer: '0xabc1234567890abcdef1234567890abcdef123456',
+        issuedAt: Math.floor(Date.now() / 1000),
+        transaction: `0x${'a'.repeat(64)}`,
+      },
+      facilitatorPrivateKey,
+      'x402-facilitator-key-2026'
+    );
+    const tamperedHeaders = { ...settlementHeaders, 'PAYMENT-RESPONSE': otherReceiptJws };
+
+    await expect(
+      recordX402Settlement(challengeBody, tamperedHeaders, settlementBody, issuerPrivateKey)
+    ).rejects.toThrow(/settlement header and body receipt differ/);
+  });
+
+  it('detects a settlement-receipt content tamper as a digest mismatch, independent of the signature tamper', async () => {
+    const r = await runDemo({ tamper: true, quiet: true });
+    expect(r.tamper?.settlementReceiptPayloadDigestMatchesAfterTamper).toBe(false);
+  });
+
+  it('detects record tampering with an invalid signature', async () => {
+    const r = await runDemo({ tamper: true, quiet: true });
+    expect(r.tamper?.payloadTamperValid).toBe(false);
+    expect(r.tamper?.payloadTamperCode).toBe('E_INVALID_SIGNATURE');
+  });
+
+  it('reports an overall ok verdict with tamper checks enabled', async () => {
+    const r = await runDemo({ tamper: true, quiet: true });
+    expect(r.ok).toBe(true);
+  });
+
+  it('refuses to record without an observed settlement artifact (offer-only data)', async () => {
+    const { privateKey: facilitatorPrivateKey } = await generateKeypair();
+    const { privateKey: issuerPrivateKey } = await generateKeypair();
+    const { challengeBody } = await buildX402Fixtures(facilitatorPrivateKey);
+    // A settlement body/headers with no offer-receipt receipt at all: offer-only data.
+    const offerOnlySettlementBody = {
+      success: true,
+      resourceUrl: 'https://api.example.com/v1/market-data/quote',
+    };
+    await expect(
+      recordX402Settlement(challengeBody, {}, offerOnlySettlementBody, issuerPrivateKey)
+    ).rejects.toThrow(/settlement artifact/);
+  });
+
+  it('refuses to record when the 402 challenge carries no x402 offer', async () => {
+    const { privateKey: facilitatorPrivateKey } = await generateKeypair();
+    const { privateKey: issuerPrivateKey } = await generateKeypair();
+    const { settlementBody, settlementHeaders } = await buildX402Fixtures(facilitatorPrivateKey);
+    const noOfferChallenge = {
+      accepts: [],
+      resourceUrl: 'https://api.example.com/v1/market-data/quote',
+    };
+    await expect(
+      recordX402Settlement(noOfferChallenge, settlementHeaders, settlementBody, issuerPrivateKey)
+    ).rejects.toThrow(/no x402 offer/);
+  });
+
+  it('rejects a naive commerce extension carrying network (strict schema; network has no commerce field)', async () => {
+    const { privateKey } = await generateKeypair();
+    await expect(
+      issue({
+        iss: 'https://api.example.com',
+        kind: 'evidence',
+        type: 'org.peacprotocol/payment',
+        pillars: ['commerce'],
+        extensions: {
+          'org.peacprotocol/commerce': {
+            payment_rail: 'x402',
+            amount_minor: '250000',
+            currency: 'USDC',
+            network: 'eip155:8453',
+          },
+        },
+        privateKey,
+        kid: 'record-key-2026',
+      })
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Adds two offline signed-record examples:

- `examples/x402-paid-resource-records`
  - settled x402 offer/receipt pair to a signed `org.peacprotocol/payment` record
  - observes settlement via both `PAYMENT-RESPONSE` header and `extensions["offer-receipt"].info.receipt`
  - fails closed if header/body settlement artifacts disagree
  - binds offer terms, signed offer artifact, signed receipt artifact, settlement header proof, normalized receipt payload, and upstream artifact by `sha256:` digest
  - verifies offline and includes signature-tamper + digest-mismatch beats

- `examples/mcp-paid-tool-records`
  - priced MCP tool call to an x402 settlement to a signed `org.peacprotocol/payment` record carried in MCP `_meta`
  - binds tool name, tool-args digest, tool-result digest, signed receipt artifact digest, normalized receipt payload digest, and upstream artifact digest
  - verifies from `_meta` offline and includes signature-tamper + result-digest-mismatch beats

Also:
- registers both example dirs in `scripts/verify-example-source-gate.mjs`
- bumps `docs/releases/facts.json` `build_targets` from 107 to 109
- updates `pnpm-lock.yaml` for the two new private workspace example packages

## Protocol boundaries / non-goals

This PR is examples-only. It does not add or change:

- receipt types
- extension groups
- schemas
- wire format
- signing envelopes
- registries
- conformance fixtures
- kernel errors
- package public APIs

The examples reuse:

- `org.peacprotocol/payment`
- `org.peacprotocol/commerce`
- example-local unregistered extension keys:
  - `com.example/paid_resource`
  - `com.example/mcp_paid_tool`

PEAC records, binds, preserves, and verifies offline. It does not settle payments, price resources/tools, gate access, or verify x402 scheme-specific invariants.

## Privacy / redaction posture

Raw x402 artifacts, settlement headers, tool arguments, and tool results are not copied into the signed record payload. They are bound by `sha256:` digest. MCP `_meta` carries the PEAC receipt JWS by design; that is the portable record carrier, not a raw x402 artifact leak.

## Validation

Ran locally on commit `6e82fb1d`:

- `pnpm --filter @peac/example-x402-paid-resource-records demo`
- `pnpm --filter @peac/example-x402-paid-resource-records demo:tamper`
- `pnpm --filter @peac/example-mcp-paid-tool-records demo`
- `pnpm --filter @peac/example-mcp-paid-tool-records demo:tamper`
- `pnpm --filter @peac/example-x402-paid-resource-records typecheck`
- `pnpm --filter @peac/example-mcp-paid-tool-records typecheck`
- `pnpm exec vitest run tests/tooling/x402-paid-resource-records-example.test.ts tests/tooling/mcp-paid-tool-records-example.test.ts`
- `pnpm exec vitest run tests/tooling`
- `pnpm typecheck:core`
- `pnpm verify:release`
- `pnpm verify:codegen-drift`
- `pnpm verify:registries-schema`
- `pnpm exec tsx scripts/extract-api-contract.ts --check`
- `git diff --check`
- `bash scripts/ci/forbid-strings.sh`
- `pnpm format:check`
- `pnpm gate:fast`
- README public-artifact / planning-leak scanners
- Unicode format-control scan

Results:
- tooling suite: 1483 passing
- example suites: 24 passing
- `verify:release`: `build_targets` matches turbo dry-run: 109
- api contract: no drift
- codegen / registries: clean
- wording grep: clean
- Unicode format-control scan: none

## Follow-up not in this PR

A separate docs-only follow-up should align `docs/guides/x402-peac.md` with the strict `org.peacprotocol/commerce` schema; fields such as `network` / `tx_hash` should not be shown inside the commerce extension. This PR intentionally does not widen scope to fix that doc.
