### PR TITLE
docs(specs): gateway decision evidence semantics

### DIFF
--- a/docs/profiles/access.md
+++ b/docs/profiles/access.md
@@ -21,8 +21,9 @@ not tighten any fields beyond what the schema already mandates.
   for review)
 - Producing machine-verifiable evidence that a gateway evaluated a request
   for a specific resource and action and reached an access decision
-- Creating auditable access decision logs that can be verified by third
-  parties independently of the system that made the decision
+- Creating auditable access-decision records whose structure and signatures
+  can be independently validated, with issuer acceptance determined by the
+  verifier's configured trust policy
 
 ## Required / Recommended / Prohibited fields
 
@@ -219,8 +220,8 @@ console.log(result.claims.type); // 'org.peacprotocol/access-decision'
 - The `action` field is an open vocabulary string. Common values include
   `read`, `write`, `execute`, `delete`, `list`, but any string up to
   256 characters is valid
-- Access decisions are observations: recording an access decision does
-  not constitute granting or revoking access
+- Access-decision records are evidence of decisions: recording one does not
+  grant or revoke access
 - The presence of `resource`, `action`, and `decision` does not prove that
   the operation executed, completed, or was prevented. The record represents
   evidence of the access decision

--- a/docs/profiles/access.md
+++ b/docs/profiles/access.md
@@ -19,8 +19,8 @@ not tighten any fields beyond what the schema already mandates.
 - Recording that an API gateway, MCP server, or service mesh evaluated
   an access request and reached a decision (allow, deny, or deferred
   for review)
-- Producing machine-verifiable evidence that a specific resource was
-  accessed (or denied) for a specific action at a specific time
+- Producing machine-verifiable evidence that a gateway evaluated a request
+  for a specific resource and action and reached an access decision
 - Creating auditable access decision logs that can be verified by third
   parties independently of the system that made the decision
 
@@ -30,8 +30,8 @@ All fields below belong to the `org.peacprotocol/access` extension group.
 
 | Field      | Schema Status | Profile Status | Rationale                                              |
 | ---------- | ------------- | -------------- | ------------------------------------------------------ |
-| `resource` | REQUIRED      | REQUIRED       | Identifies the resource being accessed                 |
-| `action`   | REQUIRED      | REQUIRED       | Identifies the action performed on the resource        |
+| `resource` | REQUIRED      | REQUIRED       | Identifies the evaluated resource or target            |
+| `action`   | REQUIRED      | REQUIRED       | Identifies the requested or evaluated operation        |
 | `decision` | REQUIRED      | REQUIRED       | Records the access control outcome (allow/deny/review) |
 
 All fields are schema-required. This profile does not tighten any
@@ -221,3 +221,6 @@ console.log(result.claims.type); // 'org.peacprotocol/access-decision'
   256 characters is valid
 - Access decisions are observations: recording an access decision does
   not constitute granting or revoking access
+- The presence of `resource`, `action`, and `decision` does not prove that
+  the operation executed, completed, or was prevented. The record represents
+  evidence of the access decision

--- a/docs/profiles/access.md
+++ b/docs/profiles/access.md
@@ -29,11 +29,11 @@ not tighten any fields beyond what the schema already mandates.
 
 All fields below belong to the `org.peacprotocol/access` extension group.
 
-| Field      | Schema Status | Profile Status | Rationale                                              |
-| ---------- | ------------- | -------------- | ------------------------------------------------------ |
-| `resource` | REQUIRED      | REQUIRED       | Identifies the evaluated resource or target            |
-| `action`   | REQUIRED      | REQUIRED       | Identifies the requested or evaluated operation        |
-| `decision` | REQUIRED      | REQUIRED       | Records the access control outcome (allow/deny/review) |
+| Field      | Schema Status | Profile Status | Rationale                                                          |
+| ---------- | ------------- | -------------- | ------------------------------------------------------------------ |
+| `resource` | REQUIRED      | REQUIRED       | Identifies the evaluated resource or target                        |
+| `action`   | REQUIRED      | REQUIRED       | Identifies the requested or evaluated operation                    |
+| `decision` | REQUIRED      | REQUIRED       | Records the access-control decision (`allow`, `deny`, or `review`) |
 
 All fields are schema-required. This profile does not tighten any
 optional fields to REQUIRED status.
@@ -47,7 +47,6 @@ required fields.
 ```json
 {
   "iss": "https://gateway.example.com",
-  "aud": "https://consumer.example.com",
   "kind": "evidence",
   "type": "org.peacprotocol/access-decision",
   "pillars": ["access"],
@@ -65,8 +64,8 @@ required fields.
 
 - **Identity** (recommended, not enforced): when the access decision
   depends on a verified identity attestation, pairing an identity
-  receipt with an access receipt provides a complete evidence chain
-  from identity proof to access outcome
+  receipt with an access receipt provides a correlated evidence chain
+  from identity proof to the recorded access decision
 - **Compliance** (recommended for audit workflows): when access
   decisions are subject to regulatory audit, a companion compliance
   receipt records the framework and audit reference
@@ -78,11 +77,11 @@ enforced dependencies. Receipts are valid without companion profiles.
 
 The access extension group supports evidence relevant to:
 
-- SOC 2 Type II: access control evidence for CC6.1 (logical and
-  physical access controls)
-- ISO 27001: access control evidence for Annex A.9 (access control)
-- NIST SP 800-53: access control evidence for AC (Access Control)
-  family
+- SOC 2: evidence relevant to the Trust Services Criteria's logical and
+  physical access controls, including CC6.1 where applicable
+- ISO/IEC 27001:2022 and ISO/IEC 27002:2022: evidence relevant to access-control
+  controls selected through the organization's risk-treatment process
+- NIST SP 800-53 Rev. 5: evidence relevant to the AC (Access Control) family
 
 This profile can help document access decisions for audit purposes.
 PEAC is evidence infrastructure; these mappings do not themselves
@@ -155,7 +154,8 @@ equivalent for this group.
 ```
 
 This receipt pairs access evidence with an identity proof reference,
-providing a complete evidence chain from identity to access outcome.
+providing a correlated evidence chain from identity proof to the recorded
+access decision.
 
 ## Quick demo
 

--- a/docs/specs/GATEWAY-DECISION-EVIDENCE.md
+++ b/docs/specs/GATEWAY-DECISION-EVIDENCE.md
@@ -131,8 +131,8 @@ distinct, and only one of them may populate the `decision` field of an
 A failed check does not, by itself, establish a denial: the gateway may
 continue, retry, fall back, hand off for review, or separately reach a terminal
 denial. A passed check does not, by itself, establish an allow decision. A check
-outcome alone never populates the access `decision` field; a separately observed
-terminal access decision may. The registered access vocabulary is exactly
+outcome alone never populates the access `decision` field; only a separately
+reached terminal access decision may. The registered access vocabulary is exactly
 `allow`, `deny`, `review`; this profile introduces no fourth value and does not
 repurpose a handling action as a decision.
 
@@ -144,8 +144,9 @@ only when all of the following hold:
 - The outcome is **terminal** for the gateway decision boundary: no retry,
   fallback, or further processing within that boundary can change the emitted
   decision.
-- The **resource** is observed.
-- The **action** is observed.
+- The issuer can truthfully populate `resource` from the evaluated target.
+- The issuer can truthfully populate `action` from the requested or evaluated
+  operation.
 - The **decision** is one of `allow`, `deny`, `review`, drawn from the observed
   outcome and not derived from a check outcome or a handling action.
 - The decision was produced within a gateway decision boundary under the
@@ -158,15 +159,16 @@ decision the gateway reached. The issuer does not add claims it did not observe
 ## 6. Mandatory non-issuance conditions
 
 An access-decision record is not issued for a gateway observation when any of
-the following is true. In these cases the correct behavior is to not issue,
-rather than to issue a weaker or inferred decision.
+the following is true. In these cases the correct behavior is not to issue the
+record, rather than to issue a weaker or inferred decision.
 
 - Only a check outcome is known.
 - A retry remains possible within the gateway decision boundary.
 - A fallback remains possible within the gateway decision boundary.
 - The gateway has not completed the decision represented by the record.
-- The `resource`, `action`, or `decision` field is unavailable or not
-  supportable (the schema requires all three; see Section 13).
+- The `resource`, `action`, or `decision` field cannot be truthfully populated
+  from the issuer-controlled observation (the schema requires all three; see
+  Section 13).
 - Terminality cannot be established.
 - The decision was not produced within an issuer-controlled gateway decision
   boundary (only a third-party report is available).

--- a/docs/specs/GATEWAY-DECISION-EVIDENCE.md
+++ b/docs/specs/GATEWAY-DECISION-EVIDENCE.md
@@ -185,10 +185,10 @@ A qualifying observation maps to the shipped record with no new surface:
 - **Receipt type**: `org.peacprotocol/access-decision`.
 - **Kind**: `evidence`.
 - **Extension**: `org.peacprotocol/access` with the three required fields
-  `resource`, `action`, and `decision` populated from the observed outcome
-  ([access profile](../profiles/access.md)). `resource` identifies the evaluated
-  target, and `action` identifies the requested or evaluated operation; their
-  presence does not prove whether the operation was executed, completed, or
+  populated so that `resource` comes from the evaluated target, `action` from
+  the requested or evaluated operation, and `decision` from the terminal gateway
+  outcome ([access profile](../profiles/access.md)). Their presence does not
+  prove whether the operation was executed, completed, or
   prevented.
 - **Occurrence time**: the time the gateway decision represented by the record
   became terminal at the issuer-controlled decision boundary, as supplied by
@@ -293,9 +293,10 @@ application-specific JSON shape.
 ## 13. Data minimization and security considerations
 
 - The three access fields `resource`, `action`, and `decision` are all
-  schema-required. If any is unavailable or not supportable, the issuer does not
-  issue the access-decision record (Section 6). Optional context is omitted
-  rather than guessed.
+  schema-required. If any required access field cannot be truthfully populated
+  from the issuer-controlled decision context, the issuer does not issue the
+  access-decision record (Section 6). Optional context is omitted rather than
+  guessed.
 - Issuance and signing remain inside the deployment trust boundary. The signing
   key may be held by the gateway process or by a constrained signing service
   acting for the issuer; raw request and response bodies need not cross the

--- a/docs/specs/GATEWAY-DECISION-EVIDENCE.md
+++ b/docs/specs/GATEWAY-DECISION-EVIDENCE.md
@@ -7,9 +7,10 @@ This document adds no normative requirement to the wire format and no field to
 any record. It does not register a new receipt type, extension group, registry
 entry, error code, or conformance requirement. It describes how PEAC's existing
 `org.peacprotocol/access-decision` record composes to carry evidence for a
-terminal gateway access decision observed within an issuer-controlled gateway
-decision boundary, and, equally important, when a gateway observation is not
-issued at all. The semantics it defines are protocol-neutral and reuse existing
+terminal gateway access decision produced within an issuer-controlled gateway
+decision boundary, and, equally important, when no access-decision record is
+issued for a gateway observation. The semantics it defines are protocol-neutral
+and reuse existing
 PEAC primitives.
 
 Lowercase requirement words in this informative profile describe composition
@@ -22,15 +23,16 @@ than restating them as new conformance requirements.
 
 A gateway is a component that evaluates a request at a defined decision boundary
 before the request proceeds, is blocked, or is handed to another decision
-workflow (for example an API gateway, a model gateway, an MCP server, or a
-service-mesh policy point).
+workflow (for example an API gateway, a model gateway, an MCP server acting as
+a policy or decision point, or a service-mesh policy point).
 
 **In scope:**
 
 - Recording a terminal gateway access decision (`allow`, `deny`, or `review`)
-  observed within an issuer-controlled gateway decision boundary, as an existing
+  produced within an issuer-controlled gateway decision boundary, as an existing
   `org.peacprotocol/access-decision` record.
-- The conditions under which a gateway observation is not issued.
+- The conditions under which no access-decision record is issued for a gateway
+  observation.
 - The distinction between a check outcome, an access decision, and a handling
   action.
 
@@ -66,11 +68,12 @@ normative behavior:
   request to an internal signer
   ([GATEWAY-ISSUANCE-RECIPES.md](GATEWAY-ISSUANCE-RECIPES.md) Sections 3.1, 4.1,
   and 5.2).
-- The verifier trust model: a valid signature proves integrity and key
-  possession, not issuer authorization, and allowlisting and key pinning are
-  configurable policy
-  ([TRUST-PINNING-POLICY.md](TRUST-PINNING-POLICY.md) Sections 3.1, 3.2, 3.3, 6,
-  7).
+- The verifier trust model: a valid signature establishes record integrity and
+  possession of the corresponding signing key, not issuer legitimacy or
+  authorization; issuer acceptance, allowlisting, and key pinning are configured
+  verifier policy
+  ([TRUST-PINNING-POLICY.md](TRUST-PINNING-POLICY.md) Sections 3.2, 3.3, 6,
+  and 7).
 - The no-inline-value invariant for lifecycle observations
   ([LIFECYCLE-OBSERVATION-PROFILE.md](LIFECYCLE-OBSERVATION-PROFILE.md)
   Section 6), which this profile references to draw the boundary between an
@@ -81,7 +84,7 @@ normative behavior:
 ## 3. Terminology
 
 - **Gateway decision evidence**: a signed record that represents evidence of a
-  terminal gateway access decision observed within an issuer-controlled gateway
+  terminal gateway access decision produced within an issuer-controlled gateway
   decision boundary.
 - **Gateway decision boundary**: the point at which the gateway completes the
   decision represented by the record, before the request proceeds, is blocked,
@@ -154,9 +157,9 @@ decision the gateway reached. The issuer does not add claims it did not observe
 
 ## 6. Mandatory non-issuance conditions
 
-A gateway observation is not issued as an access decision when any of the
-following is true. In these cases the correct behavior is to not issue, rather
-than to issue a weaker or inferred decision.
+An access-decision record is not issued for a gateway observation when any of
+the following is true. In these cases the correct behavior is to not issue,
+rather than to issue a weaker or inferred decision.
 
 - Only a check outcome is known.
 - A retry remains possible within the gateway decision boundary.
@@ -169,9 +172,9 @@ than to issue a weaker or inferred decision.
   boundary (only a third-party report is available).
 - The input describes only lifecycle or handling behavior.
 
-Declining to issue is deliberate, not a limitation: it prevents a failed policy
-check, an intermediate block that a fallback later reverses, or a logging event
-from being recorded as a portable denial.
+Declining to issue the record is deliberate, not a limitation: it prevents a
+failed policy check, an intermediate block that a fallback later reverses, or a
+logging event from being recorded as a portable denial.
 
 ## 7. Mapping to the existing access-decision record
 
@@ -237,14 +240,15 @@ Section 12) and requires application-aware verifier policy.
 
 ## 10. Signature integrity versus issuer authorization
 
-Per [TRUST-PINNING-POLICY.md](TRUST-PINNING-POLICY.md) Sections 3.1 and 3.2:
-
 Signature verification establishes record integrity and possession of the
-corresponding signing key. Association of that key with the claimed issuer, and
-authorization of that issuer for the relying application's deployment context,
-are established by the relying application's configured trust policy (Section
-11), not by the signature alone. A valid signature does not prove that the
-decision was correct or that the deployment was configured as claimed.
+corresponding signing key. Per
+[TRUST-PINNING-POLICY.md](TRUST-PINNING-POLICY.md) Sections 3.2 and 3.3, that
+does not establish issuer legitimacy or authorization. Association of that key
+with the claimed issuer, and authorization of that issuer for the relying
+application's deployment context, are established by the relying application's
+configured trust policy (Section 11), not by the signature alone. A valid
+signature does not prove that the decision was correct or that the deployment
+was configured as claimed.
 
 ## 11. Verification-policy requirements
 
@@ -294,15 +298,18 @@ application-specific JSON shape.
   key may be held by the gateway process or by a constrained signing service
   acting for the issuer; raw request and response bodies need not cross the
   boundary solely for signing.
-- Raw prompt, completion, policy, request, and response bodies are not inlined
-  into the record ([PRIVACY-PROFILE.md](PRIVACY-PROFILE.md)).
-- The record carries the decision and its minimal identifying context
-  (`resource`, `action`, `decision`, occurrence time), not the content that was
-  evaluated.
+- This profile does not inline raw prompt, completion, policy, request, or
+  response bodies. Deployments and application-specific extensions remain
+  subject to the Privacy Profile ([PRIVACY-PROFILE.md](PRIVACY-PROFILE.md)).
+- The record carries the required decision context (`resource`, `action`,
+  `decision`) and, when present, occurrence time. It does not carry the content
+  that was evaluated.
 - A gateway issuer does not assert facts it did not observe
   ([GATEWAY-ISSUANCE-RECIPES.md](GATEWAY-ISSUANCE-RECIPES.md) Section 3.1).
-- Private signing keys are protected at the edge per
+- Private signing keys are protected according to
   [GATEWAY-ISSUANCE-RECIPES.md](GATEWAY-ISSUANCE-RECIPES.md) Section 5.
+  Deployments may protect the key as an edge secret or use a constrained
+  internal signing service.
 
 ## 14. Limitations, non-claims, and interoperability
 

--- a/docs/specs/RUNTIME-GOVERNANCE-PROFILE.md
+++ b/docs/specs/RUNTIME-GOVERNANCE-PROFILE.md
@@ -40,10 +40,12 @@ This profile covers **observational records** from runtime governance systems.
 > **Note (informative): a runtime-governance outcome is not the same as a value
 > of the `decision` field of the `org.peacprotocol/access` extension.** The list
 > above is this profile's own runtime-governance vocabulary for
-> `org.peacprotocol/runtime-governance-policy-decision` records, and it mixes
-> access-control outcomes with handling actions: some entries (for example `log`)
-> are operational handling actions, not access-control outcomes. The registered
-> access vocabulary in the `org.peacprotocol/access` extension is exactly
+> `org.peacprotocol/runtime-governance-policy-decision` records, and it includes
+> both runtime policy outcomes and operational handling actions (for example
+> `log`). Some outcome labels may resemble access-control decisions, but they
+> remain values of this runtime-governance profile rather than values of the
+> `org.peacprotocol/access` extension. The registered access vocabulary in the
+> `org.peacprotocol/access` extension is exactly
 > `allow`, `deny`, `review`; a handling action such as `log`, `retry`, or
 > `fallback` never populates the `decision` field of the `org.peacprotocol/access`
 > extension. See [GATEWAY-DECISION-EVIDENCE.md](GATEWAY-DECISION-EVIDENCE.md).


### PR DESCRIPTION
## Summary

Documentation refinements to the Gateway Decision Evidence profile added in #921, and to the companion Access Profile it builds on. Wording, precision, and internal-consistency only: no wire, schema, registry, receipt type, extension, error, API, package, dependency, or conformance change. The public surface is exactly three Markdown files.

## What changed

- Access-decision records are described as **evidence of decisions**, not the decisions or execution outcomes themselves.
- **Structure/signature validation is distinct from issuer acceptance**: a valid signature establishes record integrity and key possession; issuer legitimacy and authorization are the verifier's configured trust policy.
- `resource` and `action` must be **truthfully populated from the evaluated request context**; only `decision` comes from the terminal gateway outcome, and their presence does not prove execution.
- A check outcome never becomes an access decision without a **separately reached terminal gateway decision**; non-issuance is explicit for check-only, intermediate, non-terminal, or non-issuer-controlled inputs.
- The represented decision is **produced within an issuer-controlled gateway decision boundary**; named-source collector reporting stays outside the core profile.
- `occurred_at` is optional and distinct from later signing time; the signing key may be an edge secret or a constrained internal signer.
- The Access Profile's identity-companion and regulatory-context language was aligned with these non-claims (a correlated evidence chain to the recorded access decision; version-accurate SOC 2 / ISO/IEC 27001:2022 + 27002:2022 / NIST SP 800-53 Rev. 5 wording; "these mappings do not themselves constitute compliance").

## Files

- `docs/specs/GATEWAY-DECISION-EVIDENCE.md` — the informative profile (produced-vs-observed, record-vs-observation, terminality, mandatory non-issuance, truth-oriented `resource`/`action`, signature-vs-authorization separation).
- `docs/specs/RUNTIME-GOVERNANCE-PROFILE.md` — the informative access-vs-handling note.
- `docs/profiles/access.md` — informative reconciliation of the Access Profile (evidence-not-decision, independent-validation vs issuer-acceptance, minimal example, decision-field rationale, modernized standards references).

## Not changed

No registered enum, wire semantics, schema, registry, type URI, or normative requirement. No code, example, or verification primitive.

## Validation

- format:check, gate:fast, typecheck:core, `@peac/schema` test, conformance:test, verify:release, verify:codegen-drift, verify:registries-schema, verify:no-widening, extract-api-contract --check, forbid-strings, and the repo-links doc-truth test: green.
- Control-character and whitespace scans clean at the head commit.
- The Access Profile's inline `issue()`/`verifyLocal()` demo compiles and runs against the current workspace packages (`result.valid` = true; `claims.type` = `org.peacprotocol/access-decision`).
