### PR TITLE
fix(schema): align revoked-key kid validation with PEAC JWS validation

### DIFF
--- a/packages/crypto/src/kid.ts
+++ b/packages/crypto/src/kid.ts
@@ -1,8 +1,10 @@
 /**
- * The canonical `kid` rule.
+ * The PEAC `kid` rule.
  *
  * A `kid` is a non-empty, well-formed Unicode string whose UTF-8 serialization is at most
- * MAX_KID_UTF8_BYTES bytes.
+ * MAX_KID_UTF8_BYTES bytes. RFC 7515 defines `kid` only as an optional case-sensitive string
+ * with unspecified structure; the bound and well-formedness requirements are PEAC
+ * application-level constraints.
  *
  * The bound is in UTF-8 bytes because that is what bounds the serialized protected header: 256
  * UTF-16 code units of astral code points serialize to 1024 bytes. It is also the only unit on which
@@ -70,7 +72,7 @@ export function utf8ByteLength(s: string): number {
 }
 
 /**
- * The complete canonical `kid` rule: a non-empty, well-formed Unicode string whose UTF-8
+ * The complete PEAC `kid` rule: a non-empty, well-formed Unicode string whose UTF-8
  * serialization is at most `MAX_KID_UTF8_BYTES` bytes.
  */
 export function isValidKid(kid: unknown): kid is string {

--- a/packages/schema/__tests__/issuer-config-kid.test.ts
+++ b/packages/schema/__tests__/issuer-config-kid.test.ts
@@ -1,10 +1,12 @@
 /**
- * Revoked-key `kid` semantics: the issuer-config schema accepts exactly the canonical JWS `kid`
- * domain (non-empty, well-formed Unicode, at most 256 UTF-8 bytes).
+ * Revoked-key `kid` semantics: the issuer-config schema accepts exactly the PEAC JWS `kid`
+ * domain (non-empty, well-formed Unicode, at most 256 UTF-8 bytes). RFC 7515 leaves the
+ * structure of `kid` unspecified; these constraints are PEAC application-level requirements.
  *
- * The parity suite runs the same vectors through the schema-private predicate and the canonical
- * `@peac/crypto` implementation (imported by source path: the schema package cannot depend on a
- * higher layer), so a divergence in either implementation fails here.
+ * The parity suite runs the same vectors through the schema-private predicate, the public
+ * `RevokedKeyEntrySchema` surface, and the `@peac/crypto` implementation (imported by source
+ * path: the schema package cannot depend on a higher layer), so a divergence at any of the
+ * three fails here.
  */
 import { describe, it, expect } from 'vitest';
 import { RevokedKeyEntrySchema } from '../src/issuer-config';
@@ -34,7 +36,7 @@ function kidOfBytes(n: number, width: 1 | 2 | 3 | 4): string {
 
 const entry = (kid: string) => ({ kid, revoked_at: '2026-02-28T12:00:00Z' });
 
-describe('revoked-key kid accepts the canonical JWS domain', () => {
+describe('revoked-key kid accepts the PEAC JWS domain', () => {
   it.each([1, 2, 3, 4] as const)('accepts 255 and 256 bytes of %i-byte code points', (width) => {
     for (const n of [255, 256]) {
       const kid = kidOfBytes(n, width);
@@ -49,11 +51,12 @@ describe('revoked-key kid accepts the canonical JWS domain', () => {
     expect(RevokedKeyEntrySchema.safeParse(entry(kid)).success).toBe(false);
   });
 
-  it('rejects what string-length counting used to accept', () => {
-    // 200 astral code points: 200 UTF-16 length pairs under the old max(256), 800 UTF-8 bytes.
-    const kid = '\u{1F600}'.repeat(200);
-    expect(kid.length).toBeLessThanOrEqual(256 + 256);
-    expect(encoder.encode(kid).length).toBe(800);
+  it('rejects what UTF-16 code-unit counting used to accept', () => {
+    // 65 astral code points: 130 UTF-16 code units, inside the former max(256); 260 UTF-8
+    // bytes, outside the byte bound.
+    const kid = '\u{1F600}'.repeat(65);
+    expect(kid.length).toBe(130);
+    expect(encoder.encode(kid).length).toBe(260);
     expect(RevokedKeyEntrySchema.safeParse(entry(kid)).success).toBe(false);
   });
 
@@ -80,10 +83,23 @@ describe('revoked-key kid accepts the canonical JWS domain', () => {
   });
 });
 
-describe('parity with the canonical crypto implementation', () => {
+describe('parity with the crypto implementation', () => {
   const vectors: string[] = [
     'key-2026-01',
     'a',
+    'Key',
+    'key',
+    '\u00e9', // NFC e-acute
+    'e\u0301', // NFD e-acute; 3 bytes, not normalized to the 2-byte NFC form
+    '  padded  ',
+    ' ',
+    '\u0000',
+    'a\u0000b',
+    '\u0007',
+    '\t\n',
+    '\u043a\u043b\u044e\u0447',
+    '\u200b',
+    '\ufeff',
     kidOfBytes(255, 1),
     kidOfBytes(256, 1),
     kidOfBytes(257, 1),
@@ -119,6 +135,28 @@ describe('parity with the canonical crypto implementation', () => {
         cryptoIsValidKid(v)
       );
     }
+  });
+
+  // Binds the public schema surface, not only the private predicate, so removing or altering
+  // the schema integration cannot leave parity green.
+  it('the RevokedKeyEntrySchema surface matches crypto for every vector', () => {
+    for (const v of vectors) {
+      expect(
+        RevokedKeyEntrySchema.safeParse(entry(v)).success,
+        `RevokedKeyEntrySchema ${JSON.stringify(v).slice(0, 40)}`
+      ).toBe(cryptoIsValidKid(v));
+    }
+  });
+
+  it('applies no normalization, trimming, case folding or character-class policy', () => {
+    // Accepted exactly as supplied; the two Unicode forms stay distinct values.
+    for (const v of ['Key', 'key', '\u00e9', 'e\u0301', '  padded  ', 'a\u0000b', '\u200b']) {
+      expect(RevokedKeyEntrySchema.safeParse(entry(v)).success, JSON.stringify(v)).toBe(true);
+      const parsed = RevokedKeyEntrySchema.parse(entry(v));
+      expect(parsed.kid, `unmodified ${JSON.stringify(v)}`).toBe(v);
+    }
+    expect(utf8ByteLength('\u00e9')).toBe(2);
+    expect(utf8ByteLength('e\u0301')).toBe(3);
   });
 
   it('computes identical byte lengths for well-formed vectors', () => {

--- a/packages/schema/__tests__/issuer-config-kid.test.ts
+++ b/packages/schema/__tests__/issuer-config-kid.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Revoked-key `kid` semantics: the issuer-config schema accepts exactly the canonical JWS `kid`
+ * domain (non-empty, well-formed Unicode, at most 256 UTF-8 bytes).
+ *
+ * The parity suite runs the same vectors through the schema-private predicate and the canonical
+ * `@peac/crypto` implementation (imported by source path: the schema package cannot depend on a
+ * higher layer), so a divergence in either implementation fails here.
+ */
+import { describe, it, expect } from 'vitest';
+import { RevokedKeyEntrySchema } from '../src/issuer-config';
+import {
+  MAX_KID_UTF8_BYTES,
+  isValidKid,
+  isWellFormedUnicode,
+  utf8ByteLength,
+} from '../src/internal/kid';
+import {
+  MAX_KID_UTF8_BYTES as CRYPTO_MAX,
+  isValidKid as cryptoIsValidKid,
+  utf8ByteLength as cryptoUtf8ByteLength,
+} from '../../crypto/src/kid';
+
+const encoder = new TextEncoder();
+
+/** A string of exactly `n` UTF-8 bytes built from code points of the given encoded width. */
+function kidOfBytes(n: number, width: 1 | 2 | 3 | 4): string {
+  const ch = width === 1 ? 'a' : width === 2 ? 'é' : width === 3 ? '€' : '\u{1F600}';
+  const whole = Math.floor(n / width);
+  let s = ch.repeat(whole);
+  s += 'a'.repeat(n - whole * width);
+  expect(encoder.encode(s).length).toBe(n);
+  return s;
+}
+
+const entry = (kid: string) => ({ kid, revoked_at: '2026-02-28T12:00:00Z' });
+
+describe('revoked-key kid accepts the canonical JWS domain', () => {
+  it.each([1, 2, 3, 4] as const)('accepts 255 and 256 bytes of %i-byte code points', (width) => {
+    for (const n of [255, 256]) {
+      const kid = kidOfBytes(n, width);
+      expect(RevokedKeyEntrySchema.safeParse(entry(kid)).success, `${width}-byte x ${n}`).toBe(
+        true
+      );
+    }
+  });
+
+  it.each([1, 2, 3, 4] as const)('rejects 257 bytes of %i-byte code points', (width) => {
+    const kid = kidOfBytes(257, width);
+    expect(RevokedKeyEntrySchema.safeParse(entry(kid)).success).toBe(false);
+  });
+
+  it('rejects what string-length counting used to accept', () => {
+    // 200 astral code points: 200 UTF-16 length pairs under the old max(256), 800 UTF-8 bytes.
+    const kid = '\u{1F600}'.repeat(200);
+    expect(kid.length).toBeLessThanOrEqual(256 + 256);
+    expect(encoder.encode(kid).length).toBe(800);
+    expect(RevokedKeyEntrySchema.safeParse(entry(kid)).success).toBe(false);
+  });
+
+  it('rejects malformed surrogates', () => {
+    for (const kid of ['\ud800', '\udc00', 'a\ud800z', 'a\udc00', '\ud800'.repeat(2), 'ok\ud83d']) {
+      expect(RevokedKeyEntrySchema.safeParse(entry(kid)).success, JSON.stringify(kid)).toBe(false);
+    }
+  });
+
+  it('accepts combining sequences and counts their bytes as supplied', () => {
+    const combining = 'é'; // 3 UTF-8 bytes, not normalized
+    expect(utf8ByteLength(combining)).toBe(3);
+    const kid = combining.repeat(85) + 'a'; // 256 bytes exactly
+    expect(encoder.encode(kid).length).toBe(256);
+    expect(RevokedKeyEntrySchema.safeParse(entry(kid)).success).toBe(true);
+    expect(RevokedKeyEntrySchema.safeParse(entry(kid + 'a')).success).toBe(false);
+  });
+
+  it('rejects the empty string and non-strings', () => {
+    expect(RevokedKeyEntrySchema.safeParse(entry('')).success).toBe(false);
+    expect(
+      RevokedKeyEntrySchema.safeParse({ kid: 42, revoked_at: '2026-02-28T12:00:00Z' }).success
+    ).toBe(false);
+  });
+});
+
+describe('parity with the canonical crypto implementation', () => {
+  const vectors: string[] = [
+    'key-2026-01',
+    'a',
+    kidOfBytes(255, 1),
+    kidOfBytes(256, 1),
+    kidOfBytes(257, 1),
+    kidOfBytes(255, 2),
+    kidOfBytes(256, 2),
+    kidOfBytes(257, 2),
+    kidOfBytes(255, 3),
+    kidOfBytes(256, 3),
+    kidOfBytes(257, 3),
+    kidOfBytes(255, 4),
+    kidOfBytes(256, 4),
+    kidOfBytes(257, 4),
+    '',
+    'é'.repeat(85) + 'a',
+    'é'.repeat(86),
+    '\u{1F600}'.repeat(64),
+    '\u{1F600}'.repeat(64) + 'a',
+    '\ud800',
+    '\udc00',
+    'a\ud800z',
+    'a\udc00',
+    '𐀀', // well-formed pair
+    'ok\ud83d',
+  ];
+
+  it('shares the byte bound constant', () => {
+    expect(MAX_KID_UTF8_BYTES).toBe(CRYPTO_MAX);
+  });
+
+  it('accepts and rejects identically across the vector corpus', () => {
+    for (const v of vectors) {
+      expect(isValidKid(v), `isValidKid ${JSON.stringify(v).slice(0, 40)}`).toBe(
+        cryptoIsValidKid(v)
+      );
+    }
+  });
+
+  it('computes identical byte lengths for well-formed vectors', () => {
+    for (const v of vectors) {
+      if (!isWellFormedUnicode(v)) continue;
+      expect(utf8ByteLength(v)).toBe(cryptoUtf8ByteLength(v));
+      expect(utf8ByteLength(v)).toBe(encoder.encode(v).length);
+    }
+  });
+
+  it('both throw on malformed vectors', () => {
+    for (const v of vectors) {
+      if (isWellFormedUnicode(v)) continue;
+      expect(() => utf8ByteLength(v)).toThrow();
+      expect(() => cryptoUtf8ByteLength(v)).toThrow();
+    }
+  });
+});

--- a/packages/schema/src/internal/kid.ts
+++ b/packages/schema/src/internal/kid.ts
@@ -1,0 +1,57 @@
+/**
+ * The canonical `kid` rule: a non-empty, well-formed Unicode string whose UTF-8 serialization is
+ * at most MAX_KID_UTF8_BYTES bytes.
+ *
+ * Schema-private. The canonical implementation lives in `@peac/crypto` (`src/kid.ts`), which this
+ * package cannot import without inverting the package layering, so the rule is restated here and
+ * a behavioural parity test holds the two implementations identical.
+ */
+
+/** Maximum `kid` length, measured as UTF-8 bytes of the string's serialization. */
+export const MAX_KID_UTF8_BYTES = 256;
+
+/** True when every surrogate in `s` belongs to a well-formed pair. */
+export function isWellFormedUnicode(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c >= 0xd800 && c <= 0xdbff) {
+      const next = i + 1 < s.length ? s.charCodeAt(i + 1) : 0;
+      if (next < 0xdc00 || next > 0xdfff) return false;
+      i++;
+    } else if (c >= 0xdc00 && c <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * UTF-8 byte length of a well-formed string. Throws on malformed UTF-16 rather than returning a
+ * number, so a caller cannot accept a string on length grounds when it cannot be encoded at all.
+ */
+export function utf8ByteLength(s: string): number {
+  let n = 0;
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c < 0x80) n += 1;
+    else if (c < 0x800) n += 2;
+    else if (c >= 0xd800 && c <= 0xdbff) {
+      const next = i + 1 < s.length ? s.charCodeAt(i + 1) : 0;
+      if (next < 0xdc00 || next > 0xdfff) {
+        throw new TypeError('utf8ByteLength: unpaired high surrogate');
+      }
+      n += 4;
+      i++;
+    } else if (c >= 0xdc00 && c <= 0xdfff) {
+      throw new TypeError('utf8ByteLength: unpaired low surrogate');
+    } else n += 3;
+  }
+  return n;
+}
+
+/** The complete canonical `kid` rule. */
+export function isValidKid(kid: unknown): kid is string {
+  if (typeof kid !== 'string' || kid.length === 0) return false;
+  if (!isWellFormedUnicode(kid)) return false;
+  return utf8ByteLength(kid) <= MAX_KID_UTF8_BYTES;
+}

--- a/packages/schema/src/internal/kid.ts
+++ b/packages/schema/src/internal/kid.ts
@@ -1,10 +1,11 @@
 /**
- * The canonical `kid` rule: a non-empty, well-formed Unicode string whose UTF-8 serialization is
- * at most MAX_KID_UTF8_BYTES bytes.
+ * The PEAC `kid` rule: a non-empty, well-formed Unicode string whose UTF-8 serialization is at
+ * most MAX_KID_UTF8_BYTES bytes. RFC 7515 leaves the structure of `kid` unspecified; the bound
+ * and well-formedness requirements are PEAC application-level constraints.
  *
- * Schema-private. The canonical implementation lives in `@peac/crypto` (`src/kid.ts`), which this
- * package cannot import without inverting the package layering, so the rule is restated here and
- * a behavioural parity test holds the two implementations identical.
+ * Schema-private. The authoritative implementation lives in `@peac/crypto` (`src/kid.ts`), which
+ * this package cannot import without inverting the package layering, so the rule is restated here
+ * and a behavioural parity test holds the two implementations identical.
  */
 
 /** Maximum `kid` length, measured as UTF-8 bytes of the string's serialization. */
@@ -49,7 +50,7 @@ export function utf8ByteLength(s: string): number {
   return n;
 }
 
-/** The complete canonical `kid` rule. */
+/** The complete PEAC `kid` rule. */
 export function isValidKid(kid: unknown): kid is string {
   if (typeof kid !== 'string' || kid.length === 0) return false;
   if (!isWellFormedUnicode(kid)) return false;

--- a/packages/schema/src/issuer-config.ts
+++ b/packages/schema/src/issuer-config.ts
@@ -28,7 +28,7 @@ export type RevocationReason = (typeof REVOCATION_REASONS)[number];
  */
 export const RevokedKeyEntrySchema = z
   .object({
-    /** Key ID that was revoked; same domain as canonical JWS kid validation */
+    /** Key ID that was revoked; same domain as PEAC JWS kid validation */
     kid: z.string().refine(isValidKid, {
       message: `kid must be a non-empty well-formed Unicode string of at most ${MAX_KID_UTF8_BYTES} UTF-8 bytes`,
     }),

--- a/packages/schema/src/issuer-config.ts
+++ b/packages/schema/src/issuer-config.ts
@@ -9,6 +9,7 @@
  */
 
 import { z } from 'zod';
+import { MAX_KID_UTF8_BYTES, isValidKid } from './internal/kid';
 
 /**
  * Revocation reasons: RFC 5280 CRLReason subset relevant to receipt signing keys.
@@ -27,8 +28,10 @@ export type RevocationReason = (typeof REVOCATION_REASONS)[number];
  */
 export const RevokedKeyEntrySchema = z
   .object({
-    /** Key ID that was revoked */
-    kid: z.string().min(1).max(256),
+    /** Key ID that was revoked; same domain as canonical JWS kid validation */
+    kid: z.string().refine(isValidKid, {
+      message: `kid must be a non-empty well-formed Unicode string of at most ${MAX_KID_UTF8_BYTES} UTF-8 bytes`,
+    }),
     /** ISO 8601 timestamp of revocation */
     revoked_at: z.string().datetime(),
     /** Revocation reason (optional, RFC 5280 CRLReason subset) */


### PR DESCRIPTION
## Summary

`RevokedKeyEntrySchema.kid` now matches PEAC's JWS `kid` validation: a non-empty, well-formed Unicode string whose UTF-8 serialization is at most 256 bytes. It previously used string-length validation, which counts UTF-16 code units and accepts malformed surrogates.

RFC 7515 defines `kid` as an optional case-sensitive string and leaves its structure unspecified. The 256-byte bound and well-formedness requirement are PEAC application-level constraints.

Closes #936.

## Change

A schema-private predicate implements the rule without introducing a schema-to-crypto dependency. Cross-package tests require the schema implementation, the public `RevokedKeyEntrySchema` surface and the `@peac/crypto` implementation to accept the same values.

## Validation

Boundary vectors cover 255/256/257 UTF-8 bytes across one- through four-byte code points, malformed surrogates, combining sequences, and values where UTF-16 code-unit counting differs from UTF-8 byte length. Vectors also pin the absence of normalization, trimming, case folding and character-class policy. Mutation tests verify that divergence at either implementation or at the schema integration is detected. Full repository suite passes.

## Semver

Patch-level correctness fix aligning issuer configuration with PEAC's existing JWS validation. Newly rejected values could not pass PEAC JWS validation.

## Scope

Schema validation, tests, and comment wording only. No wire format, cryptographic behavior, public API, package dependency or protocol-format change.
