### PR TITLE
chore(ci): migrate actions to Node 24 runtimes

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -29,10 +29,10 @@ runs:
         pnpm --version
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
     - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version-file: '.node-version'
         cache: 'pnpm'

--- a/.github/workflows/bench-gate.yml
+++ b/.github/workflows/bench-gate.yml
@@ -126,7 +126,7 @@ jobs:
           node scripts/update-bench-baseline.mjs --input bench-capture.json
 
       - name: Open baseline-refresh pull request
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: 'chore: refresh Go bench baseline on ubuntu-24.04'
           branch: chore/bench-baseline-refresh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Detect changed paths
         id: filter
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         with:
           filters: |
             core:
@@ -717,7 +717,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -755,7 +755,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -836,7 +836,7 @@ jobs:
           pnpm --version
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: critical
           deny-licenses: GPL-3.0, AGPL-3.0

--- a/.github/workflows/entry-doc-verification.yml
+++ b/.github/workflows/entry-doc-verification.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Detect relevant changes
         id: filter
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         with:
           filters: |
             relevant:
@@ -43,7 +43,7 @@ jobs:
         if: steps.filter.outputs.relevant != 'true'
         run: echo "No entry documents, linked targets, or tooling tests changed. Nothing to verify."
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         if: steps.filter.outputs.relevant == 'true'
 
       - name: Setup Node.js

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,7 @@ jobs:
           pnpm --version
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -119,7 +119,7 @@ jobs:
           pnpm --version
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -178,7 +178,7 @@ jobs:
           pnpm --version
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -231,7 +231,7 @@ jobs:
           pnpm --version
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@9fd676a19091d4595eefd76e4bd31c97133911f1 # v4.2.0
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -369,7 +369,7 @@ jobs:
           corepack prepare "$PM" --activate
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -415,7 +415,7 @@ jobs:
           pnpm --version
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@9fd676a19091d4595eefd76e4bd31c97133911f1 # v4.2.0
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -500,7 +500,7 @@ jobs:
           pnpm --version
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@9fd676a19091d4595eefd76e4bd31c97133911f1 # v4.2.0
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/ucp-drift.yml
+++ b/.github/workflows/ucp-drift.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: '.node-version'
 


### PR DESCRIPTION
Migrates the GitHub Actions still running on the Node 20 action runtime to their current Node 24 releases, keeping every reference SHA-pinned. GitHub is making Node 24 the default JavaScript-action runtime after Node 20 end-of-life and will remove Node 20 from runners later this year.

**Migrated (Node 20 -> Node 24), version comment and immutable SHA updated together:**
- `pnpm/action-setup` v4 / v4.2.0 -> **v6.0.9** (`0ebf47130e4866e96fce0953f49152a61190b271`), 12 references. No step passes a `version:` input; the pnpm version is resolved from `packageManager: pnpm@8.15.0` (via Corepack in the shared setup), which v6 reads identically.
- `actions/setup-node` v4.4.0 -> **v6** (`48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e`), 2 references, aligning the two stray pins with the v6 pin already used across the repo. `cache: 'pnpm'` and `node-version-file` behavior is unchanged.
- `actions/dependency-review-action` v4.7.1 -> **v5.0.0** (`a1d282b36b6f3519aa1f3fc636f609c47dddb294`). Inputs `fail-on-severity` / `deny-licenses` are unchanged.
- `dorny/paths-filter` v3 -> **v4.0.2** (`7b450fff21473bca461d4b92ce414b9d0420d706`), 2 references. `filters` input unchanged.
- `peter-evans/create-pull-request` v7.0.8 -> **v8.1.1** (`5f6978faf089d4d20b00c7766989d076bb2fc7f1`). The job already has the required `contents: write` and `pull-requests: write` permissions; the `commit-message`/`branch`/`title`/`body` inputs are unchanged.

**Left unchanged (deliberate):**
- `actions/checkout` (v6.0.2), `actions/setup-node` (v6), `actions/upload-artifact` (v7.0.1), `actions/setup-go` (v6.4.0) already run on Node 24.
- `github/codeql-action` has no Node 24 version-tagged release yet (latest v3.37.0 still declares `node20`); it stays at its current pin and GitHub runs it under the Node 24 compatibility shim until an upstream Node 24 release ships.
- `xu-cheng/latex-action` is a composite action (no Node runtime).

**Validation.** `actionlint` reports no new findings on the changed pins (the only warnings are pre-existing `SC2086:info` shellcheck notes in unrelated `run:` blocks); workflow structure preserved. End-to-end validation is this PR's own CI, which executes the migrated workflows on the new runtimes.
