### PR TITLE
fix(ci): use REST release ids consistently

### DIFF
--- a/scripts/verify-github-release-npm-consistency.mjs
+++ b/scripts/verify-github-release-npm-consistency.mjs
@@ -50,8 +50,10 @@ export const ERROR_KINDS = Object.freeze({
   REGISTRY_TRANSIENT_FAILURE: 'REGISTRY_TRANSIENT_FAILURE',
   REGISTRY_PERMANENT_FAILURE: 'REGISTRY_PERMANENT_FAILURE',
   MALFORMED_REGISTRY_RESPONSE: 'MALFORMED_REGISTRY_RESPONSE',
+  MALFORMED_GITHUB_RESPONSE: 'MALFORMED_GITHUB_RESPONSE',
   INVALID_MANIFEST: 'INVALID_MANIFEST',
   INVALID_RELEASE_TAG: 'INVALID_RELEASE_TAG',
+  INVALID_RELEASE_ID: 'INVALID_RELEASE_ID',
 });
 
 const VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
@@ -91,6 +93,80 @@ export function parseReleaseTag(tag) {
     );
   }
   return match[1];
+}
+
+/**
+ * Normalize a GitHub REST release id to a canonical decimal string.
+ *
+ * GitHub REST release objects carry a positive integer `id`; the GraphQL API
+ * (and `gh release view --json id`) carry an opaque `node_id` such as `RE_...`.
+ * Only the REST numeric id is accepted, so a GraphQL node id, a fractional or
+ * non-positive value, or a non-numeric string is a resolution failure rather
+ * than a comparison that silently returns false. Accepts a positive safe
+ * integer (number) or a string of digits with no leading zero; returns the
+ * decimal-string form. Throws INVALID_RELEASE_ID on anything else.
+ */
+export function normalizeReleaseId(raw) {
+  if (typeof raw === 'number') {
+    if (!Number.isInteger(raw) || raw <= 0 || !Number.isSafeInteger(raw)) {
+      throw new ReleaseConsistencyError(
+        ERROR_KINDS.INVALID_RELEASE_ID,
+        `release id must be a positive safe integer, got ${raw}`
+      );
+    }
+    return String(raw);
+  }
+  if (typeof raw === 'string' && /^[1-9][0-9]*$/.test(raw)) {
+    return raw;
+  }
+  throw new ReleaseConsistencyError(
+    ERROR_KINDS.INVALID_RELEASE_ID,
+    `release id is not a REST numeric id: ${raw === null ? 'null' : JSON.stringify(raw)}`
+  );
+}
+
+/**
+ * Validate a GitHub REST release object and return the fields the reconciler
+ * needs, failing closed on any shape violation. One parser is shared by the
+ * releases-by-tag and releases/latest lookups. Requires a non-array object, a
+ * normalized REST numeric `id`, a non-empty string `tag_name`, and boolean
+ * `draft` and `prerelease` flags (no truthiness coercion, so `"false"` or a
+ * missing flag is rejected, not silently treated as true or false). When
+ * `expectedTag` is supplied, `tag_name` must equal it.
+ */
+export function parseGithubReleaseObject(value, { expectedTag } = {}) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new ReleaseConsistencyError(
+      ERROR_KINDS.MALFORMED_GITHUB_RESPONSE,
+      'GitHub release response is not an object'
+    );
+  }
+  const id = normalizeReleaseId(value.id);
+  if (typeof value.tag_name !== 'string' || value.tag_name.length === 0) {
+    throw new ReleaseConsistencyError(
+      ERROR_KINDS.MALFORMED_GITHUB_RESPONSE,
+      `GitHub release response has no string tag_name: ${JSON.stringify(value.tag_name)}`
+    );
+  }
+  if (typeof value.draft !== 'boolean') {
+    throw new ReleaseConsistencyError(
+      ERROR_KINDS.MALFORMED_GITHUB_RESPONSE,
+      `GitHub release draft flag is not a boolean: ${JSON.stringify(value.draft)}`
+    );
+  }
+  if (typeof value.prerelease !== 'boolean') {
+    throw new ReleaseConsistencyError(
+      ERROR_KINDS.MALFORMED_GITHUB_RESPONSE,
+      `GitHub release prerelease flag is not a boolean: ${JSON.stringify(value.prerelease)}`
+    );
+  }
+  if (expectedTag != null && value.tag_name !== expectedTag) {
+    throw new ReleaseConsistencyError(
+      ERROR_KINDS.MALFORMED_GITHUB_RESPONSE,
+      `GitHub release tag_name ${value.tag_name} does not match the requested tag ${expectedTag}`
+    );
+  }
+  return { id, tagName: value.tag_name, isDraft: value.draft, isPrerelease: value.prerelease };
 }
 
 /** Validate the publish manifest shape and return its package list. */
@@ -329,11 +405,16 @@ export function withRetry(operation, options = {}) {
  * with `draft`/`prerelease` true is never passed through this check by
  * the CLI; `latestRelease` being absent (no Latest release resolvable)
  * means the release under test cannot be the actual latest.
+ *
+ * When both ids are present they must both normalize to REST numeric ids;
+ * a GraphQL node id or other malformed id is a resolution failure (throws
+ * INVALID_RELEASE_ID), never a silent `false` that would misclassify the
+ * current Latest release as historical and skip the npm latest invariant.
  */
 export function determineIsActualLatest({ tag, releaseId, latestRelease }) {
   if (!latestRelease) return false;
   if (releaseId != null && latestRelease.id != null) {
-    return String(latestRelease.id) === String(releaseId);
+    return normalizeReleaseId(releaseId) === normalizeReleaseId(latestRelease.id);
   }
   if (tag && latestRelease.tagName) {
     return latestRelease.tagName === tag;
@@ -468,7 +549,7 @@ function ghRaw(args) {
       return JSON.parse(result.stdout);
     } catch (err) {
       throw new ReleaseConsistencyError(
-        ERROR_KINDS.MALFORMED_REGISTRY_RESPONSE,
+        ERROR_KINDS.MALFORMED_GITHUB_RESPONSE,
         `gh ${args.join(' ')} returned unparseable JSON: ${err.message}`
       );
     }
@@ -487,24 +568,73 @@ function ghRaw(args) {
   );
 }
 
-function fetchReleaseByTag(tag, repo) {
-  const args = ['release', 'view', tag, '--json', 'id,isDraft,isPrerelease'];
-  if (repo) args.push('--repo', repo);
-  return withRetry(() => ghRaw(args), { attempts: GH_MAX_ATTEMPTS }).value;
+// Pin an explicit GitHub REST API version so both release lookups share one
+// versioned surface and cannot drift to a moving default. Requests without a
+// version currently default to 2022-11-28, but GitHub documents that the
+// unversioned default can advance as older versions retire.
+const GITHUB_API_VERSION = '2026-03-10';
+
+/**
+ * Build the exact `gh api` argument vector for a REST GET, pinned to a single
+ * Accept header and API version. Exported so tests can assert both release
+ * lookups issue the same explicitly versioned request.
+ */
+export function buildGithubApiArgs(endpoint) {
+  return [
+    'api',
+    '--method',
+    'GET',
+    '-H',
+    'Accept: application/vnd.github+json',
+    '-H',
+    `X-GitHub-Api-Version: ${GITHUB_API_VERSION}`,
+    endpoint,
+  ];
 }
 
-/** Fetch the repository's actual current Latest release via the GitHub API. */
-function fetchActualLatestRelease(repo) {
+/** Real GitHub REST JSON lookup: one versioned `gh api` GET, parsed to an object. */
+function ghApiJson(endpoint) {
+  return ghRaw(buildGithubApiArgs(endpoint));
+}
+
+/**
+ * Resolve a release by tag through the REST releases-by-tag endpoint. `request`
+ * is injected (defaults to the real `gh api` GET) so the lookup path is
+ * directly testable. The response is validated by the shared parser, so its id
+ * shares the same REST id space as `fetchActualLatestRelease`; the gh CLI's
+ * `release view --json id` (a GraphQL node id) is deliberately not used, since
+ * it never equals the REST id and would misclassify the current Latest release
+ * as historical on the dispatch and schedule paths.
+ */
+export function fetchReleaseByTag(tag, repo, request = ghApiJson) {
+  if (!repo) {
+    throw new ReleaseConsistencyError(
+      ERROR_KINDS.REGISTRY_PERMANENT_FAILURE,
+      'a repository slug is required to resolve a release by tag (pass --repo or set GITHUB_REPOSITORY)'
+    );
+  }
+  const endpoint = `repos/${repo}/releases/tags/${tag}`;
+  const value = withRetry(() => request(endpoint), { attempts: GH_MAX_ATTEMPTS }).value;
+  return parseGithubReleaseObject(value, { expectedTag: tag });
+}
+
+/**
+ * Fetch the repository's actual current Latest release through the REST
+ * releases/latest endpoint. `request` is injected (defaults to the real
+ * `gh api` GET). The response is validated by the same shared parser, so its
+ * id shares the REST id space used by `fetchReleaseByTag`.
+ */
+export function fetchActualLatestRelease(repo, request = ghApiJson) {
   if (!repo) {
     throw new ReleaseConsistencyError(
       ERROR_KINDS.REGISTRY_PERMANENT_FAILURE,
       'a repository slug is required to resolve the actual latest release (pass --repo or set GITHUB_REPOSITORY)'
     );
   }
-  const value = withRetry(() => ghRaw(['api', `repos/${repo}/releases/latest`]), {
-    attempts: GH_MAX_ATTEMPTS,
-  }).value;
-  return { id: value.id != null ? String(value.id) : null, tagName: value.tag_name ?? null };
+  const endpoint = `repos/${repo}/releases/latest`;
+  const value = withRetry(() => request(endpoint), { attempts: GH_MAX_ATTEMPTS }).value;
+  const { id, tagName } = parseGithubReleaseObject(value);
+  return { id, tagName };
 }
 
 function printUsage(stream) {

--- a/tests/tooling/verify-github-release-npm-consistency.test.ts
+++ b/tests/tooling/verify-github-release-npm-consistency.test.ts
@@ -21,6 +21,11 @@ import {
   parseReleaseTag,
   withRetry,
   determineIsActualLatest,
+  normalizeReleaseId,
+  parseGithubReleaseObject,
+  buildGithubApiArgs,
+  fetchReleaseByTag,
+  fetchActualLatestRelease,
   ReleaseConsistencyError,
   ERROR_KINDS,
 } from '../../scripts/verify-github-release-npm-consistency.mjs';
@@ -567,6 +572,257 @@ describe('determineIsActualLatest', () => {
         latestRelease: { id: null, tagName: 'v0.16.2' },
       })
     ).toBe(false);
+  });
+
+  it('matches the current Latest release when both REST ids are equal', () => {
+    expect(
+      determineIsActualLatest({
+        tag: 'v0.16.2',
+        releaseId: '353469866',
+        latestRelease: { id: '353469866', tagName: 'v0.16.2' },
+      })
+    ).toBe(true);
+    expect(
+      determineIsActualLatest({
+        tag: 'v0.16.2',
+        releaseId: '353469866',
+        latestRelease: { id: '999999999', tagName: 'v0.16.3' },
+      })
+    ).toBe(false);
+  });
+
+  it('fails closed on a mixed id space (GraphQL node id) instead of returning false', () => {
+    // A GraphQL node id versus a REST numeric id is a resolution failure, not
+    // evidence that the release is historical. Returning false here would skip
+    // the npm latest invariant, which is the original bug.
+    let kind: string | undefined;
+    try {
+      determineIsActualLatest({
+        tag: 'v0.16.2',
+        releaseId: 'RE_kwDOexampleGraphQLNodeId',
+        latestRelease: { id: '353469866', tagName: 'v0.16.2' },
+      });
+    } catch (err) {
+      kind = (err as ReleaseConsistencyError).kind;
+    }
+    expect(kind).toBe(ERROR_KINDS.INVALID_RELEASE_ID);
+  });
+});
+
+describe('normalizeReleaseId', () => {
+  it('accepts a positive REST numeric id (number or decimal string)', () => {
+    expect(normalizeReleaseId(353469866)).toBe('353469866');
+    expect(normalizeReleaseId('353469866')).toBe('353469866');
+    expect(normalizeReleaseId(1)).toBe('1');
+  });
+
+  it('rejects GraphQL node ids and other non-REST ids as INVALID_RELEASE_ID', () => {
+    const bad: unknown[] = [
+      'RE_kwDOexampleGraphQLNodeId',
+      '',
+      '0',
+      0,
+      -5,
+      '-5',
+      1.5,
+      '007',
+      'abc',
+      NaN,
+      Infinity,
+      null,
+      undefined,
+      {},
+      ['353469866'],
+    ];
+    for (const value of bad) {
+      let kind: string | undefined;
+      try {
+        normalizeReleaseId(value as never);
+      } catch (err) {
+        kind = (err as ReleaseConsistencyError).kind;
+      }
+      expect(kind, `expected ${JSON.stringify(value)} to be rejected`).toBe(
+        ERROR_KINDS.INVALID_RELEASE_ID
+      );
+    }
+  });
+});
+
+describe('parseGithubReleaseObject', () => {
+  const rest = {
+    id: 353469866,
+    node_id: 'RE_kwDOexampleGraphQLNodeId',
+    tag_name: 'v0.16.2',
+    draft: false,
+    prerelease: false,
+  };
+
+  it('returns a normalized decimal-string id and the exact boolean flags', () => {
+    const parsed = parseGithubReleaseObject(rest);
+    expect(parsed).toEqual({
+      id: '353469866',
+      tagName: 'v0.16.2',
+      isDraft: false,
+      isPrerelease: false,
+    });
+  });
+
+  it('enforces tag_name equality when expectedTag is supplied', () => {
+    expect(parseGithubReleaseObject(rest, { expectedTag: 'v0.16.2' }).tagName).toBe('v0.16.2');
+    let kind: string | undefined;
+    try {
+      parseGithubReleaseObject(rest, { expectedTag: 'v0.16.1' });
+    } catch (err) {
+      kind = (err as ReleaseConsistencyError).kind;
+    }
+    expect(kind).toBe(ERROR_KINDS.MALFORMED_GITHUB_RESPONSE);
+  });
+
+  it('fails closed on malformed shapes without truthiness coercion', () => {
+    const cases: Array<{ obj: unknown; kind: string }> = [
+      { obj: null, kind: ERROR_KINDS.MALFORMED_GITHUB_RESPONSE },
+      { obj: [rest], kind: ERROR_KINDS.MALFORMED_GITHUB_RESPONSE },
+      { obj: { ...rest, id: 'RE_kwDOexampleGraphQLNodeId' }, kind: ERROR_KINDS.INVALID_RELEASE_ID },
+      {
+        obj: { tag_name: 'v0.16.2', draft: false, prerelease: false },
+        kind: ERROR_KINDS.INVALID_RELEASE_ID,
+      },
+      { obj: { ...rest, tag_name: 123 }, kind: ERROR_KINDS.MALFORMED_GITHUB_RESPONSE },
+      { obj: { ...rest, draft: 'false' }, kind: ERROR_KINDS.MALFORMED_GITHUB_RESPONSE },
+      {
+        obj: { id: 1, tag_name: 'v0.16.2', draft: false },
+        kind: ERROR_KINDS.MALFORMED_GITHUB_RESPONSE,
+      },
+    ];
+    for (const { obj, kind } of cases) {
+      let got: string | undefined;
+      try {
+        parseGithubReleaseObject(obj as never);
+      } catch (err) {
+        got = (err as ReleaseConsistencyError).kind;
+      }
+      expect(got, `expected ${JSON.stringify(obj)} rejected`).toBe(kind);
+    }
+  });
+});
+
+describe('buildGithubApiArgs', () => {
+  it('builds a pinned, versioned REST GET for the given endpoint', () => {
+    expect(buildGithubApiArgs('repos/peacprotocol/peac/releases/tags/v0.16.2')).toEqual([
+      'api',
+      '--method',
+      'GET',
+      '-H',
+      'Accept: application/vnd.github+json',
+      '-H',
+      'X-GitHub-Api-Version: 2026-03-10',
+      'repos/peacprotocol/peac/releases/tags/v0.16.2',
+    ]);
+  });
+});
+
+describe('fetchReleaseByTag / fetchActualLatestRelease (injected REST lookup)', () => {
+  const restRelease = (over: Record<string, unknown> = {}) => ({
+    id: 353469866,
+    node_id: 'RE_kwDOexampleGraphQLNodeId',
+    tag_name: 'v0.16.2',
+    draft: false,
+    prerelease: false,
+    ...over,
+  });
+
+  it('fetchReleaseByTag calls exactly the REST releases-by-tag endpoint and normalizes the result', () => {
+    const calls: string[] = [];
+    const request = (endpoint: string) => {
+      calls.push(endpoint);
+      return restRelease();
+    };
+    const result = fetchReleaseByTag('v0.16.2', 'peacprotocol/peac', request);
+    expect(calls).toEqual(['repos/peacprotocol/peac/releases/tags/v0.16.2']);
+    expect(result).toEqual({
+      id: '353469866',
+      tagName: 'v0.16.2',
+      isDraft: false,
+      isPrerelease: false,
+    });
+  });
+
+  it('fetchActualLatestRelease calls exactly the REST releases/latest endpoint', () => {
+    const calls: string[] = [];
+    const request = (endpoint: string) => {
+      calls.push(endpoint);
+      return restRelease({ tag_name: 'v0.16.2' });
+    };
+    const result = fetchActualLatestRelease('peacprotocol/peac', request);
+    expect(calls).toEqual(['repos/peacprotocol/peac/releases/latest']);
+    expect(result).toEqual({ id: '353469866', tagName: 'v0.16.2' });
+  });
+
+  it('both lookups use the same pinned API version', () => {
+    expect(buildGithubApiArgs('repos/peacprotocol/peac/releases/tags/v0.16.2')).toContain(
+      'X-GitHub-Api-Version: 2026-03-10'
+    );
+    expect(buildGithubApiArgs('repos/peacprotocol/peac/releases/latest')).toContain(
+      'X-GitHub-Api-Version: 2026-03-10'
+    );
+  });
+
+  it('fetchReleaseByTag fails when the repository slug is missing', () => {
+    let kind: string | undefined;
+    try {
+      fetchReleaseByTag('v0.16.2', '', () => restRelease());
+    } catch (err) {
+      kind = (err as ReleaseConsistencyError).kind;
+    }
+    expect(kind).toBe(ERROR_KINDS.REGISTRY_PERMANENT_FAILURE);
+  });
+
+  it('fetchReleaseByTag fails closed on a GraphQL id, missing id, or tag mismatch', () => {
+    const bad: Array<{ over: Record<string, unknown>; kind: string }> = [
+      { over: { id: 'RE_kwDOexampleGraphQLNodeId' }, kind: ERROR_KINDS.INVALID_RELEASE_ID },
+      { over: { id: undefined }, kind: ERROR_KINDS.INVALID_RELEASE_ID },
+      { over: { tag_name: 'v0.16.1' }, kind: ERROR_KINDS.MALFORMED_GITHUB_RESPONSE },
+      { over: { draft: 'false' }, kind: ERROR_KINDS.MALFORMED_GITHUB_RESPONSE },
+    ];
+    for (const { over, kind } of bad) {
+      let got: string | undefined;
+      try {
+        fetchReleaseByTag('v0.16.2', 'peacprotocol/peac', () => restRelease(over));
+      } catch (err) {
+        got = (err as ReleaseConsistencyError).kind;
+      }
+      expect(got, `expected ${JSON.stringify(over)} rejected`).toBe(kind);
+    }
+  });
+
+  it('fetchReleaseByTag retries a transient failure within the bounded attempts', () => {
+    let calls = 0;
+    const request = (_endpoint: string) => {
+      calls += 1;
+      if (calls < 3) {
+        throw new ReleaseConsistencyError(ERROR_KINDS.REGISTRY_TRANSIENT_FAILURE, 'rate limited');
+      }
+      return restRelease();
+    };
+    const result = fetchReleaseByTag('v0.16.2', 'peacprotocol/peac', request);
+    expect(calls).toBe(3);
+    expect(result.id).toBe('353469866');
+  });
+
+  it('fetchReleaseByTag does not retry a permanent malformed-response failure', () => {
+    let calls = 0;
+    const request = (_endpoint: string) => {
+      calls += 1;
+      return restRelease({ id: 'RE_kwDOexampleGraphQLNodeId' });
+    };
+    let kind: string | undefined;
+    try {
+      fetchReleaseByTag('v0.16.2', 'peacprotocol/peac', request);
+    } catch (err) {
+      kind = (err as ReleaseConsistencyError).kind;
+    }
+    expect(kind).toBe(ERROR_KINDS.INVALID_RELEASE_ID);
+    expect(calls).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Summary

The release-consistency reconciler compared a release id obtained from the `gh` CLI (a GraphQL node id, `RE_...`) against the `releases/latest` id from the REST API (a numeric id). The two id spaces never match, so a `workflow_dispatch` or scheduled run classified the current Latest release as historical and skipped the npm `latest` dist-tag invariant. The primary release-event path is unaffected: it passes the REST `github.event.release.id`, which matches.

## Change

- Both release lookups resolve through the REST `releases/tags/{tag}` and `releases/latest` endpoints via one shared, version-pinned request helper (`Accept: application/vnd.github+json`, `X-GitHub-Api-Version: 2026-03-10`, explicit GET), so they cannot drift to different API surfaces.
- A shared parser validates each REST release object and fails closed: a non-array object, a normalized positive-integer id, a string `tag_name` (matched against the requested tag for the by-tag lookup), and boolean `draft`/`prerelease` flags with no truthiness coercion.
- A release id that is not a REST numeric id (for example a GraphQL node id) is a resolution error (`INVALID_RELEASE_ID`), never a silent `historical-stable` classification that would skip the npm `latest` invariant.
- The lookups are injectable, so the regression is tested through the actual `releases/tags` lookup path (endpoint, id normalization, response validation, bounded transient-only retry, and the mixed-id-space failure), not only through the `determineIsActualLatest` comparator.

## Scope

Two files: `scripts/verify-github-release-npm-consistency.mjs` and `tests/tooling/verify-github-release-npm-consistency.test.ts`. No protocol code, schema, registry, package, dependency, or release-state change.

## Validation

45 reconciler unit tests and the full `test:tooling` suite (1726 tests) pass, along with guard, eslint, prettier, typecheck:core, forbid-strings, the control-character scan, and `git diff --check`. The fix was exercised end to end by dispatching the Release Consistency workflow for `v0.16.2`, which now reports `state=actual-latest` and PASS across all 36 packages. CI is authoritative for the full matrix.
