### PR TITLE
ci: reconcile the latest release with npm

### DIFF
--- a/.github/workflows/release-consistency-guard.yml
+++ b/.github/workflows/release-consistency-guard.yml
@@ -1,0 +1,93 @@
+# ---------------------------------------------------------------------------
+# Release Consistency
+#
+# Reconciles a GitHub Release against npm dist-tags across the full publish
+# manifest (scripts/publish-manifest.json), not a single representative
+# package. A release that is the repository's current Latest release must
+# carry the same version at npm `latest` for every published package. A
+# finalized release that is not the current Latest only needs the version to
+# exist on npm. Draft and prerelease releases are skipped: the npm latest
+# invariant does not apply until a release is finalized.
+#
+# This is detective, not preventive: GitHub does not let a workflow block a
+# release, so a red check here surfaces an inconsistency after the fact
+# instead of leaving it silent.
+# ---------------------------------------------------------------------------
+name: Release Consistency
+
+on:
+  release:
+    types: [published, released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to reconcile (for example v0.16.2)'
+        type: string
+        required: true
+  schedule:
+    - cron: '0 6 * * *'
+
+concurrency:
+  group: release-consistency-${{ github.event.release.id || inputs.tag || github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  npm-latest-matches-release:
+    name: Stable Latest Release matches all npm packages
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
+
+      - name: Resolve current Latest release tag
+        if: github.event_name == 'schedule'
+        id: latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          TAG=$(gh api "repos/${REPO}/releases/latest" --jq .tag_name)
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Reconcile published release against npm
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_ID: ${{ github.event.release.id }}
+          RELEASE_DRAFT: ${{ github.event.release.draft }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          set -euo pipefail
+          ARGS=(--tag "$RELEASE_TAG" --release-id "$RELEASE_ID")
+          if [ "$RELEASE_DRAFT" = "true" ]; then
+            ARGS+=(--draft)
+          fi
+          if [ "$RELEASE_PRERELEASE" = "true" ]; then
+            ARGS+=(--prerelease)
+          fi
+          node scripts/verify-github-release-npm-consistency.mjs "${ARGS[@]}"
+
+      - name: Reconcile release against npm (manual dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: node scripts/verify-github-release-npm-consistency.mjs --tag "$INPUT_TAG"
+
+      - name: Reconcile current Latest release against npm (scheduled)
+        if: github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LATEST_TAG: ${{ steps.latest.outputs.tag }}
+        run: node scripts/verify-github-release-npm-consistency.mjs --tag "$LATEST_TAG"

--- a/scripts/verify-github-release-npm-consistency.mjs
+++ b/scripts/verify-github-release-npm-consistency.mjs
@@ -1,0 +1,764 @@
+#!/usr/bin/env node
+/**
+ * verify-github-release-npm-consistency
+ *
+ * Reconciles a GitHub Release against npm dist-tags for every package in
+ * `scripts/publish-manifest.json`. A GitHub Release marked as the
+ * repository's current Latest release must carry the same version at
+ * npm's `latest` dist-tag across the whole publish manifest, not just a
+ * single representative package. A finalized release that is not the
+ * current Latest (a historical release) only needs the version to exist
+ * on npm; it does not need to own the `latest` dist-tag.
+ *
+ * Import-safe: `reconcile()` and `parseReleaseTag()` are pure functions
+ * with all registry access injected through `distTagsFor`, so they can be
+ * unit-tested without any network or git access. The CLI behavior,
+ * including the real npm- and gh-backed registry lookups, lives in
+ * `main()`, which only runs when this file is executed directly.
+ *
+ * Usage:
+ *   node scripts/verify-github-release-npm-consistency.mjs --tag v0.16.2
+ *   node scripts/verify-github-release-npm-consistency.mjs --tag v0.16.2 --draft
+ *   node scripts/verify-github-release-npm-consistency.mjs --tag v0.16.2 --json
+ *
+ * Exit codes:
+ *   0  Reconciliation passed, or was skipped for a draft or prerelease release.
+ *   1  A version is missing, npm latest disagrees, or a registry lookup failed.
+ *   2  Usage error.
+ */
+
+import { appendFileSync, readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+const MANIFEST_PATH = resolve(REPO_ROOT, 'scripts/publish-manifest.json');
+
+export const RELEASE_STATES = Object.freeze([
+  'actual-latest',
+  'historical-stable',
+  'prerelease',
+  'draft',
+]);
+
+export const ERROR_KINDS = Object.freeze({
+  STATE_MISMATCH: 'STATE_MISMATCH',
+  VERSION_MISSING: 'VERSION_MISSING',
+  PACKAGE_MISSING: 'PACKAGE_MISSING',
+  REGISTRY_TRANSIENT_FAILURE: 'REGISTRY_TRANSIENT_FAILURE',
+  REGISTRY_PERMANENT_FAILURE: 'REGISTRY_PERMANENT_FAILURE',
+  MALFORMED_REGISTRY_RESPONSE: 'MALFORMED_REGISTRY_RESPONSE',
+  INVALID_MANIFEST: 'INVALID_MANIFEST',
+  INVALID_RELEASE_TAG: 'INVALID_RELEASE_TAG',
+});
+
+const VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
+const RELEASE_TAG_PATTERN = /^v(\d+\.\d+\.\d+)$/;
+
+/** Typed error carrying one of the ERROR_KINDS values on `.kind`. */
+export class ReleaseConsistencyError extends Error {
+  constructor(kind, message) {
+    super(message);
+    this.name = 'ReleaseConsistencyError';
+    this.kind = kind;
+  }
+}
+
+/**
+ * Parse and validate a release tag. Accepts only `vMAJOR.MINOR.PATCH`
+ * (no prerelease or build suffix); this is a strict subset of the looser
+ * `vMAJOR.MINOR.PATCH(-prerelease)?` grammar validated by publish.yml, so
+ * every tag this function accepts is also valid there. This guard exists
+ * to reconcile finalized releases against npm `latest`, which only ever
+ * applies to a plain `vX.Y.Z` tag.
+ *
+ * Returns the version string with the leading `v` stripped.
+ */
+export function parseReleaseTag(tag) {
+  if (typeof tag !== 'string') {
+    throw new ReleaseConsistencyError(
+      ERROR_KINDS.INVALID_RELEASE_TAG,
+      `release tag must be a string, got ${typeof tag}`
+    );
+  }
+  const match = RELEASE_TAG_PATTERN.exec(tag.trim());
+  if (!match) {
+    throw new ReleaseConsistencyError(
+      ERROR_KINDS.INVALID_RELEASE_TAG,
+      `release tag "${tag}" does not match the required format vMAJOR.MINOR.PATCH`
+    );
+  }
+  return match[1];
+}
+
+/** Validate the publish manifest shape and return its package list. */
+function validateManifest(manifest) {
+  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+    throw new ReleaseConsistencyError(
+      ERROR_KINDS.INVALID_MANIFEST,
+      'manifest must be an object with a packages array'
+    );
+  }
+  const packages = manifest.packages;
+  if (!Array.isArray(packages) || packages.length === 0) {
+    throw new ReleaseConsistencyError(
+      ERROR_KINDS.INVALID_MANIFEST,
+      'manifest.packages must be a non-empty array'
+    );
+  }
+  const seen = new Set();
+  const duplicates = new Set();
+  for (const entry of packages) {
+    if (typeof entry !== 'string' || entry.length === 0) {
+      throw new ReleaseConsistencyError(
+        ERROR_KINDS.INVALID_MANIFEST,
+        `manifest.packages contains a non-string entry: ${JSON.stringify(entry)}`
+      );
+    }
+    if (seen.has(entry)) duplicates.add(entry);
+    seen.add(entry);
+  }
+  if (duplicates.size > 0) {
+    throw new ReleaseConsistencyError(
+      ERROR_KINDS.INVALID_MANIFEST,
+      `manifest.packages contains duplicate entries: ${[...duplicates].join(', ')}`
+    );
+  }
+  if (typeof manifest.totalPackages === 'number' && manifest.totalPackages !== packages.length) {
+    throw new ReleaseConsistencyError(
+      ERROR_KINDS.INVALID_MANIFEST,
+      `manifest.totalPackages=${manifest.totalPackages} does not match packages.length=${packages.length}`
+    );
+  }
+  return packages;
+}
+
+/**
+ * Reconcile a release against npm dist-tags for every package in the
+ * manifest. Pure function: all registry access goes through the injected
+ * `distTagsFor(pkgName)`, which returns `{ latest?, next?, versions }` or
+ * throws a `ReleaseConsistencyError` (or any error carrying a `.kind`).
+ *
+ * `draft` and `prerelease` skip the npm `latest` invariant entirely (it
+ * does not apply before a release is finalized). `historical-stable`
+ * requires only that the release version exists on npm for every
+ * package. `actual-latest` requires both that the version exists and
+ * that npm `latest` equals it, for every package; the full package set
+ * is always checked, so a later mismatch is never masked by an earlier
+ * match.
+ */
+export function reconcile({ manifest, releaseVersion, releaseState, distTagsFor }) {
+  if (!RELEASE_STATES.includes(releaseState)) {
+    throw new ReleaseConsistencyError(
+      ERROR_KINDS.STATE_MISMATCH,
+      `releaseState must be one of ${RELEASE_STATES.join(', ')}, got ${JSON.stringify(releaseState)}`
+    );
+  }
+  if (typeof releaseVersion !== 'string' || !VERSION_PATTERN.test(releaseVersion)) {
+    throw new ReleaseConsistencyError(
+      ERROR_KINDS.INVALID_RELEASE_TAG,
+      `releaseVersion must be MAJOR.MINOR.PATCH with no leading "v", got ${JSON.stringify(releaseVersion)}`
+    );
+  }
+
+  const packages = validateManifest(manifest);
+  const packageCount = packages.length;
+
+  if (releaseState === 'draft' || releaseState === 'prerelease') {
+    return {
+      ok: true,
+      releaseState,
+      releaseVersion,
+      packageCount,
+      checked: 0,
+      rows: [],
+      mismatches: { versionMissing: 0, latestMismatch: 0, registryErrors: 0 },
+      errors: [],
+      summary: `skipped (${releaseState}); the npm latest invariant does not apply until the release is finalized`,
+    };
+  }
+
+  const rows = [];
+  const errors = [];
+  let versionMissingCount = 0;
+  let latestMismatchCount = 0;
+  let registryErrorCount = 0;
+
+  for (const pkg of packages) {
+    let distTags;
+    try {
+      distTags = distTagsFor(pkg);
+    } catch (err) {
+      const kind =
+        err && typeof err.kind === 'string' ? err.kind : ERROR_KINDS.REGISTRY_PERMANENT_FAILURE;
+      const detail = err && err.message ? err.message : String(err);
+      registryErrorCount += 1;
+      errors.push({ package: pkg, kind, detail });
+      rows.push({
+        package: pkg,
+        versionExists: false,
+        latest: null,
+        expected: releaseVersion,
+        status: `error: ${kind}`,
+      });
+      continue;
+    }
+
+    const versions = Array.isArray(distTags && distTags.versions) ? distTags.versions : [];
+    const versionExists = versions.includes(releaseVersion);
+    const latest = distTags && distTags.latest != null ? distTags.latest : null;
+    const latestMatches = latest === releaseVersion;
+
+    if (!versionExists) {
+      versionMissingCount += 1;
+      errors.push({
+        package: pkg,
+        kind: ERROR_KINDS.VERSION_MISSING,
+        detail: `${pkg}@${releaseVersion} is not present in npm versions`,
+      });
+    }
+    if (!latestMatches) {
+      latestMismatchCount += 1;
+      if (releaseState === 'actual-latest') {
+        errors.push({
+          package: pkg,
+          kind: ERROR_KINDS.STATE_MISMATCH,
+          detail: `${pkg} npm dist-tags.latest=${latest ?? '<none>'}, expected ${releaseVersion}`,
+        });
+      }
+    }
+
+    let status;
+    if (!versionExists) {
+      status = 'version-missing';
+    } else if (releaseState === 'actual-latest' && !latestMatches) {
+      status = 'latest-mismatch';
+    } else if (!latestMatches) {
+      status = 'ok (latest differs; not required for historical-stable)';
+    } else {
+      status = 'ok';
+    }
+
+    rows.push({ package: pkg, versionExists, latest, expected: releaseVersion, status });
+  }
+
+  const checked = packageCount;
+  const ok =
+    versionMissingCount === 0 &&
+    registryErrorCount === 0 &&
+    !(releaseState === 'actual-latest' && latestMismatchCount > 0);
+
+  const summary = ok
+    ? `${checked}/${checked} packages consistent at ${releaseVersion} (${releaseState})`
+    : `inconsistent: ${versionMissingCount} version-missing, ` +
+      `${releaseState === 'actual-latest' ? latestMismatchCount : 0} latest-mismatch, ` +
+      `${registryErrorCount} registry error(s) (of ${checked} checked)`;
+
+  return {
+    ok,
+    releaseState,
+    releaseVersion,
+    packageCount,
+    checked,
+    rows,
+    mismatches: {
+      versionMissing: versionMissingCount,
+      latestMismatch: latestMismatchCount,
+      registryErrors: registryErrorCount,
+    },
+    errors,
+    summary,
+  };
+}
+
+// ---------------------------------------------------------------------
+// Retry policy. Exported so the bounded-retry behavior itself (attempts,
+// no infinite loop, transient-only retry) is directly unit-testable with
+// a fake operation and an injected no-op sleep, independent of the real
+// npm/gh subprocess calls.
+// ---------------------------------------------------------------------
+
+const DEFAULT_MAX_ATTEMPTS = 8;
+const RETRY_BASE_DELAY_MS = 200;
+const RETRY_MAX_DELAY_MS = 2000;
+
+function backoffDelayMs(attempt) {
+  return Math.min(RETRY_BASE_DELAY_MS * 2 ** (attempt - 1), RETRY_MAX_DELAY_MS);
+}
+
+function sleepSync(ms) {
+  const view = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(view, 0, 0, ms);
+}
+
+/**
+ * Run `operation` up to `attempts` times. Only a thrown error whose
+ * `.kind` is REGISTRY_TRANSIENT_FAILURE is retried; any other error, or
+ * the final attempt, is rethrown immediately. `sleep` is injected so
+ * tests can pass a no-op and assert the attempt count deterministically
+ * without real delays.
+ */
+export function withRetry(operation, options = {}) {
+  const attempts = options.attempts ?? DEFAULT_MAX_ATTEMPTS;
+  const sleep = options.sleep ?? sleepSync;
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return { value: operation(), attempts: attempt };
+    } catch (err) {
+      const isTransient = err && err.kind === ERROR_KINDS.REGISTRY_TRANSIENT_FAILURE;
+      if (!isTransient || attempt === attempts) {
+        throw err;
+      }
+      sleep(backoffDelayMs(attempt));
+    }
+  }
+  // Unreachable: the loop above always returns or throws.
+  throw new ReleaseConsistencyError(
+    ERROR_KINDS.REGISTRY_PERMANENT_FAILURE,
+    'retry loop exited unexpectedly'
+  );
+}
+
+/**
+ * Decide whether a release is the repository's actual current Latest
+ * release. Compares the release id when both sides provide one
+ * (strongest signal), otherwise falls back to tag equality. A release
+ * with `draft`/`prerelease` true is never passed through this check by
+ * the CLI; `latestRelease` being absent (no Latest release resolvable)
+ * means the release under test cannot be the actual latest.
+ */
+export function determineIsActualLatest({ tag, releaseId, latestRelease }) {
+  if (!latestRelease) return false;
+  if (releaseId != null && latestRelease.id != null) {
+    return String(latestRelease.id) === String(releaseId);
+  }
+  if (tag && latestRelease.tagName) {
+    return latestRelease.tagName === tag;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------
+// CLI-only: real npm/gh-backed registry access, argument parsing, and
+// output formatting. None of this runs on import.
+// ---------------------------------------------------------------------
+
+const GH_MAX_ATTEMPTS = 4;
+const NPM_VIEW_TIMEOUT_MS = 30_000;
+const GH_TIMEOUT_MS = 30_000;
+const MAX_BUFFER = 10 * 1024 * 1024;
+
+const TRANSIENT_PATTERNS = [
+  /ETIMEDOUT/i,
+  /ECONNRESET/i,
+  /ECONNREFUSED/i,
+  /ENOTFOUND/i,
+  /EAI_AGAIN/i,
+  /ENETUNREACH/i,
+  /socket hang up/i,
+  /request timed out/i,
+  /\b429\b/,
+  /\b500\b/,
+  /\b502\b/,
+  /\b503\b/,
+  /\b504\b/,
+];
+
+const NOT_FOUND_PATTERNS = [/\bE404\b/i, /404 Not Found/i, /is not in (this|the) registry/i];
+
+function firstLine(text) {
+  const line = (text || '').split('\n').find((l) => l.trim().length > 0);
+  return line ? line.trim() : '';
+}
+
+function classifySpawnFailure(result) {
+  if (result.error) {
+    return { transient: false, notFound: false, detail: result.error.message };
+  }
+  const stderr = result.stderr || '';
+  const detail = firstLine(stderr) || `exit code ${result.status}`;
+  const transient = TRANSIENT_PATTERNS.some((p) => p.test(stderr));
+  const notFound = !transient && NOT_FOUND_PATTERNS.some((p) => p.test(stderr));
+  return { transient, notFound, detail };
+}
+
+function npmViewRaw(args) {
+  const result = spawnSync('npm', ['view', ...args, '--json'], {
+    encoding: 'utf8',
+    timeout: NPM_VIEW_TIMEOUT_MS,
+    maxBuffer: MAX_BUFFER,
+  });
+
+  if (!result.error && result.status === 0) {
+    try {
+      return JSON.parse(result.stdout);
+    } catch (err) {
+      throw new ReleaseConsistencyError(
+        ERROR_KINDS.MALFORMED_REGISTRY_RESPONSE,
+        `npm view ${args.join(' ')} returned unparseable JSON: ${err.message}`
+      );
+    }
+  }
+
+  const { transient, notFound, detail } = classifySpawnFailure(result);
+  if (notFound) {
+    throw new ReleaseConsistencyError(
+      ERROR_KINDS.PACKAGE_MISSING,
+      `npm view ${args.join(' ')} failed: ${detail}`
+    );
+  }
+  if (transient) {
+    throw new ReleaseConsistencyError(
+      ERROR_KINDS.REGISTRY_TRANSIENT_FAILURE,
+      `npm view ${args.join(' ')} failed: ${detail}`
+    );
+  }
+  throw new ReleaseConsistencyError(
+    ERROR_KINDS.REGISTRY_PERMANENT_FAILURE,
+    `npm view ${args.join(' ')} failed: ${detail}`
+  );
+}
+
+/**
+ * Build a real, npm-backed `distTagsFor` implementation plus a retry
+ * counter. Two `npm view` calls per package (dist-tags, versions), each
+ * independently retried per `withRetry`'s bounded transient-only policy.
+ */
+function createRealDistTagsFor() {
+  let retryCount = 0;
+  const distTagsFor = (pkgName) => {
+    const distTagsResult = withRetry(() => npmViewRaw([pkgName, 'dist-tags']));
+    retryCount += distTagsResult.attempts - 1;
+    const versionsResult = withRetry(() => npmViewRaw([pkgName, 'versions']));
+    retryCount += versionsResult.attempts - 1;
+
+    const distTags = distTagsResult.value;
+    const versions = versionsResult.value;
+
+    if (!distTags || typeof distTags !== 'object' || Array.isArray(distTags)) {
+      throw new ReleaseConsistencyError(
+        ERROR_KINDS.MALFORMED_REGISTRY_RESPONSE,
+        `npm view ${pkgName} dist-tags did not return an object`
+      );
+    }
+    if (!Array.isArray(versions)) {
+      throw new ReleaseConsistencyError(
+        ERROR_KINDS.MALFORMED_REGISTRY_RESPONSE,
+        `npm view ${pkgName} versions did not return an array`
+      );
+    }
+
+    return { latest: distTags.latest, next: distTags.next, versions };
+  };
+  return { distTagsFor, getRetryCount: () => retryCount };
+}
+
+function ghRaw(args) {
+  const result = spawnSync('gh', args, {
+    encoding: 'utf8',
+    timeout: GH_TIMEOUT_MS,
+    maxBuffer: MAX_BUFFER,
+  });
+
+  if (!result.error && result.status === 0) {
+    try {
+      return JSON.parse(result.stdout);
+    } catch (err) {
+      throw new ReleaseConsistencyError(
+        ERROR_KINDS.MALFORMED_REGISTRY_RESPONSE,
+        `gh ${args.join(' ')} returned unparseable JSON: ${err.message}`
+      );
+    }
+  }
+
+  const { transient, detail } = classifySpawnFailure(result);
+  if (transient) {
+    throw new ReleaseConsistencyError(
+      ERROR_KINDS.REGISTRY_TRANSIENT_FAILURE,
+      `gh ${args.join(' ')} failed: ${detail}`
+    );
+  }
+  throw new ReleaseConsistencyError(
+    ERROR_KINDS.REGISTRY_PERMANENT_FAILURE,
+    `gh ${args.join(' ')} failed: ${detail}`
+  );
+}
+
+function fetchReleaseByTag(tag, repo) {
+  const args = ['release', 'view', tag, '--json', 'id,isDraft,isPrerelease'];
+  if (repo) args.push('--repo', repo);
+  return withRetry(() => ghRaw(args), { attempts: GH_MAX_ATTEMPTS }).value;
+}
+
+/** Fetch the repository's actual current Latest release via the GitHub API. */
+function fetchActualLatestRelease(repo) {
+  if (!repo) {
+    throw new ReleaseConsistencyError(
+      ERROR_KINDS.REGISTRY_PERMANENT_FAILURE,
+      'a repository slug is required to resolve the actual latest release (pass --repo or set GITHUB_REPOSITORY)'
+    );
+  }
+  const value = withRetry(() => ghRaw(['api', `repos/${repo}/releases/latest`]), {
+    attempts: GH_MAX_ATTEMPTS,
+  }).value;
+  return { id: value.id != null ? String(value.id) : null, tagName: value.tag_name ?? null };
+}
+
+function printUsage(stream) {
+  stream.write(`Usage: verify-github-release-npm-consistency.mjs --tag <vX.Y.Z> [options]
+
+Reconciles a GitHub Release against npm dist-tags for every package in
+scripts/publish-manifest.json.
+
+Options:
+  --tag <vX.Y.Z>        Release tag to reconcile (required).
+  --release-id <id>     Numeric GitHub release id, when known from the event.
+  --draft               The release is a draft (skips the npm latest invariant).
+  --prerelease          The release is a prerelease (skips the npm latest invariant).
+  --repo <owner/name>   Repository slug for release lookups.
+                        Defaults to \$GITHUB_REPOSITORY.
+  --json                Emit machine-readable JSON instead of a text report.
+  --help                Show this message.
+
+When --draft and --prerelease are both omitted, the release state is
+looked up from GitHub directly. A non-draft, non-prerelease release is
+then compared against the repository's current Latest release (not
+inferred from draft/prerelease alone) to decide whether the npm latest
+invariant applies.
+
+Exit codes:
+  0  Reconciliation passed, or was skipped for a draft or prerelease release.
+  1  A version is missing, npm latest disagrees, or a registry lookup failed.
+  2  Usage error.
+`);
+}
+
+function parseArgs(argv) {
+  const opts = {
+    tag: null,
+    releaseId: null,
+    draft: false,
+    draftGiven: false,
+    prerelease: false,
+    prereleaseGiven: false,
+    repo: process.env.GITHUB_REPOSITORY || null,
+    json: false,
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--help' || a === '-h') {
+      opts.help = true;
+    } else if (a === '--tag' && argv[i + 1] !== undefined) {
+      opts.tag = argv[i + 1];
+      i += 1;
+    } else if (a === '--release-id' && argv[i + 1] !== undefined) {
+      opts.releaseId = argv[i + 1];
+      i += 1;
+    } else if (a === '--repo' && argv[i + 1] !== undefined) {
+      opts.repo = argv[i + 1];
+      i += 1;
+    } else if (a === '--draft') {
+      opts.draft = true;
+      opts.draftGiven = true;
+    } else if (a === '--prerelease') {
+      opts.prerelease = true;
+      opts.prereleaseGiven = true;
+    } else if (a === '--json') {
+      opts.json = true;
+    } else {
+      throw new Error(`unknown argument: ${a}`);
+    }
+  }
+  return opts;
+}
+
+function printTextSummary(result, context) {
+  console.log(
+    `verify-github-release-npm-consistency: tag=${context.tag} version=${result.releaseVersion} state=${result.releaseState}`
+  );
+  console.log(
+    `release id=${context.releaseId ?? '<unknown>'} actual-latest=${context.isActualLatest}`
+  );
+  console.log(`manifest packages=${result.packageCount} checked=${result.checked}`);
+  console.log(
+    `mismatches: version-missing=${result.mismatches.versionMissing} ` +
+      `latest-mismatch=${result.mismatches.latestMismatch} ` +
+      `registry-errors=${result.mismatches.registryErrors} retries=${context.retryCount}`
+  );
+  console.log(`result: ${result.ok ? 'PASS' : 'FAIL'} - ${result.summary}`);
+  if (!result.ok && result.errors.length > 0) {
+    console.log('');
+    console.log('mismatched packages:');
+    for (const e of result.errors) {
+      console.log(`  ${e.package}: ${e.kind} - ${e.detail}`);
+    }
+  }
+}
+
+function writeStepSummary(result, context) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+
+  const lines = [
+    '## Release Consistency',
+    '',
+    `- Release: \`${context.tag}\` (id: ${context.releaseId ?? 'unknown'})`,
+    `- State: \`${result.releaseState}\``,
+    `- Actual latest: ${context.isActualLatest ? 'yes' : 'no'}`,
+    `- Manifest packages: ${result.packageCount}`,
+    `- Packages checked: ${result.checked}`,
+    `- Version-missing count: ${result.mismatches.versionMissing}`,
+    `- Latest-mismatch count: ${result.mismatches.latestMismatch}`,
+    `- Registry-error count: ${result.mismatches.registryErrors}`,
+    `- Retry count: ${context.retryCount}`,
+    `- Result: ${result.ok ? 'PASS' : 'FAIL'}`,
+    '',
+  ];
+
+  if (result.rows.length > 0) {
+    lines.push('| package | version exists | npm latest | expected | status |');
+    lines.push('|---|---|---|---|---|');
+    for (const row of result.rows) {
+      lines.push(
+        `| ${row.package} | ${row.versionExists} | ${row.latest ?? '<none>'} | ${row.expected} | ${row.status} |`
+      );
+    }
+  } else {
+    lines.push('_Reconciliation skipped: release state is draft or prerelease._');
+  }
+  lines.push('');
+
+  appendFileSync(summaryPath, lines.join('\n') + '\n', 'utf8');
+}
+
+function writeStepSummaryFailure(tag, message) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+  const lines = [
+    '## Release Consistency',
+    '',
+    `- Release: \`${tag}\``,
+    '- Result: FAIL (unable to resolve release state)',
+    `- Detail: ${message}`,
+    '',
+  ];
+  appendFileSync(summaryPath, lines.join('\n') + '\n', 'utf8');
+}
+
+function main() {
+  let opts;
+  try {
+    opts = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    process.stderr.write(`error: ${err.message}\n\n`);
+    printUsage(process.stderr);
+    process.exit(2);
+    return;
+  }
+
+  if (opts.help) {
+    printUsage(process.stdout);
+    process.exit(0);
+    return;
+  }
+
+  if (!opts.tag) {
+    printUsage(process.stderr);
+    process.exit(2);
+    return;
+  }
+
+  let releaseVersion;
+  try {
+    releaseVersion = parseReleaseTag(opts.tag);
+  } catch (err) {
+    process.stderr.write(`error: ${err.message}\n`);
+    process.exit(2);
+    return;
+  }
+
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
+  } catch (err) {
+    process.stderr.write(
+      `error: unable to read publish manifest at ${MANIFEST_PATH}: ${err.message}\n`
+    );
+    process.exit(2);
+    return;
+  }
+
+  let releaseState;
+  let latestRelease = null;
+  let isActualLatest = false;
+  let releaseId = opts.releaseId;
+
+  try {
+    let isDraft = opts.draft;
+    let isPrerelease = opts.prerelease;
+
+    if (!opts.draftGiven && !opts.prereleaseGiven) {
+      const release = fetchReleaseByTag(opts.tag, opts.repo);
+      isDraft = Boolean(release.isDraft);
+      isPrerelease = Boolean(release.isPrerelease);
+      if (releaseId == null && release.id != null) {
+        releaseId = String(release.id);
+      }
+    }
+
+    if (isDraft) {
+      releaseState = 'draft';
+    } else if (isPrerelease) {
+      releaseState = 'prerelease';
+    } else {
+      latestRelease = fetchActualLatestRelease(opts.repo);
+      isActualLatest = determineIsActualLatest({ tag: opts.tag, releaseId, latestRelease });
+      releaseState = isActualLatest ? 'actual-latest' : 'historical-stable';
+    }
+  } catch (err) {
+    const message = err && err.message ? err.message : String(err);
+    process.stderr.write(`error: unable to resolve release state for ${opts.tag}: ${message}\n`);
+    writeStepSummaryFailure(opts.tag, message);
+    process.exit(1);
+    return;
+  }
+
+  const { distTagsFor, getRetryCount } = createRealDistTagsFor();
+
+  let result;
+  try {
+    result = reconcile({ manifest, releaseVersion, releaseState, distTagsFor });
+  } catch (err) {
+    process.stderr.write(`error: ${err.message}\n`);
+    process.exit(2);
+    return;
+  }
+
+  const context = {
+    tag: opts.tag,
+    releaseId,
+    isActualLatest,
+    latestReleaseTag: latestRelease ? latestRelease.tagName : null,
+    retryCount: getRetryCount(),
+  };
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify({ ...result, context }, null, 2) + '\n');
+  } else {
+    printTextSummary(result, context);
+  }
+
+  writeStepSummary(result, context);
+
+  process.exit(result.ok ? 0 : 1);
+}
+
+const invokedDirectly =
+  Boolean(process.argv[1]) && pathToFileURL(process.argv[1]).href === import.meta.url;
+if (invokedDirectly) {
+  main();
+}

--- a/tests/tooling/verify-github-release-npm-consistency.test.ts
+++ b/tests/tooling/verify-github-release-npm-consistency.test.ts
@@ -1,0 +1,584 @@
+/**
+ * Unit gate for scripts/verify-github-release-npm-consistency.mjs.
+ *
+ * Exercises the pure `reconcile()` and `parseReleaseTag()` functions with a
+ * mocked `distTagsFor` (no real network, no real git), plus the exported
+ * `withRetry()` and `determineIsActualLatest()` helpers in isolation.
+ *
+ * Importing the module must be side-effect-free: `main()` runs only when
+ * the script is invoked directly, so these tests never touch npm, gh, or
+ * the filesystem outside of a direct CLI smoke test at the bottom.
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  reconcile,
+  parseReleaseTag,
+  withRetry,
+  determineIsActualLatest,
+  ReleaseConsistencyError,
+  ERROR_KINDS,
+} from '../../scripts/verify-github-release-npm-consistency.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = resolve(
+  __dirname,
+  '..',
+  '..',
+  'scripts',
+  'verify-github-release-npm-consistency.mjs'
+);
+
+const PACKAGES = ['@peac/kernel', '@peac/schema', '@peac/crypto', '@peac/cli'];
+
+function manifestOf(packages: string[], totalPackages?: number) {
+  return { packages, totalPackages: totalPackages ?? packages.length };
+}
+
+/** A distTagsFor that reports every package at `version` for both latest and versions. */
+function allAt(version: string) {
+  return (_pkg: string) => ({ latest: version, next: version, versions: [version, '0.0.1'] });
+}
+
+describe('parseReleaseTag', () => {
+  it('parses a valid vX.Y.Z tag', () => {
+    expect(parseReleaseTag('v0.16.2')).toBe('0.16.2');
+    expect(parseReleaseTag('v1.0.0')).toBe('1.0.0');
+  });
+
+  it('throws INVALID_RELEASE_TAG for a non-matching tag', () => {
+    const attempts = ['0.16.2', 'v0.16', 'v0.16.2-rc.1', 'v0.16.2.1', 'vX.Y.Z', '', 'v0.16.2 '];
+    for (const tag of attempts) {
+      // v0.16.2 with trailing space is trimmed and valid; assert the rest throw.
+      if (tag === 'v0.16.2 ') {
+        expect(parseReleaseTag(tag)).toBe('0.16.2');
+        continue;
+      }
+      let threw = false;
+      try {
+        parseReleaseTag(tag);
+      } catch (err) {
+        threw = true;
+        expect(err).toBeInstanceOf(ReleaseConsistencyError);
+        expect((err as ReleaseConsistencyError).kind).toBe(ERROR_KINDS.INVALID_RELEASE_TAG);
+      }
+      expect(threw).toBe(true);
+    }
+  });
+
+  it('throws INVALID_RELEASE_TAG for a non-string tag', () => {
+    expect(() => parseReleaseTag(undefined as unknown as string)).toThrow(ReleaseConsistencyError);
+    try {
+      parseReleaseTag(null as unknown as string);
+    } catch (err) {
+      expect((err as ReleaseConsistencyError).kind).toBe(ERROR_KINDS.INVALID_RELEASE_TAG);
+    }
+  });
+});
+
+describe('reconcile - actual-latest, all packages match', () => {
+  it('is ok when every package (small representative manifest) is at latest', () => {
+    const result = reconcile({
+      manifest: manifestOf(PACKAGES),
+      releaseVersion: '0.16.2',
+      releaseState: 'actual-latest',
+      distTagsFor: allAt('0.16.2'),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.packageCount).toBe(4);
+    expect(result.checked).toBe(4);
+    expect(result.rows).toHaveLength(4);
+    expect(result.rows.every((r) => r.status === 'ok')).toBe(true);
+    expect(result.mismatches).toEqual({ versionMissing: 0, latestMismatch: 0, registryErrors: 0 });
+    expect(result.errors).toHaveLength(0);
+  });
+});
+
+describe('reconcile - actual-latest, single-package failures', () => {
+  it('fails when one package is missing the target version', () => {
+    const distTagsFor = (pkg: string) => {
+      if (pkg === '@peac/schema') {
+        return { latest: '0.16.1', next: '0.16.1', versions: ['0.16.1'] };
+      }
+      return { latest: '0.16.2', next: '0.16.2', versions: ['0.16.2'] };
+    };
+    const result = reconcile({
+      manifest: manifestOf(PACKAGES),
+      releaseVersion: '0.16.2',
+      releaseState: 'actual-latest',
+      distTagsFor,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.mismatches.versionMissing).toBe(1);
+    const row = result.rows.find((r) => r.package === '@peac/schema')!;
+    expect(row.versionExists).toBe(false);
+    expect(row.status).toBe('version-missing');
+    expect(
+      result.errors.some(
+        (e) => e.package === '@peac/schema' && e.kind === ERROR_KINDS.VERSION_MISSING
+      )
+    ).toBe(true);
+  });
+
+  it('fails when one package has a stale npm latest', () => {
+    const distTagsFor = (pkg: string) => {
+      if (pkg === '@peac/crypto') {
+        return { latest: '0.16.1', next: '0.16.2', versions: ['0.16.1', '0.16.2'] };
+      }
+      return allAt('0.16.2')(pkg);
+    };
+    const result = reconcile({
+      manifest: manifestOf(PACKAGES),
+      releaseVersion: '0.16.2',
+      releaseState: 'actual-latest',
+      distTagsFor,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.mismatches.latestMismatch).toBe(1);
+    expect(result.mismatches.versionMissing).toBe(0);
+    const row = result.rows.find((r) => r.package === '@peac/crypto')!;
+    expect(row.versionExists).toBe(true);
+    expect(row.latest).toBe('0.16.1');
+    expect(row.status).toBe('latest-mismatch');
+    expect(
+      result.errors.some(
+        (e) => e.package === '@peac/crypto' && e.kind === ERROR_KINDS.STATE_MISMATCH
+      )
+    ).toBe(true);
+  });
+
+  it('reports multiple mismatches together in one complete table (no short-circuit)', () => {
+    const distTagsFor = (pkg: string) => {
+      if (pkg === '@peac/schema') return { latest: '0.16.2', next: '0.16.2', versions: ['0.16.1'] };
+      if (pkg === '@peac/crypto')
+        return { latest: '0.16.1', next: '0.16.2', versions: ['0.16.1', '0.16.2'] };
+      return allAt('0.16.2')(pkg);
+    };
+    const result = reconcile({
+      manifest: manifestOf(PACKAGES),
+      releaseVersion: '0.16.2',
+      releaseState: 'actual-latest',
+      distTagsFor,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.checked).toBe(4);
+    expect(result.rows).toHaveLength(4);
+    expect(result.mismatches.versionMissing).toBe(1);
+    expect(result.mismatches.latestMismatch).toBe(1);
+    // Both mismatched packages are present, proving the loop does not stop
+    // at the first failure.
+    const names = result.errors.map((e) => e.package);
+    expect(names).toContain('@peac/schema');
+    expect(names).toContain('@peac/crypto');
+  });
+
+  it('regression: an early package matches but a later package is missing or stale', () => {
+    // The predecessor guard checked only the first published package
+    // (@peac/kernel). This locks that a later package's failure is never
+    // masked by an earlier package's success.
+    const distTagsFor = (pkg: string) => {
+      if (pkg === '@peac/kernel') return allAt('0.16.2')(pkg);
+      if (pkg === '@peac/cli') return { latest: '0.16.1', next: '0.16.1', versions: ['0.16.1'] };
+      return allAt('0.16.2')(pkg);
+    };
+    const result = reconcile({
+      manifest: manifestOf(PACKAGES),
+      releaseVersion: '0.16.2',
+      releaseState: 'actual-latest',
+      distTagsFor,
+    });
+    expect(result.ok).toBe(false);
+    const kernelRow = result.rows.find((r) => r.package === '@peac/kernel')!;
+    expect(kernelRow.status).toBe('ok');
+    const cliRow = result.rows.find((r) => r.package === '@peac/cli')!;
+    expect(cliRow.status).toBe('version-missing');
+  });
+});
+
+describe('reconcile - manifest validation', () => {
+  it('throws INVALID_MANIFEST for a duplicate package entry', () => {
+    const manifest = {
+      packages: ['@peac/kernel', '@peac/schema', '@peac/kernel'],
+      totalPackages: 3,
+    };
+    expect(() =>
+      reconcile({
+        manifest,
+        releaseVersion: '0.16.2',
+        releaseState: 'actual-latest',
+        distTagsFor: allAt('0.16.2'),
+      })
+    ).toThrow(ReleaseConsistencyError);
+    try {
+      reconcile({
+        manifest,
+        releaseVersion: '0.16.2',
+        releaseState: 'actual-latest',
+        distTagsFor: allAt('0.16.2'),
+      });
+    } catch (err) {
+      expect((err as ReleaseConsistencyError).kind).toBe(ERROR_KINDS.INVALID_MANIFEST);
+    }
+  });
+
+  it('throws INVALID_MANIFEST for a malformed manifest (missing packages array)', () => {
+    const manifest = { totalPackages: 3 } as unknown as { packages: string[] };
+    let kind: string | undefined;
+    try {
+      reconcile({
+        manifest,
+        releaseVersion: '0.16.2',
+        releaseState: 'actual-latest',
+        distTagsFor: allAt('0.16.2'),
+      });
+    } catch (err) {
+      kind = (err as ReleaseConsistencyError).kind;
+    }
+    expect(kind).toBe(ERROR_KINDS.INVALID_MANIFEST);
+  });
+
+  it('throws INVALID_MANIFEST for a non-string package entry', () => {
+    const manifest = { packages: ['@peac/kernel', 42], totalPackages: 2 } as unknown as {
+      packages: string[];
+    };
+    let kind: string | undefined;
+    try {
+      reconcile({
+        manifest,
+        releaseVersion: '0.16.2',
+        releaseState: 'actual-latest',
+        distTagsFor: allAt('0.16.2'),
+      });
+    } catch (err) {
+      kind = (err as ReleaseConsistencyError).kind;
+    }
+    expect(kind).toBe(ERROR_KINDS.INVALID_MANIFEST);
+  });
+
+  it('throws INVALID_MANIFEST when totalPackages disagrees with packages.length', () => {
+    const manifest = manifestOf(PACKAGES, 99);
+    let kind: string | undefined;
+    try {
+      reconcile({
+        manifest,
+        releaseVersion: '0.16.2',
+        releaseState: 'actual-latest',
+        distTagsFor: allAt('0.16.2'),
+      });
+    } catch (err) {
+      kind = (err as ReleaseConsistencyError).kind;
+    }
+    expect(kind).toBe(ERROR_KINDS.INVALID_MANIFEST);
+  });
+});
+
+describe('reconcile - draft and prerelease are skipped', () => {
+  it('draft: ok true, no packages checked, distTagsFor never called', () => {
+    const distTagsFor = vi.fn();
+    const result = reconcile({
+      manifest: manifestOf(PACKAGES),
+      releaseVersion: '0.16.2',
+      releaseState: 'draft',
+      distTagsFor,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.checked).toBe(0);
+    expect(result.rows).toHaveLength(0);
+    expect(result.summary).toContain('skipped');
+    expect(distTagsFor).not.toHaveBeenCalled();
+  });
+
+  it('prerelease: ok true, no packages checked, distTagsFor never called', () => {
+    const distTagsFor = vi.fn();
+    const result = reconcile({
+      manifest: manifestOf(PACKAGES),
+      releaseVersion: '0.16.2',
+      releaseState: 'prerelease',
+      distTagsFor,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.checked).toBe(0);
+    expect(result.summary).toContain('skipped');
+    expect(distTagsFor).not.toHaveBeenCalled();
+  });
+});
+
+describe('reconcile - historical-stable', () => {
+  it('does not require npm latest to equal the release version', () => {
+    // Every package already moved latest on to a newer version, but the
+    // release version still exists on npm; historical-stable must pass.
+    const distTagsFor = (_pkg: string) => ({
+      latest: '0.17.0',
+      next: '0.17.0',
+      versions: ['0.16.2', '0.17.0'],
+    });
+    const result = reconcile({
+      manifest: manifestOf(PACKAGES),
+      releaseVersion: '0.16.2',
+      releaseState: 'historical-stable',
+      distTagsFor,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.mismatches.latestMismatch).toBe(4);
+    expect(result.rows.every((r) => r.status.startsWith('ok'))).toBe(true);
+  });
+
+  it('still requires the release version to exist for every package', () => {
+    const distTagsFor = (pkg: string) => {
+      if (pkg === '@peac/cli') return { latest: '0.17.0', next: '0.17.0', versions: ['0.17.0'] };
+      return { latest: '0.17.0', next: '0.17.0', versions: ['0.16.2', '0.17.0'] };
+    };
+    const result = reconcile({
+      manifest: manifestOf(PACKAGES),
+      releaseVersion: '0.16.2',
+      releaseState: 'historical-stable',
+      distTagsFor,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.mismatches.versionMissing).toBe(1);
+    const row = result.rows.find((r) => r.package === '@peac/cli')!;
+    expect(row.status).toBe('version-missing');
+  });
+});
+
+describe('reconcile - registry error propagation', () => {
+  it('malformed registry JSON surfaces as MALFORMED_REGISTRY_RESPONSE and fails ok', () => {
+    const distTagsFor = (pkg: string) => {
+      if (pkg === '@peac/schema') {
+        throw new ReleaseConsistencyError(
+          ERROR_KINDS.MALFORMED_REGISTRY_RESPONSE,
+          'unparseable JSON'
+        );
+      }
+      return allAt('0.16.2')(pkg);
+    };
+    const result = reconcile({
+      manifest: manifestOf(PACKAGES),
+      releaseVersion: '0.16.2',
+      releaseState: 'actual-latest',
+      distTagsFor,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.mismatches.registryErrors).toBe(1);
+    const row = result.rows.find((r) => r.package === '@peac/schema')!;
+    expect(row.status).toBe(`error: ${ERROR_KINDS.MALFORMED_REGISTRY_RESPONSE}`);
+    expect(
+      result.errors.some(
+        (e) => e.package === '@peac/schema' && e.kind === ERROR_KINDS.MALFORMED_REGISTRY_RESPONSE
+      )
+    ).toBe(true);
+  });
+
+  it('a distTagsFor that ultimately throws REGISTRY_TRANSIENT_FAILURE (retries exhausted) fails ok', () => {
+    const distTagsFor = (pkg: string) => {
+      if (pkg === '@peac/crypto') {
+        throw new ReleaseConsistencyError(
+          ERROR_KINDS.REGISTRY_TRANSIENT_FAILURE,
+          'rate limited (429)'
+        );
+      }
+      return allAt('0.16.2')(pkg);
+    };
+    const result = reconcile({
+      manifest: manifestOf(PACKAGES),
+      releaseVersion: '0.16.2',
+      releaseState: 'actual-latest',
+      distTagsFor,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.mismatches.registryErrors).toBe(1);
+    expect(
+      result.errors.some(
+        (e) => e.package === '@peac/crypto' && e.kind === ERROR_KINDS.REGISTRY_TRANSIENT_FAILURE
+      )
+    ).toBe(true);
+  });
+
+  it('passes when a wrapped distTagsFor internally retries a transient failure to success', () => {
+    // reconcile() itself does not retry (retries live in the CLI's real
+    // distTagsFor implementation, built on withRetry). This wraps one
+    // package's lookup in withRetry directly to prove the two compose:
+    // a 429/5xx that clears within the bounded attempts still yields ok:true.
+    let calls = 0;
+    const flaky = () => {
+      calls += 1;
+      if (calls < 3) {
+        throw new ReleaseConsistencyError(
+          ERROR_KINDS.REGISTRY_TRANSIENT_FAILURE,
+          'rate limited (429)'
+        );
+      }
+      return { latest: '0.16.2', next: '0.16.2', versions: ['0.16.2'] };
+    };
+    const distTagsFor = (pkg: string) => {
+      if (pkg === '@peac/schema') {
+        return withRetry(flaky, { attempts: 8, sleep: () => {} }).value;
+      }
+      return allAt('0.16.2')(pkg);
+    };
+    const result = reconcile({
+      manifest: manifestOf(PACKAGES),
+      releaseVersion: '0.16.2',
+      releaseState: 'actual-latest',
+      distTagsFor,
+    });
+    expect(result.ok).toBe(true);
+    expect(calls).toBe(3);
+  });
+
+  it('a package that does not exist at all reports PACKAGE_MISSING as a registry error', () => {
+    const distTagsFor = (pkg: string) => {
+      if (pkg === '@peac/kernel') {
+        throw new ReleaseConsistencyError(
+          ERROR_KINDS.PACKAGE_MISSING,
+          'npm view failed: 404 Not Found'
+        );
+      }
+      return allAt('0.16.2')(pkg);
+    };
+    const result = reconcile({
+      manifest: manifestOf(PACKAGES),
+      releaseVersion: '0.16.2',
+      releaseState: 'actual-latest',
+      distTagsFor,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.mismatches.registryErrors).toBe(1);
+    expect(
+      result.errors.some(
+        (e) => e.package === '@peac/kernel' && e.kind === ERROR_KINDS.PACKAGE_MISSING
+      )
+    ).toBe(true);
+  });
+});
+
+describe('reconcile - scoped package names', () => {
+  it('handles scoped names correctly in rows, errors, and status', () => {
+    const result = reconcile({
+      manifest: manifestOf(['@peac/kernel', '@peac/adapter-openai-compatible']),
+      releaseVersion: '0.16.2',
+      releaseState: 'actual-latest',
+      distTagsFor: (pkg) =>
+        pkg === '@peac/adapter-openai-compatible'
+          ? { latest: '0.16.1', next: '0.16.1', versions: ['0.16.1'] }
+          : allAt('0.16.2')(pkg),
+    });
+    expect(result.ok).toBe(false);
+    const row = result.rows.find((r) => r.package === '@peac/adapter-openai-compatible');
+    expect(row).toBeDefined();
+    expect(row!.status).toBe('version-missing');
+  });
+});
+
+describe('withRetry', () => {
+  it('retries a transient failure then returns the eventual success', () => {
+    let calls = 0;
+    const op = () => {
+      calls += 1;
+      if (calls < 3) {
+        throw new ReleaseConsistencyError(ERROR_KINDS.REGISTRY_TRANSIENT_FAILURE, '503');
+      }
+      return 'ok';
+    };
+    const { value, attempts } = withRetry(op, { attempts: 8, sleep: () => {} });
+    expect(value).toBe('ok');
+    expect(attempts).toBe(3);
+    expect(calls).toBe(3);
+  });
+
+  it('throws REGISTRY_TRANSIENT_FAILURE after exhausting the bounded attempts (no infinite retry)', () => {
+    let calls = 0;
+    const op = () => {
+      calls += 1;
+      throw new ReleaseConsistencyError(ERROR_KINDS.REGISTRY_TRANSIENT_FAILURE, '503 every time');
+    };
+    let thrownKind: string | undefined;
+    try {
+      withRetry(op, { attempts: 3, sleep: () => {} });
+    } catch (err) {
+      thrownKind = (err as ReleaseConsistencyError).kind;
+    }
+    expect(thrownKind).toBe(ERROR_KINDS.REGISTRY_TRANSIENT_FAILURE);
+    expect(calls).toBe(3);
+  });
+
+  it('never retries a permanent failure', () => {
+    let calls = 0;
+    const op = () => {
+      calls += 1;
+      throw new ReleaseConsistencyError(ERROR_KINDS.PACKAGE_MISSING, '404');
+    };
+    expect(() => withRetry(op, { attempts: 8, sleep: () => {} })).toThrow(ReleaseConsistencyError);
+    expect(calls).toBe(1);
+  });
+
+  it('never retries a state mismatch style error', () => {
+    let calls = 0;
+    const op = () => {
+      calls += 1;
+      throw new ReleaseConsistencyError(ERROR_KINDS.STATE_MISMATCH, 'latest disagrees');
+    };
+    expect(() => withRetry(op, { attempts: 8, sleep: () => {} })).toThrow(ReleaseConsistencyError);
+    expect(calls).toBe(1);
+  });
+});
+
+describe('determineIsActualLatest', () => {
+  it('is false when there is no resolvable latest release', () => {
+    expect(determineIsActualLatest({ tag: 'v0.16.2', releaseId: '1', latestRelease: null })).toBe(
+      false
+    );
+  });
+
+  it('matches on release id when both sides provide one', () => {
+    expect(
+      determineIsActualLatest({
+        tag: 'v0.16.2',
+        releaseId: '12345',
+        latestRelease: { id: '12345', tagName: 'v0.16.2' },
+      })
+    ).toBe(true);
+    expect(
+      determineIsActualLatest({
+        tag: 'v0.16.2',
+        releaseId: '99999',
+        latestRelease: { id: '12345', tagName: 'v0.16.2' },
+      })
+    ).toBe(false);
+  });
+
+  it('falls back to tag comparison when no release id is available', () => {
+    expect(
+      determineIsActualLatest({
+        tag: 'v0.16.2',
+        releaseId: null,
+        latestRelease: { id: null, tagName: 'v0.16.2' },
+      })
+    ).toBe(true);
+    expect(
+      determineIsActualLatest({
+        tag: 'v0.16.1',
+        releaseId: null,
+        latestRelease: { id: null, tagName: 'v0.16.2' },
+      })
+    ).toBe(false);
+  });
+});
+
+describe('CLI', () => {
+  it('--help prints usage and exits 0 (proves the module imports without side effects)', () => {
+    const out = execFileSync(process.execPath, [SCRIPT, '--help'], { encoding: 'utf8' });
+    expect(out).toContain('Usage: verify-github-release-npm-consistency.mjs');
+  });
+
+  it('no arguments prints usage to stderr and exits non-zero', () => {
+    const result = spawnSync(process.execPath, [SCRIPT], { encoding: 'utf8' });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('Usage: verify-github-release-npm-consistency.mjs');
+  });
+});


### PR DESCRIPTION
## Summary

Reconciles a finalized GitHub Release against npm dist-tags across every package in `scripts/publish-manifest.json`, rather than a single package. This is a detective check: GitHub cannot block a release, so a red result surfaces an inconsistency after the fact instead of leaving it silent.

The invariant: a release that is the repository's current Latest release must carry its version at npm `latest` for every published package. A finalized release that is not the current Latest (a historical stable release) only needs the version to exist on npm; it does not need to own the `latest` dist-tag. Draft and prerelease releases are skipped, since the `latest` invariant does not apply until a release is finalized.

## Changes

- `scripts/verify-github-release-npm-consistency.mjs` (new): an import-safe reconciler. The pure `reconcile()` and `parseReleaseTag()` functions take all registry access through an injected `distTagsFor`, so they unit-test without network or git. The full package set is always checked, so a later package's mismatch is never masked by an earlier match.
  - Registry error taxonomy: `STATE_MISMATCH`, `VERSION_MISSING`, `PACKAGE_MISSING`, `REGISTRY_TRANSIENT_FAILURE`, `REGISTRY_PERMANENT_FAILURE`, `MALFORMED_REGISTRY_RESPONSE`, `INVALID_MANIFEST`, `INVALID_RELEASE_TAG`. A permanent 404 for a package or version is a real failure, never a silent pass.
  - Bounded, transient-only retries (rate limit, 5xx, network); permanent failures and state mismatches are never retried. No suppressed exit codes.
  - The actual current Latest release is resolved from `repos/{owner}/{repo}/releases/latest`, not inferred from draft and prerelease flags alone.
  - Strict tag grammar `vMAJOR.MINOR.PATCH`.
- `tests/tooling/verify-github-release-npm-consistency.test.ts` (new): 30 unit tests over the pure functions with a mocked registry, including a package set where an early package matches but a later package is missing or stale, retry exhaustion, historical-stable versus actual-latest semantics, manifest validation, and an import-safety CLI smoke test.
- `.github/workflows/release-consistency-guard.yml`: runs on `published` and `released` release events, manual dispatch with a tag input, and a daily schedule that reconciles the current Latest release. Pinned checkout, least-privilege `contents: read`, and a job step-summary table listing every package.

## Validation

- 30 of 30 unit tests pass.
- Prettier, actionlint, and eslint are clean; the module is import-safe (importing it does not run the CLI).

## Scope

No wire, schema, registry, or package changes. Adds one workflow, one script, and one test.
