### PR TITLE
chore(release): stamp v0.16.3 release state

### DIFF
--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable surface classification for PEAC Protocol workspace. CI fails if any workspace member is missing. See docs/PACKAGE_STATUS.md for human-readable view.",
   "version": "0.13.0",
-  "updated": "2026-07-13",
+  "updated": "2026-07-21",
   "states": {
     "default": "Current recommended path. Actively maintained, Wire 0.2 native.",
     "supported": "Actively maintained, published, production-ready. May not be on default quickstart path.",

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -2,7 +2,7 @@
 
 Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scripts/generate-surface-status.mjs`.
 
-**Version:** 0.13.0 | **Updated:** 2026-07-13
+**Version:** 0.13.0 | **Updated:** 2026-07-21
 
 ## Layer 1
 


### PR DESCRIPTION
Post-release stamp for v0.16.3. Updates the repo surface-status date and its regenerated projection now that v0.16.3 is published (npm latest 0.16.3, tag v0.16.3, GitHub Release finalized).

## Scope

- `REPO_SURFACE_STATUS.json`: `updated` 2026-07-13 -> 2026-07-21.
- `docs/SURFACE_STATUS.md`: regenerated from the source.

No version, wire, schema, registry, API, published-package, or CHANGELOG change.
