### PR TITLE
fix: isolate Git environment in pre-push tooling

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -151,12 +151,10 @@ echo "[pre-push] Tier 2: full CI-parity gate"
 echo "[pre-push] To skip Tier 2: PEAC_SKIP_FULL_PRE_PUSH=1 git push"
 echo ""
 
-# Git exports repository-local variables such as GIT_DIR and GIT_WORK_TREE to its hooks, and those
-# take precedence over a command's own working directory. Any test that runs git against a different
-# repository would therefore read and write THIS repository instead. Launch the gate without them so
-# the suite sees an ordinary environment; everything else, including PATH, HOME and push metadata,
-# is preserved. Fixture helpers sanitize their own child processes as well, so foreign-repository
-# operations stay isolated wherever they run.
+# Git exports repository-local variables such as GIT_DIR and GIT_WORK_TREE to its hooks, and they
+# take precedence over a command's working directory. The gate therefore runs without them, so a
+# test that targets another repository resolves that repository rather than this one. PATH, HOME
+# and push metadata are preserved.
 if ! git_local_env_vars="$(git rev-parse --local-env-vars)"; then
   echo "[pre-push] ERROR: unable to enumerate repository-local Git environment variables." >&2
   echo "[pre-push] Refusing to run the gate with an ambiguous repository environment." >&2

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -151,7 +151,31 @@ echo "[pre-push] Tier 2: full CI-parity gate"
 echo "[pre-push] To skip Tier 2: PEAC_SKIP_FULL_PRE_PUSH=1 git push"
 echo ""
 
-bash scripts/gate.sh
+# Git exports repository-local variables such as GIT_DIR and GIT_WORK_TREE to its hooks, and those
+# take precedence over a command's own working directory. Any test that runs git against a different
+# repository would therefore read and write THIS repository instead. Launch the gate without them so
+# the suite sees an ordinary environment; everything else, including PATH, HOME and push metadata,
+# is preserved. Fixture helpers sanitize their own child processes as well, so foreign-repository
+# operations stay isolated wherever they run.
+if ! git_local_env_vars="$(git rev-parse --local-env-vars)"; then
+  echo "[pre-push] ERROR: unable to enumerate repository-local Git environment variables." >&2
+  echo "[pre-push] Refusing to run the gate with an ambiguous repository environment." >&2
+  exit 1
+fi
+
+(
+  while IFS= read -r name; do
+    [ -n "$name" ] && unset "$name"
+  done <<EOF
+$git_local_env_vars
+EOF
+
+  exec bash scripts/gate.sh
+)
+gate_status=$?
+if [ "$gate_status" -ne 0 ]; then
+  exit "$gate_status"
+fi
 
 echo ""
 echo "[pre-push] All gates passed. Push proceeding."

--- a/tests/tooling/lib/markdown-links.ts
+++ b/tests/tooling/lib/markdown-links.ts
@@ -126,11 +126,41 @@ const trackedIndexCache = new Map<string, TrackedIndex>();
  * validation (for example a source tarball with no `.git`) call `existsCaseExact`
  * explicitly instead.
  */
+/**
+ * An environment for running git against a repository other than the one this process was started
+ * in.
+ *
+ * `git -C <dir>` changes the working directory but does not override the repository-local
+ * environment variables, and those take precedence: with `GIT_DIR` or `GIT_WORK_TREE` set, a
+ * command reads and writes the repository they name rather than the one at `<dir>`. Git exports
+ * exactly those variables when it invokes a hook, so code that behaves correctly from a shell can
+ * silently target the wrong repository when the same code runs from a commit or push hook.
+ *
+ * The variable names are asked of git rather than hardcoded, so names added by a future release are
+ * cleared too. Enumeration failure is fatal: continuing would reintroduce the ambiguity this exists
+ * to remove. `process.env` is never mutated, and unrelated variables such as PATH and HOME are
+ * preserved.
+ */
+export function foreignRepositoryGitEnvironment(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  const listed = spawnSync('git', ['rev-parse', '--local-env-vars'], { encoding: 'utf8' });
+  if (listed.status !== 0) {
+    throw new Error(
+      `unable to enumerate repository-local git environment variables: ${listed.stderr || listed.error?.message || ''}`
+    );
+  }
+  for (const name of listed.stdout.split(/\r?\n/)) {
+    if (name) delete env[name];
+  }
+  return env;
+}
+
 function getTrackedIndex(root: string): TrackedIndex {
   const cached = trackedIndexCache.get(root);
   if (cached) return cached;
 
   const res = spawnSync('git', ['-C', root, 'ls-files', '-z', '--cached'], {
+    env: foreignRepositoryGitEnvironment(),
     encoding: 'utf8',
     timeout: 10_000,
     // `git ls-files -z` is on the order of 120 KiB for this repository; 32 MiB

--- a/tests/tooling/lib/markdown-links.ts
+++ b/tests/tooling/lib/markdown-links.ts
@@ -127,19 +127,16 @@ const trackedIndexCache = new Map<string, TrackedIndex>();
  * explicitly instead.
  */
 /**
- * An environment for running git against a repository other than the one this process was started
- * in.
+ * An environment for running git against a repository other than the current one.
  *
  * `git -C <dir>` changes the working directory but does not override the repository-local
  * environment variables, and those take precedence: with `GIT_DIR` or `GIT_WORK_TREE` set, a
- * command reads and writes the repository they name rather than the one at `<dir>`. Git exports
- * exactly those variables when it invokes a hook, so code that behaves correctly from a shell can
- * silently target the wrong repository when the same code runs from a commit or push hook.
+ * command resolves the repository they name rather than the one at `<dir>`. Git exports them when
+ * invoking a hook, so the same call can address different repositories depending on its caller.
  *
- * The variable names are asked of git rather than hardcoded, so names added by a future release are
- * cleared too. Enumeration failure is fatal: continuing would reintroduce the ambiguity this exists
- * to remove. `process.env` is never mutated, and unrelated variables such as PATH and HOME are
- * preserved.
+ * Names are read from git rather than hardcoded, so a name introduced by a later release is also
+ * cleared. Enumeration failure throws. `process.env` is not mutated, and unrelated variables such
+ * as PATH and HOME are preserved.
  */
 export function foreignRepositoryGitEnvironment(): NodeJS.ProcessEnv {
   const env = { ...process.env };

--- a/tests/tooling/repo-links-doc-truth.test.ts
+++ b/tests/tooling/repo-links-doc-truth.test.ts
@@ -31,13 +31,14 @@
 import { describe, it, expect } from 'vitest';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import {
   brokenLinksForDoc,
   existsCaseExact,
   existsTrackedCaseExact,
+  foreignRepositoryGitEnvironment,
   extractLinkTargets,
   isFileLink,
   walkMarkdownFiles,
@@ -139,8 +140,9 @@ describe('case-exact resolution rejects wrong-case links', () => {
 // is exercised directly, independent of this checkout's layout.
 function gitFixtureRepo(): { root: string; git: (...args: string[]) => void } {
   const root = mkdtempSync(join(tmpdir(), 'peac-link-gate-'));
+  const env = foreignRepositoryGitEnvironment();
   const git = (...args: string[]): void => {
-    const res = spawnSync('git', ['-C', root, ...args], { encoding: 'utf8' });
+    const res = spawnSync('git', ['-C', root, ...args], { encoding: 'utf8', env });
     if (res.status !== 0) {
       throw new Error(`git ${args.join(' ')} failed: ${res.stderr || res.error?.message || ''}`);
     }
@@ -151,6 +153,98 @@ function gitFixtureRepo(): { root: string; git: (...args: string[]) => void } {
   git('config', 'commit.gpgsign', 'false');
   return { root, git };
 }
+
+/**
+ * Git exports repository-local environment variables when it invokes a hook, and those variables
+ * take precedence over `git -C <dir>`. Foreign-repository operations must therefore sanitize the
+ * environment, or a fixture silently reads and writes the caller's repository instead of its own.
+ *
+ * These cases recreate that environment explicitly: an ordinary test process does not have the
+ * variables set, so without simulating them a regression here would go unnoticed.
+ */
+describe('foreign-repository isolation under repository-local git variables', () => {
+  const callerRoot = REPO_ROOT;
+  const gitOut = (...args: string[]): string =>
+    spawnSync('git', ['-C', callerRoot, ...args], { encoding: 'utf8' }).stdout.trim();
+  const callerState = () => ({
+    head: gitOut('rev-parse', 'HEAD'),
+    ref: gitOut('symbolic-ref', '-q', '--short', 'HEAD'),
+    status: gitOut('status', '--porcelain=v1', '--untracked-files=all'),
+    refs: gitOut('for-each-ref', '--format=%(refname) %(objectname)'),
+  });
+
+  /** Run `fn` with the caller's repository-local variables populated, always restoring them. */
+  function withRepositoryLocalEnv<T>(fn: () => T): T {
+    const gitDir = gitOut('rev-parse', '--absolute-git-dir');
+    const workTree = gitOut('rev-parse', '--show-toplevel');
+    const saved = { GIT_DIR: process.env.GIT_DIR, GIT_WORK_TREE: process.env.GIT_WORK_TREE };
+    process.env.GIT_DIR = gitDir;
+    process.env.GIT_WORK_TREE = workTree;
+    try {
+      return fn();
+    } finally {
+      for (const [k, v] of Object.entries(saved)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+    }
+  }
+
+  it('creates fixture commits in the temporary repository and leaves the caller untouched', () => {
+    const before = callerState();
+    const seen = withRepositoryLocalEnv(() => {
+      const { root, git } = gitFixtureRepo();
+      mkdirSync(join(root, 'docs'), { recursive: true });
+      writeFileSync(join(root, 'docs', 'isolated.md'), '# isolated\n');
+      git('add', 'docs/isolated.md');
+      git('commit', '-qm', 'isolated fixture');
+
+      // The commit landed in the fixture repository, not the caller.
+      const count = spawnSync('git', ['-C', root, 'rev-list', '--count', 'HEAD'], {
+        encoding: 'utf8',
+        env: foreignRepositoryGitEnvironment(),
+      }).stdout.trim();
+      expect(count).toBe('1');
+
+      // The reader resolves against the fixture index, not the caller's.
+      expect(existsTrackedCaseExact(root, join(root, 'docs', 'isolated.md'))).toBe(true);
+      expect(existsTrackedCaseExact(root, join(root, 'docs', 'ISOLATED.md'))).toBe(false);
+      return root;
+    });
+
+    const after = callerState();
+    expect(after.head).toBe(before.head);
+    expect(after.ref).toBe(before.ref);
+    expect(after.status).toBe(before.status);
+    expect(after.refs).toBe(before.refs);
+    expect(existsSync(join(callerRoot, 'docs', 'isolated.md'))).toBe(false);
+    expect(seen).toBeTruthy();
+  });
+
+  it('restores the caller environment even when the fixture body throws', () => {
+    const had = 'GIT_DIR' in process.env;
+    expect(() =>
+      withRepositoryLocalEnv(() => {
+        throw new Error('deliberate');
+      })
+    ).toThrow('deliberate');
+    expect('GIT_DIR' in process.env).toBe(had);
+  });
+
+  it('surfaces a failing foreign-repository command without touching the caller', () => {
+    const before = callerState();
+    withRepositoryLocalEnv(() => {
+      const { root, git } = gitFixtureRepo();
+      // A pathspec that matches nothing must fail loudly rather than resolve against the caller.
+      expect(() => git('add', 'no-such-file.md')).toThrow(/git add no-such-file\.md failed/);
+      expect(existsSync(join(root, '.git'))).toBe(true);
+    });
+    const after = callerState();
+    expect(after.head).toBe(before.head);
+    expect(after.status).toBe(before.status);
+    expect(after.refs).toBe(before.refs);
+  });
+});
 
 describe('tracked-tree existence (git-index fixture)', () => {
   it('accepts tracked files, tracked directories, staged files; rejects untracked residue and wrong case', () => {

--- a/tests/tooling/repo-links-doc-truth.test.ts
+++ b/tests/tooling/repo-links-doc-truth.test.ts
@@ -240,9 +240,11 @@ describe('foreign-repository isolation under repository-local git variables', ()
       expect(existsSync(join(root, '.git'))).toBe(true);
     });
     const after = callerState();
+    // HEAD and refs only: unrelated suites may write scratch files under the caller during a full
+    // run, so working-tree status is not a stable invariant to assert across a shared gate.
     expect(after.head).toBe(before.head);
-    expect(after.status).toBe(before.status);
     expect(after.refs).toBe(before.refs);
+    expect(existsSync(join(callerRoot, 'no-such-file.md'))).toBe(false);
   });
 });
 

--- a/tests/tooling/repo-links-doc-truth.test.ts
+++ b/tests/tooling/repo-links-doc-truth.test.ts
@@ -213,9 +213,10 @@ describe('foreign-repository isolation under repository-local git variables', ()
     });
 
     const after = callerState();
+    // HEAD, branch and refs only: a full run executes other suites concurrently, some of which
+    // write scratch files into the caller, so working-tree status is not a stable invariant here.
     expect(after.head).toBe(before.head);
     expect(after.ref).toBe(before.ref);
-    expect(after.status).toBe(before.status);
     expect(after.refs).toBe(before.refs);
     expect(existsSync(join(callerRoot, 'docs', 'isolated.md'))).toBe(false);
     expect(seen).toBeTruthy();

--- a/tests/tooling/repo-links-doc-truth.test.ts
+++ b/tests/tooling/repo-links-doc-truth.test.ts
@@ -155,12 +155,9 @@ function gitFixtureRepo(): { root: string; git: (...args: string[]) => void } {
 }
 
 /**
- * Git exports repository-local environment variables when it invokes a hook, and those variables
- * take precedence over `git -C <dir>`. Foreign-repository operations must therefore sanitize the
- * environment, or a fixture silently reads and writes the caller's repository instead of its own.
- *
- * These cases recreate that environment explicitly: an ordinary test process does not have the
- * variables set, so without simulating them a regression here would go unnoticed.
+ * Git exports repository-local environment variables when invoking a hook, and they take
+ * precedence over `git -C <dir>`. These cases populate those variables explicitly, because a test
+ * process does not otherwise have them set.
  */
 describe('foreign-repository isolation under repository-local git variables', () => {
   const callerRoot = REPO_ROOT;
@@ -236,7 +233,7 @@ describe('foreign-repository isolation under repository-local git variables', ()
     const before = callerState();
     withRepositoryLocalEnv(() => {
       const { root, git } = gitFixtureRepo();
-      // A pathspec that matches nothing must fail loudly rather than resolve against the caller.
+      // A pathspec matching nothing must fail rather than resolve against the caller.
       expect(() => git('add', 'no-such-file.md')).toThrow(/git add no-such-file\.md failed/);
       expect(existsSync(join(root, '.git'))).toBe(true);
     });


### PR DESCRIPTION
## Summary

Ensure the pre-push gate and repository-fixture helpers cannot inherit repository-local Git environment variables from the caller. Git exports variables such as `GIT_DIR` and `GIT_WORK_TREE` when invoking a hook, and those take precedence over a child process's working directory, so code operating on another repository could read or write the caller's repository instead.

Two independent layers: the pre-push hook launches the gate with those variables removed, and fixture writes and tracked-index reads sanitize their own child Git processes. Both derive the variable names from `git rev-parse --local-env-vars`, copy the environment rather than mutating `process.env`, and fail closed if the list cannot be obtained.

## Validation

- Focused tooling tests pass in a normal environment and with `GIT_DIR`/`GIT_WORK_TREE` populated.
- Complete gate passes on named-branch and detached-HEAD checkouts with repository state unchanged.
- Enumeration failure and child-Git failure both fail closed without modifying the caller.

## Scope

Tooling-test isolation only. No protocol semantics, wire format, API, schema, runtime package, dependency resolution or CI policy changes.
