### PR TITLE
ci: run verifier tests on the required path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -647,6 +647,26 @@ jobs:
       - name: DID verification example
         run: pnpm --filter @peac/example-did-verification verify
 
+      - name: Verifier typecheck
+        run: pnpm --filter @peac/app-verifier typecheck
+
+      - name: Verifier tests
+        run: pnpm --filter @peac/app-verifier test
+
+      - name: Verifier source boundary
+        run: |
+          node scripts/check-browser-verifier-boundary.mjs
+          node scripts/check-browser-verifier-boundary.mjs --self-test
+
+      # The emitted-bundle check inspects build output, so it must follow the build.
+      - name: Verifier build
+        run: pnpm --filter @peac/app-verifier build
+
+      - name: Verifier emitted bundle
+        run: |
+          node scripts/check-verifier-bundle.mjs
+          node scripts/check-verifier-bundle.mjs --self-test
+
       - name: ERC-8004 mapping conformance
         run: pnpm --filter @peac/example-erc8004-feedback verify
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       adapters: ${{ steps.filter.outputs.adapters }}
       examples: ${{ steps.filter.outputs.examples }}
       apps: ${{ steps.filter.outputs.apps }}
+      verifier_ci: ${{ steps.filter.outputs.verifier_ci }}
       published: ${{ steps.filter.outputs.published }}
       ci: ${{ steps.filter.outputs.ci }}
       root_config: ${{ steps.filter.outputs.root_config }}
@@ -62,6 +63,12 @@ jobs:
               - 'examples/**'
             apps:
               - 'apps/**'
+            verifier_ci:
+              - 'apps/verifier/**'
+              - 'scripts/check-browser-verifier-boundary.mjs'
+              - 'scripts/check-verifier-bundle.mjs'
+              - '.github/workflows/ci.yml'
+              - 'tests/tooling/verifier-ci-coverage.test.ts'
             published:
               - 'packages/*/package.json'
               - 'packages/*/src/**'
@@ -623,6 +630,7 @@ jobs:
     if: >-
       needs.detect-changes.outputs.examples == 'true' ||
       needs.detect-changes.outputs.apps == 'true' ||
+      needs.detect-changes.outputs.verifier_ci == 'true' ||
       needs.detect-changes.outputs.core == 'true' ||
       needs.detect-changes.outputs.adapters == 'true' ||
       needs.detect-changes.outputs.root_config == 'true' ||

--- a/tests/tooling/verifier-ci-coverage.test.ts
+++ b/tests/tooling/verifier-ci-coverage.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The browser verifier's tests must run on the required CI path.
+ *
+ * The verifier is a private application, so it is not covered by the root test project or by the
+ * core-package test lane. Without an explicit job step its suite never executes in CI, and a
+ * regression can merge while every required check reports success. That failure mode is invisible:
+ * a green required check looks identical whether the suite ran or was never invoked.
+ *
+ * These assertions pin the wiring itself rather than the workflow file's exact shape, so ordinary
+ * edits to unrelated steps do not break them.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = join(__dirname, '..', '..');
+const CI = readFileSync(join(ROOT, '.github', 'workflows', 'ci.yml'), 'utf8');
+
+const OWNING_JOB = 'examples-apps';
+const REQUIRED_CHECK = 'Build, Lint, Test';
+
+/** The body of one top-level job, from its key to the next job key at the same indentation. */
+function jobBody(name: string): string {
+  const start = CI.indexOf(`\n  ${name}:\n`);
+  expect(start, `job ${name} is not defined`).toBeGreaterThan(-1);
+  const rest = CI.slice(start + 1);
+  const next = /\n {2}[a-z][a-z0-9-]*:\n/.exec(rest.slice(1));
+  return next ? rest.slice(0, next.index + 1) : rest;
+}
+
+describe('the verifier suite runs on the required path', () => {
+  const body = jobBody(OWNING_JOB);
+
+  it.each([
+    ['typecheck', 'pnpm --filter @peac/app-verifier typecheck'],
+    ['tests', 'pnpm --filter @peac/app-verifier test'],
+    ['build', 'pnpm --filter @peac/app-verifier build'],
+    ['source boundary', 'node scripts/check-browser-verifier-boundary.mjs'],
+    ['source boundary self-test', 'node scripts/check-browser-verifier-boundary.mjs --self-test'],
+    ['emitted bundle', 'node scripts/check-verifier-bundle.mjs'],
+    ['emitted bundle self-test', 'node scripts/check-verifier-bundle.mjs --self-test'],
+  ])('the %s command is present in the owning job', (_label, command) => {
+    expect(body).toContain(command);
+  });
+
+  it('builds the verifier before inspecting its emitted bundle', () => {
+    // The bundle check reads build output. Running it first would inspect a stale or absent dist
+    // and could pass without examining anything this commit produced.
+    const build = body.indexOf('pnpm --filter @peac/app-verifier build');
+    const bundle = body.indexOf('node scripts/check-verifier-bundle.mjs');
+    expect(build).toBeGreaterThan(-1);
+    expect(bundle).toBeGreaterThan(-1);
+    expect(build).toBeLessThan(bundle);
+  });
+});
+
+describe('the owning job is genuinely required', () => {
+  it('is listed in the required aggregator dependencies', () => {
+    const required = new RegExp(
+      `name: ${REQUIRED_CHECK}\\s*\\n\\s*needs:\\s*\\n\\s*\\[([^\\]]+)\\]`
+    );
+    const match = required.exec(CI);
+    expect(match, `the ${REQUIRED_CHECK} aggregator was not found`).not.toBeNull();
+    expect(match?.[1]).toContain(OWNING_JOB);
+  });
+
+  it('blocks the aggregator when it fails', () => {
+    // Being in `needs` is not sufficient: the aggregator runs with `if: always()` and decides per
+    // lane, so a lane whose failure is not inspected would never block a merge.
+    const aggregator = CI.slice(CI.indexOf(`name: ${REQUIRED_CHECK}`));
+    expect(aggregator).toMatch(
+      new RegExp(`needs\\.${OWNING_JOB}\\.result.*==.*["']failure["'][\\s\\S]{0,200}exit 1`)
+    );
+  });
+
+  it('runs whenever the verifier changes', () => {
+    // The job is conditional, so the path filter that gates it must cover the verifier's tree.
+    expect(CI).toMatch(/apps:\s*\n\s*- 'apps\/\*\*'/);
+    const body = jobBody(OWNING_JOB);
+    expect(body).toContain("needs.detect-changes.outputs.apps == 'true'");
+  });
+});

--- a/tests/tooling/verifier-ci-coverage.test.ts
+++ b/tests/tooling/verifier-ci-coverage.test.ts
@@ -1,10 +1,11 @@
 /**
  * The browser verifier's tests must run on the required CI path.
  *
- * The verifier is a private application, so it is not covered by the root test project or by the
- * core-package test lane. Without an explicit job step its suite never executes in CI, and a
- * regression can merge while every required check reports success. That failure mode is invisible:
- * a green required check looks identical whether the suite ran or was never invoked.
+ * The verifier is a non-published workspace application, so it is not covered by the root test
+ * project or by the core-package test lane. Without an explicit job step its suite never executes
+ * in CI, and a regression can merge while every required check reports success. That failure mode
+ * is invisible twice over: a green required check looks identical whether the suite ran or was
+ * never invoked, and a conditionally skipped job also reports success to its dependents.
  *
  * These assertions pin the wiring itself rather than the workflow file's exact shape, so ordinary
  * edits to unrelated steps do not break them.
@@ -17,6 +18,16 @@ const ROOT = join(__dirname, '..', '..');
 const CI = readFileSync(join(ROOT, '.github', 'workflows', 'ci.yml'), 'utf8');
 
 const OWNING_JOB = 'examples-apps';
+const ACTIVATION_OUTPUT = 'verifier_ci';
+
+/** Paths that must activate the owning job, because each can change verifier behaviour. */
+const ACTIVATING_PATHS = [
+  'apps/verifier/**',
+  'scripts/check-browser-verifier-boundary.mjs',
+  'scripts/check-verifier-bundle.mjs',
+  '.github/workflows/ci.yml',
+  'tests/tooling/verifier-ci-coverage.test.ts',
+];
 const REQUIRED_CHECK = 'Build, Lint, Test';
 
 /** The body of one top-level job, from its key to the next job key at the same indentation. */
@@ -78,5 +89,38 @@ describe('the owning job is genuinely required', () => {
     expect(CI).toMatch(/apps:\s*\n\s*- 'apps\/\*\*'/);
     const body = jobBody(OWNING_JOB);
     expect(body).toContain("needs.detect-changes.outputs.apps == 'true'");
+  });
+});
+
+describe('the owning job activates for every path that can change verifier behaviour', () => {
+  /** The filter block declaring which paths set the activation output. */
+  const filterBlock = (() => {
+    const start = CI.indexOf(`\n            ${ACTIVATION_OUTPUT}:\n`);
+    expect(start, `no ${ACTIVATION_OUTPUT} filter is declared`).toBeGreaterThan(-1);
+    const rest = CI.slice(start + 1);
+    const next = /\n {12}[a-z_]+:\n/.exec(rest.slice(1));
+    return next ? rest.slice(0, next.index + 1) : rest;
+  })();
+
+  it.each(ACTIVATING_PATHS)('%s activates the lane', (path) => {
+    expect(filterBlock).toContain(`'${path}'`);
+  });
+
+  it('the activation output is declared and consumed by the owning job', () => {
+    expect(CI).toContain(`${ACTIVATION_OUTPUT}: \${{ steps.filter.outputs.${ACTIVATION_OUTPUT} }}`);
+    expect(jobBody(OWNING_JOB)).toContain(
+      `needs.detect-changes.outputs.${ACTIVATION_OUTPUT} == 'true'`
+    );
+  });
+
+  it('an unrelated documentation change does not activate the lane', () => {
+    // The filter must stay narrow. Routing every docs edit through the apps lane would spend CI
+    // time without exercising anything, and would make the lane's signal meaningless.
+    for (const unrelated of ['docs/**', 'README.md', 'CHANGELOG.md', 'sdks/**']) {
+      expect(filterBlock).not.toContain(`'${unrelated}'`);
+    }
+    // A broad scripts or workflow glob would have the same effect.
+    expect(filterBlock).not.toMatch(/'scripts\/\*\*'/);
+    expect(filterBlock).not.toMatch(/'\.github\/\*\*'/);
   });
 });


### PR DESCRIPTION
## Summary

Runs the browser verifier's test suite on the required CI path. The verifier is a non-published workspace application whose tests were not executed by any job the required `Build, Lint, Test` check depends on.

## Changes

Adds verifier typecheck, tests, source-boundary check, build and emitted-bundle check to the `Examples and Apps` job, which is in the required aggregator's `needs`.

A `verifier_ci` change-detection output activates the job for `apps/verifier/**`, the two verifier check scripts, `.github/workflows/ci.yml` and the coverage test itself, so any change to the enforcement mechanism triggers the lane it governs.

`tests/tooling/verifier-ci-coverage.test.ts` asserts the wiring: the commands are present, the build precedes the bundle check, the job is in the aggregator's `needs`, the aggregator inspects its result, and each activation path triggers the lane.

## Validation

Branch and fresh clean clone from an empty store with identical results: frozen install, build, lint, full test suite, verifier suite, `scripts/guard.sh`, `verify-trust-artifacts.mjs`, `git diff --check`. Each wiring assertion was mutation-checked.

## Scope

No protocol, Wire, schema, cryptographic, package-export, dependency or lockfile change.
