### PR TITLE
fix(verifier): bind results to the submitted input snapshot

### DIFF
--- a/apps/verifier/src/ui/app.ts
+++ b/apps/verifier/src/ui/app.ts
@@ -4,6 +4,10 @@
  * Deliberately minimal rather than designed. This exists so the no-network,
  * no-persistence and CSP gates run against a built application that actually verifies, rather than
  * against an empty shell.
+ *
+ * A displayed result always describes the exact inputs submitted for that run. Verification and
+ * file reads are both asynchronous, so a run is bound to a monotonic run token and to the input
+ * revision captured at submission, and renders only while both remain current.
  */
 import { initializeLocalVerifier, type LocalVerifier } from '../verify.js';
 import { verifierBuildFromEnvironment } from '../lib/build-info.js';
@@ -57,14 +61,19 @@ export async function initApp(root: HTMLElement): Promise<void> {
     return;
   }
 
-  /**
-   * Monotonic run token.
-   *
-   * Verification is asynchronous, so two runs can be in flight and complete out of order. Rendering
-   * whichever finishes last would show a verdict for inputs the operator has already replaced. Each
-   * run captures the token it started with and renders only while that token is still current.
-   */
   let runToken = 0;
+  let running = false;
+
+  function updateAvailability(): void {
+    // Unavailable while a run is active, and while any file read is unresolved: the field contents
+    // are not yet settled, so a submission could carry a value the operator has not seen.
+    button.disabled = running || fields.hasPendingRead();
+  }
+
+  function clearOutputs(): void {
+    results.replaceChildren();
+    renderReport(undefined, reportPanel);
+  }
 
   function showRunFailure(): void {
     results.replaceChildren();
@@ -76,37 +85,51 @@ export async function initApp(root: HTMLElement): Promise<void> {
     renderReport(undefined, reportPanel);
   }
 
+  fields.onChange(() => {
+    updateAvailability();
+    // The inputs no longer match anything on screen.
+    clearOutputs();
+  });
+  updateAvailability();
+
   button.addEventListener('click', () => {
-    // A second submission while a run is active would start a concurrent verification whose result
-    // races the first. The button is disabled for the duration and restored in `finally`.
     if (button.disabled) return;
-    button.disabled = true;
 
     const token = ++runToken;
-    const ctx = fields.contextDocument.value;
+    const revision = fields.revision();
+    const contextDocument = fields.contextDocument.value;
+    // Captured once. Nothing read from the fields after this point reaches the verifier.
+    const input = Object.freeze({
+      record: fields.record.value,
+      keyDocument: fields.keyDocument.value,
+      ...(contextDocument.length > 0 ? { contextDocument } : {}),
+      evaluationTimeUnixSeconds: Math.floor(Date.now() / 1000),
+      maxClockSkewSeconds: DEFAULT_MAX_CLOCK_SKEW_SECONDS,
+    });
+
+    running = true;
+    fields.setDisabled(true);
+    updateAvailability();
 
     void verifier
-      .verify({
-        record: fields.record.value,
-        keyDocument: fields.keyDocument.value,
-        ...(ctx.length > 0 ? { contextDocument: ctx } : {}),
-        evaluationTimeUnixSeconds: Math.floor(Date.now() / 1000),
-        maxClockSkewSeconds: DEFAULT_MAX_CLOCK_SKEW_SECONDS,
-      })
+      .verify(input)
       .then((result) => {
-        if (token !== runToken) return;
+        if (token !== runToken || revision !== fields.revision()) return;
         renderResults(result, results);
         renderReport(result.report, reportPanel);
       })
       .catch(() => {
         // verify() is a total boundary and should not reject. If it does, the operator must still
         // see that the run failed rather than face a control that silently does nothing.
-        if (token !== runToken) return;
+        if (token !== runToken || revision !== fields.revision()) return;
         showRunFailure();
       })
       .finally(() => {
-        // Restored on every path, so a failure cannot leave the interface permanently inert.
-        button.disabled = false;
+        // A superseded run must not restore controls a newer run is holding.
+        if (token !== runToken) return;
+        running = false;
+        fields.setDisabled(false);
+        updateAvailability();
       });
   });
 }

--- a/apps/verifier/src/ui/inputs.ts
+++ b/apps/verifier/src/ui/inputs.ts
@@ -3,6 +3,9 @@
  *
  * File reads go through the fatal UTF-8 decoder on raw bytes, never File.text(), because byte
  * identity matters for the record digest.
+ *
+ * Every value change advances a shared revision and every unresolved read is counted, so a caller
+ * can bind a verification to the exact input state it submitted.
  */
 import { decodeFileBytesStrict } from '../lib/strict-json.js';
 
@@ -10,9 +13,32 @@ export interface InputFields {
   readonly record: HTMLTextAreaElement;
   readonly keyDocument: HTMLTextAreaElement;
   readonly contextDocument: HTMLTextAreaElement;
+  /** Monotonic across all three fields. Any change to any value advances it. */
+  revision(): number;
+  /** True while any field holds an unresolved file read. */
+  hasPendingRead(): boolean;
+  /** Disable or restore every mutable control. */
+  setDisabled(disabled: boolean): void;
+  /** Invoked after any value change or pending-read transition. */
+  onChange(listener: () => void): void;
 }
 
-function field(parent: HTMLElement, id: string, label: string, hint: string): HTMLTextAreaElement {
+interface SharedState {
+  /** Record a value change and notify listeners. */
+  bump(): void;
+  /** Adjust the count of unresolved reads. Apply before bump so listeners see settled state. */
+  pendingDelta(delta: number): void;
+  /** Register a control the caller may disable for the duration of a run. */
+  register(control: { disabled: boolean }): void;
+}
+
+function field(
+  parent: HTMLElement,
+  id: string,
+  label: string,
+  hint: string,
+  shared: SharedState
+): HTMLTextAreaElement {
   const wrap = document.createElement('div');
   const l = document.createElement('label');
   l.htmlFor = id;
@@ -24,43 +50,69 @@ function field(parent: HTMLElement, id: string, label: string, hint: string): HT
   p.textContent = hint;
   const file = document.createElement('input');
   file.type = 'file';
+  shared.register(ta);
+  shared.register(file);
 
   /**
    * Per-field read generation.
    *
-   * Reads are asynchronous, so selecting a second file before the first resolves leaves two reads in
-   * flight. Whichever settles last would win, which can place the contents of a file the operator
-   * has already replaced into the field. Each read captures the generation it started with and
-   * applies its result only while that generation is still current.
+   * Reads are asynchronous, so two can be in flight at once and settle out of order. Each read
+   * captures the generation it started with and applies its result only while that generation is
+   * still current. Anything that supersedes a read advances the generation.
    */
   let readGeneration = 0;
+  let pending = false;
+
+  function setPending(next: boolean): void {
+    if (pending === next) return;
+    pending = next;
+    shared.pendingDelta(next ? 1 : -1);
+  }
+
+  ta.addEventListener('input', () => {
+    // Manual text supersedes any read in flight: without this a file chosen moments earlier could
+    // overwrite what the operator has since typed.
+    readGeneration++;
+    setPending(false);
+    shared.bump();
+  });
 
   file.addEventListener('change', () => {
-    const f = file.files?.[0];
-    if (!f) return;
+    // Advance before inspecting the selection, so clearing it also invalidates reads in flight.
     const generation = ++readGeneration;
+    const f = file.files?.[0];
+    if (!f) {
+      setPending(false);
+      shared.bump();
+      return;
+    }
+    setPending(true);
+    shared.bump();
 
     void f
       .arrayBuffer()
       .then((buf) => {
         if (generation !== readGeneration) return;
+        setPending(false);
         try {
           ta.value = decodeFileBytesStrict(new Uint8Array(buf), 'E_VERIFIER_RECORD_MALFORMED');
-          // Restore the field's own guidance after a successful read, so a previous failure notice
-          // does not persist beside content that loaded correctly.
+          // Restore the field's own guidance, so a previous failure notice does not persist beside
+          // content that loaded correctly.
           p.textContent = hint;
         } catch {
           ta.value = '';
           p.textContent = 'That file is not valid UTF-8 and was not loaded.';
         }
+        shared.bump();
       })
       .catch(() => {
         // arrayBuffer() rejects when the file is unreadable: removed, permission-denied, or a
-        // hardware error mid-read. Without this the rejection would be unhandled and the operator
-        // would see no indication that nothing was loaded.
+        // hardware error mid-read. The notice is a fixed string; no file name or content is echoed.
         if (generation !== readGeneration) return;
+        setPending(false);
         ta.value = '';
         p.textContent = 'That file could not be read and was not loaded.';
+        shared.bump();
       });
   });
   wrap.append(l, ta, file, p);
@@ -69,24 +121,59 @@ function field(parent: HTMLElement, id: string, label: string, hint: string): HT
 }
 
 export function renderInputs(container: HTMLElement): InputFields {
+  let revision = 0;
+  let pendingReads = 0;
+  const listeners: Array<() => void> = [];
+  const controls: Array<{ disabled: boolean }> = [];
+
+  const shared: SharedState = {
+    bump() {
+      revision++;
+      for (const listener of listeners) listener();
+    },
+    pendingDelta(delta) {
+      pendingReads += delta;
+    },
+    register(control) {
+      controls.push(control);
+    },
+  };
+
+  const record = field(
+    container,
+    'record',
+    'PEAC record (compact JWS)',
+    'Paste the record exactly as received. Surrounding whitespace is rejected, not trimmed.',
+    shared
+  );
+  const keyDocument = field(
+    container,
+    'key',
+    'Public key (JWK or JWKS)',
+    'Public Ed25519 key material only. Private key material is rejected.',
+    shared
+  );
+  const contextDocument = field(
+    container,
+    'context',
+    'Verification expectations (optional)',
+    'A VerificationContextV1 document: trusted key thumbprints and/or issuer, key id and record ' +
+      'type constraints. Obtain trusted thumbprints independently or out of band. This verifier ' +
+      'does not establish where a supplied thumbprint came from.',
+    shared
+  );
+
   return {
-    record: field(
-      container,
-      'record',
-      'PEAC record (compact JWS)',
-      'Paste the record exactly as received. Surrounding whitespace is rejected, not trimmed.'
-    ),
-    keyDocument: field(
-      container,
-      'key',
-      'Public key (JWK or JWKS)',
-      'Public Ed25519 key material only. Private key material is rejected.'
-    ),
-    contextDocument: field(
-      container,
-      'context',
-      'Verification expectations (optional)',
-      'A VerificationContextV1 document: trusted key thumbprints and/or issuer, key id and record type constraints.'
-    ),
+    record,
+    keyDocument,
+    contextDocument,
+    revision: () => revision,
+    hasPendingRead: () => pendingReads > 0,
+    setDisabled(disabled) {
+      for (const control of controls) control.disabled = disabled;
+    },
+    onChange(listener) {
+      listeners.push(listener);
+    },
   };
 }

--- a/apps/verifier/src/ui/results.ts
+++ b/apps/verifier/src/ui/results.ts
@@ -14,7 +14,7 @@ const MODE_COPY: Record<UiMode, string> = {
   'constraints-checked':
     'The reported values matched the supplied constraints, but the signing key was not independently trusted.',
   'trusted-key':
-    'The signature is valid under a verifier-trusted key. The reported issuer and record type matched the supplied constraints where present.',
+    'The selected key matched a thumbprint in the supplied verification context. The verifier did not establish how that context was obtained.',
 };
 
 function el(tag: string, text?: string, cls?: string): HTMLElement {

--- a/apps/verifier/tests/input-snapshot-binding.test.ts
+++ b/apps/verifier/tests/input-snapshot-binding.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Binding between a displayed result and the inputs it describes.
+ *
+ * Verification and file reads are both asynchronous, so the inputs can change while a run is in
+ * flight. A verification surface that shows a verdict beside inputs it did not evaluate is worse
+ * than one that shows nothing, so each of these properties is asserted directly.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  installMiniDom,
+  uninstallMiniDom,
+  createContainer,
+  findByText,
+} from './helpers/mini-dom.js';
+import type { MiniNode } from './helpers/mini-dom.js';
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+const enc = new TextEncoder();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  uninstallMiniDom();
+});
+
+const accepted = {
+  ok: true as const,
+  mode: 'integrity-only' as const,
+  signature: 'valid_under_supplied_key' as const,
+  recordValidation: 'valid' as const,
+  trustedKey: 'not_provided' as const,
+  issuerConstraint: 'not_provided' as const,
+  kidConstraint: 'not_provided' as const,
+  recordTypeConstraint: 'not_provided' as const,
+  claimTruth: 'not_evaluated' as const,
+  claims: {} as never,
+  limitations: [] as string[],
+  report: { reportVersion: '1', outcome: 'accepted' } as never,
+};
+
+/** Mount the app with a verifier whose completions this test controls. */
+async function mount(verify: (input: unknown) => Promise<unknown>) {
+  installMiniDom();
+  const verifyModule = await import('../src/verify.js');
+  vi.spyOn(verifyModule, 'initializeLocalVerifier').mockResolvedValue({
+    supported: true,
+    verify,
+  } as never);
+
+  const { initApp } = await import('../src/ui/app.js');
+  const root = createContainer() as unknown as HTMLElement;
+  await initApp(root);
+  await flush();
+
+  const node = root as unknown as MiniNode;
+  const button = findByText(node, 'button', /verify/i);
+  if (!button) throw new Error('verify button was not rendered');
+  return {
+    root: node,
+    button,
+    textareas: node.querySelectorAll('textarea'),
+    files: node.querySelectorAll('input'),
+  };
+}
+
+/** A file whose read resolves when the returned `settle` is called. */
+function deferredFile(bytes: Uint8Array) {
+  let settle: () => void = () => {};
+  const gate = new Promise<void>((r) => (settle = r));
+  return {
+    file: {
+      async arrayBuffer() {
+        await gate;
+        return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+      },
+    },
+    settle: () => settle(),
+  };
+}
+
+function type(textarea: MiniNode, value: string): void {
+  textarea.value = value;
+  textarea.dispatchEvent('input');
+}
+
+function visible(root: MiniNode): string {
+  return root
+    .querySelectorAll('h2')
+    .concat(root.querySelectorAll('p'), root.querySelectorAll('pre'))
+    .map((n) => n.textContent)
+    .join(' | ');
+}
+
+describe('verification is unavailable while a file read is pending', () => {
+  it('the control is disabled for the duration of the read and restored afterwards', async () => {
+    const { button, files } = await mount(async () => accepted);
+    expect(button.disabled).toBe(false);
+
+    const pending = deferredFile(enc.encode('RECORD'));
+    files[0].files = [pending.file];
+    files[0].dispatchEvent('change');
+    await flush();
+    expect(button.disabled).toBe(true);
+
+    pending.settle();
+    await flush();
+    expect(button.disabled).toBe(false);
+  });
+});
+
+describe('a run whose inputs changed does not render', () => {
+  it('an input event during the run suppresses its completion', async () => {
+    let release: () => void = () => {};
+    const gate = new Promise<void>((r) => (release = r));
+    const { root, button, textareas } = await mount(async () => {
+      await gate;
+      return accepted;
+    });
+
+    type(textareas[0], 'ORIGINAL');
+    button.dispatchEvent('click');
+    await flush();
+
+    // The controls are disabled, but an event that arrives regardless must still not be ignored.
+    type(textareas[0], 'REPLACED');
+    release();
+    await flush();
+    await flush();
+
+    expect(visible(root)).not.toMatch(/Verification succeeded/);
+    expect(root.querySelectorAll('pre')).toHaveLength(0);
+  });
+
+  it('a rejection whose inputs changed is also suppressed', async () => {
+    let reject: () => void = () => {};
+    const gate = new Promise<void>((_r, rej) => (reject = () => rej(new Error('failed'))));
+    const { root, button, textareas } = await mount(async () => {
+      await gate;
+      return accepted;
+    });
+
+    button.dispatchEvent('click');
+    await flush();
+    type(textareas[0], 'REPLACED');
+    reject();
+    await flush();
+    await flush();
+
+    expect(visible(root)).not.toMatch(/failed unexpectedly/);
+  });
+});
+
+describe('changing an input after a completed run clears what is on screen', () => {
+  it('both the result and the report are removed', async () => {
+    const { root, button, textareas } = await mount(async () => accepted);
+    button.dispatchEvent('click');
+    await flush();
+    await flush();
+
+    expect(visible(root)).toMatch(/Verification succeeded/);
+    expect(root.querySelectorAll('pre').length).toBeGreaterThan(0);
+
+    type(textareas[1], 'A DIFFERENT KEY');
+
+    expect(visible(root)).not.toMatch(/Verification succeeded/);
+    expect(root.querySelectorAll('pre')).toHaveLength(0);
+  });
+
+  it('a completed file read also clears it', async () => {
+    const { root, button, files } = await mount(async () => accepted);
+    button.dispatchEvent('click');
+    await flush();
+    await flush();
+    expect(visible(root)).toMatch(/Verification succeeded/);
+
+    const loaded = deferredFile(enc.encode('NEW-RECORD'));
+    files[0].files = [loaded.file];
+    files[0].dispatchEvent('change');
+    loaded.settle();
+    await flush();
+
+    expect(visible(root)).not.toMatch(/Verification succeeded/);
+  });
+});
+
+describe('a superseded run does not restore controls a newer run holds', () => {
+  it('the older completion leaves every control disabled', async () => {
+    const releases: Array<() => void> = [];
+    const { button, textareas, files } = await mount(async () => {
+      await new Promise<void>((r) => releases.push(r));
+      return accepted;
+    });
+
+    button.dispatchEvent('click');
+    await flush();
+    // Force a second run past the interface guard, so two are genuinely in flight.
+    button.disabled = false;
+    button.dispatchEvent('click');
+    await flush();
+    expect(releases).toHaveLength(2);
+
+    // Settle the SUPERSEDED run. Its `finally` must not hand the controls back.
+    releases[0]();
+    await flush();
+    await flush();
+
+    expect(textareas.every((t) => t.disabled)).toBe(true);
+    expect(files.every((f) => f.disabled)).toBe(true);
+    expect(button.disabled).toBe(true);
+
+    // The current run still owns them and restores them normally.
+    releases[1]();
+    await flush();
+    await flush();
+    expect(textareas.some((t) => t.disabled)).toBe(false);
+    expect(button.disabled).toBe(false);
+  });
+});
+
+describe('only the captured snapshot reaches the verifier', () => {
+  it('later edits to the fields do not change what was submitted', async () => {
+    const seen: Array<Record<string, unknown>> = [];
+    let release: () => void = () => {};
+    const gate = new Promise<void>((r) => (release = r));
+    const { button, textareas } = await mount(async (input) => {
+      seen.push(input as Record<string, unknown>);
+      await gate;
+      return accepted;
+    });
+
+    type(textareas[0], 'RECORD-AT-SUBMISSION');
+    type(textareas[1], 'KEY-AT-SUBMISSION');
+    type(textareas[2], 'CONTEXT-AT-SUBMISSION');
+    button.dispatchEvent('click');
+    await flush();
+
+    type(textareas[0], 'RECORD-CHANGED');
+    type(textareas[1], 'KEY-CHANGED');
+    type(textareas[2], 'CONTEXT-CHANGED');
+    release();
+    await flush();
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].record).toBe('RECORD-AT-SUBMISSION');
+    expect(seen[0].keyDocument).toBe('KEY-AT-SUBMISSION');
+    expect(seen[0].contextDocument).toBe('CONTEXT-AT-SUBMISSION');
+    // The submitted object is frozen, so nothing downstream can rewrite it either.
+    expect(Object.isFrozen(seen[0])).toBe(true);
+  });
+
+  it('an absent context is omitted rather than submitted as an empty document', async () => {
+    const seen: Array<Record<string, unknown>> = [];
+    const { button, textareas } = await mount(async (input) => {
+      seen.push(input as Record<string, unknown>);
+      return accepted;
+    });
+    type(textareas[0], 'RECORD');
+    type(textareas[1], 'KEY');
+    button.dispatchEvent('click');
+    await flush();
+
+    expect('contextDocument' in seen[0]).toBe(false);
+  });
+});
+
+describe('controls are restored when the current run ends', () => {
+  it.each([
+    ['succeeds', async () => accepted],
+    [
+      'fails',
+      async () => {
+        throw new Error('rejected run');
+      },
+    ],
+  ])('after the run %s', async (_label, verify) => {
+    const { button, textareas, files } = await mount(verify as (i: unknown) => Promise<unknown>);
+    // Submission disables the controls synchronously, before the run can settle.
+    button.dispatchEvent('click');
+    expect(textareas.every((t) => t.disabled)).toBe(true);
+    expect(button.disabled).toBe(true);
+
+    await flush();
+    await flush();
+    expect(textareas.some((t) => t.disabled)).toBe(false);
+    expect(files.some((f) => f.disabled)).toBe(false);
+    expect(button.disabled).toBe(false);
+  });
+});

--- a/apps/verifier/tests/inputs-file-read.test.ts
+++ b/apps/verifier/tests/inputs-file-read.test.ts
@@ -163,6 +163,92 @@ describe('the normal hint returns after a successful read', () => {
   });
 });
 
+describe('a superseded read cannot apply', () => {
+  it('clearing the selection invalidates a read already in flight', async () => {
+    const { fields, inputs } = await mountInputs();
+    const target = fields.record as unknown as MiniNode;
+    const recordInput = inputs[0];
+
+    const inFlight = deferredFile(enc.encode('FILE-BYTES'));
+    selectFile(recordInput, inFlight.file);
+    await flush();
+    expect(fields.hasPendingRead()).toBe(true);
+
+    // Clearing the control is a change event with no file. The read must not land afterwards.
+    recordInput.files = [];
+    recordInput.dispatchEvent('change');
+    await flush();
+    expect(fields.hasPendingRead()).toBe(false);
+
+    inFlight.settle();
+    await flush();
+    expect(target.value).toBe('');
+  });
+
+  it('manual input invalidates a read already in flight', async () => {
+    const { fields, node, inputs } = await mountInputs();
+    const target = fields.record as unknown as MiniNode;
+    const textarea = node.querySelectorAll('textarea')[0];
+
+    const inFlight = deferredFile(enc.encode('FILE-BYTES'));
+    selectFile(inputs[0], inFlight.file);
+    await flush();
+    expect(fields.hasPendingRead()).toBe(true);
+
+    textarea.value = 'TYPED-BY-OPERATOR';
+    textarea.dispatchEvent('input');
+    expect(fields.hasPendingRead()).toBe(false);
+
+    inFlight.settle();
+    await flush();
+    expect(target.value).toBe('TYPED-BY-OPERATOR');
+  });
+
+  it('a read cannot overwrite text typed after it started', async () => {
+    const { fields, node, inputs } = await mountInputs();
+    const target = fields.record as unknown as MiniNode;
+    const textarea = node.querySelectorAll('textarea')[0];
+
+    const slow = deferredFile(enc.encode('FROM-FILE'));
+    selectFile(inputs[0], slow.file);
+    await flush();
+
+    textarea.value = 'TYPED-LATER';
+    textarea.dispatchEvent('input');
+    slow.settle();
+    await flush();
+    await flush();
+
+    expect(target.value).toBe('TYPED-LATER');
+  });
+});
+
+describe('the shared revision advances on every value change', () => {
+  it('covers manual input, a completed read and a failed read', async () => {
+    const { fields, node, inputs } = await mountInputs();
+    const textarea = node.querySelectorAll('textarea')[0];
+
+    const start = fields.revision();
+    textarea.value = 'x';
+    textarea.dispatchEvent('input');
+    const afterTyping = fields.revision();
+    expect(afterTyping).toBeGreaterThan(start);
+
+    const ok = deferredFile(enc.encode('LOADED'));
+    selectFile(inputs[0], ok.file);
+    ok.settle();
+    await flush();
+    const afterRead = fields.revision();
+    expect(afterRead).toBeGreaterThan(afterTyping);
+
+    const broken = deferredFile(null);
+    selectFile(inputs[1], broken.file);
+    broken.settle();
+    await flush();
+    expect(fields.revision()).toBeGreaterThan(afterRead);
+  });
+});
+
 describe('each field tracks its own reads', () => {
   it('a read on one field does not disturb another', async () => {
     const { fields, inputs } = await mountInputs();


### PR DESCRIPTION
## Summary

Binds each displayed verification result to the exact record, key document and verification context submitted for that run.

Input edits and asynchronous file reads can no longer replace the visible inputs while an older verification result remains on screen.

## Changes

* invalidate stale file reads on selection changes and manual edits;
* prevent verification while a file read is pending;
* disable mutable inputs during an active verification;
* render only when the run token and input revision remain current;
* clear previous results when inputs change;
* describe supplied trust context without implying independent provenance.

## Scope

No change to record verification, Wire format, cryptographic profile, report schema, package exports or protocol error codes.

## Validation

Package suites, from a clean checkout of this branch at `e585a246`:

| Suite | Result |
| --- | --- |
| `@peac/crypto` | 278 passed (13 files) |
| `@peac/schema` | 2718 passed (60 files) |
| `@peac/protocol` | 2143 passed (59 files) |
| `@peac/app-verifier` | 354 passed, 1 skipped (25 files); 340 passed on the base commit |

The 14 added tests cover: a cleared file selection invalidating an older read; manual input invalidating a pending read; a read never overwriting later manual text; the revision advancing on manual input, a completed read and a failed read; Verify unavailable while a read is pending; an input change during a run suppressing both its result and its rejection; an input change after success clearing the result and the report; a completed file read clearing them; a superseded run's `finally` not restoring controls a newer run holds; only the captured frozen snapshot reaching `verify()`; an absent context omitted rather than submitted empty; controls restored after the current run succeeds and after it fails.

Each guard was mutation-checked by removing it and confirming the corresponding test fails: generation advanced before the empty-selection check, manual input superseding a read in flight, pending-read reporting, the revision check on the success path, the revision check on the rejection path, output clearing on input change, the run-token check in `finally`, and the frozen snapshot. All eight were detected; the sources were restored and re-verified byte-identical.

Gates:

* `tsc --noEmit`: clean;
* `apps/verifier` production build: clean;
* `scripts/check-browser-verifier-boundary.mjs` and `--self-test`: pass, 19 files scanned, 9 negative fixtures caught;
* `scripts/check-verifier-bundle.mjs` and `--self-test`: pass, 7 negative fixtures caught;
* `scripts/guard.sh`: exit 0, production audit reports no high or critical vulnerability;
* hidden-Unicode and Trojan-source byte scan over all five changed files: clean;
* public-artifact and source-hygiene scans over the complete diff: clean;
* API-contract drift check: unchanged.

Real-browser smoke, Google Chrome 151.0.7922.72 against the built application: five flows behaved as specified (integrity-only accepted, trusted-key accepted, signature rejection at the signature stage, malformed rejection at the pre-signature record-validation stage, input-stage rejection with no report); the downloaded report validated against the schema and its hash recomputed; zero unexpected network requests, storage writes, service-worker registrations and console errors were observed.

Reproduced end to end from a fresh clean clone with `--frozen-lockfile`, with identical counts.
