### PR TITLE
fix(docs): resolve clean-tree markdown links

### DIFF
--- a/docs/baselines/BASELINE-v0.13.0.md
+++ b/docs/baselines/BASELINE-v0.13.0.md
@@ -19,7 +19,7 @@ What v0.13.0 holds invariant:
   default and the only format actively documented in the public OpenAPI
   contract. `peac-receipt/0.1` (Wire 0.1) remains a frozen verify-only
   path with no new-feature extensions. `peac.receipt/0.9` is archived
-  under [`archive/0.9.0-0.9.14/packages-core/`](../../archive/0.9.0-0.9.14/packages-core/);
+  under `archive/0.9.0-0.9.14/packages-core/`;
   `@peac/core` is not in the v0.13.0 active publish manifest.
 - The signing envelope. JWS Compact Serialization (RFC 7515) with
   Ed25519 (RFC 8032) is the only accepted shape. There is no algorithm

--- a/examples/agent-action-records/README.md
+++ b/examples/agent-action-records/README.md
@@ -46,7 +46,7 @@ pnpm verify
 ```
 
 `pnpm issue` writes the signed records and the public key to
-[`./out/`](./out/). `pnpm verify` reads them back and verifies each
+`./out/`. `pnpm verify` reads them back and verifies each
 record offline. The `out/` directory is gitignored.
 
 Expected output: 6 records issued, 6 verified, exit code 0.

--- a/examples/commerce-mandate-records/README.md
+++ b/examples/commerce-mandate-records/README.md
@@ -53,7 +53,7 @@ pnpm verify
 ```
 
 `pnpm issue` writes the signed records and the public key to
-[`./out/`](./out/). `pnpm verify` reads them back and verifies each
+`./out/`. `pnpm verify` reads them back and verifies each
 record offline. The `out/` directory is gitignored.
 
 Expected output: 7 records issued, 7 verified, exit code 0.

--- a/examples/gateway-export-records/README.md
+++ b/examples/gateway-export-records/README.md
@@ -58,7 +58,7 @@ pnpm verify
 ```
 
 `pnpm issue` writes the signed records and the public key to
-[`./out/`](./out/). `pnpm verify` reads them back and verifies each
+`./out/`. `pnpm verify` reads them back and verifies each
 record offline. The `out/` directory is gitignored.
 
 Expected output: 8 records issued, 8 verified, exit code 0.

--- a/examples/provisioning-lifecycle/README.md
+++ b/examples/provisioning-lifecycle/README.md
@@ -48,7 +48,7 @@ pnpm verify
 ```
 
 `pnpm issue` writes the signed records and the public key to
-[`./out/`](./out/). `pnpm verify` reads them back and verifies each
+`./out/`. `pnpm verify` reads them back and verifies each
 record offline. The `out/` directory is gitignored.
 
 ## Files


### PR DESCRIPTION
Removes broken relative links to paths not present in a clean checkout (the archive tree removed from HEAD and example build-output directories), converting them to inline code so repository Markdown-link validation passes on a clean tree.
