### PR TITLE
fix(conformance): bind runtime observations to measurement-relevant inputs

### DIFF
--- a/packages/crypto/tests/observation-integrity.test.ts
+++ b/packages/crypto/tests/observation-integrity.test.ts
@@ -13,8 +13,12 @@ import {
   LOCKFILE_PATH,
   MEASURED_ARTIFACT_PATH,
   PRODUCTION_SOURCES,
+  fileAtRevision,
   fileDigest,
+  observationDependencyProblems,
   productionSourceManifestDigest,
+  readRepositoryFile,
+  sha256,
 } from './tools/evidence-provenance.mjs';
 
 const CRYPTO_ROOT = resolve(__dirname, '..');
@@ -97,11 +101,37 @@ describe('the committed runtime observations', () => {
     }
   });
 
-  it('recomputes the lockfile digest', () => {
-    const expected = fileDigest(REPO_ROOT, LOCKFILE_PATH);
-    for (const [id, environment] of Object.entries(document.environments)) {
-      expect(environment.lockfile_sha256, `${id}: lockfile digest`).toBe(expected);
+  // The lockfile digest is provenance of the measurement event; current-tree applicability is
+  // bound to the measurement-relevant dependencies, not to the whole lockfile.
+  it('records one well-formed lockfile digest across all environments', () => {
+    const digests = new Set(
+      Object.values(document.environments).map((environment) => environment.lockfile_sha256)
+    );
+    expect([...digests], 'all environments were measured from one lockfile').toHaveLength(1);
+    expect([...digests][0]).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('the recorded lockfile digest matches the lockfile at the measurement revision', () => {
+    const revision = document.measurement_source_revision;
+    const historical = fileAtRevision(REPO_ROOT, revision, LOCKFILE_PATH);
+    if (historical === null) {
+      // Shallow clones and source archives cannot resolve the recorded revision.
+      expect(
+        process.env.PEAC_REQUIRE_PROVENANCE_HISTORY,
+        `revision ${revision} is not resolvable here; audit the lockfile digest from a full-history checkout`
+      ).toBeUndefined();
+      return;
     }
+    const expected = sha256(historical);
+    for (const [id, environment] of Object.entries(document.environments)) {
+      expect(environment.lockfile_sha256, `${id}: lockfile digest at ${revision}`).toBe(expected);
+    }
+  });
+
+  it('the current lockfile resolves every measurement dependency to its measured version', () => {
+    const lockfile = readRepositoryFile(REPO_ROOT, LOCKFILE_PATH).toString('utf8');
+    const problems = observationDependencyProblems(document.environments, lockfile);
+    expect(problems, 'measurement-relevant dependencies match the lockfile').toEqual([]);
   });
 
   it('recomputes the production source manifest for every wrapper surface', () => {

--- a/packages/crypto/tests/provenance-guards.test.ts
+++ b/packages/crypto/tests/provenance-guards.test.ts
@@ -12,9 +12,13 @@ import { join, resolve } from 'node:path';
 import {
   CORPUS_PATH,
   LOCKFILE_PATH,
+  MEASUREMENT_DEPENDENCIES,
   PRODUCTION_SOURCES,
   deriveSourceRevision,
+  fileAtRevision,
   fileDigest,
+  lockfileResolvedVersions,
+  observationDependencyProblems,
   productionSourceManifestDigest,
   readRepositoryFile,
   resolveSourceRevision,
@@ -123,5 +127,132 @@ describe('digests are over unmodified file bytes', () => {
     expect(fileDigest(REPO_ROOT, CORPUS_PATH)).toBe(
       sha256(readRepositoryFile(REPO_ROOT, CORPUS_PATH))
     );
+  });
+});
+
+describe('observation applicability is bound to measurement-relevant dependencies', () => {
+  const lockfile = readRepositoryFile(REPO_ROOT, LOCKFILE_PATH).toString('utf8');
+  const noblePackage = '@noble/ed25519';
+
+  /** Environments recording the noble version the current lockfile resolves, with the lockfile
+   * digest of their measurement event, as the committed document records both. */
+  const environments = (): Record<
+    string,
+    { implementation: string; version: string; lockfile_sha256: string }
+  > => {
+    const [version] = lockfileResolvedVersions(lockfile, noblePackage);
+    expect(version, 'the lockfile resolves the measured dependency').toBeTruthy();
+    const lockfileSha256 = sha256(lockfile);
+    return {
+      'noble-strict': { implementation: 'noble:strict', version, lockfile_sha256: lockfileSha256 },
+      'noble-zip215': { implementation: 'noble:zip215', version, lockfile_sha256: lockfileSha256 },
+      'node-crypto': {
+        implementation: 'node:crypto',
+        version: '24.19.0',
+        lockfile_sha256: lockfileSha256,
+      },
+    };
+  };
+
+  it('declares the noble dependency as measurement relevant', () => {
+    expect(MEASUREMENT_DEPENDENCIES.map((d) => d.package)).toEqual([noblePackage]);
+  });
+
+  it('resolves the measured dependency from the committed lockfile', () => {
+    expect(lockfileResolvedVersions(lockfile, noblePackage)).toHaveLength(1);
+  });
+
+  it('accepts the committed lockfile', () => {
+    expect(observationDependencyProblems(environments(), lockfile)).toEqual([]);
+  });
+
+  it('a resolution change outside the measurement closure does not invalidate the observations', () => {
+    const changed = lockfile.replace(/^  \/js-yaml@[0-9][^:]*:/gm, '  /js-yaml@9.9.9:');
+    expect(changed, 'the unrelated mutation applied').not.toBe(lockfile);
+    expect(observationDependencyProblems(environments(), changed)).toEqual([]);
+  });
+
+  it('a measurement-relevant resolution change invalidates the observations', () => {
+    const changed = lockfile.replace(
+      /^  \/@noble\/ed25519@[0-9][^:(]*/gm,
+      '  /@noble/ed25519@9.9.9'
+    );
+    expect(changed, 'the relevant mutation applied').not.toBe(lockfile);
+    const problems = observationDependencyProblems(environments(), changed);
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain(noblePackage);
+    expect(problems[0]).toContain('9.9.9');
+  });
+
+  it('a lockfile that resolves no version for a measured dependency is a failure, not an absence', () => {
+    const removed = lockfile
+      .split('\n')
+      .filter((line) => !/^  \/@noble\/ed25519@/.test(line))
+      .join('\n');
+    expect(removed, 'the removal applied').not.toBe(lockfile);
+    const problems = observationDependencyProblems(environments(), removed);
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('resolves no version');
+  });
+
+  it('an unrecognized lockfile format is a failure, not an absence', () => {
+    const problems = observationDependencyProblems(environments(), 'lockfileVersion: unknown\n');
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('resolves no version');
+  });
+
+  it('environments that disagree on the measured version are a failure', () => {
+    const disagreeing = {
+      ...environments(),
+      'noble-other': { implementation: 'noble:strict', version: '0.0.1' },
+    };
+    const problems = observationDependencyProblems(disagreeing, lockfile);
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('distinct versions');
+  });
+
+  it('a document without the measured surface is a failure', () => {
+    const problems = observationDependencyProblems(
+      { 'node-crypto': { implementation: 'node:crypto', version: '24.19.0' } },
+      lockfile
+    );
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('no measured environment');
+  });
+
+  it('parses the packages-section key forms with and without a leading slash or quotes', () => {
+    const fixture = [
+      'packages:',
+      '  /left@1.0.0:',
+      '  right@2.0.0:',
+      "  'quoted@3.0.0':",
+      '  /peer@4.0.0(host@1.0.0):',
+      '',
+    ].join('\n');
+    expect(lockfileResolvedVersions(fixture, 'left')).toEqual(['1.0.0']);
+    expect(lockfileResolvedVersions(fixture, 'right')).toEqual(['2.0.0']);
+    expect(lockfileResolvedVersions(fixture, 'quoted')).toEqual(['3.0.0']);
+    expect(lockfileResolvedVersions(fixture, 'peer')).toEqual(['4.0.0']);
+    expect(lockfileResolvedVersions(fixture, 'absent')).toEqual([]);
+  });
+});
+
+describe('historical files resolve only through the recorded revision', () => {
+  it('reads a committed file at an available revision and reports an unavailable one as null', () => {
+    const dir = scratchRepo();
+    try {
+      const head = deriveSourceRevision(dir);
+      expect(fileAtRevision(dir, head, 'seed.txt').toString()).toBe('seed\n');
+      expect(fileAtRevision(dir, 'f'.repeat(40), 'seed.txt')).toBeNull();
+      expect(fileAtRevision(dir, head, 'absent.txt')).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses a malformed revision and a path that escapes the repository', () => {
+    expect(() => fileAtRevision(REPO_ROOT, 'HEAD', LOCKFILE_PATH)).toThrow(/commit SHA/);
+    expect(() => fileAtRevision(REPO_ROOT, 'a'.repeat(40), '../outside.txt')).toThrow(/escapes/);
+    expect(() => fileAtRevision(REPO_ROOT, 'a'.repeat(40), '/etc/hosts')).toThrow(/relative/);
   });
 });

--- a/packages/crypto/tests/tools/evidence-provenance.mjs
+++ b/packages/crypto/tests/tools/evidence-provenance.mjs
@@ -29,6 +29,15 @@ export const PRODUCTION_SOURCES = Object.freeze([
   'packages/crypto/src/internal/ed25519-admissibility.ts',
 ]);
 
+/**
+ * Lockfile-resolved dependencies that participate in a measured surface. Browser engines and
+ * runners are installed outside the workspace, Node and Go are toolchains, and the PEAC wrapper
+ * is bound by its artifact and source-manifest digests; none of those bind through the lockfile.
+ */
+export const MEASUREMENT_DEPENDENCIES = Object.freeze([
+  Object.freeze({ package: '@noble/ed25519', implementationPrefix: 'noble:' }),
+]);
+
 export const sha256 = (buffer) => createHash('sha256').update(buffer).digest('hex');
 
 /**
@@ -101,6 +110,97 @@ export function deriveSourceRevision(repoRoot) {
     );
   }
   return revision;
+}
+
+/**
+ * Distinct versions a pnpm lockfile resolves for a package, sorted. Reads the packages-section
+ * keys in their slash, bare and quoted forms, ignoring peer suffixes. An unrecognized format
+ * yields an empty result, which callers must treat as a failure.
+ */
+export function lockfileResolvedVersions(lockfileText, packageName) {
+  if (typeof lockfileText !== 'string' || lockfileText.length === 0) {
+    throw new Error('lockfile text is required');
+  }
+  if (typeof packageName !== 'string' || packageName.length === 0) {
+    throw new Error('a package name is required');
+  }
+  const escaped = packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const key = new RegExp(`^  ['"]?/?${escaped}@([0-9][^:('"]*)`, 'gm');
+  const versions = new Set();
+  for (const match of lockfileText.matchAll(key)) {
+    versions.add(match[1]);
+  }
+  return [...versions].sort();
+}
+
+/**
+ * Applicability of recorded observation environments to a lockfile: every measurement-relevant
+ * dependency must resolve to exactly its measured version. Returns problems; empty means
+ * applicable. The recorded lockfile digest is provenance of the measurement event and is not
+ * compared against the current lockfile.
+ */
+export function observationDependencyProblems(environments, lockfileText) {
+  const problems = [];
+  for (const dependency of MEASUREMENT_DEPENDENCIES) {
+    const measured = Object.entries(environments).filter(
+      ([, environment]) =>
+        typeof environment.implementation === 'string' &&
+        environment.implementation.startsWith(dependency.implementationPrefix)
+    );
+    if (measured.length === 0) {
+      problems.push(`${dependency.package}: no measured environment records it`);
+      continue;
+    }
+    const recorded = new Set(measured.map(([, environment]) => environment.version));
+    if (recorded.size !== 1) {
+      problems.push(
+        `${dependency.package}: environments record ${recorded.size} distinct versions: ${[...recorded].sort().join(', ')}`
+      );
+      continue;
+    }
+    const [measuredVersion] = recorded;
+    const resolved = lockfileResolvedVersions(lockfileText, dependency.package);
+    if (resolved.length === 0) {
+      problems.push(`${dependency.package}: the lockfile resolves no version`);
+    } else if (resolved.length > 1) {
+      problems.push(
+        `${dependency.package}: the lockfile resolves multiple versions: ${resolved.join(', ')}`
+      );
+    } else if (resolved[0] !== measuredVersion) {
+      problems.push(
+        `${dependency.package}: measured ${measuredVersion}, the lockfile resolves ${resolved[0]}`
+      );
+    }
+  }
+  return problems;
+}
+
+/**
+ * Bytes of a repository-relative path at a revision, or null when the revision's objects are
+ * not present locally. Nothing is fetched.
+ */
+export function fileAtRevision(repoRoot, revision, relativePath) {
+  if (typeof revision !== 'string' || !/^[0-9a-f]{40}$/.test(revision)) {
+    throw new Error(`a full lowercase commit SHA is required: ${revision}`);
+  }
+  if (typeof relativePath !== 'string' || relativePath.length === 0 || isAbsolute(relativePath)) {
+    throw new Error(`a repository-relative path is required: ${relativePath}`);
+  }
+  const normalized = normalize(relativePath);
+  if (normalized.startsWith('..') || normalized.split('/').includes('..')) {
+    throw new Error(`path escapes the repository: ${relativePath}`);
+  }
+  const spec = `${revision}:${normalized}`;
+  const options = { cwd: resolve(repoRoot), stdio: ['ignore', 'pipe', 'pipe'] };
+  try {
+    execFileSync('git', ['cat-file', '-e', spec], options);
+  } catch {
+    return null;
+  }
+  return execFileSync('git', ['cat-file', 'blob', spec], {
+    ...options,
+    maxBuffer: 256 * 1024 * 1024,
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

Runtime-observation applicability is now scoped to measurement-relevant inputs rather than the complete workspace lockfile.

## Invariant

`lockfile_sha256` records measurement provenance. Current applicability requires lockfile-resolved measurement dependencies to match the versions recorded by the observations. Corpus, harness, production-source and measured-artifact integrity checks remain unchanged.

Historical lockfile verification is performed when the recorded revision is locally available and can be required explicitly for full-history audits.

## Validation

- Unrelated dependency resolution changes preserve observation applicability.
- Changes to `@noble/ed25519` invalidate it.
- Shallow and full-history checkout behavior is covered.
- 13,063 repository tests and the existing integrity and guard checks pass.

## Scope

Test and evidence tooling only. No runtime, protocol, wire-format, schema, API, dependency or release-state change.
