### PR TITLE
docs(x402): align commerce extension examples with the strict schema

### DIFF
--- a/docs/guides/x402-peac.md
+++ b/docs/guides/x402-peac.md
@@ -44,11 +44,8 @@ const { jws } = await issue({
       currency: 'USD',
       asset: 'USDC',
       env: 'live',
-      network: 'eip155:8453', // Base mainnet
-      tx_hash: txHash,
-      recipient: recipientAddress,
-      x402_version: 'v2',
-      reference: `x402_${paymentId}`,
+      event: 'settlement',
+      reference: `x402_${txHash}`, // caller-assigned reference; e.g. bind the x402 transaction hash
     },
   },
   privateKey,
@@ -58,6 +55,12 @@ const { jws } = await issue({
 // Set the PEAC-Receipt header in your response
 response.setHeader('PEAC-Receipt', jws);
 ```
+
+> The `org.peacprotocol/commerce` extension is strict: it carries only `payment_rail`, `amount_minor`,
+> `currency`, `asset`, `reference`, `env`, and `event`. x402-specific transaction details such as `network`,
+> transaction hash, and recipient are not commerce fields. Preserve them through the x402 mapping path, for
+> example `@peac/adapter-x402`'s record-mapping helpers (`toPeacRecord`), which normalize x402-specific fields
+> into the record evidence instead of adding them to the commerce extension.
 
 ### 3. Verify a Receipt
 
@@ -329,7 +332,7 @@ app.get('/premium', async (req, res) => {
 
 // Endpoint called after x402 payment succeeds
 app.post('/issue-receipt', async (req, res) => {
-  const { resource, txHash, network } = req.body;
+  const { txHash } = req.body;
 
   const { jws } = await issue({
     iss: 'https://your-api.com',
@@ -343,9 +346,7 @@ app.post('/issue-receipt', async (req, res) => {
         currency: 'USD',
         asset: 'USDC',
         env: 'live',
-        network,
-        tx_hash: txHash,
-        x402_version: 'v2',
+        event: 'settlement',
         reference: `x402_${txHash}`,
       },
     },


### PR DESCRIPTION
## Summary

Aligns the manual x402 `issue()` examples in `docs/guides/x402-peac.md` with the strict `org.peacprotocol/commerce` schema.

The examples previously showed x402-specific fields inside the commerce extension:

- `network`
- `tx_hash`
- `recipient`
- `x402_version`

Those are not valid commerce-extension fields and would fail `issue()`.

This PR:

- removes those invalid fields from both manual commerce-extension examples
- adds `event: 'settlement'`
- keeps the valid fields only: `payment_rail`, `amount_minor`, `currency`, `asset`, `env`, `event`, `reference`
- clarifies that x402-specific transaction details belong in the record evidence through the x402 mapping path, for example `@peac/adapter-x402`'s `toPeacRecord`

## Boundaries

Docs-only. No code, schema, registry, wire, package, sentinel, or generated artifact changes.

Left untouched intentionally:

- the x402 payment-challenge object, where `network` / `asset` / `amount` are valid x402 fields
- the decoded output shape showing `payment.evidence.tx_hash`, where x402-specific details are expected

## Validation

Ran locally on commit `84b5c9b6`:

- `pnpm exec prettier --check docs/guides/x402-peac.md`
- `pnpm exec vitest run tests/tooling/repo-links-doc-truth.test.ts`
- `git diff --check`
- `bash scripts/ci/forbid-strings.sh`
- `bash scripts/check-planning-leak.sh docs/guides/x402-peac.md`
- `node scripts/check-public-artifacts.mjs --body-file docs/guides/x402-peac.md`
- Unicode Cf scan
- `node reference/scripts/verify-local-doc-truth.mjs`
- `node reference/scripts/verify-final-hygiene.mjs`

Results:

- link gate: 340 passing
- public artifact checks: clean
- Unicode Cf scan: clean
- reference verifiers: 26/26 and hygiene OK
