### PR TITLE
chore(security): js-yaml overrides to the patched releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,8 +173,8 @@
       "form-data@<4.0.6": ">=4.0.6",
       "vite@<6.4.2": ">=8.0.16",
       "ws@>=8.0.0 <8.21.0": "8.21.0",
-      "js-yaml@>=4.0.0 <4.3.0": "4.3.0",
-      "js-yaml@>=3.0.0 <3.15.0": "3.15.0"
+      "js-yaml@>=4.0.0 <4.3.1": "4.3.1",
+      "js-yaml@>=3.0.0 <3.15.1": "3.15.1"
     },
     "overridesComments": {
       "minimatch": "Cross-major pin to 10.2.4: typescript-estree requires ^9.0.4 but 9.x has no patch for GHSA-3ppc-4f35-3m26. minimatch 10.x is API-compatible (same globbing interface). 10.2.4 patches GHSA-7r86-cg39-jmmj and GHSA-23c5-xmqv-rm74 (ReDoS). Drops Node 18 (fine: repo baseline is >=22.0.0). Lint verified clean.",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ overrides:
   form-data@<4.0.6: '>=4.0.6'
   vite@<6.4.2: '>=8.0.16'
   ws@>=8.0.0 <8.21.0: 8.21.0
-  js-yaml@>=4.0.0 <4.3.0: 4.3.0
-  js-yaml@>=3.0.0 <3.15.0: 3.15.0
+  js-yaml@>=4.0.0 <4.3.1: 4.3.1
+  js-yaml@>=3.0.0 <3.15.1: 3.15.1
 
 importers:
 
@@ -81,8 +81,8 @@ importers:
         specifier: ^17.4.0
         version: 17.4.0
       js-yaml:
-        specifier: 4.3.0
-        version: 4.3.0
+        specifier: 4.3.1
+        version: 4.3.1
       lint-staged:
         specifier: ^16.3.1
         version: 16.3.1
@@ -3980,7 +3980,7 @@ packages:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       resolve-from: 5.0.0
     dev: true
 
@@ -7827,16 +7827,16 @@ packages:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
     dev: true
 
-  /js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  /js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
     dev: true
 
-  /js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  /js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
     dependencies:
       argparse: 2.0.1


### PR DESCRIPTION
## Summary

GHSA-5p4m-2wfm-xmqj affects `js-yaml >=3.0.0 <3.15.1` and `>=4.0.0 <4.3.1`. The existing range-scoped overrides floored at `3.15.0` and `4.3.0`, both of which the advisory now covers, so the strict audit gate reports two high advisories on every branch.

Both entries advance to the patched releases:

| Override | Was | Now |
|---|---|---|
| `js-yaml@>=3.0.0 <3.15.1` | `3.15.0` | `3.15.1` |
| `js-yaml@>=4.0.0 <4.3.1` | `4.3.0` | `4.3.1` |

No published package resolves `js-yaml`. The affected paths are the root development toolchain and the `apps/api` jest toolchain.

## Validation

- `pnpm audit`: no high or critical advisory; production audit reports OK.
- Lockfile regenerated by pnpm and verified with a frozen install from an empty store.
- `scripts/guard.sh` full mode: exit 0.
- Full repository test suite passes.

## Scope

Dependency resolution only. No protocol, wire format, API, schema, cryptographic profile, package surface or CI policy change.
