### PR TITLE
feat(audit): receipt Merkle commitment helpers

### DIFF
--- a/docs/specs/WORKFLOW-CORRELATION.md
+++ b/docs/specs/WORKFLOW-CORRELATION.md
@@ -409,23 +409,23 @@ Implementations MAY additionally check:
 
 ## 7. Merkle Commitment
 
-> **Implementation Status:** Merkle commitment is specified for large workflows but implementation is deferred. The schema supports `receipt_merkle_root` field; helper functions for Merkle tree construction and verification will be added to `@peac/audit` in a future release.
+> **Implementation Status:** Implemented in `@peac/audit` as `buildReceiptMerkleCommitment`, `generateReceiptMerkleInclusionProof`, and `verifyReceiptMerkleInclusion` (tree algorithm id `peac.merkle.ct-sorted-set-sha256-v1`). The schema `receipt_merkle_root` / `receipt_count` fields carry the commitment's `root` / `tree_size`. This is a CT-style Merkle Tree Hash following the RFC 9162 Section 2.1.1 formulas (RFC 9162 obsoletes RFC 6962), adapted as a **sorted-set commitment over PEAC `receipt_ref` digests**. It is NOT a Certificate Transparency append-only log; PEAC does not operate a log or anchor these roots. A commitment proves inclusion in the committed set; by itself it proves neither completeness nor the validity of any record. Operators additionally check that the workflow summary's `receipt_merkle_root` / `receipt_count` match the commitment's `root` / `tree_size`, and each PEAC record is still verified independently.
 
-For large workflows (100+ receipts), use Merkle root instead of listing all receipt IDs.
+For large workflows, a summary can carry `receipt_merkle_root` and `receipt_count` instead of listing every `receipt_ref`.
 
-### 7.1 Construction (RFC 6962 Style)
+### 7.1 Construction (CT-style, RFC 9162 Section 2.1.1)
 
 ```
 MTH({d(0)}) = SHA-256(0x00 || d(0))  // Leaf
-MTH(D[n]) = SHA-256(0x01 || MTH(D[0:k]) || MTH(D[k:n]))  // Internal node
+MTH(D[n]) = SHA-256(0x01 || MTH(D[0:k]) || MTH(D[k:n]))  // Internal node, k = largest power of two < n
 ```
 
 Where:
 
-- `d(i)` is the receipt digest (SHA-256 of JWS bytes)
-- Leaves are prefixed with `0x00`
-- Internal nodes are prefixed with `0x01`
-- Tree is computed over lexicographically sorted receipt digests
+- `d(i)` is the receipt digest (the raw 32 bytes decoded from the `receipt_ref` = `sha256:{hex64}`)
+- Leaves are prefixed with `0x00`, internal nodes with `0x01` (domain separation for second-preimage resistance)
+- The tree is computed over **bytewise lexicographically sorted** receipt digests (shuffled input yields the same root)
+- Duplicate refs are rejected; **empty input is rejected as a PEAC policy** (the RFC 9162 empty-list hash `MTH({}) = HASH()` is intentionally not emitted, since an empty commitment is never meaningful for a workflow)
 
 ### 7.2 Digest Computation
 
@@ -442,20 +442,24 @@ Format in workflow summary: `sha256:{hex64}`
 To prove a receipt is part of a workflow:
 
 ```typescript
-interface MerkleInclusionProof {
-  leaf_index: number;
+interface ReceiptMerkleInclusionProof {
+  tree_alg: 'peac.merkle.ct-sorted-set-sha256-v1';
+  hash_alg: 'sha256';
+  leaf_index: number; // index within the sorted leaf order
   tree_size: number;
-  hashes: string[]; // sha256:{hex64}
+  hashes: string[]; // sibling path, leaf -> root, each sha256:{hex64}
 }
 ```
 
 ### 7.4 Verification
 
+Verification takes the full commitment (so the proof is bound to the commitment's `tree_size` as well as its `root`) and uses the RFC 9162 Section 2.1.3.2 inclusion-proof fold (`fn = leaf_index`, `sn = tree_size - 1`), not a simplified perfect-tree bit-walk. It returns `false` for a well-formed but cryptographically wrong proof (including one whose `tree_size` disagrees with the commitment) and throws a package-local `MerkleInputError` only on malformed input.
+
 ```typescript
-function verifyMerkleInclusion(
-  root: string, // Expected Merkle root
-  receiptDigest: string, // SHA-256 of receipt JWS
-  proof: MerkleInclusionProof
+function verifyReceiptMerkleInclusion(
+  commitment: ReceiptMerkleCommitment, // { tree_alg, hash_alg, root, tree_size }
+  targetRef: string, // The receipt_ref being proven (sha256:{hex64})
+  proof: ReceiptMerkleInclusionProof
 ): boolean;
 ```
 

--- a/packages/audit/src/index.ts
+++ b/packages/audit/src/index.ts
@@ -168,3 +168,22 @@ export {
   serializeCommerceBundle,
   groupByLifecycle,
 } from './commerce-bundle.js';
+
+// Merkle commitment helpers for workflow receipt sets.
+export type {
+  Sha256DigestRef,
+  ReceiptMerkleRoot,
+  MerkleNodeHash,
+  ReceiptMerkleCommitment,
+  ReceiptMerkleInclusionProof,
+  MerkleInputErrorCode,
+} from './merkle.js';
+
+export {
+  MERKLE_TREE_ALG,
+  MERKLE_HASH_ALG,
+  MerkleInputError,
+  buildReceiptMerkleCommitment,
+  generateReceiptMerkleInclusionProof,
+  verifyReceiptMerkleInclusion,
+} from './merkle.js';

--- a/packages/audit/src/merkle.ts
+++ b/packages/audit/src/merkle.ts
@@ -1,0 +1,404 @@
+/**
+ * @peac/audit - Merkle commitment helpers for workflow receipt sets.
+ *
+ * Executes the deferred WORKFLOW-CORRELATION section 7 Merkle commitment as
+ * deterministic, offline helpers. This is a CT-style Merkle Tree Hash following
+ * the RFC 9162 section 2.1.1 formulas (RFC 9162 obsoletes RFC 6962), adapted as
+ * a sorted-set commitment over PEAC `receipt_ref` digests. It is NOT a
+ * Certificate Transparency append-only log and PEAC does not operate a log or
+ * anchor these roots anywhere.
+ *
+ * Proves inclusion in the committed set; it does NOT prove chronology,
+ * completeness, payment finality, payment validity, privacy, or legal validity.
+ * Callers must still verify each PEAC record independently.
+ *
+ * Inputs are `receipt_ref` strings (`sha256:<hex64>`, DD-129) only. Callers that
+ * start from compact JWS bytes use `@peac/schema` `computeReceiptRef(jws)` first;
+ * this module does not re-implement digest computation.
+ */
+
+import { createHash, timingSafeEqual } from 'node:crypto';
+import type { ReceiptRef } from '@peac/kernel';
+
+/** Algorithm identifier for this sorted-set commitment construction. */
+export const MERKLE_TREE_ALG = 'peac.merkle.ct-sorted-set-sha256-v1' as const;
+/** Hash algorithm used for leaves and internal nodes. */
+export const MERKLE_HASH_ALG = 'sha256' as const;
+
+/**
+ * A `sha256:<hex64>` digest reference. Shares its grammar with `ReceiptRef` but
+ * carries different semantics (a Merkle hash, not a PEAC record reference).
+ */
+export type Sha256DigestRef = `sha256:${string}`;
+/** A Merkle root digest (NOT a receipt reference). */
+export type ReceiptMerkleRoot = Sha256DigestRef;
+/** A Merkle inclusion-proof sibling hash (NOT a receipt reference). */
+export type MerkleNodeHash = Sha256DigestRef;
+
+/** Self-describing commitment over a sorted set of receipt references. */
+export interface ReceiptMerkleCommitment {
+  readonly tree_alg: typeof MERKLE_TREE_ALG;
+  readonly hash_alg: typeof MERKLE_HASH_ALG;
+  readonly root: ReceiptMerkleRoot;
+  readonly tree_size: number;
+}
+
+/** Inclusion proof for a single receipt reference against a committed root. */
+export interface ReceiptMerkleInclusionProof {
+  readonly tree_alg: typeof MERKLE_TREE_ALG;
+  readonly hash_alg: typeof MERKLE_HASH_ALG;
+  /** Index of the target within the SORTED leaf order. */
+  readonly leaf_index: number;
+  readonly tree_size: number;
+  /** Sibling path, leaf -> root order, each `sha256:<hex64>`. */
+  readonly hashes: readonly MerkleNodeHash[];
+}
+
+export type MerkleInputErrorCode =
+  | 'audit.merkle.empty_input'
+  | 'audit.merkle.invalid_receipt_ref'
+  | 'audit.merkle.duplicate_receipt_ref'
+  | 'audit.merkle.target_not_found'
+  | 'audit.merkle.invalid_commitment'
+  | 'audit.merkle.invalid_merkle_root'
+  | 'audit.merkle.invalid_proof'
+  | 'audit.merkle.invalid_proof_hash'
+  | 'audit.merkle.unsupported_tree_alg'
+  | 'audit.merkle.unsupported_hash_alg';
+
+/**
+ * Thrown ONLY on malformed input (bad grammar, empty/duplicate input,
+ * unsupported algorithm, out-of-range index, target not found). A well-formed
+ * but cryptographically wrong proof returns `false` from
+ * {@link verifyReceiptMerkleInclusion} and does not throw. These are
+ * package-local errors; they are not kernel protocol errors.
+ */
+export class MerkleInputError extends Error {
+  readonly code: MerkleInputErrorCode;
+  constructor(code: MerkleInputErrorCode, message: string) {
+    super(message);
+    this.name = 'MerkleInputError';
+    this.code = code;
+  }
+}
+
+const DIGEST_REF_RE = /^sha256:[0-9a-f]{64}$/;
+const LEAF_PREFIX = 0x00;
+const NODE_PREFIX = 0x01;
+
+function assertDigestRef(
+  value: unknown,
+  code: MerkleInputErrorCode,
+  label: string
+): asserts value is Sha256DigestRef {
+  if (typeof value !== 'string' || !DIGEST_REF_RE.test(value)) {
+    throw new MerkleInputError(
+      code,
+      `${label} must match sha256:<hex64> (lowercase); received ${describe(value)}`
+    );
+  }
+}
+
+function describe(value: unknown): string {
+  if (typeof value === 'string') return value.length > 74 ? `${value.slice(0, 71)}...` : value;
+  return Object.prototype.toString.call(value);
+}
+
+/** Decode a validated `sha256:<hex64>` ref to its raw 32-byte digest. */
+function decodeDigest(ref: Sha256DigestRef): Uint8Array {
+  return Uint8Array.from(Buffer.from(ref.slice('sha256:'.length), 'hex'));
+}
+
+/** Encode a 32-byte digest as `sha256:<hex64>` (lowercase). */
+function encodeDigest(bytes: Uint8Array): Sha256DigestRef {
+  return `sha256:${Buffer.from(bytes).toString('hex')}` as Sha256DigestRef;
+}
+
+function sha256(...chunks: Uint8Array[]): Uint8Array {
+  const h = createHash('sha256');
+  for (const c of chunks) h.update(c);
+  return Uint8Array.from(h.digest());
+}
+
+/** RFC 9162 leaf hash: SHA-256(0x00 || digest). */
+function leafHash(digest: Uint8Array): Uint8Array {
+  return sha256(Uint8Array.of(LEAF_PREFIX), digest);
+}
+
+/** RFC 9162 internal node hash: SHA-256(0x01 || left || right). */
+function nodeHash(left: Uint8Array, right: Uint8Array): Uint8Array {
+  return sha256(Uint8Array.of(NODE_PREFIX), left, right);
+}
+
+/** Largest power of two strictly smaller than n (n >= 2). */
+function largestPow2LessThan(n: number): number {
+  let k = 1;
+  while (k * 2 < n) k *= 2;
+  return k;
+}
+
+function compareBytes(a: Uint8Array, b: Uint8Array): number {
+  const len = Math.min(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return a.length - b.length;
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+// Integer helpers using arithmetic (not JS bitwise operators, which coerce to
+// signed 32-bit). Tree sizes / indices are protocol integers bounded only by
+// Number.isSafeInteger, so the RFC 9162 fold uses % 2 and Math.floor(n / 2).
+function isSafePositiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 1;
+}
+
+function isSafeNonNegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+}
+
+function isOdd(value: number): boolean {
+  return value % 2 === 1;
+}
+
+function halve(value: number): number {
+  return Math.floor(value / 2);
+}
+
+/**
+ * RFC 9162 section 2.1.1 Merkle Tree Hash over `digests[start, end)`.
+ * Range-based to avoid recursive array allocation.
+ */
+function merkleTreeHash(digests: readonly Uint8Array[], start: number, end: number): Uint8Array {
+  const n = end - start;
+  if (n === 1) return leafHash(digests[start]);
+  const k = largestPow2LessThan(n);
+  return nodeHash(
+    merkleTreeHash(digests, start, start + k),
+    merkleTreeHash(digests, start + k, end)
+  );
+}
+
+/**
+ * RFC 9162 section 2.1.3.1 inclusion path for the leaf at range-relative index
+ * `m` over `digests[start, end)`. Returns sibling hashes in leaf -> root order.
+ */
+function inclusionPath(
+  m: number,
+  digests: readonly Uint8Array[],
+  start: number,
+  end: number
+): Uint8Array[] {
+  const n = end - start;
+  if (n === 1) return [];
+  const k = largestPow2LessThan(n);
+  if (m < k) {
+    return [
+      ...inclusionPath(m, digests, start, start + k),
+      merkleTreeHash(digests, start + k, end),
+    ];
+  }
+  return [
+    ...inclusionPath(m - k, digests, start + k, end),
+    merkleTreeHash(digests, start, start + k),
+  ];
+}
+
+/**
+ * RFC 9162 section 2.1.3.2 inclusion-proof fold using fn = leaf_index and
+ * sn = tree_size - 1. Returns the recomputed root, or null if the proof is
+ * well-formed in shape but does not fold to a root (truncated / extra sibling).
+ * NOTE: this is deliberately NOT a simplified perfect-tree bit-walk.
+ */
+function foldInclusionProof(
+  leaf: Uint8Array,
+  siblings: readonly Uint8Array[],
+  leafIndex: number,
+  treeSize: number
+): Uint8Array | null {
+  if (leafIndex >= treeSize) return null;
+  let fn = leafIndex;
+  let sn = treeSize - 1;
+  let r = leaf;
+  for (const p of siblings) {
+    if (sn === 0) return null; // extra sibling beyond the path
+    if (isOdd(fn) || fn === sn) {
+      r = nodeHash(p, r);
+      if (!isOdd(fn)) {
+        while (!isOdd(fn) && fn !== 0) {
+          fn = halve(fn);
+          sn = halve(sn);
+        }
+      }
+    } else {
+      r = nodeHash(r, p);
+    }
+    fn = halve(fn);
+    sn = halve(sn);
+  }
+  return sn === 0 ? r : null; // sn != 0 => truncated path
+}
+
+/** Validate + decode + sort a receipt-ref set into deduplicated, sorted digests. */
+function toSortedDigests(refs: readonly ReceiptRef[]): {
+  sorted: Uint8Array[];
+  sortedRefs: Sha256DigestRef[];
+} {
+  if (!Array.isArray(refs) || refs.length === 0) {
+    throw new MerkleInputError(
+      'audit.merkle.empty_input',
+      'refs must be a non-empty array of sha256:<hex64> receipt refs'
+    );
+  }
+  const seen = new Set<string>();
+  const entries: { ref: Sha256DigestRef; digest: Uint8Array }[] = [];
+  for (const ref of refs) {
+    assertDigestRef(ref, 'audit.merkle.invalid_receipt_ref', 'receipt_ref');
+    if (seen.has(ref)) {
+      throw new MerkleInputError(
+        'audit.merkle.duplicate_receipt_ref',
+        `duplicate receipt_ref: ${ref}`
+      );
+    }
+    seen.add(ref);
+    entries.push({ ref, digest: decodeDigest(ref) });
+  }
+  entries.sort((a, b) => compareBytes(a.digest, b.digest));
+  return { sorted: entries.map((e) => e.digest), sortedRefs: entries.map((e) => e.ref) };
+}
+
+/**
+ * Build a Merkle commitment over a sorted set of receipt references.
+ *
+ * Rejects empty input and duplicate refs. The returned `root`/`tree_size` map
+ * directly to a workflow summary's `receipt_merkle_root`/`receipt_count`.
+ * @throws {MerkleInputError} on empty input, malformed ref, or duplicate ref.
+ */
+export function buildReceiptMerkleCommitment(refs: readonly ReceiptRef[]): ReceiptMerkleCommitment {
+  const { sorted } = toSortedDigests(refs);
+  return {
+    tree_alg: MERKLE_TREE_ALG,
+    hash_alg: MERKLE_HASH_ALG,
+    root: encodeDigest(merkleTreeHash(sorted, 0, sorted.length)),
+    tree_size: sorted.length,
+  };
+}
+
+/**
+ * Generate an offline inclusion proof for `targetRef` against the committed set.
+ * `leaf_index` in the returned proof is the index within the SORTED leaf order.
+ * @throws {MerkleInputError} on empty input, malformed ref, duplicate ref, or
+ * when `targetRef` is not present in `refs`.
+ */
+export function generateReceiptMerkleInclusionProof(
+  refs: readonly ReceiptRef[],
+  targetRef: ReceiptRef
+): ReceiptMerkleInclusionProof {
+  assertDigestRef(targetRef, 'audit.merkle.invalid_receipt_ref', 'targetRef');
+  const { sorted, sortedRefs } = toSortedDigests(refs);
+  const leafIndex = sortedRefs.indexOf(targetRef);
+  if (leafIndex === -1) {
+    throw new MerkleInputError(
+      'audit.merkle.target_not_found',
+      `targetRef not in refs: ${targetRef}`
+    );
+  }
+  return {
+    tree_alg: MERKLE_TREE_ALG,
+    hash_alg: MERKLE_HASH_ALG,
+    leaf_index: leafIndex,
+    tree_size: sorted.length,
+    hashes: inclusionPath(leafIndex, sorted, 0, sorted.length).map(encodeDigest),
+  };
+}
+
+/**
+ * Verify an inclusion proof offline against a full commitment.
+ *
+ * Verifying against the {@link ReceiptMerkleCommitment} (not a naked root) binds
+ * the proof to the commitment's `tree_size` as well as its `root`, so a proof
+ * whose `tree_size` disagrees with the commitment is rejected up front.
+ *
+ * Returns `false` for a well-formed but cryptographically wrong proof (wrong
+ * root, wrong sibling, wrong target, mismatched tree_size, truncated/extra path).
+ * @throws {MerkleInputError} on malformed input: a structurally invalid
+ * commitment/proof, bad root/target/sibling grammar, unsupported
+ * `tree_alg`/`hash_alg`, or non-integer/out-of-range `leaf_index`/`tree_size`.
+ */
+export function verifyReceiptMerkleInclusion(
+  commitment: ReceiptMerkleCommitment,
+  targetRef: ReceiptRef,
+  proof: ReceiptMerkleInclusionProof
+): boolean {
+  if (commitment === null || typeof commitment !== 'object') {
+    throw new MerkleInputError('audit.merkle.invalid_commitment', 'commitment must be an object');
+  }
+  if (commitment.tree_alg !== MERKLE_TREE_ALG) {
+    throw new MerkleInputError(
+      'audit.merkle.unsupported_tree_alg',
+      `unsupported commitment tree_alg: ${describe(commitment.tree_alg)}`
+    );
+  }
+  if (commitment.hash_alg !== MERKLE_HASH_ALG) {
+    throw new MerkleInputError(
+      'audit.merkle.unsupported_hash_alg',
+      `unsupported commitment hash_alg: ${describe(commitment.hash_alg)}`
+    );
+  }
+  assertDigestRef(commitment.root, 'audit.merkle.invalid_merkle_root', 'commitment.root');
+  if (!isSafePositiveInteger(commitment.tree_size)) {
+    throw new MerkleInputError(
+      'audit.merkle.invalid_commitment',
+      `commitment.tree_size must be a positive safe integer; received ${describe(commitment.tree_size)}`
+    );
+  }
+  assertDigestRef(targetRef, 'audit.merkle.invalid_receipt_ref', 'targetRef');
+  if (proof === null || typeof proof !== 'object') {
+    throw new MerkleInputError('audit.merkle.invalid_proof', 'proof must be an object');
+  }
+  if (proof.tree_alg !== MERKLE_TREE_ALG) {
+    throw new MerkleInputError(
+      'audit.merkle.unsupported_tree_alg',
+      `unsupported tree_alg: ${describe(proof.tree_alg)}`
+    );
+  }
+  if (proof.hash_alg !== MERKLE_HASH_ALG) {
+    throw new MerkleInputError(
+      'audit.merkle.unsupported_hash_alg',
+      `unsupported hash_alg: ${describe(proof.hash_alg)}`
+    );
+  }
+  if (!isSafePositiveInteger(proof.tree_size)) {
+    throw new MerkleInputError(
+      'audit.merkle.invalid_proof',
+      `tree_size must be a positive safe integer; received ${describe(proof.tree_size)}`
+    );
+  }
+  if (!isSafeNonNegativeInteger(proof.leaf_index) || proof.leaf_index >= proof.tree_size) {
+    throw new MerkleInputError(
+      'audit.merkle.invalid_proof',
+      `leaf_index must be a safe integer in [0, tree_size); received ${describe(proof.leaf_index)}`
+    );
+  }
+  if (!Array.isArray(proof.hashes)) {
+    throw new MerkleInputError('audit.merkle.invalid_proof', 'proof.hashes must be an array');
+  }
+  const siblings: Uint8Array[] = [];
+  for (const h of proof.hashes) {
+    assertDigestRef(h, 'audit.merkle.invalid_proof_hash', 'proof.hashes[]');
+    siblings.push(decodeDigest(h));
+  }
+  // Bind the proof to the commitment: a proof for a different-sized tree is not
+  // a proof for this commitment.
+  if (proof.tree_size !== commitment.tree_size) return false;
+  const recomputed = foldInclusionProof(
+    leafHash(decodeDigest(targetRef)),
+    siblings,
+    proof.leaf_index,
+    proof.tree_size
+  );
+  return recomputed !== null && bytesEqual(recomputed, decodeDigest(commitment.root));
+}

--- a/packages/audit/tests/fixtures/merkle-vectors.json
+++ b/packages/audit/tests/fixtures/merkle-vectors.json
@@ -1,0 +1,129 @@
+{
+  "note": "RFC 9162 CT-style sorted-set Merkle vectors; leaf=SHA256(0x00||digest), node=SHA256(0x01||l||r); tree_alg peac.merkle.ct-sorted-set-sha256-v1",
+  "vectors": [
+    {
+      "n": 1,
+      "input_refs": ["sha256:e40f92f9659cca2acdf03a11ebb73685aeb7d2f1cacf73a379c4efa0d6de8554"],
+      "sorted_refs": ["sha256:e40f92f9659cca2acdf03a11ebb73685aeb7d2f1cacf73a379c4efa0d6de8554"],
+      "root": "sha256:5aaf86cc094f108da5b59c9acdd4f074e4c2e98931a8f737280152324a775edc",
+      "proofs": [
+        {
+          "target_ref": "sha256:e40f92f9659cca2acdf03a11ebb73685aeb7d2f1cacf73a379c4efa0d6de8554",
+          "leaf_index": 0,
+          "hashes": []
+        }
+      ]
+    },
+    {
+      "n": 2,
+      "input_refs": [
+        "sha256:e40f92f9659cca2acdf03a11ebb73685aeb7d2f1cacf73a379c4efa0d6de8554",
+        "sha256:3638ec5c42b29eec10e54f25031734d728fd99673bcaa64e012c0a1c8ed2e355"
+      ],
+      "sorted_refs": [
+        "sha256:3638ec5c42b29eec10e54f25031734d728fd99673bcaa64e012c0a1c8ed2e355",
+        "sha256:e40f92f9659cca2acdf03a11ebb73685aeb7d2f1cacf73a379c4efa0d6de8554"
+      ],
+      "root": "sha256:d494ccdb8b9669602ff51a2d230c4e5de3afc6e977866fe8bec9e82691f93b3c",
+      "proofs": [
+        {
+          "target_ref": "sha256:3638ec5c42b29eec10e54f25031734d728fd99673bcaa64e012c0a1c8ed2e355",
+          "leaf_index": 0,
+          "hashes": ["sha256:5aaf86cc094f108da5b59c9acdd4f074e4c2e98931a8f737280152324a775edc"]
+        },
+        {
+          "target_ref": "sha256:e40f92f9659cca2acdf03a11ebb73685aeb7d2f1cacf73a379c4efa0d6de8554",
+          "leaf_index": 1,
+          "hashes": ["sha256:34d0908f37b8aa6911b8427fbcfeb77af3c9e044704f5cade77110dd2a305714"]
+        }
+      ]
+    },
+    {
+      "n": 3,
+      "input_refs": [
+        "sha256:e40f92f9659cca2acdf03a11ebb73685aeb7d2f1cacf73a379c4efa0d6de8554",
+        "sha256:3638ec5c42b29eec10e54f25031734d728fd99673bcaa64e012c0a1c8ed2e355",
+        "sha256:1f7928919575206f03b53d360f5bcd5c4cfa1f15f3a63ea4ce214457353cadf7"
+      ],
+      "sorted_refs": [
+        "sha256:1f7928919575206f03b53d360f5bcd5c4cfa1f15f3a63ea4ce214457353cadf7",
+        "sha256:3638ec5c42b29eec10e54f25031734d728fd99673bcaa64e012c0a1c8ed2e355",
+        "sha256:e40f92f9659cca2acdf03a11ebb73685aeb7d2f1cacf73a379c4efa0d6de8554"
+      ],
+      "root": "sha256:8ebdabac94cbc7908d563c1762d2d41635f329e44c2a371c631369a14a7ad2fb",
+      "proofs": [
+        {
+          "target_ref": "sha256:1f7928919575206f03b53d360f5bcd5c4cfa1f15f3a63ea4ce214457353cadf7",
+          "leaf_index": 0,
+          "hashes": [
+            "sha256:34d0908f37b8aa6911b8427fbcfeb77af3c9e044704f5cade77110dd2a305714",
+            "sha256:5aaf86cc094f108da5b59c9acdd4f074e4c2e98931a8f737280152324a775edc"
+          ]
+        },
+        {
+          "target_ref": "sha256:3638ec5c42b29eec10e54f25031734d728fd99673bcaa64e012c0a1c8ed2e355",
+          "leaf_index": 1,
+          "hashes": [
+            "sha256:6c1e5788c85c67cc8c30e332ad732011640bdb3d21a17ab7bd352593901ebec4",
+            "sha256:5aaf86cc094f108da5b59c9acdd4f074e4c2e98931a8f737280152324a775edc"
+          ]
+        },
+        {
+          "target_ref": "sha256:e40f92f9659cca2acdf03a11ebb73685aeb7d2f1cacf73a379c4efa0d6de8554",
+          "leaf_index": 2,
+          "hashes": ["sha256:47527e93e2b7956f3554d55cd9d4d86498e2818617863ec0c2d2716ba1bac5b8"]
+        }
+      ]
+    },
+    {
+      "n": 7,
+      "input_refs": [
+        "sha256:e40f92f9659cca2acdf03a11ebb73685aeb7d2f1cacf73a379c4efa0d6de8554",
+        "sha256:3638ec5c42b29eec10e54f25031734d728fd99673bcaa64e012c0a1c8ed2e355",
+        "sha256:1f7928919575206f03b53d360f5bcd5c4cfa1f15f3a63ea4ce214457353cadf7",
+        "sha256:4a06ec01bf8398aaa56b46ce49072730563a4a230579f8f80faf8dd56b5c0018",
+        "sha256:23b30a70ea7fa2aaf14bfa34044eade9d0d7063c0ff4b67b098fbecb4dde48ed",
+        "sha256:7a1dd406bfb23560a42392bc9073230993a3dd0be6da4b5b6f0e7e2f45a83631",
+        "sha256:9b943e2ac3bbe6e74fec209a6c9fb5e5729bb3bcfb934d6e3fc285564e3e8004"
+      ],
+      "sorted_refs": [
+        "sha256:1f7928919575206f03b53d360f5bcd5c4cfa1f15f3a63ea4ce214457353cadf7",
+        "sha256:23b30a70ea7fa2aaf14bfa34044eade9d0d7063c0ff4b67b098fbecb4dde48ed",
+        "sha256:3638ec5c42b29eec10e54f25031734d728fd99673bcaa64e012c0a1c8ed2e355",
+        "sha256:4a06ec01bf8398aaa56b46ce49072730563a4a230579f8f80faf8dd56b5c0018",
+        "sha256:7a1dd406bfb23560a42392bc9073230993a3dd0be6da4b5b6f0e7e2f45a83631",
+        "sha256:9b943e2ac3bbe6e74fec209a6c9fb5e5729bb3bcfb934d6e3fc285564e3e8004",
+        "sha256:e40f92f9659cca2acdf03a11ebb73685aeb7d2f1cacf73a379c4efa0d6de8554"
+      ],
+      "root": "sha256:d8bf7c843a84ca676ea43a337b06b7112d606a746e212e574122aba3cf8ced1a",
+      "proofs": [
+        {
+          "target_ref": "sha256:1f7928919575206f03b53d360f5bcd5c4cfa1f15f3a63ea4ce214457353cadf7",
+          "leaf_index": 0,
+          "hashes": [
+            "sha256:2119e373cf5432110696c6308591c0c5fe6ee69dd982c81ca272dbf092b17359",
+            "sha256:40a5189fc0fad2fa40c11638a87fd11a5fdaf5bb05bc4d46a577c73fee5cf204",
+            "sha256:ffd2f571d4c2cf33dc9b2b4c159d4fabdf532affe385748286c1d5046ca55b03"
+          ]
+        },
+        {
+          "target_ref": "sha256:4a06ec01bf8398aaa56b46ce49072730563a4a230579f8f80faf8dd56b5c0018",
+          "leaf_index": 3,
+          "hashes": [
+            "sha256:34d0908f37b8aa6911b8427fbcfeb77af3c9e044704f5cade77110dd2a305714",
+            "sha256:33500ba6f423603fbe1d4597501575c2847c0d0c0c1285eeb5596c312d9deaaa",
+            "sha256:ffd2f571d4c2cf33dc9b2b4c159d4fabdf532affe385748286c1d5046ca55b03"
+          ]
+        },
+        {
+          "target_ref": "sha256:e40f92f9659cca2acdf03a11ebb73685aeb7d2f1cacf73a379c4efa0d6de8554",
+          "leaf_index": 6,
+          "hashes": [
+            "sha256:1c169eda067e7186db9f63246a2dd5155effc0d9f1a8515c693d8cbca1db23f6",
+            "sha256:0ceb286663b5bfe60137342d88f4ad421c40f3fab059ff0d5d3825cd00757ffc"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/audit/tests/merkle.test.ts
+++ b/packages/audit/tests/merkle.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Tests for @peac/audit Merkle commitment helpers (WORKFLOW-CORRELATION section 7;
+ * RFC 9162 CT-style sorted-set commitment).
+ *
+ * Uses committed JSON vectors (tests/fixtures/merkle-vectors.json) generated
+ * independently from the implementation, PLUS a hand-rolled RFC 9162 oracle in
+ * this file, so the implementation is not self-certifying. A deliberately naive
+ * perfect-tree verifier is included to prove that n=3 / n=7 vectors catch a wrong
+ * fold; the implementation MUST use the RFC 9162 section 2.1.3.2 fn/sn fold.
+ *
+ * verifyReceiptMerkleInclusion takes the full commitment (root + tree_size + algs)
+ * so a proof is bound to the commitment it is verified against.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import {
+  MERKLE_TREE_ALG,
+  MERKLE_HASH_ALG,
+  MerkleInputError,
+  buildReceiptMerkleCommitment,
+  generateReceiptMerkleInclusionProof,
+  verifyReceiptMerkleInclusion,
+  type ReceiptMerkleCommitment,
+  type ReceiptMerkleInclusionProof,
+} from '../src/merkle.js';
+import vectorsFile from './fixtures/merkle-vectors.json';
+
+type Ref = `sha256:${string}`;
+interface Vector {
+  n: number;
+  input_refs: Ref[];
+  sorted_refs: Ref[];
+  root: Ref;
+  proofs: { target_ref: Ref; leaf_index: number; hashes: Ref[] }[];
+}
+const VECTORS = (vectorsFile as { vectors: Vector[] }).vectors;
+
+// ---- independent hand-rolled RFC 9162 oracle (separate code path) ----
+const sha = (...c: Uint8Array[]) => {
+  const h = createHash('sha256');
+  for (const x of c) h.update(x);
+  return Uint8Array.from(h.digest());
+};
+const dec = (r: Ref) => Uint8Array.from(Buffer.from(r.slice(7), 'hex'));
+const enc = (b: Uint8Array): Ref => `sha256:${Buffer.from(b).toString('hex')}` as Ref;
+const oLeaf = (d: Uint8Array) => sha(Uint8Array.of(0x00), d);
+const oNode = (l: Uint8Array, r: Uint8Array) => sha(Uint8Array.of(0x01), l, r);
+const oPow2 = (n: number) => {
+  let k = 1;
+  while (k * 2 < n) k *= 2;
+  return k;
+};
+const oMth = (D: Uint8Array[]): Uint8Array =>
+  D.length === 1
+    ? oLeaf(D[0])
+    : oNode(oMth(D.slice(0, oPow2(D.length))), oMth(D.slice(oPow2(D.length))));
+const eq = (a: Uint8Array, b: Uint8Array) => a.length === b.length && a.every((x, i) => x === b[i]);
+const odd = (n: number) => n % 2 === 1;
+const half = (n: number) => Math.floor(n / 2);
+// oracle verify via the RFC 9162 fn/sn fold (arithmetic, not JS bitwise)
+function oracleVerify(
+  root: Ref,
+  target: Ref,
+  proof: { leaf_index: number; tree_size: number; hashes: Ref[] }
+): boolean {
+  let fn = proof.leaf_index;
+  let sn = proof.tree_size - 1;
+  if (fn < 0 || fn >= proof.tree_size) return false;
+  let r = oLeaf(dec(target));
+  for (const p of proof.hashes.map(dec)) {
+    if (sn === 0) return false;
+    if (odd(fn) || fn === sn) {
+      r = oNode(p, r);
+      if (!odd(fn)) while (!odd(fn) && fn !== 0) ((fn = half(fn)), (sn = half(sn)));
+    } else {
+      r = oNode(r, p);
+    }
+    fn = half(fn);
+    sn = half(sn);
+  }
+  return sn === 0 && eq(r, dec(root));
+}
+// deliberately WRONG naive perfect-tree fold (no fn==sn / no while-shift)
+function naiveVerify(
+  root: Ref,
+  target: Ref,
+  proof: { leaf_index: number; hashes: Ref[] }
+): boolean {
+  let idx = proof.leaf_index;
+  let r = oLeaf(dec(target));
+  for (const p of proof.hashes.map(dec)) {
+    r = odd(idx) ? oNode(p, r) : oNode(r, p);
+    idx = half(idx);
+  }
+  return eq(r, dec(root));
+}
+
+const refOf = (label: string): Ref => enc(sha(Buffer.from(label, 'utf8')));
+
+describe('@peac/audit merkle: exported API surface', () => {
+  it('exports the expected names and constants', () => {
+    expect(MERKLE_TREE_ALG).toBe('peac.merkle.ct-sorted-set-sha256-v1');
+    expect(MERKLE_HASH_ALG).toBe('sha256');
+    expect(typeof buildReceiptMerkleCommitment).toBe('function');
+    expect(typeof generateReceiptMerkleInclusionProof).toBe('function');
+    expect(typeof verifyReceiptMerkleInclusion).toBe('function');
+    expect(new MerkleInputError('audit.merkle.empty_input', 'x')).toBeInstanceOf(Error);
+  });
+
+  it('production merkle.ts uses no JS bitwise integer operators (RFC 9162 fold is arithmetic)', () => {
+    const src = readFileSync(path.join(__dirname, '../src/merkle.ts'), 'utf8');
+    // strip block + line comments so prose/JSDoc cannot trip the guard
+    const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+    expect(code).not.toMatch(/>>|<<|&\s*1\b|\|\s*0\b|~~/);
+  });
+});
+
+describe('@peac/audit merkle: committed vectors (helper == oracle == golden)', () => {
+  for (const v of VECTORS) {
+    it(`n=${v.n}: commitment root matches golden + oracle`, () => {
+      const c = buildReceiptMerkleCommitment(v.input_refs);
+      expect(c.tree_alg).toBe(MERKLE_TREE_ALG);
+      expect(c.hash_alg).toBe(MERKLE_HASH_ALG);
+      expect(c.tree_size).toBe(v.n);
+      expect(c.root).toBe(v.root); // golden
+      expect(c.root).toBe(enc(oMth(v.sorted_refs.map(dec)))); // oracle
+    });
+
+    it(`n=${v.n}: shuffled input yields the identical root`, () => {
+      const shuffled = [...v.input_refs].reverse();
+      expect(buildReceiptMerkleCommitment(shuffled).root).toBe(v.root);
+    });
+
+    for (const p of v.proofs) {
+      it(`n=${v.n} leaf ${p.leaf_index}: proof matches golden, verifies (helper + oracle)`, () => {
+        const c = buildReceiptMerkleCommitment(v.input_refs);
+        const proof = generateReceiptMerkleInclusionProof(v.input_refs, p.target_ref);
+        expect(proof.leaf_index).toBe(p.leaf_index);
+        expect(proof.tree_size).toBe(v.n);
+        expect(proof.hashes).toEqual(p.hashes); // golden
+        expect(verifyReceiptMerkleInclusion(c, p.target_ref, proof)).toBe(true);
+        expect(oracleVerify(v.root, p.target_ref, proof)).toBe(true);
+      });
+    }
+  }
+
+  it('n=1 proof has empty hashes and verifies', () => {
+    const v = VECTORS.find((x) => x.n === 1)!;
+    const c = buildReceiptMerkleCommitment(v.input_refs);
+    const proof = generateReceiptMerkleInclusionProof(v.input_refs, v.input_refs[0]);
+    expect(proof.hashes).toEqual([]);
+    expect(verifyReceiptMerkleInclusion(c, v.input_refs[0], proof)).toBe(true);
+  });
+
+  it('first-principles anchor: n=1 root = SHA-256(0x00 || digest)', () => {
+    const v = VECTORS.find((x) => x.n === 1)!;
+    expect(v.root).toBe(enc(oLeaf(dec(v.input_refs[0]))));
+  });
+
+  it('first-principles anchor: n=2 root = node(leaf(min), leaf(max))', () => {
+    const v = VECTORS.find((x) => x.n === 2)!;
+    const [a, b] = v.sorted_refs.map(dec);
+    expect(v.root).toBe(enc(oNode(oLeaf(a), oLeaf(b))));
+  });
+});
+
+describe('@peac/audit merkle: n=3 / n=7 fold guard (RFC 9162, not perfect-tree bit-walk)', () => {
+  for (const n of [3, 7]) {
+    it(`n=${n} last leaf: RFC fold verifies but a naive perfect-tree fold does NOT`, () => {
+      const v = VECTORS.find((x) => x.n === n)!;
+      const c = buildReceiptMerkleCommitment(v.input_refs);
+      const last = v.sorted_refs.length - 1;
+      const proof = generateReceiptMerkleInclusionProof(v.input_refs, v.sorted_refs[last]);
+      expect(verifyReceiptMerkleInclusion(c, v.sorted_refs[last], proof)).toBe(true);
+      expect(
+        naiveVerify(v.root, v.sorted_refs[last], {
+          leaf_index: proof.leaf_index,
+          hashes: proof.hashes,
+        })
+      ).toBe(false);
+    });
+  }
+});
+
+describe('@peac/audit merkle: malformed input throws MerkleInputError', () => {
+  const good = [refOf('a'), refOf('b'), refOf('c')];
+  const commitment = () => buildReceiptMerkleCommitment(good);
+  const baseProof = (): ReceiptMerkleInclusionProof =>
+    generateReceiptMerkleInclusionProof(good, good[0]);
+  const codeOf = (fn: () => unknown): string => {
+    try {
+      fn();
+    } catch (e) {
+      expect(e).toBeInstanceOf(MerkleInputError);
+      return (e as MerkleInputError).code;
+    }
+    throw new Error('expected throw');
+  };
+
+  // build / generate input
+  it('empty input', () =>
+    expect(codeOf(() => buildReceiptMerkleCommitment([]))).toBe('audit.merkle.empty_input'));
+  it('duplicate ref', () =>
+    expect(codeOf(() => buildReceiptMerkleCommitment([good[0], good[0]]))).toBe(
+      'audit.merkle.duplicate_receipt_ref'
+    ));
+  it('malformed ref (short hex)', () =>
+    expect(codeOf(() => buildReceiptMerkleCommitment(['sha256:abcd' as Ref]))).toBe(
+      'audit.merkle.invalid_receipt_ref'
+    ));
+  it('uppercase ref', () =>
+    expect(codeOf(() => buildReceiptMerkleCommitment([good[0].toUpperCase() as Ref]))).toBe(
+      'audit.merkle.invalid_receipt_ref'
+    ));
+  it('target not found', () =>
+    expect(codeOf(() => generateReceiptMerkleInclusionProof(good, refOf('z')))).toBe(
+      'audit.merkle.target_not_found'
+    ));
+
+  // commitment
+  it('null commitment', () =>
+    expect(
+      codeOf(() =>
+        verifyReceiptMerkleInclusion(
+          null as unknown as ReceiptMerkleCommitment,
+          good[0],
+          baseProof()
+        )
+      )
+    ).toBe('audit.merkle.invalid_commitment'));
+  it('commitment.tree_size not a positive integer', () =>
+    expect(
+      codeOf(() =>
+        verifyReceiptMerkleInclusion({ ...commitment(), tree_size: 0 }, good[0], baseProof())
+      )
+    ).toBe('audit.merkle.invalid_commitment'));
+  it('commitment.root bad grammar', () =>
+    expect(
+      codeOf(() =>
+        verifyReceiptMerkleInclusion(
+          { ...commitment(), root: 'sha256:xyz' as ReceiptMerkleCommitment['root'] },
+          good[0],
+          baseProof()
+        )
+      )
+    ).toBe('audit.merkle.invalid_merkle_root'));
+  it('unsupported commitment tree_alg', () =>
+    expect(
+      codeOf(() =>
+        verifyReceiptMerkleInclusion(
+          { ...commitment(), tree_alg: 'other' } as unknown as ReceiptMerkleCommitment,
+          good[0],
+          baseProof()
+        )
+      )
+    ).toBe('audit.merkle.unsupported_tree_alg'));
+  it('unsupported commitment hash_alg', () =>
+    expect(
+      codeOf(() =>
+        verifyReceiptMerkleInclusion(
+          { ...commitment(), hash_alg: 'sha512' } as unknown as ReceiptMerkleCommitment,
+          good[0],
+          baseProof()
+        )
+      )
+    ).toBe('audit.merkle.unsupported_hash_alg'));
+
+  // proof
+  it('unsupported proof tree_alg', () =>
+    expect(
+      codeOf(() =>
+        verifyReceiptMerkleInclusion(commitment(), good[0], {
+          ...baseProof(),
+          tree_alg: 'other',
+        } as unknown as ReceiptMerkleInclusionProof)
+      )
+    ).toBe('audit.merkle.unsupported_tree_alg'));
+  it('unsupported proof hash_alg', () =>
+    expect(
+      codeOf(() =>
+        verifyReceiptMerkleInclusion(commitment(), good[0], {
+          ...baseProof(),
+          hash_alg: 'sha512',
+        } as unknown as ReceiptMerkleInclusionProof)
+      )
+    ).toBe('audit.merkle.unsupported_hash_alg'));
+  it('out-of-range leaf_index', () =>
+    expect(
+      codeOf(() =>
+        verifyReceiptMerkleInclusion(commitment(), good[0], { ...baseProof(), leaf_index: 99 })
+      )
+    ).toBe('audit.merkle.invalid_proof'));
+  it('non-integer leaf_index', () =>
+    expect(
+      codeOf(() =>
+        verifyReceiptMerkleInclusion(commitment(), good[0], { ...baseProof(), leaf_index: 1.5 })
+      )
+    ).toBe('audit.merkle.invalid_proof'));
+  it('bad proof tree_size', () =>
+    expect(
+      codeOf(() =>
+        verifyReceiptMerkleInclusion(commitment(), good[0], { ...baseProof(), tree_size: 0 })
+      )
+    ).toBe('audit.merkle.invalid_proof'));
+
+  // safe-integer bounds (JS bitwise coercion / precision safety)
+  it('commitment.tree_size must be a safe integer', () =>
+    expect(
+      codeOf(() =>
+        verifyReceiptMerkleInclusion(
+          { ...commitment(), tree_size: Number.MAX_SAFE_INTEGER + 1 },
+          good[0],
+          baseProof()
+        )
+      )
+    ).toBe('audit.merkle.invalid_commitment'));
+  it('proof.tree_size must be a safe integer', () =>
+    expect(
+      codeOf(() =>
+        verifyReceiptMerkleInclusion(commitment(), good[0], {
+          ...baseProof(),
+          tree_size: Number.MAX_SAFE_INTEGER + 1,
+        })
+      )
+    ).toBe('audit.merkle.invalid_proof'));
+  it('proof.leaf_index must be a safe integer', () =>
+    expect(
+      codeOf(() =>
+        verifyReceiptMerkleInclusion(commitment(), good[0], {
+          ...baseProof(),
+          leaf_index: Number.MAX_SAFE_INTEGER + 1,
+        })
+      )
+    ).toBe('audit.merkle.invalid_proof'));
+  it('malformed proof sibling hash grammar (throws, not false)', () =>
+    expect(
+      codeOf(() =>
+        verifyReceiptMerkleInclusion(commitment(), good[0], {
+          ...baseProof(),
+          hashes: ['sha256:zz' as Ref],
+        })
+      )
+    ).toBe('audit.merkle.invalid_proof_hash'));
+});
+
+describe('@peac/audit merkle: well-formed but wrong proof returns false', () => {
+  const refs = [refOf('p'), refOf('q'), refOf('r'), refOf('s'), refOf('t'), refOf('u'), refOf('v')]; // n=7
+  const commitment = () => buildReceiptMerkleCommitment(refs);
+
+  it('wrong root -> false', () => {
+    const p = generateReceiptMerkleInclusionProof(refs, refs[0]);
+    expect(
+      verifyReceiptMerkleInclusion({ ...commitment(), root: refOf('not-the-root') }, refs[0], p)
+    ).toBe(false);
+  });
+  it('wrong targetRef -> false', () => {
+    const p = generateReceiptMerkleInclusionProof(refs, refs[0]);
+    expect(verifyReceiptMerkleInclusion(commitment(), refs[1], p)).toBe(false);
+  });
+  it('wrong sibling bytes -> false', () => {
+    const p = generateReceiptMerkleInclusionProof(refs, refs[0]);
+    const mutated = { ...p, hashes: [refOf('bogus-sibling'), ...p.hashes.slice(1)] };
+    expect(verifyReceiptMerkleInclusion(commitment(), refs[0], mutated)).toBe(false);
+  });
+  it('proof.tree_size != commitment.tree_size -> false', () => {
+    const p = generateReceiptMerkleInclusionProof(refs, refs[0]);
+    expect(
+      verifyReceiptMerkleInclusion(commitment(), refs[0], { ...p, tree_size: p.tree_size + 1 })
+    ).toBe(false);
+  });
+  it('truncated proof -> false', () => {
+    const p = generateReceiptMerkleInclusionProof(refs, refs[0]);
+    expect(
+      verifyReceiptMerkleInclusion(commitment(), refs[0], { ...p, hashes: p.hashes.slice(0, -1) })
+    ).toBe(false);
+  });
+  it('extra sibling -> false', () => {
+    const p = generateReceiptMerkleInclusionProof(refs, refs[0]);
+    expect(
+      verifyReceiptMerkleInclusion(commitment(), refs[0], {
+        ...p,
+        hashes: [...p.hashes, refOf('extra')],
+      })
+    ).toBe(false);
+  });
+});
+
+describe('@peac/audit merkle: no logging of material', () => {
+  it('build/generate/verify do not write to console', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const refs = [refOf('m'), refOf('n'), refOf('o')];
+      const c = buildReceiptMerkleCommitment(refs);
+      const p = generateReceiptMerkleInclusionProof(refs, refs[0]);
+      verifyReceiptMerkleInclusion(c, refs[0], p);
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(errSpy).not.toHaveBeenCalled();
+    } finally {
+      logSpy.mockRestore();
+      errSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements the deferred WORKFLOW-CORRELATION §7 Merkle commitment as deterministic, offline helpers in `@peac/audit`.

CT-style Merkle Tree Hash following RFC 9162 §2.1.1 (RFC 9162 obsoletes RFC 6962), adapted as a **sorted-set commitment over PEAC `receipt_ref` digests** — not a Certificate Transparency append-only log. A commitment proves inclusion in the committed set; by itself it proves neither completeness nor record validity.

## Public API (`@peac/audit`)

- `buildReceiptMerkleCommitment(refs) -> ReceiptMerkleCommitment { tree_alg, hash_alg, root, tree_size }`
- `generateReceiptMerkleInclusionProof(refs, targetRef) -> ReceiptMerkleInclusionProof`
- `verifyReceiptMerkleInclusion(commitment, targetRef, proof) -> boolean` (takes the full `ReceiptMerkleCommitment`, binding the proof to the commitment `tree_size` as well as its `root`)
- Types: `ReceiptMerkleCommitment`, `ReceiptMerkleInclusionProof`, `Sha256DigestRef`, `ReceiptMerkleRoot`, `MerkleNodeHash`, `MerkleInputErrorCode`
- `MerkleInputError` (audit-local); consts `MERKLE_TREE_ALG = 'peac.merkle.ct-sorted-set-sha256-v1'`, `MERKLE_HASH_ALG = 'sha256'`

## Algorithm

- Leaf `SHA-256(0x00 || rawDigest)`; node `SHA-256(0x01 || left || right)`; k = largest power of two < n (RFC 9162 §2.1.1).
- Input = `receipt_ref` strings (`sha256:<hex64>`, lowercase) only; decoded to raw 32-byte digests; bytewise-sorted (shuffled input yields the same root).
- Empty input and duplicates rejected. `MerkleInputError` on malformed input; `false` on well-formed-but-wrong proofs.
- Verification uses the RFC 9162 §2.1.3.2 `fn`/`sn` fold (arithmetic, not JS bitwise operators; not a perfect-tree bit-walk); it verifies against the full commitment, so a proof whose `tree_size` disagrees with the commitment is rejected. `tree_size`/`leaf_index` are validated as safe integers.

## Boundaries

`@peac/audit` only. No chain, network, CLI, verifier UI, schema, registry, wire, receipt type, extension group, or conformance change. No new runtime dependency (`@peac/audit` already depends on `@peac/schema`/`@peac/kernel`/`@peac/crypto`; hashing via `node:crypto`). Callers starting from JWS bytes use `@peac/schema` `computeReceiptRef` first — this module does not re-implement digest computation.

## Docs

Informative `docs/specs/WORKFLOW-CORRELATION.md` §7 de-deferred: "RFC 6962 Style" -> "CT-style / RFC 9162 §2.1.1"; proof shape + verifier name updated; PEAC empty-input deviation + completeness/validity boundary documented.

## Validation

- 50 new tests (206 in `@peac/audit`): committed JSON vectors (n=1,2,3,7) cross-checked against a hand-rolled RFC 9162 oracle and first-principles anchors; a naive perfect-tree fold guard proving the n=3/n=7 fold is required; throw-set and return-false-set; no-logging.
- `api_contract` 27 (unchanged), build_targets 110 (unchanged), kernel errors 189 (unchanged).
- No network/chain imports in `merkle.ts` (grep-verified).
