### PR TITLE
chore(security): update qs override to 6.15.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "overrides": {
       "minimatch": "10.2.4",
       "picomatch": ">=4.0.4",
-      "qs@>=6.7.0 <=6.14.1": "6.14.2",
+      "qs@>=6.7.0 <6.15.2": "6.15.2",
       "zod": "^4.3.6",
       "rollup": ">=4.59.0",
       "express-rate-limit": ">=8.2.2",
@@ -176,7 +176,7 @@
     "overridesComments": {
       "minimatch": "Cross-major pin to 10.2.4: typescript-estree requires ^9.0.4 but 9.x has no patch for GHSA-3ppc-4f35-3m26. minimatch 10.x is API-compatible (same globbing interface). 10.2.4 patches GHSA-7r86-cg39-jmmj and GHSA-23c5-xmqv-rm74 (ReDoS). Drops Node 18 (fine: repo baseline is >=22.0.0). Lint verified clean.",
       "picomatch": "Override to >=4.0.4: patches GHSA-c2c7-rcm5-vvqj (ReDoS via extglob quantifiers). Dev-only via vitest/vite/dependency-cruiser.",
-      "qs": "Range-scoped: only overrides vulnerable 6.7.0-6.14.1 to 6.14.2 (fixes GHSA-w7fw-mjwx-w883 arrayLimit bypass). Minimal blast radius.",
+      "qs": "Combined range override for two advisories. (1) qs 6.7.0-6.14.1: GHSA-w7fw-mjwx-w883 (arrayLimit bypass), previously pinned to 6.14.2. (2) qs 6.11.1-6.15.1: GHSA-q8mj-m7cp-5q26 / CVE-2026-8723 (qs.stringify DoS on null/undefined in comma-format arrays with encodeValuesOnly), patched in 6.15.2. The newer advisory does NOT affect the whole 6.7.0 range; the override starts at 6.7.0 only to preserve the earlier arrayLimit coverage. Production path: @peac/mcp-server -> @modelcontextprotocol/sdk -> express -> qs.",
       "zod": "Workspace-wide Zod 4 enforcement: prevents mixed Zod 3/4 which causes runtime TypeError (incompatible internal _parse API). All workspace packages must use Zod 4.",
       "rollup": "Override vulnerable 4.53.2 to >=4.59.0 (fixes GHSA-mw96-cpmx-2vgc path traversal). Dev-only via vitest/vite/tsup.",
       "express-rate-limit": "Override 8.2.1 to >=8.2.2 (fixes GHSA-46wh-pxpv-q5gq IPv4-mapped IPv6 bypass). Prod dep via @modelcontextprotocol/sdk.",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   minimatch: 10.2.4
   picomatch: '>=4.0.4'
-  qs@>=6.7.0 <=6.14.1: 6.14.2
+  qs@>=6.7.0 <6.15.2: 6.15.2
   zod: ^4.3.6
   rollup: '>=4.59.0'
   express-rate-limit: '>=8.2.2'
@@ -6835,7 +6835,7 @@ packages:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.14.2
+      qs: 6.15.2
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -6852,7 +6852,7 @@ packages:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.14.2
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -7875,7 +7875,7 @@ packages:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.14.2
+      qs: 6.15.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2
@@ -7912,7 +7912,7 @@ packages:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.2
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -10067,8 +10067,8 @@ packages:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
     dev: true
 
-  /qs@6.14.2:
-    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+  /qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
     dependencies:
       side-channel: 1.1.0
@@ -10824,7 +10824,7 @@ packages:
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
-      qs: 6.14.2
+      qs: 6.15.2
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
## Summary

Widen the `qs` override to `6.15.2` to clear a production-reachable denial-of-service advisory.

- Override: `qs@>=6.7.0 <=6.14.1: 6.14.2` -> `qs@>=6.7.0 <6.15.2: 6.15.2`.
- Advisory: GHSA-q8mj-m7cp-5q26 / CVE-2026-8723 (`qs.stringify` DoS on null/undefined entries in comma-format arrays with `encodeValuesOnly`), affecting `qs` 6.11.1-6.15.1, patched in 6.15.2.
- The override range also preserves the earlier GHSA-w7fw-mjwx-w883 (arrayLimit bypass) coverage for the older range; the `overridesComments.qs` entry documents both.
- Production path: `@peac/mcp-server` -> `@modelcontextprotocol/sdk` -> `express` -> `qs`.

## Scope

Only `package.json` (override + comment) and `pnpm-lock.yaml` (qs resolves to 6.15.2 across all edges). No source, schema, registry, wire, API, or other dependency change.

## Validation

- All `qs` lockfile edges resolve to `6.15.2`; production path `express@5.2.1 -> qs 6.15.2`.
- `pnpm audit --prod` no longer reports the qs advisory.
- `pnpm --filter @peac/mcp-server test` (289 tests), `pnpm gate:fast`, `pnpm verify:release`, `pnpm format:check`, `git diff --check` all pass.
