### PR TITLE
fix(verifier): validate local verification across browser engines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -737,6 +737,39 @@ jobs:
   # Audit Gate (Windows), node-compat, and scope-guard remain separate checks
   # and are intentionally evaluated outside this aggregator.
   # ---------------------------------------------------------------------------
+  browser-matrix:
+    name: Verifier Browser Matrix
+    needs: detect-changes
+    if: >-
+      needs.detect-changes.outputs.verifier_ci == 'true' ||
+      github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/setup-env
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Build verifier
+        run: pnpm --filter @peac/app-verifier build
+
+      # Playwright is never a repository dependency; an exact release is installed into an
+      # isolated directory for this job only.
+      - name: Install browser tooling (isolated)
+        run: |
+          DEPS="$RUNNER_TEMP/browser-deps"
+          mkdir -p "$DEPS"
+          cd "$DEPS"
+          pnpm init > /dev/null
+          pnpm add playwright@1.62.1
+          pnpm exec playwright install --with-deps chromium firefox webkit
+
+      - name: Browser matrix
+        run: node apps/verifier/tests/browser/run-browser-matrix.mjs --deps "$RUNNER_TEMP/browser-deps"
+
   ci:
     name: Build, Lint, Test
     needs:
@@ -750,6 +783,7 @@ jobs:
         examples-apps,
         pack-smoke,
         node-compat,
+        browser-matrix,
       ]
     if: always()
     runs-on: ubuntu-latest
@@ -765,6 +799,7 @@ jobs:
           echo "examples-apps: ${{ needs.examples-apps.result }}"
           echo "pack-smoke:    ${{ needs.pack-smoke.result }}"
           echo "node-compat:   ${{ needs.node-compat.result }}"
+          echo "browser-matrix: ${{ needs.browser-matrix.result }}"
 
           # workflow-lint: always required, must succeed
           if [[ "${{ needs.workflow-lint.result }}" != "success" ]]; then
@@ -814,6 +849,15 @@ jobs:
           # so without this the aggregate could stay green while the verifier never ran.
           if [[ "${{ needs.detect-changes.outputs.verifier_ci }}" == "true" && "${{ needs.examples-apps.result }}" != "success" ]]; then
             echo "FAIL: verifier-affecting paths changed but the verifier lane did not succeed (result: ${{ needs.examples-apps.result }})"; exit 1
+          fi
+
+          # browser-matrix: same activation rule as the verifier lane. A failure always blocks;
+          # when verifier-affecting paths changed the matrix must have actually succeeded.
+          if [[ "${{ needs.browser-matrix.result }}" == "failure" || "${{ needs.browser-matrix.result }}" == "cancelled" ]]; then
+            echo "FAIL: browser-matrix failed"; exit 1
+          fi
+          if [[ "${{ needs.detect-changes.outputs.verifier_ci }}" == "true" && "${{ needs.browser-matrix.result }}" != "success" ]]; then
+            echo "FAIL: verifier-affecting paths changed but the browser matrix did not succeed (result: ${{ needs.browser-matrix.result }})"; exit 1
           fi
 
           # node-compat: the runtime compatibility matrix. Membership in `needs` alone does

--- a/apps/verifier/README.md
+++ b/apps/verifier/README.md
@@ -1,58 +1,67 @@
 # @peac/app-verifier
 
-Browser-based PEAC receipt verifier. Pure client-side: no server, all verification runs locally.
+Browser-based PEAC record verifier. A user supplies a compact PEAC record, the public key
+material (JWK or JWKS) and optional verification expectations; verification runs entirely in the
+browser with `verifyLocal()` from `@peac/protocol`. The application performs no network requests
+after loading, stores nothing, registers no service worker, and renders claims only after a
+signature verifies.
 
-## Quick Start
+## Quick start
 
 ```bash
 pnpm install
-pnpm dev
-# Opens on http://localhost:5173
+pnpm build            # workspace packages first
+pnpm --filter @peac/app-verifier dev
 ```
 
 Build for production:
 
 ```bash
-pnpm build
-# Static output in dist/ -- deploy anywhere
+pnpm --filter @peac/app-verifier build
+# Static output in dist/
 ```
 
-## How It Works
+## Verification model
 
-The verifier uses `verifyLocal()` from `@peac/protocol` to verify receipt signatures entirely in the browser. No receipts are sent to any server.
+- The supplied key document is the only key material; nothing is fetched or persisted.
+- Results distinguish signature validity, record validation, trusted-key expectation and claim
+  constraints; claims are shown only on success.
+- A supplied trusted JWK thumbprint is the only trust anchor. Issuer, key id and record type
+  expectations are claim constraints, not trust anchors.
+- Reports are deterministic and unsigned; identical inputs produce identical assessments.
 
-### Verification Flow
+## Browser support
 
-1. Paste a JWS receipt or upload a file (.jwt, .jws, .json)
-2. The app decodes the JWS header to extract `kid` (key ID)
-3. Looks up the key in the local trust store
-4. Verifies the Ed25519 signature using `verifyLocal()`
-5. Displays claims breakdown with VALID/INVALID status
+| Tier                            | Coverage                                                                       |
+| ------------------------------- | ------------------------------------------------------------------------------ |
+| Continuously tested engines     | Current Chromium, Firefox and WebKit via the browser matrix below              |
+| Release-smoke tested            | Chrome Stable and Safari Stable before a release; Edge Stable as a light smoke |
+| Mobile-smoke tested             | Mobile Safari and Mobile Chrome emulation profiles                             |
+| Other Chromium-derived browsers | Expected to work; not individually certified                                   |
 
-## Features
+WebCrypto is a secure-context API: serve the application over HTTPS (or localhost during
+development). A runtime without WebCrypto Ed25519 receives a capability message and a disabled
+verify control rather than a verification failure.
 
-- **Paste and verify**: Textarea input for JWS receipts
-- **File upload**: Drag-and-drop support for .jwt, .jws, .json files
-- **Trust configuration**: Add/remove trusted issuers and public keys via the UI
-- **Offline mode**: Service worker caches the app shell for offline use
-- **Claims display**: Formatted breakdown of all record claims
+## Browser matrix
 
-## Trust Store
+```bash
+pnpm --filter @peac/app-verifier build
+node apps/verifier/tests/browser/run-browser-matrix.mjs --deps <playwright-install-root>
+```
 
-The verifier maintains a local trust store in `localStorage`. You must add trusted issuer public keys before verification will succeed.
+The matrix drives the production build through Chromium, Firefox and WebKit plus mobile
+emulation, and asserts the verification flows, deterministic results, input-snapshot binding,
+the capability path, zero network requests during verification, zero persistence and an
+eval-free bundle. Playwright is provided externally and is never a repository dependency;
+`tests/browser-matrix-wiring.test.ts` verifies the contract shape in ordinary CI.
 
-To verify sandbox receipts:
+## Deployment notes
 
-1. Open the Trust Configuration tab
-2. Add the sandbox issuer public key (from `https://sandbox.peacprotocol.org/.well-known/jwks.json`)
-
-## Architecture
-
-- Pure static site built with Vite
-- No API calls, no Hono, no server component
-- All verification via `verifyLocal()` in-browser
-- Service worker (`public/sw.js`) caches app shell
-- Trust store persisted in `localStorage`
+- Serve over HTTPS with `frame-ancestors 'none'` (HTTP header; user agents ignore it in a meta
+  tag) and `X-Frame-Options: DENY`.
+- An origin that previously served a service worker must ship an unregistration path; deleting
+  the worker file does not remove an existing registration.
 
 ## License
 

--- a/apps/verifier/README.md
+++ b/apps/verifier/README.md
@@ -30,18 +30,19 @@ pnpm --filter @peac/app-verifier build
   expectations are claim constraints, not trust anchors.
 - Reports are deterministic and unsigned; identical inputs produce identical assessments.
 
-## Browser support
+## Browser support and validation
 
-| Tier                            | Coverage                                                                       |
-| ------------------------------- | ------------------------------------------------------------------------------ |
-| Continuously tested engines     | Current Chromium, Firefox and WebKit via the browser matrix below              |
-| Release-smoke tested            | Chrome Stable and Safari Stable before a release; Edge Stable as a light smoke |
-| Mobile-smoke tested             | Mobile Safari and Mobile Chrome emulation profiles                             |
-| Other Chromium-derived browsers | Expected to work; not individually certified                                   |
+| Category                        | Coverage                                                            |
+| ------------------------------- | ------------------------------------------------------------------- |
+| Automated compatibility matrix  | Chromium, Firefox and WebKit against the production build           |
+| Release validation requirement  | Chrome Stable, Safari Stable and Edge Stable                        |
+| Mobile compatibility matrix     | Mobile Safari and Mobile Chrome emulation                           |
+| Other Chromium-derived browsers | Expected to work from the shared engine; not individually validated |
 
-WebCrypto is a secure-context API: serve the application over HTTPS (or localhost during
-development). A runtime without WebCrypto Ed25519 receives a capability message and a disabled
-verify control rather than a verification failure.
+WebCrypto is a secure-context API: production deployments use HTTPS; loopback origins serve
+local development and testing, where user agents treat them as trustworthy. A runtime without
+WebCrypto Ed25519 receives a capability message and a disabled verify control rather than a
+verification failure. Application console errors fail the matrix.
 
 ## Browser matrix
 

--- a/apps/verifier/README.md
+++ b/apps/verifier/README.md
@@ -28,7 +28,7 @@ pnpm --filter @peac/app-verifier build
   constraints; claims are shown only on success.
 - A supplied trusted JWK thumbprint is the only trust anchor. Issuer, key id and record type
   expectations are claim constraints, not trust anchors.
-- Reports are deterministic and unsigned; identical inputs produce identical assessments.
+- Reports are deterministic and unsigned; identical verification inputs and evaluation time produce byte-identical reports.
 
 ## Browser support and validation
 

--- a/apps/verifier/src/lib/runtime-support.ts
+++ b/apps/verifier/src/lib/runtime-support.ts
@@ -10,9 +10,9 @@
  */
 
 // RFC 8032 section 7.1, TEST 2 (one-byte message 0x72). Deliberately NOT the empty-message
-// TEST 1: at least one WebCrypto implementation rejects Ed25519 verification of zero-length
-// messages while verifying every non-empty message correctly, and a PEAC signing input is never
-// empty, so an empty-message probe would misreport a capable runtime as unsupported.
+// TEST 1: zero-length Ed25519 verification is not portable across the supported WebCrypto
+// runtimes measured for this profile, and a PEAC JWS signing input is never empty, so an
+// empty-message probe would misreport a capable runtime as unsupported.
 const RFC8032_VECTOR2_PUBLIC_KEY =
   '3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c';
 const RFC8032_VECTOR2_SIGNATURE =

--- a/apps/verifier/src/lib/runtime-support.ts
+++ b/apps/verifier/src/lib/runtime-support.ts
@@ -9,11 +9,15 @@
  * Memoized: the probe runs ONCE. Concurrent initialization shares the in-flight promise.
  */
 
-// RFC 8032 section 7.1, TEST 1 (empty message).
-const RFC8032_VECTOR1_PUBLIC_KEY =
-  'd75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a';
-const RFC8032_VECTOR1_SIGNATURE =
-  'e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b';
+// RFC 8032 section 7.1, TEST 2 (one-byte message 0x72). Deliberately NOT the empty-message
+// TEST 1: at least one WebCrypto implementation rejects Ed25519 verification of zero-length
+// messages while verifying every non-empty message correctly, and a PEAC signing input is never
+// empty, so an empty-message probe would misreport a capable runtime as unsupported.
+const RFC8032_VECTOR2_PUBLIC_KEY =
+  '3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c';
+const RFC8032_VECTOR2_SIGNATURE =
+  '92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da085ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00';
+const RFC8032_VECTOR2_MESSAGE = '72';
 
 function hexToBytes(hex: string): Uint8Array {
   const out = new Uint8Array(hex.length / 2);
@@ -29,7 +33,7 @@ async function probe(): Promise<boolean> {
   try {
     const key = await subtle.importKey(
       'raw',
-      hexToBytes(RFC8032_VECTOR1_PUBLIC_KEY) as BufferSource,
+      hexToBytes(RFC8032_VECTOR2_PUBLIC_KEY) as BufferSource,
       { name: 'Ed25519' },
       false,
       ['verify']
@@ -37,8 +41,8 @@ async function probe(): Promise<boolean> {
     return await subtle.verify(
       { name: 'Ed25519' },
       key,
-      hexToBytes(RFC8032_VECTOR1_SIGNATURE) as BufferSource,
-      new Uint8Array(0) as BufferSource
+      hexToBytes(RFC8032_VECTOR2_SIGNATURE) as BufferSource,
+      hexToBytes(RFC8032_VECTOR2_MESSAGE) as BufferSource
     );
   } catch {
     // NotSupportedError, or any failure verifying the known-good vector, means this runtime cannot

--- a/apps/verifier/tests/browser-matrix-wiring.test.ts
+++ b/apps/verifier/tests/browser-matrix-wiring.test.ts
@@ -1,71 +1,37 @@
 /**
- * Static wiring of the browser matrix runner.
+ * Static invariants of the browser-matrix contract.
  *
- * The matrix itself needs external browser installations, so ordinary CI verifies the contract
- * shape instead: the runner exists, refuses to run without a build, covers the required flows
- * and assertions, and Playwright is not a dependency of any workspace package.
+ * Behavior is proven by executing the matrix in CI; this file pins only what execution cannot
+ * prove cheaply: the runner exists and refuses to run unbuilt, Playwright is not a dependency of
+ * any workspace package, and the CI lane that runs the matrix is activated and required.
  */
 import { describe, it, expect } from 'vitest';
-import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { readFileSync, existsSync, statSync, globSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
 const APP_ROOT = resolve(__dirname, '..');
 const REPO_ROOT = resolve(APP_ROOT, '..', '..');
 const RUNNER = join(APP_ROOT, 'tests', 'browser', 'run-browser-matrix.mjs');
-const source = readFileSync(RUNNER, 'utf8');
+const CI = readFileSync(join(REPO_ROOT, '.github', 'workflows', 'ci.yml'), 'utf8');
 
 describe('the browser matrix runner', () => {
   it('exists and refuses to run without a build', () => {
+    const source = readFileSync(RUNNER, 'utf8');
     expect(source).toContain("existsSync(join(DIST, 'index.html'))");
     expect(source).toContain('process.exit(2)');
   });
 
-  it.each([
-    'accept-bare-jwk',
-    'accept-jwks-selection',
-    'accept-unicode-kid',
-    'trusted-key-match',
-    'wrong-key',
-    'tamper',
-    'malformed-record',
-    'malformed-key',
-    'oversized-record',
-    'trusted-key-mismatch',
-  ])('covers the %s flow', (id) => {
-    expect(source).toContain(`'${id}'`);
-  });
-
-  it.each([
-    ['determinism', 'determinism:'],
-    ['input-snapshot binding', 'input-snapshot:'],
-    ['capability path', 'runCapabilityCheck'],
-    ['network prohibition', 'network request(s)'],
-    ['localStorage', 'localStorage'],
-    ['sessionStorage', 'sessionStorage'],
-    ['IndexedDB', 'indexedDb'],
-    ['CacheStorage', 'caches'],
-    ['service workers', 'serviceWorkers'],
-    ['bundle eval scan', 'scanBundles'],
-  ])('asserts %s', (_label, marker) => {
-    expect(source).toContain(marker);
-  });
-
-  it('targets all three engines and both mobile profiles by default', () => {
-    expect(source).toContain('chromium,firefox,webkit');
-    expect(source).toContain('iPhone');
-    expect(source).toContain('Pixel');
-  });
-
-  it('is never satisfied by a repository Playwright dependency', () => {
-    const manifests: string[] = [join(REPO_ROOT, 'package.json')];
-    for (const dir of ['packages', 'apps']) {
-      const root = join(REPO_ROOT, dir);
-      if (!existsSync(root)) continue;
-      for (const name of readdirSync(root)) {
-        const manifest = join(root, name, 'package.json');
+  it('is never satisfied by a workspace Playwright dependency', () => {
+    const workspace = readFileSync(join(REPO_ROOT, 'pnpm-workspace.yaml'), 'utf8');
+    const globs = [...workspace.matchAll(/- '([^']+)'/g)].map((m) => m[1]);
+    const manifests = [join(REPO_ROOT, 'package.json')];
+    for (const pattern of globs) {
+      for (const dir of globSync(pattern, { cwd: REPO_ROOT })) {
+        const manifest = join(REPO_ROOT, dir, 'package.json');
         if (existsSync(manifest) && statSync(manifest).isFile()) manifests.push(manifest);
       }
     }
+    expect(manifests.length).toBeGreaterThan(30);
     for (const manifest of manifests) {
       const parsed = JSON.parse(readFileSync(manifest, 'utf8')) as Record<
         string,
@@ -78,5 +44,32 @@ describe('the browser matrix runner', () => {
         ).not.toContain('playwright');
       }
     }
+  });
+});
+
+describe('the browser matrix CI lane', () => {
+  it('exists, builds the app, and runs the runner against an isolated installation', () => {
+    expect(CI).toContain('browser-matrix:');
+    expect(CI).toContain('pnpm --filter @peac/app-verifier build');
+    expect(CI).toContain('run-browser-matrix.mjs --deps');
+  });
+
+  it('pins an exact stable Playwright release', () => {
+    const pins = [...CI.matchAll(/playwright@(\S+)/g)].map((m) => m[1]);
+    expect(pins.length).toBeGreaterThan(0);
+    for (const pin of pins) {
+      expect(pin, 'exact release, no range or pre-release tag').toMatch(/^\d+\.\d+\.\d+$/);
+    }
+  });
+
+  it('activates on verifier-affecting paths and is required by the aggregate', () => {
+    const job = CI.slice(CI.indexOf('browser-matrix:'), CI.indexOf('\n  ci:'));
+    expect(job).toContain("needs.detect-changes.outputs.verifier_ci == 'true'");
+    const aggregate = CI.slice(CI.indexOf('\n  ci:'));
+    expect(aggregate).toContain('browser-matrix,');
+    expect(aggregate).toContain('needs.browser-matrix.result');
+    expect(aggregate).toMatch(
+      /verifier_ci }}" == "true" && "\$\{\{ needs\.browser-matrix\.result }}" != "success"/
+    );
   });
 });

--- a/apps/verifier/tests/browser-matrix-wiring.test.ts
+++ b/apps/verifier/tests/browser-matrix-wiring.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Static wiring of the browser matrix runner.
+ *
+ * The matrix itself needs external browser installations, so ordinary CI verifies the contract
+ * shape instead: the runner exists, refuses to run without a build, covers the required flows
+ * and assertions, and Playwright is not a dependency of any workspace package.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const APP_ROOT = resolve(__dirname, '..');
+const REPO_ROOT = resolve(APP_ROOT, '..', '..');
+const RUNNER = join(APP_ROOT, 'tests', 'browser', 'run-browser-matrix.mjs');
+const source = readFileSync(RUNNER, 'utf8');
+
+describe('the browser matrix runner', () => {
+  it('exists and refuses to run without a build', () => {
+    expect(source).toContain("existsSync(join(DIST, 'index.html'))");
+    expect(source).toContain('process.exit(2)');
+  });
+
+  it.each([
+    'accept-bare-jwk',
+    'accept-jwks-selection',
+    'accept-unicode-kid',
+    'trusted-key-match',
+    'wrong-key',
+    'tamper',
+    'malformed-record',
+    'malformed-key',
+    'oversized-record',
+    'trusted-key-mismatch',
+  ])('covers the %s flow', (id) => {
+    expect(source).toContain(`'${id}'`);
+  });
+
+  it.each([
+    ['determinism', 'determinism:'],
+    ['input-snapshot binding', 'input-snapshot:'],
+    ['capability path', 'runCapabilityCheck'],
+    ['network prohibition', 'network request(s)'],
+    ['localStorage', 'localStorage'],
+    ['sessionStorage', 'sessionStorage'],
+    ['IndexedDB', 'indexedDb'],
+    ['CacheStorage', 'caches'],
+    ['service workers', 'serviceWorkers'],
+    ['bundle eval scan', 'scanBundles'],
+  ])('asserts %s', (_label, marker) => {
+    expect(source).toContain(marker);
+  });
+
+  it('targets all three engines and both mobile profiles by default', () => {
+    expect(source).toContain('chromium,firefox,webkit');
+    expect(source).toContain('iPhone');
+    expect(source).toContain('Pixel');
+  });
+
+  it('is never satisfied by a repository Playwright dependency', () => {
+    const manifests: string[] = [join(REPO_ROOT, 'package.json')];
+    for (const dir of ['packages', 'apps']) {
+      const root = join(REPO_ROOT, dir);
+      if (!existsSync(root)) continue;
+      for (const name of readdirSync(root)) {
+        const manifest = join(root, name, 'package.json');
+        if (existsSync(manifest) && statSync(manifest).isFile()) manifests.push(manifest);
+      }
+    }
+    for (const manifest of manifests) {
+      const parsed = JSON.parse(readFileSync(manifest, 'utf8')) as Record<
+        string,
+        Record<string, string> | undefined
+      >;
+      for (const section of ['dependencies', 'devDependencies', 'optionalDependencies']) {
+        expect(
+          Object.keys(parsed[section] ?? {}),
+          `${manifest} must not depend on playwright`
+        ).not.toContain('playwright');
+      }
+    }
+  });
+});

--- a/apps/verifier/tests/browser/run-browser-matrix.mjs
+++ b/apps/verifier/tests/browser/run-browser-matrix.mjs
@@ -2,16 +2,17 @@
  * Browser matrix for the built verifier application.
  *
  * Drives the production build through Chromium, Firefox and WebKit, plus mobile emulation
- * profiles, and asserts per engine: the verification flow contract, deterministic results,
- * input-snapshot binding, the capability error path, zero network requests caused by
- * verification, zero persistence (localStorage, sessionStorage, IndexedDB, CacheStorage,
- * service workers), and no console errors. The served bundles are also scanned for dynamic
- * code evaluation, which the application must not contain.
+ * profiles, and asserts per engine: the verification flow contract, deterministic report
+ * output, input-snapshot behavior under asynchronous reads, the file-input path, the
+ * capability error path, zero network requests caused by verification, zero persistence
+ * attempts and zero residual persistence (localStorage, sessionStorage, IndexedDB,
+ * CacheStorage, service workers), and no application console errors. The served bundles are
+ * scanned for dynamic code evaluation, which the application must not contain.
  *
  * Playwright is never a repository dependency. Provide an external installation:
  *
  *   mkdir -p /tmp/peac-browser-deps && cd /tmp/peac-browser-deps
- *   pnpm init && pnpm add playwright
+ *   pnpm init && pnpm add playwright@<exact-stable>
  *   pnpm exec playwright install chromium firefox webkit
  *
  * Usage:
@@ -22,13 +23,13 @@
  * Fixtures are issued per run with the real issuing API; no key material is committed.
  */
 import { createServer } from 'node:http';
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { dirname, extname, join, normalize, resolve } from 'node:path';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, extname, join, normalize, relative, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const SELF = fileURLToPath(import.meta.url);
 const APP_ROOT = resolve(dirname(SELF), '..', '..');
-const DIST = join(APP_ROOT, 'dist');
+const DIST = resolve(APP_ROOT, 'dist');
 
 const args = process.argv.slice(2);
 const opt = (name, fallback) => {
@@ -45,7 +46,7 @@ const skipMobile = args.includes('--skip-mobile');
 const SETUP =
   'external Playwright installation required:\n' +
   '  mkdir -p /tmp/peac-browser-deps && cd /tmp/peac-browser-deps\n' +
-  '  pnpm init && pnpm add playwright\n' +
+  '  pnpm init && pnpm add playwright@<exact-stable>\n' +
   '  pnpm exec playwright install chromium firefox webkit\n' +
   'then pass --deps /tmp/peac-browser-deps';
 
@@ -56,23 +57,28 @@ if (!existsSync(join(DIST, 'index.html'))) {
 }
 
 let playwright;
+let playwrightVersion = 'unknown';
 try {
   const specifier = depsRoot
     ? pathToFileURL(join(resolve(depsRoot), 'node_modules', 'playwright', 'index.js')).href
     : 'playwright';
   const pw = await import(specifier);
   playwright = pw.default ?? pw;
+  const manifest = depsRoot
+    ? join(resolve(depsRoot), 'node_modules', 'playwright', 'package.json')
+    : fileURLToPath(import.meta.resolve('playwright/package.json'));
+  playwrightVersion = JSON.parse(readFileSync(manifest, 'utf8')).version;
 } catch (err) {
   console.error(`run-browser-matrix: ${err.message}\n\n${SETUP}`);
   process.exit(2);
 }
+console.log(`playwright ${playwrightVersion} on node ${process.version}`);
 
-const { generateKeypair, base64urlEncode, computeJwkThumbprint } = await import('@peac/crypto');
+const { generateKeypair, base64urlEncode, base64urlDecode, computeJwkThumbprint } =
+  await import('@peac/crypto');
 const { issue } = await import('@peac/protocol');
 
 // The application must not evaluate dynamic code; verified against the exact bundles served.
-// Automation tooling injects its own evaluated scripts, so console messages reporting a blocked
-// eval are excluded from the console-error assertion only because of this scan.
 function scanBundles() {
   const problems = [];
   const assets = join(DIST, 'assets');
@@ -84,7 +90,14 @@ function scanBundles() {
   }
   return problems;
 }
-const AUTOMATION_CONSOLE_PATTERN = /blocked a JavaScript eval/;
+
+// Firefox reports Playwright's own injected evaluation as a page CSP violation. The bundle scan
+// above proves the application ships no dynamic code, so exactly this diagnostic, in Firefox
+// only, is classified as an automation diagnostic; every other console error fails the run.
+const FIREFOX_AUTOMATION_DIAGNOSTIC =
+  /Content-Security-Policy.*blocked a JavaScript eval.*script-src/;
+
+const LIMITS = { record: 64 * 1024, key: 128 * 1024, context: 8 * 1024 };
 
 async function makeFixtures() {
   const kid = 'browser-matrix-k1';
@@ -123,20 +136,29 @@ async function makeFixtures() {
     x: otherJwk.x,
   });
 
+  // Tamper by flipping one decoded payload byte and re-encoding, keeping the signature, so the
+  // signed bytes provably change.
   const segments = issued.jws.split('.');
-  const payload = segments[1];
-  const flipped = payload.slice(0, -1) + (payload.at(-1) === 'A' ? 'B' : 'A');
+  const payloadBytes = base64urlDecode(segments[1]);
+  const tamperedBytes = Uint8Array.from(payloadBytes);
+  tamperedBytes[0] ^= 0x01;
+  if (Buffer.from(payloadBytes).equals(Buffer.from(tamperedBytes))) {
+    throw new Error('tamper fixture failed to change the signed bytes');
+  }
+  const tampered = [segments[0], base64urlEncode(tamperedBytes), segments[2]].join('.');
 
   return {
     record: issued.jws,
     unicodeRecord: unicodeIssued.jws,
-    tampered: [segments[0], flipped, segments[2]].join('.'),
-    oversizedRecord: 'a'.repeat(64 * 1024 + 1),
+    tampered,
     bareJwk: JSON.stringify(jwk),
     jwks: JSON.stringify({ keys: [otherJwk, jwk] }),
     unicodeJwks: JSON.stringify({ keys: [otherJwk, unicodeJwk] }),
     wrongKey: JSON.stringify(otherJwk),
     malformedKey: '{ not json',
+    oversizedRecord: 'a'.repeat(LIMITS.record + 1),
+    oversizedKey: 'a'.repeat(LIMITS.key + 1),
+    oversizedContext: 'a'.repeat(LIMITS.context + 1),
     trustMatch: JSON.stringify({
       contextVersion: '1',
       trust: { trustedJwkThumbprints: [thumbprint] },
@@ -168,6 +190,14 @@ function flows(f) {
     { id: 'malformed-record', record: 'not-a-compact-jws', key: f.bareJwk, heading: REJECT },
     { id: 'malformed-key', record: f.record, key: f.malformedKey, heading: REJECT },
     { id: 'oversized-record', record: f.oversizedRecord, key: f.bareJwk, heading: REJECT },
+    { id: 'oversized-key', record: f.record, key: f.oversizedKey, heading: REJECT },
+    {
+      id: 'oversized-context',
+      record: f.record,
+      key: f.bareJwk,
+      context: f.oversizedContext,
+      heading: REJECT,
+    },
     {
       id: 'trusted-key-mismatch',
       record: f.record,
@@ -192,8 +222,9 @@ const MIME = {
 function serveDist() {
   const server = createServer((req, res) => {
     const path = normalize(new URL(req.url, 'http://127.0.0.1').pathname).replace(/^\/+/, '');
-    const file = join(DIST, path === '' ? 'index.html' : path);
-    if (!file.startsWith(DIST) || !existsSync(file)) {
+    const file = resolve(DIST, path === '' ? 'index.html' : path);
+    const contained = !relative(DIST, file).startsWith('..');
+    if (!contained || !existsSync(file) || !statSync(file).isFile()) {
       res.writeHead(404).end();
       return;
     }
@@ -206,6 +237,32 @@ function serveDist() {
     });
   });
 }
+
+// Counts persistence ATTEMPTS from before application code runs; the observers never mutate the
+// surfaces they watch.
+const PERSISTENCE_OBSERVER = () => {
+  const counts = {
+    storageWrites: 0,
+    indexedDbOpens: 0,
+    cacheOpens: 0,
+    serviceWorkerRegistrations: 0,
+  };
+  Object.defineProperty(globalThis, '__peacPersistenceAttempts', { value: counts });
+  const wrap = (object, method, key) => {
+    if (!object || typeof object[method] !== 'function') return;
+    const original = object[method];
+    object[method] = function (...a) {
+      counts[key] += 1;
+      return original.apply(this, a);
+    };
+  };
+  wrap(Storage.prototype, 'setItem', 'storageWrites');
+  wrap(globalThis.indexedDB, 'open', 'indexedDbOpens');
+  if (globalThis.caches) wrap(globalThis.caches, 'open', 'cacheOpens');
+  if (navigator.serviceWorker) {
+    wrap(navigator.serviceWorker, 'register', 'serviceWorkerRegistrations');
+  }
+};
 
 async function runFlow(page, flow) {
   await page.fill('#record', '');
@@ -224,21 +281,93 @@ async function runFlow(page, flow) {
   };
 }
 
-async function assessmentText(page) {
-  return page.locator('section dl').first().textContent();
+async function reportJson(page) {
+  const pre = page.locator('section pre').first();
+  await pre.waitFor({ state: 'visible', timeout: 15000 });
+  return pre.textContent();
 }
 
-async function runSession(page, fixtures, origin, flowIds) {
+// Identical inputs must produce a byte-identical report, including its hash. The evaluation
+// time is a declared report input, so equality is asserted on a pair of runs that share it.
+async function checkDeterministicReport(page, flow, problems) {
+  for (let attempt = 0; attempt < 6; attempt++) {
+    await runFlow(page, flow);
+    const first = await reportJson(page);
+    await runFlow(page, flow);
+    const second = await reportJson(page);
+    const a = JSON.parse(first);
+    const b = JSON.parse(second);
+    if (a.evaluationTimeUnixSeconds !== b.evaluationTimeUnixSeconds) continue;
+    if (first !== second) {
+      problems.push('determinism: identical inputs and evaluation time produced different reports');
+    }
+    if (!a.reportSha256 || a.reportSha256 !== b.reportSha256) {
+      problems.push('determinism: report hashes differ for identical inputs');
+    }
+    for (const key of Object.keys(a)) {
+      if (/userAgent|platform|locale|path|random/i.test(key)) {
+        problems.push(`determinism: environment-shaped field "${key}" in the report core`);
+      }
+    }
+    return;
+  }
+  problems.push('determinism: could not obtain two runs sharing an evaluation second');
+}
+
+// A pending asynchronous file read must not replace newer manual input.
+async function checkReadSupersession(page, fixtures, problems) {
+  const fileInput = page.locator('input[type=file]').first();
+  await fileInput.setInputFiles({
+    name: 'record.jws',
+    mimeType: 'application/jose',
+    buffer: Buffer.from(fixtures.tampered),
+  });
+  await page.fill('#record', fixtures.record);
+  await page.waitForTimeout(250);
+  const value = await page.inputValue('#record');
+  if (value !== fixtures.record) {
+    problems.push('supersession: an asynchronous file read replaced newer manual input');
+  }
+}
+
+// The file controls must feed the same verification path as pasted input.
+async function checkFileInput(page, fixtures, problems) {
+  await page.fill('#record', '');
+  await page.fill('#key', '');
+  await page.fill('#context', '');
+  await page
+    .locator('input[type=file]')
+    .first()
+    .setInputFiles({
+      name: 'record.jws',
+      mimeType: 'application/jose',
+      buffer: Buffer.from(fixtures.record),
+    });
+  await page.fill('#key', fixtures.bareJwk);
+  await page.waitForSelector('button:enabled', { timeout: 15000 });
+  await page.click('button:has-text("Verify")');
+  const heading = page.locator('section h2').first();
+  await heading.waitFor({ state: 'visible', timeout: 15000 });
+  const text = await heading.textContent();
+  if (text !== ACCEPT) problems.push(`file-input: expected "${ACCEPT}", saw "${text}"`);
+}
+
+async function runSession(engineName, page, fixtures, origin, flowIds) {
   const problems = [];
   const consoleErrors = [];
+  let automationDiagnostics = 0;
   page.on('pageerror', (err) => consoleErrors.push(String(err)));
   page.on('console', (m) => {
-    if (m.type() === 'error' && !AUTOMATION_CONSOLE_PATTERN.test(m.text())) {
-      consoleErrors.push(m.text());
+    if (m.type() !== 'error') return;
+    if (engineName === 'firefox' && FIREFOX_AUTOMATION_DIAGNOSTIC.test(m.text())) {
+      automationDiagnostics += 1;
+      return;
     }
+    consoleErrors.push(m.text());
   });
   const requests = [];
   page.on('request', (r) => requests.push(r.url()));
+  await page.addInitScript(PERSISTENCE_OBSERVER);
 
   await page.goto(`${origin}/`, { waitUntil: 'networkidle' });
   const requestsAfterLoad = requests.length;
@@ -259,19 +388,15 @@ async function runSession(page, fixtures, origin, flowIds) {
   }
 
   if (!flowIds) {
-    // Determinism: identical inputs render an identical assessment.
-    const first = flows(fixtures)[0];
-    await runFlow(page, first);
-    const a = await assessmentText(page);
-    await runFlow(page, first);
-    const b = await assessmentText(page);
-    if (a !== b) problems.push('determinism: two identical runs rendered different assessments');
+    await checkDeterministicReport(page, flows(fixtures)[0], problems);
 
-    // Input-snapshot binding: editing an input clears the displayed result.
-    await page.fill('#record', first.record + ' ');
+    await page.fill('#record', fixtures.record + ' ');
     const headings = await page.locator('section h2').count();
     if (headings !== 0)
       problems.push('input-snapshot: an edited input left a stale result visible');
+
+    await checkReadSupersession(page, fixtures, problems);
+    await checkFileInput(page, fixtures, problems);
   }
 
   if (requests.length !== requestsAfterLoad) {
@@ -281,6 +406,10 @@ async function runSession(page, fixtures, origin, flowIds) {
     );
   }
 
+  const attempts = await page.evaluate(() => globalThis.__peacPersistenceAttempts);
+  for (const [surface, count] of Object.entries(attempts ?? {})) {
+    if (count !== 0) problems.push(`persistence attempt: ${surface} = ${count}`);
+  }
   const persistence = await page.evaluate(async () => ({
     localStorage: window.localStorage.length,
     sessionStorage: window.sessionStorage.length,
@@ -293,7 +422,7 @@ async function runSession(page, fixtures, origin, flowIds) {
     if (count !== 0) problems.push(`persistence: ${surface} holds ${count} entr(ies)`);
   }
   for (const message of consoleErrors) problems.push(`console error: ${message}`);
-  return problems;
+  return { problems, automationDiagnostics };
 }
 
 // A runtime without WebCrypto Ed25519 must present a capability message, not a cryptic failure.
@@ -344,13 +473,18 @@ try {
     }
     const browser = await playwright[name].launch();
     const context = await browser.newContext();
-    const problems = await runSession(await context.newPage(), fixtures, origin);
-    problems.push(...(await runCapabilityCheck(browser, origin)));
+    const session = await runSession(name, await context.newPage(), fixtures, origin);
+    const problems = [...session.problems, ...(await runCapabilityCheck(browser, origin))];
+    const version = browser.version();
     await browser.close();
+    const diag = session.automationDiagnostics
+      ? `, ${session.automationDiagnostics} automation diagnostic(s) classified`
+      : '';
     report(
       name,
       problems,
-      `${flows(fixtures).length} flows + determinism + snapshot + capability, no network, no persistence`
+      `${version}; ${flows(fixtures).length} flows + report determinism + snapshot + ` +
+        `supersession + file input + capability; no network, no persistence attempts${diag}`
     );
   }
 
@@ -367,9 +501,15 @@ try {
       }
       const browser = await playwright[m.engine].launch();
       const context = await browser.newContext({ ...device });
-      const problems = await runSession(await context.newPage(), fixtures, origin, MOBILE_FLOW_IDS);
+      const session = await runSession(
+        m.engine,
+        await context.newPage(),
+        fixtures,
+        origin,
+        MOBILE_FLOW_IDS
+      );
       await browser.close();
-      report(m.label, problems, `${MOBILE_FLOW_IDS.join(', ')}`);
+      report(m.label, session.problems, MOBILE_FLOW_IDS.join(', '));
     }
   }
 } finally {

--- a/apps/verifier/tests/browser/run-browser-matrix.mjs
+++ b/apps/verifier/tests/browser/run-browser-matrix.mjs
@@ -23,7 +23,7 @@
  * Fixtures are issued per run with the real issuing API; no key material is committed.
  */
 import { createServer } from 'node:http';
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { closeSync, existsSync, fstatSync, openSync, readFileSync, readdirSync } from 'node:fs';
 import { dirname, extname, join, normalize, relative, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
@@ -223,13 +223,28 @@ function serveDist() {
   const server = createServer((req, res) => {
     const path = normalize(new URL(req.url, 'http://127.0.0.1').pathname).replace(/^\/+/, '');
     const file = resolve(DIST, path === '' ? 'index.html' : path);
-    const contained = !relative(DIST, file).startsWith('..');
-    if (!contained || !existsSync(file) || !statSync(file).isFile()) {
+    if (relative(DIST, file).startsWith('..')) {
       res.writeHead(404).end();
       return;
     }
-    res.writeHead(200, { 'content-type': MIME[extname(file)] ?? 'application/octet-stream' });
-    res.end(readFileSync(file));
+    // One descriptor for the type check and the read, so the file cannot change between them.
+    let fd;
+    try {
+      fd = openSync(file, 'r');
+    } catch {
+      res.writeHead(404).end();
+      return;
+    }
+    try {
+      if (!fstatSync(fd).isFile()) {
+        res.writeHead(404).end();
+        return;
+      }
+      res.writeHead(200, { 'content-type': MIME[extname(file)] ?? 'application/octet-stream' });
+      res.end(readFileSync(fd));
+    } finally {
+      closeSync(fd);
+    }
   });
   return new Promise((resolveServer) => {
     server.listen(0, '127.0.0.1', () => {

--- a/apps/verifier/tests/browser/run-browser-matrix.mjs
+++ b/apps/verifier/tests/browser/run-browser-matrix.mjs
@@ -1,0 +1,378 @@
+/**
+ * Browser matrix for the built verifier application.
+ *
+ * Drives the production build through Chromium, Firefox and WebKit, plus mobile emulation
+ * profiles, and asserts per engine: the verification flow contract, deterministic results,
+ * input-snapshot binding, the capability error path, zero network requests caused by
+ * verification, zero persistence (localStorage, sessionStorage, IndexedDB, CacheStorage,
+ * service workers), and no console errors. The served bundles are also scanned for dynamic
+ * code evaluation, which the application must not contain.
+ *
+ * Playwright is never a repository dependency. Provide an external installation:
+ *
+ *   mkdir -p /tmp/peac-browser-deps && cd /tmp/peac-browser-deps
+ *   pnpm init && pnpm add playwright
+ *   pnpm exec playwright install chromium firefox webkit
+ *
+ * Usage:
+ *   pnpm --filter @peac/app-verifier build
+ *   node apps/verifier/tests/browser/run-browser-matrix.mjs --deps /tmp/peac-browser-deps
+ *     [--engines chromium,firefox,webkit] [--skip-mobile]
+ *
+ * Fixtures are issued per run with the real issuing API; no key material is committed.
+ */
+import { createServer } from 'node:http';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, extname, join, normalize, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const SELF = fileURLToPath(import.meta.url);
+const APP_ROOT = resolve(dirname(SELF), '..', '..');
+const DIST = join(APP_ROOT, 'dist');
+
+const args = process.argv.slice(2);
+const opt = (name, fallback) => {
+  const i = args.indexOf(name);
+  return i >= 0 && args[i + 1] !== undefined ? args[i + 1] : fallback;
+};
+const depsRoot = opt('--deps', null);
+const engines = opt('--engines', 'chromium,firefox,webkit')
+  .split(',')
+  .map((e) => e.trim())
+  .filter(Boolean);
+const skipMobile = args.includes('--skip-mobile');
+
+const SETUP =
+  'external Playwright installation required:\n' +
+  '  mkdir -p /tmp/peac-browser-deps && cd /tmp/peac-browser-deps\n' +
+  '  pnpm init && pnpm add playwright\n' +
+  '  pnpm exec playwright install chromium firefox webkit\n' +
+  'then pass --deps /tmp/peac-browser-deps';
+
+if (!existsSync(join(DIST, 'index.html'))) {
+  console.error('run-browser-matrix: apps/verifier/dist is absent; build the app first:');
+  console.error('  pnpm --filter @peac/app-verifier build');
+  process.exit(2);
+}
+
+let playwright;
+try {
+  const specifier = depsRoot
+    ? pathToFileURL(join(resolve(depsRoot), 'node_modules', 'playwright', 'index.js')).href
+    : 'playwright';
+  const pw = await import(specifier);
+  playwright = pw.default ?? pw;
+} catch (err) {
+  console.error(`run-browser-matrix: ${err.message}\n\n${SETUP}`);
+  process.exit(2);
+}
+
+const { generateKeypair, base64urlEncode, computeJwkThumbprint } = await import('@peac/crypto');
+const { issue } = await import('@peac/protocol');
+
+// The application must not evaluate dynamic code; verified against the exact bundles served.
+// Automation tooling injects its own evaluated scripts, so console messages reporting a blocked
+// eval are excluded from the console-error assertion only because of this scan.
+function scanBundles() {
+  const problems = [];
+  const assets = join(DIST, 'assets');
+  for (const name of readdirSync(assets)) {
+    if (!name.endsWith('.js')) continue;
+    const text = readFileSync(join(assets, name), 'utf8');
+    if (/\beval\s*\(/.test(text)) problems.push(`${name}: contains eval()`);
+    if (/new Function/.test(text)) problems.push(`${name}: contains new Function`);
+  }
+  return problems;
+}
+const AUTOMATION_CONSOLE_PATTERN = /blocked a JavaScript eval/;
+
+async function makeFixtures() {
+  const kid = 'browser-matrix-k1';
+  const unicodeKid = 'é'.repeat(127) + 'aa'; // 256 UTF-8 bytes exactly
+  const { privateKey, publicKey } = await generateKeypair();
+  const other = await generateKeypair();
+  const base = {
+    iss: 'https://issuer.example',
+    kind: 'evidence',
+    type: 'org.example/browser-matrix',
+    occurred_at: '2026-04-01T00:00:00Z',
+    purpose_declared: 'browser-matrix',
+    pillars: ['safety'],
+    privateKey,
+  };
+  const issued = await issue({ ...base, kid, jti: '01940000-0000-7000-8000-000000000002' });
+  const unicodeIssued = await issue({
+    ...base,
+    kid: unicodeKid,
+    jti: '01940000-0000-7000-8000-000000000003',
+  });
+
+  const x = base64urlEncode(publicKey);
+  const jwk = { kty: 'OKP', crv: 'Ed25519', x, kid };
+  const unicodeJwk = { kty: 'OKP', crv: 'Ed25519', x, kid: unicodeKid };
+  const otherJwk = {
+    kty: 'OKP',
+    crv: 'Ed25519',
+    x: base64urlEncode(other.publicKey),
+    kid: 'browser-matrix-k2',
+  };
+  const thumbprint = await computeJwkThumbprint({ kty: 'OKP', crv: 'Ed25519', x });
+  const wrongThumbprint = await computeJwkThumbprint({
+    kty: 'OKP',
+    crv: 'Ed25519',
+    x: otherJwk.x,
+  });
+
+  const segments = issued.jws.split('.');
+  const payload = segments[1];
+  const flipped = payload.slice(0, -1) + (payload.at(-1) === 'A' ? 'B' : 'A');
+
+  return {
+    record: issued.jws,
+    unicodeRecord: unicodeIssued.jws,
+    tampered: [segments[0], flipped, segments[2]].join('.'),
+    oversizedRecord: 'a'.repeat(64 * 1024 + 1),
+    bareJwk: JSON.stringify(jwk),
+    jwks: JSON.stringify({ keys: [otherJwk, jwk] }),
+    unicodeJwks: JSON.stringify({ keys: [otherJwk, unicodeJwk] }),
+    wrongKey: JSON.stringify(otherJwk),
+    malformedKey: '{ not json',
+    trustMatch: JSON.stringify({
+      contextVersion: '1',
+      trust: { trustedJwkThumbprints: [thumbprint] },
+    }),
+    trustMismatch: JSON.stringify({
+      contextVersion: '1',
+      trust: { trustedJwkThumbprints: [wrongThumbprint] },
+    }),
+  };
+}
+
+const ACCEPT = 'Verification succeeded';
+const REJECT = 'Verification failed';
+
+function flows(f) {
+  return [
+    { id: 'accept-bare-jwk', record: f.record, key: f.bareJwk, heading: ACCEPT },
+    { id: 'accept-jwks-selection', record: f.record, key: f.jwks, heading: ACCEPT },
+    { id: 'accept-unicode-kid', record: f.unicodeRecord, key: f.unicodeJwks, heading: ACCEPT },
+    {
+      id: 'trusted-key-match',
+      record: f.record,
+      key: f.bareJwk,
+      context: f.trustMatch,
+      heading: ACCEPT,
+    },
+    { id: 'wrong-key', record: f.record, key: f.wrongKey, heading: REJECT, stage: 'signature' },
+    { id: 'tamper', record: f.tampered, key: f.bareJwk, heading: REJECT, stage: 'signature' },
+    { id: 'malformed-record', record: 'not-a-compact-jws', key: f.bareJwk, heading: REJECT },
+    { id: 'malformed-key', record: f.record, key: f.malformedKey, heading: REJECT },
+    { id: 'oversized-record', record: f.oversizedRecord, key: f.bareJwk, heading: REJECT },
+    {
+      id: 'trusted-key-mismatch',
+      record: f.record,
+      key: f.bareJwk,
+      context: f.trustMismatch,
+      heading: REJECT,
+      stage: 'trusted_key',
+    },
+  ];
+}
+const MOBILE_FLOW_IDS = ['accept-bare-jwk', 'tamper'];
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.json': 'application/json',
+};
+
+function serveDist() {
+  const server = createServer((req, res) => {
+    const path = normalize(new URL(req.url, 'http://127.0.0.1').pathname).replace(/^\/+/, '');
+    const file = join(DIST, path === '' ? 'index.html' : path);
+    if (!file.startsWith(DIST) || !existsSync(file)) {
+      res.writeHead(404).end();
+      return;
+    }
+    res.writeHead(200, { 'content-type': MIME[extname(file)] ?? 'application/octet-stream' });
+    res.end(readFileSync(file));
+  });
+  return new Promise((resolveServer) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolveServer({ server, origin: `http://127.0.0.1:${server.address().port}` });
+    });
+  });
+}
+
+async function runFlow(page, flow) {
+  await page.fill('#record', '');
+  await page.fill('#record', flow.record);
+  await page.fill('#key', '');
+  await page.fill('#key', flow.key);
+  await page.fill('#context', '');
+  if (flow.context) await page.fill('#context', flow.context);
+  await page.waitForSelector('button:enabled', { timeout: 15000 });
+  await page.click('button:has-text("Verify")');
+  const heading = page.locator('section h2').first();
+  await heading.waitFor({ state: 'visible', timeout: 15000 });
+  return {
+    heading: await heading.textContent(),
+    body: await page.locator('section').first().textContent(),
+  };
+}
+
+async function assessmentText(page) {
+  return page.locator('section dl').first().textContent();
+}
+
+async function runSession(page, fixtures, origin, flowIds) {
+  const problems = [];
+  const consoleErrors = [];
+  page.on('pageerror', (err) => consoleErrors.push(String(err)));
+  page.on('console', (m) => {
+    if (m.type() === 'error' && !AUTOMATION_CONSOLE_PATTERN.test(m.text())) {
+      consoleErrors.push(m.text());
+    }
+  });
+  const requests = [];
+  page.on('request', (r) => requests.push(r.url()));
+
+  await page.goto(`${origin}/`, { waitUntil: 'networkidle' });
+  const requestsAfterLoad = requests.length;
+  for (const url of requests) {
+    if (!url.startsWith(origin)) problems.push(`load requested a non-loopback URL: ${url}`);
+  }
+
+  const selected = flows(fixtures).filter((f) => !flowIds || flowIds.includes(f.id));
+  for (const flow of selected) {
+    const result = await runFlow(page, flow);
+    if (result.heading !== flow.heading) {
+      problems.push(`${flow.id}: expected "${flow.heading}", saw "${result.heading}"`);
+      continue;
+    }
+    if (flow.stage && !result.body.includes(flow.stage)) {
+      problems.push(`${flow.id}: expected failure stage "${flow.stage}" in the result`);
+    }
+  }
+
+  if (!flowIds) {
+    // Determinism: identical inputs render an identical assessment.
+    const first = flows(fixtures)[0];
+    await runFlow(page, first);
+    const a = await assessmentText(page);
+    await runFlow(page, first);
+    const b = await assessmentText(page);
+    if (a !== b) problems.push('determinism: two identical runs rendered different assessments');
+
+    // Input-snapshot binding: editing an input clears the displayed result.
+    await page.fill('#record', first.record + ' ');
+    const headings = await page.locator('section h2').count();
+    if (headings !== 0)
+      problems.push('input-snapshot: an edited input left a stale result visible');
+  }
+
+  if (requests.length !== requestsAfterLoad) {
+    problems.push(
+      `verification caused ${requests.length - requestsAfterLoad} network request(s): ` +
+        requests.slice(requestsAfterLoad).join(', ')
+    );
+  }
+
+  const persistence = await page.evaluate(async () => ({
+    localStorage: window.localStorage.length,
+    sessionStorage: window.sessionStorage.length,
+    indexedDb: 'databases' in indexedDB ? (await indexedDB.databases()).length : 0,
+    caches: 'caches' in window ? (await caches.keys()).length : 0,
+    serviceWorkers:
+      'serviceWorker' in navigator ? (await navigator.serviceWorker.getRegistrations()).length : 0,
+  }));
+  for (const [surface, count] of Object.entries(persistence)) {
+    if (count !== 0) problems.push(`persistence: ${surface} holds ${count} entr(ies)`);
+  }
+  for (const message of consoleErrors) problems.push(`console error: ${message}`);
+  return problems;
+}
+
+// A runtime without WebCrypto Ed25519 must present a capability message, not a cryptic failure.
+async function runCapabilityCheck(browser, origin) {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await page.addInitScript(() => {
+    Object.defineProperty(globalThis.crypto, 'subtle', { value: undefined });
+  });
+  await page.goto(`${origin}/`, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(500);
+  const problems = [];
+  const body = await page.locator('body').textContent();
+  if (!body.includes('This browser cannot perform the Ed25519 verification profile')) {
+    problems.push('capability: no clear capability message for a runtime without WebCrypto');
+  }
+  const enabled = await page.locator('button:enabled').count();
+  if (enabled !== 0) problems.push('capability: the verify control stayed enabled');
+  await context.close();
+  return problems;
+}
+
+const bundleProblems = scanBundles();
+if (bundleProblems.length > 0) {
+  for (const p of bundleProblems) console.error(`bundle: ${p}`);
+  process.exit(1);
+}
+
+const fixtures = await makeFixtures();
+const { server, origin } = await serveDist();
+let failed = false;
+const report = (name, problems, detail) => {
+  if (problems.length === 0) {
+    console.log(`${name}: OK${detail ? ` (${detail})` : ''}`);
+  } else {
+    failed = true;
+    console.error(`${name}: FAIL`);
+    for (const p of problems) console.error(`  - ${p}`);
+  }
+};
+
+try {
+  for (const name of engines) {
+    if (!playwright[name]) {
+      console.error(`${name}: unknown engine`);
+      failed = true;
+      continue;
+    }
+    const browser = await playwright[name].launch();
+    const context = await browser.newContext();
+    const problems = await runSession(await context.newPage(), fixtures, origin);
+    problems.push(...(await runCapabilityCheck(browser, origin)));
+    await browser.close();
+    report(
+      name,
+      problems,
+      `${flows(fixtures).length} flows + determinism + snapshot + capability, no network, no persistence`
+    );
+  }
+
+  if (!skipMobile) {
+    const mobile = [
+      { label: 'mobile-safari', engine: 'webkit', device: 'iPhone 14' },
+      { label: 'mobile-chrome', engine: 'chromium', device: 'Pixel 7' },
+    ];
+    for (const m of mobile) {
+      const device = playwright.devices[m.device];
+      if (!device) {
+        report(m.label, [`device profile "${m.device}" is not available`]);
+        continue;
+      }
+      const browser = await playwright[m.engine].launch();
+      const context = await browser.newContext({ ...device });
+      const problems = await runSession(await context.newPage(), fixtures, origin, MOBILE_FLOW_IDS);
+      await browser.close();
+      report(m.label, problems, `${MOBILE_FLOW_IDS.join(', ')}`);
+    }
+  }
+} finally {
+  server.close();
+}
+process.exit(failed ? 1 : 0);

--- a/apps/verifier/tests/browser/run-browser-matrix.mjs
+++ b/apps/verifier/tests/browser/run-browser-matrix.mjs
@@ -22,10 +22,10 @@
  *
  * Fixtures are issued per run with the real issuing API; no key material is committed.
  */
-import { createServer } from 'node:http';
-import { closeSync, existsSync, fstatSync, openSync, readFileSync, readdirSync } from 'node:fs';
-import { dirname, extname, join, normalize, relative, resolve } from 'node:path';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { loadAssets, serveAssets } from './static-assets.mjs';
 
 const SELF = fileURLToPath(import.meta.url);
 const APP_ROOT = resolve(dirname(SELF), '..', '..');
@@ -210,49 +210,6 @@ function flows(f) {
 }
 const MOBILE_FLOW_IDS = ['accept-bare-jwk', 'tamper'];
 
-const MIME = {
-  '.html': 'text/html; charset=utf-8',
-  '.js': 'text/javascript; charset=utf-8',
-  '.mjs': 'text/javascript; charset=utf-8',
-  '.css': 'text/css; charset=utf-8',
-  '.svg': 'image/svg+xml',
-  '.json': 'application/json',
-};
-
-function serveDist() {
-  const server = createServer((req, res) => {
-    const path = normalize(new URL(req.url, 'http://127.0.0.1').pathname).replace(/^\/+/, '');
-    const file = resolve(DIST, path === '' ? 'index.html' : path);
-    if (relative(DIST, file).startsWith('..')) {
-      res.writeHead(404).end();
-      return;
-    }
-    // One descriptor for the type check and the read, so the file cannot change between them.
-    let fd;
-    try {
-      fd = openSync(file, 'r');
-    } catch {
-      res.writeHead(404).end();
-      return;
-    }
-    try {
-      if (!fstatSync(fd).isFile()) {
-        res.writeHead(404).end();
-        return;
-      }
-      res.writeHead(200, { 'content-type': MIME[extname(file)] ?? 'application/octet-stream' });
-      res.end(readFileSync(fd));
-    } finally {
-      closeSync(fd);
-    }
-  });
-  return new Promise((resolveServer) => {
-    server.listen(0, '127.0.0.1', () => {
-      resolveServer({ server, origin: `http://127.0.0.1:${server.address().port}` });
-    });
-  });
-}
-
 // Counts persistence ATTEMPTS from before application code runs; the observers never mutate the
 // surfaces they watch.
 const PERSISTENCE_OBSERVER = () => {
@@ -329,20 +286,49 @@ async function checkDeterministicReport(page, flow, problems) {
   problems.push('determinism: could not obtain two runs sharing an evaluation second');
 }
 
-// A pending asynchronous file read must not replace newer manual input.
+// A pending asynchronous file read must not replace newer manual input. The first read is held
+// open by a test-only wrapper so the race is exercised deterministically, then released.
 async function checkReadSupersession(page, fixtures, problems) {
-  const fileInput = page.locator('input[type=file]').first();
-  await fileInput.setInputFiles({
-    name: 'record.jws',
-    mimeType: 'application/jose',
-    buffer: Buffer.from(fixtures.tampered),
+  await page.evaluate(() => {
+    const original = File.prototype.arrayBuffer;
+    let intercepted = false;
+    File.prototype.arrayBuffer = function (...a) {
+      const result = original.apply(this, a);
+      if (intercepted) return result;
+      intercepted = true;
+      return new Promise((release) => {
+        globalThis.__releaseHeldRead = () => release(result);
+      });
+    };
+    globalThis.__restoreArrayBuffer = () => {
+      File.prototype.arrayBuffer = original;
+    };
   });
+  await page
+    .locator('input[type=file]')
+    .first()
+    .setInputFiles({
+      name: 'record.jws',
+      mimeType: 'application/jose',
+      buffer: Buffer.from(fixtures.tampered),
+    });
+  const pendingDisabled = await page.locator('button:disabled').count();
+  if (pendingDisabled === 0) {
+    problems.push('supersession: a pending file read left verification enabled');
+  }
   await page.fill('#record', fixtures.record);
-  await page.waitForTimeout(250);
+  await page.evaluate(() => globalThis.__releaseHeldRead());
+  await page.waitForTimeout(100);
   const value = await page.inputValue('#record');
   if (value !== fixtures.record) {
-    problems.push('supersession: an asynchronous file read replaced newer manual input');
+    problems.push('supersession: a superseded file read replaced newer manual input');
   }
+  const stale = await page.locator('section h2').count();
+  if (stale !== 0) problems.push('supersession: a superseded read produced a result');
+  await page
+    .waitForSelector('button:enabled', { timeout: 5000 })
+    .catch(() => problems.push('supersession: controls did not recover'));
+  await page.evaluate(() => globalThis.__restoreArrayBuffer());
 }
 
 // The file controls must feed the same verification path as pasted input.
@@ -467,7 +453,12 @@ if (bundleProblems.length > 0) {
 }
 
 const fixtures = await makeFixtures();
-const { server, origin } = await serveDist();
+const assets = loadAssets(DIST);
+if (!assets.has('/index.html')) {
+  console.error('run-browser-matrix: the build output has no index.html');
+  process.exit(2);
+}
+const { server, origin } = await serveAssets(assets);
 let failed = false;
 const report = (name, problems, detail) => {
   if (problems.length === 0) {

--- a/apps/verifier/tests/browser/static-assets.mjs
+++ b/apps/verifier/tests/browser/static-assets.mjs
@@ -7,7 +7,7 @@
  * and malformed URL encoding fails closed as a 404.
  */
 import { createServer } from 'node:http';
-import { lstatSync, readFileSync, readdirSync } from 'node:fs';
+import { closeSync, constants, fstatSync, openSync, readFileSync, readdirSync } from 'node:fs';
 import { extname, join } from 'node:path';
 
 const MIME = {
@@ -20,24 +20,36 @@ const MIME = {
 };
 
 /**
- * Reads a directory tree into a Map of URL path to { body, type }. Throws on symbolic links and
- * ignores anything that is not a regular file or directory.
+ * Reads a directory tree into a Map of URL path to { body, type }. Symbolic links are rejected
+ * atomically by opening with O_NOFOLLOW, and each file's type check and read share one
+ * descriptor, so no check-then-use gap exists.
  */
 export function loadAssets(root) {
   const assets = new Map();
   const walk = (dir, prefix) => {
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
       const absolute = join(dir, entry.name);
-      if (entry.isSymbolicLink() || lstatSync(absolute).isSymbolicLink()) {
-        throw new Error(`refusing symbolic link: ${prefix}${entry.name}`);
-      }
       if (entry.isDirectory()) {
         walk(absolute, `${prefix}${entry.name}/`);
-      } else if (entry.isFile()) {
+        continue;
+      }
+      let fd;
+      try {
+        fd = openSync(absolute, constants.O_RDONLY | constants.O_NOFOLLOW);
+      } catch (err) {
+        if (err.code === 'ELOOP' || err.code === 'EMLINK') {
+          throw new Error(`refusing symbolic link: ${prefix}${entry.name}`);
+        }
+        throw err;
+      }
+      try {
+        if (!fstatSync(fd).isFile()) continue;
         assets.set(`/${prefix}${entry.name}`, {
-          body: readFileSync(absolute),
+          body: readFileSync(fd),
           type: MIME[extname(entry.name)] ?? 'application/octet-stream',
         });
+      } finally {
+        closeSync(fd);
       }
     }
   };

--- a/apps/verifier/tests/browser/static-assets.mjs
+++ b/apps/verifier/tests/browser/static-assets.mjs
@@ -1,0 +1,75 @@
+/**
+ * Immutable in-memory static assets for the browser matrix.
+ *
+ * The built application is loaded once, before the test server starts; requests are answered
+ * from the map with no request-time filesystem access, so no filesystem race or path ambiguity
+ * exists at serving time. Symbolic links are rejected at load, regular files only are served,
+ * and malformed URL encoding fails closed as a 404.
+ */
+import { createServer } from 'node:http';
+import { lstatSync, readFileSync, readdirSync } from 'node:fs';
+import { extname, join } from 'node:path';
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.json': 'application/json',
+};
+
+/**
+ * Reads a directory tree into a Map of URL path to { body, type }. Throws on symbolic links and
+ * ignores anything that is not a regular file or directory.
+ */
+export function loadAssets(root) {
+  const assets = new Map();
+  const walk = (dir, prefix) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const absolute = join(dir, entry.name);
+      if (entry.isSymbolicLink() || lstatSync(absolute).isSymbolicLink()) {
+        throw new Error(`refusing symbolic link: ${prefix}${entry.name}`);
+      }
+      if (entry.isDirectory()) {
+        walk(absolute, `${prefix}${entry.name}/`);
+      } else if (entry.isFile()) {
+        assets.set(`/${prefix}${entry.name}`, {
+          body: readFileSync(absolute),
+          type: MIME[extname(entry.name)] ?? 'application/octet-stream',
+        });
+      }
+    }
+  };
+  walk(root, '');
+  return assets;
+}
+
+/** Answers a request from the asset map. Returns the response that was served, for tests. */
+export function respond(assets, url, res) {
+  let pathname;
+  try {
+    pathname = decodeURIComponent(new URL(url, 'http://127.0.0.1').pathname);
+  } catch {
+    res.writeHead(404).end();
+    return 404;
+  }
+  const asset = assets.get(pathname === '/' ? '/index.html' : pathname);
+  if (!asset) {
+    res.writeHead(404).end();
+    return 404;
+  }
+  res.writeHead(200, { 'content-type': asset.type });
+  res.end(asset.body);
+  return 200;
+}
+
+/** Serves the asset map on a loopback origin. */
+export function serveAssets(assets) {
+  const server = createServer((req, res) => respond(assets, req.url, res));
+  return new Promise((resolveServer) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolveServer({ server, origin: `http://127.0.0.1:${server.address().port}` });
+    });
+  });
+}

--- a/apps/verifier/tests/runtime-support.test.ts
+++ b/apps/verifier/tests/runtime-support.test.ts
@@ -22,6 +22,17 @@ describe('ed25519WebCryptoSupported', () => {
     expect(await ed25519WebCryptoSupported()).toBe(true);
   });
 
+  it('probes with a non-empty message', async () => {
+    // A PEAC signing input is never empty, and at least one WebCrypto implementation rejects
+    // Ed25519 verification of zero-length messages while verifying non-empty messages correctly.
+    const spy = vi.spyOn(globalThis.crypto.subtle, 'verify');
+    resetRuntimeProbeForTests();
+    await ed25519WebCryptoSupported();
+    expect(spy).toHaveBeenCalled();
+    const message = spy.mock.calls[0][3] as ArrayBufferView;
+    expect(message.byteLength).toBeGreaterThan(0);
+  });
+
   it('is memoized: the probe runs once even under concurrent initialization', async () => {
     resetRuntimeProbeForTests();
     const spy = vi.spyOn(globalThis.crypto.subtle, 'verify');

--- a/apps/verifier/tests/runtime-support.test.ts
+++ b/apps/verifier/tests/runtime-support.test.ts
@@ -23,8 +23,8 @@ describe('ed25519WebCryptoSupported', () => {
   });
 
   it('probes with a non-empty message', async () => {
-    // A PEAC signing input is never empty, and at least one WebCrypto implementation rejects
-    // Ed25519 verification of zero-length messages while verifying non-empty messages correctly.
+    // Zero-length Ed25519 verification is not portable across the supported WebCrypto runtimes
+    // measured for this profile, and a PEAC JWS signing input is never empty.
     const spy = vi.spyOn(globalThis.crypto.subtle, 'verify');
     resetRuntimeProbeForTests();
     await ed25519WebCryptoSupported();

--- a/apps/verifier/tests/static-server.test.ts
+++ b/apps/verifier/tests/static-server.test.ts
@@ -6,7 +6,6 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error plain module without type declarations
 import { loadAssets, respond } from './browser/static-assets.mjs';
 

--- a/apps/verifier/tests/static-server.test.ts
+++ b/apps/verifier/tests/static-server.test.ts
@@ -1,0 +1,98 @@
+/**
+ * The browser-matrix static server: assets load once into an immutable map, symbolic links are
+ * rejected, and requests are answered without touching the filesystem.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error plain module without type declarations
+import { loadAssets, respond } from './browser/static-assets.mjs';
+
+let root: string;
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), 'peac-static-'));
+  writeFileSync(join(root, 'index.html'), '<p>index</p>');
+  mkdirSync(join(root, 'assets'));
+  writeFileSync(join(root, 'assets', 'app.js'), 'export {};');
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+interface Served {
+  status: number;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+function serve(assets: Map<string, unknown>, url: string): Served {
+  const out: Served = { status: 0 };
+  const res = {
+    writeHead(status: number, headers?: Record<string, string>) {
+      out.status = status;
+      out.headers = headers;
+      return this;
+    },
+    end(body?: Buffer) {
+      if (body) out.body = body.toString();
+    },
+  };
+  respond(assets, url, res);
+  return out;
+}
+
+describe('the in-memory static server', () => {
+  it('serves the index for the root path', () => {
+    const assets = loadAssets(root);
+    const served = serve(assets, '/');
+    expect(served.status).toBe(200);
+    expect(served.body).toBe('<p>index</p>');
+  });
+
+  it('serves an asset with its content type', () => {
+    const assets = loadAssets(root);
+    const served = serve(assets, '/assets/app.js');
+    expect(served.status).toBe(200);
+    expect(served.headers?.['content-type']).toContain('text/javascript');
+    expect(served.body).toBe('export {};');
+  });
+
+  it('returns 404 for an unknown path', () => {
+    expect(serve(loadAssets(root), '/absent.js').status).toBe(404);
+  });
+
+  it('traversal input cannot escape the asset namespace', () => {
+    const assets = loadAssets(root);
+    const bodies = new Set(
+      [...assets.values()].map((a) => (a as { body: Buffer }).body.toString())
+    );
+    // URL normalization may resolve dotted segments to a legitimate asset; anything served must
+    // be a member of the loaded namespace, and unresolvable traversal must 404.
+    for (const url of ['/../index.html', '/assets/../index.html']) {
+      const served = serve(assets, url);
+      expect(served.status === 404 || bodies.has(served.body ?? ''), url).toBe(true);
+    }
+    for (const url of ['/..%2F..%2Fetc%2Fhosts', '/%2e%2e/%2e%2e/etc/hosts', '/etc/hosts']) {
+      expect(serve(assets, url).status, url).toBe(404);
+    }
+  });
+
+  it('malformed URL encoding fails closed', () => {
+    expect(serve(loadAssets(root), '/%zz').status).toBe(404);
+  });
+
+  it('rejects symbolic links at load', () => {
+    const linked = mkdtempSync(join(tmpdir(), 'peac-static-link-'));
+    try {
+      writeFileSync(join(linked, 'index.html'), 'x');
+      symlinkSync(join(root, 'index.html'), join(linked, 'escape.html'));
+      expect(() => loadAssets(linked)).toThrow(/symbolic link/);
+    } finally {
+      rmSync(linked, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/tooling/verifier-lane-aggregation.test.ts
+++ b/tests/tooling/verifier-lane-aggregation.test.ts
@@ -49,8 +49,12 @@ function evaluate(values: Record<string, string>): number {
   }
 }
 
-/** All lanes passing, with the verifier activation flag and lane result under test. */
-function lanes(verifierCi: string, examplesApps: string): Record<string, string> {
+/** All lanes passing, with the verifier activation flag and lane results under test. */
+function lanes(
+  verifierCi: string,
+  examplesApps: string,
+  browserMatrix = examplesApps
+): Record<string, string> {
   return {
     'needs.detect-changes.outputs.verifier_ci': verifierCi,
     // Unrelated activation outputs, held at values that keep the other rules satisfied so each
@@ -65,6 +69,7 @@ function lanes(verifierCi: string, examplesApps: string): Record<string, string>
     'needs.examples-apps.result': examplesApps,
     'needs.pack-smoke.result': 'success',
     'needs.node-compat.result': 'success',
+    'needs.browser-matrix.result': browserMatrix,
   };
 }
 
@@ -90,5 +95,27 @@ describe('a verifier lane that did not run cannot pass the aggregate', () => {
   it('verifier paths unchanged and the lane failed: still rejected', () => {
     // The pre-existing generic failure handling must survive the added rule.
     expect(evaluate(lanes('false', 'failure'))).not.toBe(0);
+  });
+});
+
+describe('a browser matrix that did not run cannot pass the aggregate', () => {
+  it('verifier paths changed and the matrix succeeded: accepted', () => {
+    expect(evaluate(lanes('true', 'success', 'success'))).toBe(0);
+  });
+
+  it('verifier paths changed and the matrix was SKIPPED: rejected', () => {
+    expect(evaluate(lanes('true', 'success', 'skipped'))).not.toBe(0);
+  });
+
+  it('verifier paths changed and the matrix failed: rejected', () => {
+    expect(evaluate(lanes('true', 'success', 'failure'))).not.toBe(0);
+  });
+
+  it('verifier paths unchanged and the matrix was skipped: allowed', () => {
+    expect(evaluate(lanes('false', 'success', 'skipped'))).toBe(0);
+  });
+
+  it('verifier paths unchanged and the matrix failed: still rejected', () => {
+    expect(evaluate(lanes('false', 'success', 'failure'))).not.toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

The verifier's runtime capability probe verified an empty-message Ed25519 vector. Zero-length Ed25519 verification is not portable across the supported WebCrypto runtimes measured for this profile, so a capable browser was reported as unsupported and the verify control stayed disabled. PEAC JWS signing inputs are never empty; the probe now uses a non-empty RFC 8032 vector, with a unit test pinning that property.

The production build is now validated across browser engines by an executable matrix, required in CI whenever verifier-affecting paths change.

## Compatibility

The matrix drives the built application through Chromium, Firefox and WebKit, plus Mobile Safari and Mobile Chrome emulation profiles, asserting per engine: twelve verification flows (bare JWK, JWKS key selection, a 256-byte Unicode key id, trusted-key match and mismatch, wrong key, byte-level tamper, malformed and oversized record, key and expectation inputs), byte-identical report output for identical verification inputs and evaluation time, stale-result clearing on edit, a deliberately held file read never replacing newer input, the file-input path, and a clear capability message when WebCrypto is absent. Verification causes zero network requests; persistence is instrumented at the API level and must show zero attempts and zero residual state across localStorage, sessionStorage, IndexedDB, CacheStorage and service workers; served bundles must contain no dynamic code evaluation and are preloaded into an immutable in-memory map so the test server performs no request-time filesystem access; application console errors fail the run.

Playwright is installed into an isolated directory (exact release 1.62.1, resolved from the registry's stable tag) and is not a dependency of any workspace package. The aggregate refuses a skipped matrix whenever verifier paths changed, using the existing activation model; the decision table is exercised by test in both directions.

## Validation

Matrix results on this head: Chromium 151.0.7922.34, Firefox 153.0 and WebKit 26.5 all pass every assertion; both mobile profiles pass. The RFC 8032 vector was verified by execution against WebCrypto and independently re-derived from the section 7.1 secret key with a second implementation. Verifier suite 367 tests; full repository suite 13,086 across 503 files; verifier source-boundary, guard, format and whitespace checks pass.

## Scope

Verifier application probe fix, browser-matrix tooling, CI lane and documentation. No wire format, cryptographic profile, schema, public API, package dependency or protocol change.
