### PR TITLE
ci: run the repository tooling gates in PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,6 +443,41 @@ jobs:
           retention-days: 90
 
   # ---------------------------------------------------------------------------
+  # Lane 3a: Tooling gates (tests/tooling)
+  #
+  # Runs the same `tests/tooling/**` suite included by the full release preflight
+  # `pnpm test`: the doc-truth / link gate, package-surface audit, distribution
+  # checks, and more. The per-package `pnpm test:core` run does not cover that
+  # suite, so before this lane a tooling-gate failure (such as a broken Markdown
+  # link, whose target can be any tracked file) could pass PR CI and only surface
+  # at release preflight. Because such a failure can be caused by a change
+  # anywhere in the tree, this lane runs on every non-stamp PR and every push to
+  # main, and skips only genuinely stamp-only PRs (whose paths are separately
+  # constrained). The build step is required: several tooling tests
+  # (verify-dist-private-leaks, verify-tarball-contents, readme-quickstart, and
+  # others) read built dist/ output.
+  # ---------------------------------------------------------------------------
+  tooling-gates:
+    name: Tooling Gates
+    needs: detect-changes
+    if: >-
+      github.ref == 'refs/heads/main' ||
+      needs.detect-changes.outputs.non_stamp == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-env
+
+      - name: Build all packages
+        run: pnpm build
+
+      - name: Tooling gates (tests/tooling)
+        run: pnpm test:tooling
+
+  # ---------------------------------------------------------------------------
   # Lane 3b: Protocol rollback-path matrix (release-class gate)
   #
   # Runs the @peac/protocol test suite twice, once with the internal
@@ -652,7 +687,17 @@ jobs:
   # ---------------------------------------------------------------------------
   ci:
     name: Build, Lint, Test
-    needs: [workflow-lint, fast-guards, type-build, tests-core, examples-apps, pack-smoke]
+    needs:
+      [
+        detect-changes,
+        workflow-lint,
+        fast-guards,
+        type-build,
+        tests-core,
+        tooling-gates,
+        examples-apps,
+        pack-smoke,
+      ]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 1
@@ -663,6 +708,7 @@ jobs:
           echo "fast-guards:   ${{ needs.fast-guards.result }}"
           echo "type-build:    ${{ needs.type-build.result }}"
           echo "tests-core:    ${{ needs.tests-core.result }}"
+          echo "tooling-gates: ${{ needs.tooling-gates.result }}"
           echo "examples-apps: ${{ needs.examples-apps.result }}"
           echo "pack-smoke:    ${{ needs.pack-smoke.result }}"
 
@@ -684,6 +730,24 @@ jobs:
           # tests-core: required when it runs, OK when skipped
           if [[ "${{ needs.tests-core.result }}" == "failure" || "${{ needs.tests-core.result }}" == "cancelled" ]]; then
             echo "FAIL: tests-core failed"; exit 1
+          fi
+
+          # tooling-gates: must SUCCEED on every non-stamp PR (an unexpected
+          # skip must not pass silently). A genuinely stamp-only PR
+          # (stamp_any and not non_stamp) may skip it.
+          TOOLING="${{ needs.tooling-gates.result }}"
+          STAMP_ANY="${{ needs.detect-changes.outputs.stamp_any }}"
+          NON_STAMP="${{ needs.detect-changes.outputs.non_stamp }}"
+          STAMP_ONLY="false"
+          if [[ "$STAMP_ANY" == "true" && "$NON_STAMP" == "false" ]]; then
+            STAMP_ONLY="true"
+          fi
+          if [[ "$STAMP_ONLY" == "true" ]]; then
+            if [[ "$TOOLING" != "success" && "$TOOLING" != "skipped" ]]; then
+              echo "FAIL: tooling-gates result '$TOOLING' unexpected on a stamp-only PR"; exit 1
+            fi
+          elif [[ "$TOOLING" != "success" ]]; then
+            echo "FAIL: tooling-gates must succeed on a non-stamp change (got '$TOOLING')"; exit 1
           fi
 
           # examples-apps: optional (success or skipped OK, failure blocks)

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:coverage": "vitest --coverage",
     "test:core": "turbo run test --filter=@peac/crypto --filter=@peac/protocol --filter=@peac/policy-kit --filter=@peac/http-signatures --filter=@peac/jwks-cache --filter=@peac/mappings-mcp --filter=@peac/mappings-acp --filter=@peac/mappings-rsl --filter=@peac/mappings-tap --filter=@peac/rails-x402 --filter=@peac/rails-stripe --filter=@peac/rails-razorpay --filter=@peac/adapter-x402-daydreams --filter=@peac/adapter-x402-fluora --filter=@peac/adapter-x402-pinata --filter=@peac/worker-fastly --filter=@peac/worker-akamai --filter=@peac/transport-grpc",
     "test:conformance": "vitest run tests/conformance/",
+    "test:tooling": "vitest run tests/tooling/",
     "conformance:test": "vitest run tests/conformance/",
     "schemas:lint": "pnpm format:check -- 'specs/wire/*.json' && node scripts/lint-schemas.js",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary

Runs the repository tooling suite (`tests/tooling/**`) in PR CI, so PR CI and the
release preflight evaluate the same gates. The per-package `pnpm test:core` lane
does not cover that suite (the doc-truth / link gate, package-surface audit,
distribution checks), so before this change a tooling-gate failure such as a
broken Markdown link could pass PR CI and only surface at release preflight,
which runs the full `pnpm test`.

## Scope

- `package.json`: adds `test:tooling` (`vitest run tests/tooling/`), the same
  `tests/tooling/**` suite included by the full `pnpm test`.
- `.github/workflows/ci.yml`:
  - adds a `Tooling Gates` lane that builds and runs `pnpm test:tooling`. Because
    a tooling-gate failure (for example a broken link whose target can be any
    tracked file) can be caused by a change anywhere in the tree, the lane runs
    on every non-stamp change and every push to `main`, and skips only genuinely
    stamp-only PRs;
  - the aggregate gate requires the lane to succeed on non-stamp changes; an
    unexpected skip, failure, or cancellation blocks. A stamp-only PR may skip it.

The build step is retained because several tooling tests read built `dist/`
output. Merge queues are not in use in this repository (no `merge_group`
trigger), so no `merge_group` configuration is added.

CI configuration and a package script only. No product code, protocol surface,
schema, registry, or public API change.

## Validation

- `pnpm test:tooling` passes locally.
- `actionlint` reports no issues on the updated workflow.
