### PR TITLE
test(tooling): resolve doc links to the git tracked tree

### DIFF
--- a/tests/tooling/lib/markdown-links.ts
+++ b/tests/tooling/lib/markdown-links.ts
@@ -6,16 +6,24 @@
  * parser instead of duplicating it. The entry gate keeps its own inline copy so
  * that curated, high-traffic gate cannot be affected by changes here.
  *
- * Filesystem-only: node:fs + node:path, no spawn, no network, no dependency.
- *
  * Case-exact note: development commonly happens on case-insensitive filesystems
  * (APFS/NTFS) while CI runs on case-sensitive Linux. `existsSync` would accept a
  * link whose case does not match the real file, then fail in CI. `existsCaseExact`
  * verifies every path segment against its parent directory listing.
+ *
+ * Tracked-tree note: a link target that exists on disk but is NOT part of the git
+ * index (untracked working-directory residue such as a stale `node_modules` or an
+ * old build output) must NOT satisfy a repository link. `existsTrackedCaseExact`
+ * validates against the git index (via `git ls-files --cached`) so the link gate
+ * cannot be silently satisfied by residue that is absent from a clean checkout. It
+ * fails closed: if the git index cannot be read it throws rather than degrading to
+ * a weaker check. For deliberate filesystem-only validation (for example a source
+ * tarball with no `.git`) call `existsCaseExact` explicitly.
  */
 
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, join, relative, resolve, sep } from 'node:path';
+import { spawnSync } from 'node:child_process';
 
 /**
  * Remove fenced code blocks AND inline code spans so code text (e.g. a regex
@@ -100,6 +108,97 @@ export function existsCaseExact(repoRoot: string, absPath: string): boolean {
   return true;
 }
 
+interface TrackedIndex {
+  files: ReadonlySet<string>;
+  dirs: ReadonlySet<string>;
+}
+
+const trackedIndexCache = new Map<string, TrackedIndex>();
+
+/**
+ * Build (and cache) the set of git-tracked file and directory paths for a repo,
+ * keyed by the canonical (resolved) repo root. Paths are POSIX-separated and
+ * case-sensitive, exactly as the git index stores them.
+ *
+ * Fails closed: if the git index cannot be read (git missing, non-zero exit,
+ * a process error/signal, or unreadable output) this throws rather than quietly
+ * degrading to a weaker check. Callers that deliberately want filesystem-only
+ * validation (for example a source tarball with no `.git`) call `existsCaseExact`
+ * explicitly instead.
+ */
+function getTrackedIndex(root: string): TrackedIndex {
+  const cached = trackedIndexCache.get(root);
+  if (cached) return cached;
+
+  const res = spawnSync('git', ['-C', root, 'ls-files', '-z', '--cached'], {
+    encoding: 'utf8',
+    timeout: 10_000,
+    // `git ls-files -z` is on the order of 120 KiB for this repository; 32 MiB
+    // is generous but bounded headroom that rejects pathological output rather
+    // than allocating without limit.
+    maxBuffer: 32 * 1024 * 1024,
+    windowsHide: true,
+  });
+
+  if (res.error) {
+    throw new Error(
+      `Unable to read the git tracked-file index (git ls-files failed: ${res.error.message}); tracked-tree link validation cannot continue.`
+    );
+  }
+  if (res.signal) {
+    throw new Error(
+      `git ls-files was terminated by signal ${res.signal}; tracked-tree link validation cannot continue.`
+    );
+  }
+  if (res.status !== 0) {
+    const stderr = typeof res.stderr === 'string' ? res.stderr.trim() : '';
+    throw new Error(
+      `git ls-files exited with status ${String(res.status)}${stderr ? `: ${stderr}` : ''}; tracked-tree link validation cannot continue.`
+    );
+  }
+  if (typeof res.stdout !== 'string') {
+    throw new Error(
+      'git ls-files produced no readable output; tracked-tree link validation cannot continue.'
+    );
+  }
+
+  const files = new Set<string>();
+  const dirs = new Set<string>();
+  for (const path of res.stdout.split('\0')) {
+    if (!path) continue;
+    files.add(path);
+    const segments = path.split('/');
+    for (let i = 1; i < segments.length; i++) {
+      dirs.add(segments.slice(0, i).join('/'));
+    }
+  }
+
+  const index: TrackedIndex = { files, dirs };
+  trackedIndexCache.set(root, index);
+  return index;
+}
+
+/**
+ * True when `absPath` resolves to a git-TRACKED file, or a directory that
+ * contains at least one tracked file, matched case-exactly against the git
+ * index. Untracked working-directory residue (a file or directory present on
+ * disk but absent from the index) does NOT satisfy the check, so a broken link
+ * cannot be masked by local residue that a clean checkout would not have.
+ *
+ * Fails closed: throws when the git index cannot be read (see getTrackedIndex).
+ * For deliberate filesystem-only validation, use `existsCaseExact`.
+ */
+export function existsTrackedCaseExact(repoRoot: string, absPath: string): boolean {
+  const root = resolve(repoRoot);
+  const rel = relative(root, resolve(absPath));
+  if (rel === '') return true;
+  if (rel.startsWith('..')) return false;
+
+  const index = getTrackedIndex(root);
+  const relPosix = rel.split(sep).join('/');
+  return index.files.has(relPosix) || index.dirs.has(relPosix);
+}
+
 /**
  * Recursively collect repo-relative paths of Markdown files under the given
  * repo-relative roots, skipping generated/vendored directories.
@@ -151,7 +250,7 @@ export function brokenLinksForDoc(repoRoot: string, relDocPath: string): string[
       failures.add(`"${target}" escapes repository root`);
       continue;
     }
-    if (!existsCaseExact(repoRoot, resolved)) {
+    if (!existsTrackedCaseExact(repoRoot, resolved)) {
       failures.add(`"${target}" -> ${relative(repoRoot, resolved)}`);
     }
   }

--- a/tests/tooling/repo-links-doc-truth.test.ts
+++ b/tests/tooling/repo-links-doc-truth.test.ts
@@ -7,9 +7,12 @@
  * entry-doc set. Every relative file link must resolve to a real repository file
  * with EXACT case (development is often case-insensitive; CI is not).
  *
- * Static, filesystem-only: node:fs + node:path, no spawn, no network, no
- * dependency. Anchor (#fragment) validation and external URL liveness are out of
- * scope; only in-repo file existence is gated.
+ * Tracked-tree existence: a link must resolve to a git-TRACKED file or directory
+ * (validated against the git index), not merely to a path present in the local
+ * working directory. Untracked residue (a stale node_modules, an old build
+ * output) therefore cannot mask a broken link that a clean checkout would fail.
+ * Anchor (#fragment) validation and external URL liveness are out of scope; only
+ * in-repo tracked existence is gated.
  *
  * Scope:
  *   - Roots: docs/, .github/, surfaces/, examples/ (recursive).
@@ -26,12 +29,15 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { join } from 'node:path';
-import { dirname } from 'node:path';
+import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
 import {
   brokenLinksForDoc,
   existsCaseExact,
+  existsTrackedCaseExact,
   extractLinkTargets,
   isFileLink,
   walkMarkdownFiles,
@@ -122,6 +128,103 @@ describe('case-exact resolution rejects wrong-case links', () => {
     expect(existsCaseExact(REPO_ROOT, join(REPO_ROOT, 'README.md'))).toBe(true);
     expect(existsCaseExact(REPO_ROOT, join(REPO_ROOT, 'README.MD'))).toBe(false);
     expect(existsCaseExact(REPO_ROOT, join(REPO_ROOT, 'does-not-exist.md'))).toBe(false);
+  });
+});
+
+// The tracked-tree check must resolve links against the git index, not the
+// working directory: an untracked file or directory present on disk (residue
+// such as a stale node_modules or an old build output) must NOT satisfy a
+// repository-relative link, because a clean checkout would not have it. These
+// tests build throwaway git repositories with a known index so the abstraction
+// is exercised directly, independent of this checkout's layout.
+function gitFixtureRepo(): { root: string; git: (...args: string[]) => void } {
+  const root = mkdtempSync(join(tmpdir(), 'peac-link-gate-'));
+  const git = (...args: string[]): void => {
+    const res = spawnSync('git', ['-C', root, ...args], { encoding: 'utf8' });
+    if (res.status !== 0) {
+      throw new Error(`git ${args.join(' ')} failed: ${res.stderr || res.error?.message || ''}`);
+    }
+  };
+  git('init', '-q');
+  git('config', 'user.email', 'test@example.invalid');
+  git('config', 'user.name', 'Link Gate Test');
+  git('config', 'commit.gpgsign', 'false');
+  return { root, git };
+}
+
+describe('tracked-tree existence (git-index fixture)', () => {
+  it('accepts tracked files, tracked directories, staged files; rejects untracked residue and wrong case', () => {
+    const { root, git } = gitFixtureRepo();
+    try {
+      mkdirSync(join(root, 'docs'), { recursive: true });
+      writeFileSync(join(root, 'docs', 'guide.md'), '# guide\n');
+      // A tracked filename containing a space exercises NUL-delimited parsing.
+      writeFileSync(join(root, 'docs', 'a file.md'), '# spaced\n');
+      git('add', 'docs/guide.md', 'docs/a file.md');
+      git('commit', '-qm', 'init');
+
+      // Staged but not committed: present in the index, so it resolves.
+      writeFileSync(join(root, 'staged.md'), '# staged\n');
+      git('add', 'staged.md');
+
+      // Present on disk but never added: must NOT resolve.
+      writeFileSync(join(root, 'untracked.md'), '# untracked\n');
+      mkdirSync(join(root, 'residue'), { recursive: true });
+      writeFileSync(join(root, 'residue', 'x.md'), '# residue\n');
+
+      expect(existsTrackedCaseExact(root, join(root, 'docs', 'guide.md'))).toBe(true);
+      expect(existsTrackedCaseExact(root, join(root, 'docs'))).toBe(true);
+      expect(existsTrackedCaseExact(root, join(root, 'docs', 'a file.md'))).toBe(true);
+      expect(existsTrackedCaseExact(root, join(root, 'staged.md'))).toBe(true);
+      expect(existsTrackedCaseExact(root, root)).toBe(true);
+
+      // Untracked residue is on disk (the plain check accepts it) but is absent
+      // from the index (the tracked-tree check rejects it).
+      expect(existsCaseExact(root, join(root, 'untracked.md'))).toBe(true);
+      expect(existsTrackedCaseExact(root, join(root, 'untracked.md'))).toBe(false);
+      expect(existsCaseExact(root, join(root, 'residue'))).toBe(true);
+      expect(existsTrackedCaseExact(root, join(root, 'residue'))).toBe(false);
+
+      // Wrong case and repository escape are rejected.
+      expect(existsTrackedCaseExact(root, join(root, 'docs', 'GUIDE.md'))).toBe(false);
+      expect(existsTrackedCaseExact(root, join(root, '..', 'outside.md'))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not share cached index state between two repositories', () => {
+    const a = gitFixtureRepo();
+    const b = gitFixtureRepo();
+    try {
+      writeFileSync(join(a.root, 'only-in-a.md'), '# a\n');
+      a.git('add', 'only-in-a.md');
+      a.git('commit', '-qm', 'a');
+      writeFileSync(join(b.root, 'only-in-b.md'), '# b\n');
+      b.git('add', 'only-in-b.md');
+      b.git('commit', '-qm', 'b');
+
+      expect(existsTrackedCaseExact(a.root, join(a.root, 'only-in-a.md'))).toBe(true);
+      expect(existsTrackedCaseExact(a.root, join(a.root, 'only-in-b.md'))).toBe(false);
+      expect(existsTrackedCaseExact(b.root, join(b.root, 'only-in-b.md'))).toBe(true);
+      expect(existsTrackedCaseExact(b.root, join(b.root, 'only-in-a.md'))).toBe(false);
+    } finally {
+      rmSync(a.root, { recursive: true, force: true });
+      rmSync(b.root, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed when the git index cannot be read', () => {
+    // A fresh temp directory that is not a git repository has no readable index.
+    const notARepo = mkdtempSync(join(tmpdir(), 'peac-link-gate-norepo-'));
+    try {
+      writeFileSync(join(notARepo, 'file.md'), '# f\n');
+      expect(() => existsTrackedCaseExact(notARepo, join(notARepo, 'file.md'))).toThrow(
+        /tracked-tree link validation cannot continue/
+      );
+    } finally {
+      rmSync(notARepo, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Resolves repository-relative Markdown link targets against the git tracked tree
(the index), not the local working directory. A target that exists on disk but
is not tracked (untracked residue such as a stale `node_modules` or an old build
output) no longer satisfies a link, so a broken link cannot be masked locally
and then surface only in a clean checkout.

## Scope

- `tests/tooling/lib/markdown-links.ts`: adds `existsTrackedCaseExact`, which
  validates a resolved target case-exactly against the git index
  (`git ls-files -z --cached`). `brokenLinksForDoc` uses it. The check fails
  closed: if the git index cannot be read (git missing, non-zero exit, a process
  error or signal, or unreadable output) it throws with an actionable message
  rather than degrading to a weaker filesystem check. The subprocess is bounded
  (fixed argument array, timeout, proportionate buffer, `windowsHide`). Deliberate
  filesystem-only validation remains available through the existing
  `existsCaseExact` helper.
- `tests/tooling/repo-links-doc-truth.test.ts`: adds a deterministic
  git-repository fixture that asserts tracked files and directories and staged
  files resolve; untracked on-disk files and directories, wrong-case paths, and
  repository escapes do not; filenames containing spaces are parsed correctly;
  two repositories do not share cached index state; and an unreadable index fails
  closed.

Test-tooling only. No product code, protocol surface, schema, registry, or
public API change.
