### PR TITLE
ci: require the verifier lane to succeed when it is activated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -812,6 +812,13 @@ jobs:
             echo "FAIL: examples-apps failed"; exit 1
           fi
 
+          # When verifier-affecting paths changed, the verifier lane MUST have succeeded.
+          # `skipped` is not acceptable here: a skipped job reports success to its dependents,
+          # so without this the aggregate could stay green while the verifier never ran.
+          if [[ "${{ needs.detect-changes.outputs.verifier_ci }}" == "true" && "${{ needs.examples-apps.result }}" != "success" ]]; then
+            echo "FAIL: verifier-affecting paths changed but the verifier lane did not succeed (result: ${{ needs.examples-apps.result }})"; exit 1
+          fi
+
           # pack-smoke: optional (success or skipped OK, failure blocks)
           if [[ "${{ needs.pack-smoke.result }}" == "failure" || "${{ needs.pack-smoke.result }}" == "cancelled" ]]; then
             echo "FAIL: pack-smoke failed"; exit 1

--- a/tests/tooling/verifier-lane-aggregation.test.ts
+++ b/tests/tooling/verifier-lane-aggregation.test.ts
@@ -1,0 +1,94 @@
+/**
+ * The required aggregate must refuse a verifier lane that did not run.
+ *
+ * GitHub reports a conditionally skipped job as `success` to its dependents. An aggregate that only
+ * rejects `failure` therefore stays green when the lane never executed, which is indistinguishable
+ * from the lane having passed.
+ *
+ * These tests extract the aggregate's decision script from the workflow and execute it under bash
+ * with substituted lane results, so they observe the decision rather than asserting that some text
+ * is present. A rule that is merely spelled correctly is not a rule that behaves correctly.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = join(__dirname, '..', '..');
+const CI = readFileSync(join(ROOT, '.github', 'workflows', 'ci.yml'), 'utf8');
+
+/** The `run:` script of the aggregate's evaluation step, dedented to column zero. */
+function aggregatorScript(): string {
+  const marker = '      - name: Evaluate lane results\n        run: |\n';
+  const start = CI.indexOf(marker);
+  expect(start, 'the aggregate evaluation step was not found').toBeGreaterThan(-1);
+  const rest = CI.slice(start + marker.length);
+  const lines: string[] = [];
+  for (const line of rest.split('\n')) {
+    // The block ends at the first line that is neither blank nor indented past the script body.
+    if (line.trim() !== '' && !line.startsWith('          ')) break;
+    lines.push(line.slice(10));
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Run the aggregate's decision with the given lane results substituted for their expressions.
+ * Returns the exit status, which is what actually gates a merge.
+ */
+function evaluate(values: Record<string, string>): number {
+  let script = aggregatorScript();
+  script = script.replace(/\$\{\{\s*([a-zA-Z0-9_.\-]+)\s*\}\}/g, (_m, expr: string) => {
+    if (!(expr in values)) throw new Error(`unsubstituted workflow expression: ${expr}`);
+    return values[expr];
+  });
+  try {
+    execFileSync('bash', ['-c', script], { encoding: 'utf8', stdio: 'pipe' });
+    return 0;
+  } catch (e) {
+    return (e as { status?: number }).status ?? 1;
+  }
+}
+
+/** All lanes passing, with the verifier activation flag and lane result under test. */
+function lanes(verifierCi: string, examplesApps: string): Record<string, string> {
+  return {
+    'needs.detect-changes.outputs.verifier_ci': verifierCi,
+    // Unrelated activation outputs, held at values that keep the other rules satisfied so each
+    // test isolates the verifier rule.
+    'needs.detect-changes.outputs.stamp_any': 'false',
+    'needs.detect-changes.outputs.non_stamp': 'true',
+    'needs.workflow-lint.result': 'success',
+    'needs.fast-guards.result': 'success',
+    'needs.type-build.result': 'success',
+    'needs.tests-core.result': 'success',
+    'needs.tooling-gates.result': 'success',
+    'needs.examples-apps.result': examplesApps,
+    'needs.pack-smoke.result': 'success',
+  };
+}
+
+describe('a verifier lane that did not run cannot pass the aggregate', () => {
+  it('verifier paths changed and the lane succeeded: accepted', () => {
+    expect(evaluate(lanes('true', 'success'))).toBe(0);
+  });
+
+  it('verifier paths changed and the lane was SKIPPED: rejected', () => {
+    // The exact defect this exists to prevent: skipped reads as success to dependents.
+    expect(evaluate(lanes('true', 'skipped'))).not.toBe(0);
+  });
+
+  it('verifier paths changed and the lane failed: rejected', () => {
+    expect(evaluate(lanes('true', 'failure'))).not.toBe(0);
+  });
+
+  it('verifier paths unchanged and the lane was skipped: allowed', () => {
+    // Unrelated changes must not be forced through the application lane.
+    expect(evaluate(lanes('false', 'skipped'))).toBe(0);
+  });
+
+  it('verifier paths unchanged and the lane failed: still rejected', () => {
+    // The pre-existing generic failure handling must survive the added rule.
+    expect(evaluate(lanes('false', 'failure'))).not.toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Makes the required aggregate refuse a verifier lane that did not run. GitHub reports a conditionally skipped job as `success` to its dependents, so the aggregate could stay green while the lane never executed.

## Change

When verifier-affecting paths changed, the `Examples and Apps` lane must have concluded `success`; the pre-existing generic handling for unrelated changes is unchanged.

`tests/tooling/verifier-lane-aggregation.test.ts` extracts the aggregate's decision script from the workflow and executes it under bash with substituted lane results, failing closed on any expression it does not supply.

## Validation

Full test suite, `scripts/guard.sh`, `git diff --check`. The accepted/rejected decision table and its mutations (accepting `skipped`, removing the invariant, ignoring the activation flag) are covered by the test.

## Scope

Workflow and one test file. No protocol, schema, cryptographic, dependency or lockfile change.
