### PR TITLE
chore(release): stamp v0.16.2 release state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to PEAC Protocol will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.16.2] - 2026-07-14
+## [0.16.2] - 2026-07-13
 
 Portable Evidence Pack.
 

--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable surface classification for PEAC Protocol workspace. CI fails if any workspace member is missing. See docs/PACKAGE_STATUS.md for human-readable view.",
   "version": "0.13.0",
-  "updated": "2026-06-29",
+  "updated": "2026-07-13",
   "states": {
     "default": "Current recommended path. Actively maintained, Wire 0.2 native.",
     "supported": "Actively maintained, published, production-ready. May not be on default quickstart path.",

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -2,7 +2,7 @@
 
 Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scripts/generate-surface-status.mjs`.
 
-**Version:** 0.13.0 | **Updated:** 2026-06-29
+**Version:** 0.13.0 | **Updated:** 2026-07-13
 
 ## Layer 1
 

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -4,7 +4,7 @@
   "version": "0.16.2",
   "wire_format_version": "0.2",
   "dist_tag": "latest",
-  "release_date": "2026-06-28",
+  "release_date": "2026-07-13",
   "metrics": {
     "tests": 12666,
     "test_files": 487,


### PR DESCRIPTION
Stamps post-publish and post-promotion release state for v0.16.2: release date, dist-tag, and surface-status update timestamp, and aligns the changelog date to the release date. Release-state reconciliation only; no protocol, package, schema, or API change.
