### PR TITLE
fix(verifier): eliminate CSP dynamic-code probing

### DIFF
--- a/apps/verifier/package.json
+++ b/apps/verifier/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "@peac/crypto": "workspace:*",
     "@peac/protocol": "workspace:*",
-    "@peac/schema": "workspace:*"
+    "@peac/schema": "workspace:*",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.19.11",

--- a/apps/verifier/src/lib/schema-runtime.ts
+++ b/apps/verifier/src/lib/schema-runtime.ts
@@ -1,0 +1,15 @@
+/**
+ * Disables Zod's just-in-time validator compilation for the whole application.
+ *
+ * Zod's default fast path constructs a validator with the Function constructor, gated by a
+ * capability probe that itself calls `Function("")`. Under the verifier's Content-Security-Policy
+ * (`script-src 'self'`, no `unsafe-eval`) that call is refused, which both raises a policy
+ * violation and defeats the intent of a closed, offline surface. Jitless mode uses the
+ * interpreted validator and performs no dynamic code construction.
+ *
+ * The probe fires at schema construction, so this must run before any schema is built. It is
+ * imported for its side effect as the first import of every application and test entry point.
+ */
+import { config } from 'zod';
+
+config({ jitless: true });

--- a/apps/verifier/src/lib/schema-runtime.ts
+++ b/apps/verifier/src/lib/schema-runtime.ts
@@ -8,7 +8,8 @@
  * interpreted validator and performs no dynamic code construction.
  *
  * The probe fires at schema construction, so this must run before any schema is built. It is
- * imported for its side effect as the first import of every application and test entry point.
+ * imported for its side effect ahead of the application graph and ahead of the verification
+ * orchestrator's schema-producing dependencies.
  */
 import { config } from 'zod';
 

--- a/apps/verifier/src/main.ts
+++ b/apps/verifier/src/main.ts
@@ -12,6 +12,7 @@
  * operator nothing, and "nothing happened" is the one outcome a verifier must never produce
  * silently.
  */
+import './lib/schema-runtime.js';
 import { initApp } from './ui/app.js';
 
 function fatal(message: string): void {

--- a/apps/verifier/src/verify.ts
+++ b/apps/verifier/src/verify.ts
@@ -7,6 +7,7 @@
  * verifier uses internally, so it provided no independent assurance while doubling the work and
  * adding a reconciliation matrix and misleading inconsistency semantics.
  */
+import './lib/schema-runtime.js';
 import { sha256Hex } from '@peac/crypto';
 import { verifyLocal as verifyLocalImpl } from '@peac/protocol/verify-local';
 import { VerifierError, isVerifierError, DIAGNOSTIC } from './lib/errors.js';

--- a/apps/verifier/tests/browser/run-browser-matrix.mjs
+++ b/apps/verifier/tests/browser/run-browser-matrix.mjs
@@ -78,7 +78,10 @@ const { generateKeypair, base64urlEncode, base64urlDecode, computeJwkThumbprint 
   await import('@peac/crypto');
 const { issue } = await import('@peac/protocol');
 
-// The application must not evaluate dynamic code; verified against the exact bundles served.
+// Static scan of the served bundles. eval() and new Function() are forbidden outright. A bare
+// Function() constructor is reported unless it is the one recognised dependency capability probe,
+// which application-wide jitless configuration leaves unexecuted -- the runtime instrumentation
+// below is what proves it never runs.
 function scanBundles() {
   const problems = [];
   const assets = join(DIST, 'assets');
@@ -87,15 +90,17 @@ function scanBundles() {
     const text = readFileSync(join(assets, name), 'utf8');
     if (/\beval\s*\(/.test(text)) problems.push(`${name}: contains eval()`);
     if (/new Function/.test(text)) problems.push(`${name}: contains new Function`);
+    const re = /(^|[^\w.$])Function\s*\(/g;
+    let m;
+    while ((m = re.exec(text)) !== null) {
+      const at = m.index + m[1].length;
+      const context = text.slice(Math.max(0, at - 90), at + 12);
+      const known = /Cloudflare/.test(context) && /Function\s*\(\s*(``|''|"")\s*\)/.test(context);
+      if (!known) problems.push(`${name}: unrecognised Function() constructor`);
+    }
   }
   return problems;
 }
-
-// Firefox reports Playwright's own injected evaluation as a page CSP violation. The bundle scan
-// above proves the application ships no dynamic code, so exactly this diagnostic, in Firefox
-// only, is classified as an automation diagnostic; every other console error fails the run.
-const FIREFOX_AUTOMATION_DIAGNOSTIC =
-  /Content-Security-Policy.*blocked a JavaScript eval.*script-src/;
 
 const LIMITS = { record: 64 * 1024, key: 128 * 1024, context: 8 * 1024 };
 
@@ -212,6 +217,23 @@ const MOBILE_FLOW_IDS = ['accept-bare-jwk', 'tamper'];
 
 // Counts persistence ATTEMPTS from before application code runs; the observers never mutate the
 // surfaces they watch.
+// Records Content-Security-Policy violations, installed before application code runs. Under the
+// shipped policy (script-src 'self', no unsafe-eval) any dynamic code the application executes is
+// refused and raises a violation, so a clean record proves the application constructs and runs no
+// dynamic code under policy. Automation-injected evaluation is delivered out of band and does not
+// raise a page violation, so this signal is not polluted by the test harness.
+const DYNAMIC_CODE_OBSERVER = () => {
+  const violations = [];
+  Object.defineProperty(globalThis, '__peacCspViolations', { value: violations });
+  document.addEventListener('securitypolicyviolation', (e) => {
+    violations.push({
+      directive: e.violatedDirective,
+      source: e.sourceFile,
+      blocked: e.blockedURI,
+    });
+  });
+};
+
 const PERSISTENCE_OBSERVER = () => {
   const counts = {
     storageWrites: 0,
@@ -353,22 +375,17 @@ async function checkFileInput(page, fixtures, problems) {
   if (text !== ACCEPT) problems.push(`file-input: expected "${ACCEPT}", saw "${text}"`);
 }
 
-async function runSession(engineName, page, fixtures, origin, flowIds) {
+async function runSession(page, fixtures, origin, flowIds) {
   const problems = [];
   const consoleErrors = [];
-  let automationDiagnostics = 0;
   page.on('pageerror', (err) => consoleErrors.push(String(err)));
   page.on('console', (m) => {
-    if (m.type() !== 'error') return;
-    if (engineName === 'firefox' && FIREFOX_AUTOMATION_DIAGNOSTIC.test(m.text())) {
-      automationDiagnostics += 1;
-      return;
-    }
-    consoleErrors.push(m.text());
+    if (m.type() === 'error') consoleErrors.push(m.text());
   });
   const requests = [];
   page.on('request', (r) => requests.push(r.url()));
   await page.addInitScript(PERSISTENCE_OBSERVER);
+  await page.addInitScript(DYNAMIC_CODE_OBSERVER);
 
   await page.goto(`${origin}/`, { waitUntil: 'networkidle' });
   const requestsAfterLoad = requests.length;
@@ -422,8 +439,12 @@ async function runSession(engineName, page, fixtures, origin, flowIds) {
   for (const [surface, count] of Object.entries(persistence)) {
     if (count !== 0) problems.push(`persistence: ${surface} holds ${count} entr(ies)`);
   }
+  const cspViolations = await page.evaluate(() => globalThis.__peacCspViolations ?? []);
+  for (const v of cspViolations) {
+    problems.push(`CSP violation: ${v.directive} (${v.blocked ?? v.source ?? 'inline'})`);
+  }
   for (const message of consoleErrors) problems.push(`console error: ${message}`);
-  return { problems, automationDiagnostics };
+  return { problems };
 }
 
 // A runtime without WebCrypto Ed25519 must present a capability message, not a cryptic failure.
@@ -479,18 +500,15 @@ try {
     }
     const browser = await playwright[name].launch();
     const context = await browser.newContext();
-    const session = await runSession(name, await context.newPage(), fixtures, origin);
+    const session = await runSession(await context.newPage(), fixtures, origin);
     const problems = [...session.problems, ...(await runCapabilityCheck(browser, origin))];
     const version = browser.version();
     await browser.close();
-    const diag = session.automationDiagnostics
-      ? `, ${session.automationDiagnostics} automation diagnostic(s) classified`
-      : '';
     report(
       name,
       problems,
       `${version}; ${flows(fixtures).length} flows + report determinism + snapshot + ` +
-        `supersession + file input + capability; no network, no persistence attempts${diag}`
+        `supersession + file input + capability; no network, no persistence, no dynamic code, no CSP violation`
     );
   }
 
@@ -507,13 +525,7 @@ try {
       }
       const browser = await playwright[m.engine].launch();
       const context = await browser.newContext({ ...device });
-      const session = await runSession(
-        m.engine,
-        await context.newPage(),
-        fixtures,
-        origin,
-        MOBILE_FLOW_IDS
-      );
+      const session = await runSession(await context.newPage(), fixtures, origin, MOBILE_FLOW_IDS);
       await browser.close();
       report(m.label, session.problems, MOBILE_FLOW_IDS.join(', '));
     }

--- a/apps/verifier/tests/browser/run-browser-matrix.mjs
+++ b/apps/verifier/tests/browser/run-browser-matrix.mjs
@@ -82,9 +82,13 @@ const { issue } = await import('@peac/protocol');
 // Function() constructor is reported unless it is the one recognised dependency capability probe,
 // which application-wide jitless configuration leaves unexecuted -- the runtime instrumentation
 // below is what proves it never runs.
+const CAPABILITY_PROBE =
+  /includes\(\s*(["'`])Cloudflare\1\s*\)[^]{0,60}?Function\s*\(\s*(``|''|"")\s*\)/;
+
 function scanBundles() {
   const problems = [];
   const assets = join(DIST, 'assets');
+  let knownProbes = 0;
   for (const name of readdirSync(assets)) {
     if (!name.endsWith('.js')) continue;
     const text = readFileSync(join(assets, name), 'utf8');
@@ -94,11 +98,12 @@ function scanBundles() {
     let m;
     while ((m = re.exec(text)) !== null) {
       const at = m.index + m[1].length;
-      const context = text.slice(Math.max(0, at - 90), at + 12);
-      const known = /Cloudflare/.test(context) && /Function\s*\(\s*(``|''|"")\s*\)/.test(context);
-      if (!known) problems.push(`${name}: unrecognised Function() constructor`);
+      const context = text.slice(Math.max(0, at - 90), at + 20);
+      if (CAPABILITY_PROBE.test(context)) knownProbes += 1;
+      else problems.push(`${name}: unrecognised Function() constructor`);
     }
   }
+  if (knownProbes > 1) problems.push(`more than one recognised capability probe (${knownProbes})`);
   return problems;
 }
 
@@ -447,6 +452,25 @@ async function runSession(page, fixtures, origin, flowIds) {
   return { problems };
 }
 
+// Proves the CSP-violation observer is functional in this engine before the observation is used
+// as evidence: on a disposable page under the shipped policy, a deliberate blocked eval must be
+// recorded. A silent zero from a non-functional observer is thereby ruled out.
+async function runObserverControl(browser, origin) {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await page.addInitScript(DYNAMIC_CODE_OBSERVER);
+  await page.goto(`${origin}/`, { waitUntil: 'networkidle' });
+  // A same-origin script (subject to the page CSP, unlike automation-injected evaluation) whose
+  // Function() call is refused. addScriptTag rejects when the script errors, which is expected.
+  await page.addScriptTag({ url: `${origin}/csp-observer-control.js` }).catch(() => undefined);
+  await page.waitForTimeout(200);
+  const recorded = await page.evaluate(() =>
+    (globalThis.__peacCspViolations ?? []).some((v) => /script-src/.test(v.directive))
+  );
+  await context.close();
+  return recorded ? [] : ['csp-observer: no violation recorded for a deliberate blocked eval'];
+}
+
 // A runtime without WebCrypto Ed25519 must present a capability message, not a cryptic failure.
 async function runCapabilityCheck(browser, origin) {
   const context = await browser.newContext();
@@ -479,6 +503,13 @@ if (!assets.has('/index.html')) {
   console.error('run-browser-matrix: the build output has no index.html');
   process.exit(2);
 }
+// A same-origin control script for the CSP-observer negative control. Loaded via <script src>, it
+// is permitted by script-src 'self' and runs subject to the page policy; its Function() call is
+// refused, which must raise a violation the observer records.
+assets.set('/csp-observer-control.js', {
+  body: Buffer.from('try{Function("return 1")()}catch(e){}'),
+  type: 'text/javascript; charset=utf-8',
+});
 const { server, origin } = await serveAssets(assets);
 let failed = false;
 const report = (name, problems, detail) => {
@@ -500,15 +531,21 @@ try {
     }
     const browser = await playwright[name].launch();
     const context = await browser.newContext();
+    const observerControl = await runObserverControl(browser, origin);
     const session = await runSession(await context.newPage(), fixtures, origin);
-    const problems = [...session.problems, ...(await runCapabilityCheck(browser, origin))];
+    const problems = [
+      ...observerControl,
+      ...session.problems,
+      ...(await runCapabilityCheck(browser, origin)),
+    ];
     const version = browser.version();
     await browser.close();
     report(
       name,
       problems,
       `${version}; ${flows(fixtures).length} flows + report determinism + snapshot + ` +
-        `supersession + file input + capability; no network, no persistence, no dynamic code, no CSP violation`
+        `supersession + file input + capability + CSP-observer control; no network, no persistence, ` +
+        `no application CSP unsafe-eval violation`
     );
   }
 

--- a/apps/verifier/tests/schema-runtime.test.ts
+++ b/apps/verifier/tests/schema-runtime.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Validator compilation is disabled application-wide, and the module that disables it is loaded
+ * before any schema is constructed. Zod's fast path builds a validator with the Function
+ * constructor behind a probe that itself calls Function(""); under the verifier's CSP that call
+ * is refused, so the fast path must never be reached.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SRC = resolve(__dirname, '..', 'src');
+const read = (p: string) => readFileSync(resolve(SRC, p), 'utf8');
+
+describe('validator compilation is disabled before schemas load', () => {
+  it('the runtime module configures jitless mode', () => {
+    const module = read('lib/schema-runtime.ts');
+    expect(module).toMatch(/config\(\s*\{\s*jitless:\s*true\s*\}\s*\)/);
+    expect(module).toMatch(/from 'zod'/);
+  });
+
+  it('every entry point imports it before anything that builds a schema', () => {
+    for (const entry of ['main.ts', 'verify.ts']) {
+      const lines = read(entry).split('\n');
+      const preludeAt = lines.findIndex((l) => l.includes("schema-runtime.js'"));
+      const firstOtherImport = lines.findIndex(
+        (l) => /^import /.test(l) && !l.includes('schema-runtime.js')
+      );
+      expect(preludeAt, `${entry}: schema-runtime prelude is imported`).toBeGreaterThanOrEqual(0);
+      expect(preludeAt, `${entry}: the prelude must be the first import`).toBeLessThan(
+        firstOtherImport
+      );
+    }
+  });
+
+  it('sets jitless on the same zod instance the app parses with', async () => {
+    // Configure, then confirm a freshly constructed object schema performs no dynamic-code
+    // construction on parse: instrument the Function constructor and require zero calls.
+    await import('../src/lib/schema-runtime.js');
+    const { z } = await import('zod');
+    const RealFunction = globalThis.Function;
+    let calls = 0;
+    globalThis.Function = new Proxy(RealFunction, {
+      apply: (t, s, a) => (calls++, Reflect.apply(t, s, a)),
+      construct: (t, a, n) => (calls++, Reflect.construct(t, a, n)),
+    });
+    try {
+      const schema = z.object({ a: z.string() });
+      schema.safeParse({ a: 'x' });
+    } finally {
+      globalThis.Function = RealFunction;
+    }
+    expect(calls, 'no Function() construction during construct + parse').toBe(0);
+  });
+});

--- a/apps/verifier/tests/schema-runtime.test.ts
+++ b/apps/verifier/tests/schema-runtime.test.ts
@@ -32,9 +32,10 @@ describe('validator compilation is disabled before schemas load', () => {
     }
   });
 
-  it('sets jitless on the same zod instance the app parses with', async () => {
-    // Configure, then confirm a freshly constructed object schema performs no dynamic-code
-    // construction on parse: instrument the Function constructor and require zero calls.
+  it('leaves construct and parse free of dynamic-code construction once configured', async () => {
+    // With the runtime module loaded, a freshly constructed object schema builds and parses
+    // without any Function-constructor call. The integrated application graph is covered by the
+    // browser matrix; this pins the mechanism on the verifier's own Zod import.
     await import('../src/lib/schema-runtime.js');
     const { z } = await import('zod');
     const RealFunction = globalThis.Function;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,9 @@ importers:
       '@peac/schema':
         specifier: workspace:*
         version: link:../../packages/schema
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: ^22.19.11

--- a/scripts/check-verifier-bundle.mjs
+++ b/scripts/check-verifier-bundle.mjs
@@ -64,20 +64,24 @@ function bareFunctionConstructors(text) {
   let m;
   while ((m = re.exec(text)) !== null) {
     const at = m.index + m[1].length;
-    hits.push(text.slice(Math.max(0, at - 90), at + 12));
+    hits.push(text.slice(Math.max(0, at - 90), at + 20));
   }
   return hits;
 }
 
 /**
- * A bare constructor is the dependency's Ed25519-unrelated capability probe: a memoized check that
- * builds an empty function to learn whether the environment permits dynamic evaluation. It is
- * gated off at runtime (validator compilation is disabled application-wide) and never executes
- * under the shipped policy, which the browser matrix proves by instrumentation. It is recognised
- * by its own guard and its empty argument, so any other dynamic-code construction still fails.
+ * The one recognised bare constructor is the schema dependency's capability probe: a guarded check
+ * that builds an empty function to learn whether the environment permits dynamic evaluation. It is
+ * disabled before schema construction and never executes under the shipped policy, which the
+ * browser matrix proves by instrumentation. Recognition requires the probe's own environment guard
+ * immediately before an empty-argument constructor, so an unrelated constructor is not excused by a
+ * distant occurrence of the guard word. Any other bare constructor still fails.
  */
+const CAPABILITY_PROBE =
+  /includes\(\s*(["'`])Cloudflare\1\s*\)[^]{0,60}?Function\s*\(\s*(``|''|"")\s*\)/;
+
 function isKnownCapabilityProbe(context) {
-  return /Cloudflare/.test(context) && /Function\s*\(\s*(``|''|"")\s*\)/.test(context);
+  return CAPABILITY_PROBE.test(context);
 }
 
 function selfTest() {
@@ -115,6 +119,19 @@ function selfTest() {
     console.error('  SELF-TEST FAIL: capability probe not recognised');
     failed++;
   } else console.log('  ok  capability probe recognised (allowed, unexecuted)');
+  // A distant occurrence of the guard word must not excuse an unrelated constructor.
+  const distant = 'const ua="Cloudflare";' + 'x'.repeat(120) + 'const y=Function("return 1");';
+  if (bareFunctionConstructors(distant).some(isKnownCapabilityProbe)) {
+    console.error('  SELF-TEST FAIL: distant guard word excused an unrelated constructor');
+    failed++;
+  } else console.log('  ok  distant guard word does not excuse an unrelated constructor');
+  // Two recognised probes must fail the aggregate check.
+  const twoProbes = probe + ';' + probe;
+  const recognised = bareFunctionConstructors(twoProbes).filter(isKnownCapabilityProbe).length;
+  if (recognised <= 1) {
+    console.error('  SELF-TEST FAIL: two probes not both recognised for the >1 guard');
+    failed++;
+  } else console.log('  ok  more than one recognised probe is detectable (fails the aggregate)');
   const clean =
     'const n=document.createElement("p");n.textContent=x;await crypto.subtle.digest("SHA-256",b);';
   const bad = FORBIDDEN.filter((f) => f.re.test(clean));
@@ -169,6 +186,11 @@ for (const f of js) {
     else violations.push(`${relative(ROOT, f)}: unrecognised Function() constructor`);
   }
 }
+// Zero recognised probes is fine (a future dependency may drop it); one is today's known
+// artifact; more than one is unexpected and must be investigated.
+if (knownProbeCount > 1) {
+  violations.push(`more than one recognised capability probe (${knownProbeCount}); investigate`);
+}
 
 // The emitted HTML must carry the closed CSP.
 const html = assets.filter((f) => f.endsWith('.html'));
@@ -195,8 +217,9 @@ console.log(
     'no forbidden pattern in the emitted output (Node builtin, browser-external stub, network, ' +
     'storage, service-worker, HTML-injection, eval or new Function); ' +
     probeNote +
-    'no other dynamic-code construction. This is a static scan; the browser matrix observes at ' +
-    'runtime that no dynamic code executes and no policy violation is raised. Framing protection ' +
-    '(frame-ancestors, X-Frame-Options) is not expressible in the emitted HTML and remains a ' +
-    'response-header requirement at the serving origin.'
+    'no other bare Function() constructor. Direct eval(), new Function() and bare Function(...) ' +
+    'forms are covered by this static scan; the shipped CSP disallows unsafe evaluation, and the ' +
+    'browser matrix observes at runtime that the application raises no CSP unsafe-eval violation. ' +
+    'Framing protection (frame-ancestors, X-Frame-Options) is not expressible in the emitted HTML ' +
+    'and remains a response-header requirement at the serving origin.'
 );

--- a/scripts/check-verifier-bundle.mjs
+++ b/scripts/check-verifier-bundle.mjs
@@ -16,7 +16,10 @@ import { fileURLToPath } from 'node:url';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const argIdx = process.argv.indexOf('--dist');
-const DIST = join(ROOT, argIdx >= 0 && process.argv[argIdx + 1] ? process.argv[argIdx + 1] : 'apps/verifier/dist');
+const DIST = join(
+  ROOT,
+  argIdx >= 0 && process.argv[argIdx + 1] ? process.argv[argIdx + 1] : 'apps/verifier/dist'
+);
 
 /**
  * Patterns that must not survive into emitted JavaScript.
@@ -25,9 +28,17 @@ const DIST = join(ROOT, argIdx >= 0 && process.argv[argIdx + 1] ? process.argv[a
  * source-shaped. Comment text cannot be relied on to exist or to be excluded.
  */
 const FORBIDDEN = [
-  { id: 'browser-external-stub', re: /__vite-browser-external/, msg: 'Vite browser-external stub (a Node builtin reached the bundle)' },
+  {
+    id: 'browser-external-stub',
+    re: /__vite-browser-external/,
+    msg: 'Vite browser-external stub (a Node builtin reached the bundle)',
+  },
   { id: 'node-protocol-import', re: /["'`]node:[a-z_]+["'`]/, msg: 'node: builtin specifier' },
-  { id: 'node-globals', re: /\brequire\s*\(\s*["'`](fs|path|os|child_process|worker_threads)["'`]\s*\)/, msg: 'CommonJS require of a Node builtin' },
+  {
+    id: 'node-globals',
+    re: /\brequire\s*\(\s*["'`](fs|path|os|child_process|worker_threads)["'`]\s*\)/,
+    msg: 'CommonJS require of a Node builtin',
+  },
   { id: 'fetch', re: /\bfetch\s*\(/, msg: 'fetch() call' },
   { id: 'xhr', re: /\bXMLHttpRequest\b/, msg: 'XMLHttpRequest' },
   { id: 'websocket', re: /new\s+WebSocket\b/, msg: 'WebSocket' },
@@ -42,6 +53,33 @@ const FORBIDDEN = [
   { id: 'newfunction', re: /new\s+Function\s*\(/, msg: 'new Function()' },
 ];
 
+/**
+ * Bare `Function(...)` constructor calls, excluding `new Function` (covered above), property
+ * accesses like `.Function(` and identifiers ending in `Function`. Each hit is reported with a
+ * little surrounding context so it can be classified.
+ */
+function bareFunctionConstructors(text) {
+  const hits = [];
+  const re = /(^|[^\w.$])Function\s*\(/g;
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    const at = m.index + m[1].length;
+    hits.push(text.slice(Math.max(0, at - 90), at + 12));
+  }
+  return hits;
+}
+
+/**
+ * A bare constructor is the dependency's Ed25519-unrelated capability probe: a memoized check that
+ * builds an empty function to learn whether the environment permits dynamic evaluation. It is
+ * gated off at runtime (validator compilation is disabled application-wide) and never executes
+ * under the shipped policy, which the browser matrix proves by instrumentation. It is recognised
+ * by its own guard and its empty argument, so any other dynamic-code construction still fails.
+ */
+function isKnownCapabilityProbe(context) {
+  return /Cloudflare/.test(context) && /Function\s*\(\s*(``|''|"")\s*\)/.test(context);
+}
+
 function selfTest() {
   const cases = [
     ['import("./__vite-browser-external-x.js")', 'browser-external-stub'],
@@ -55,19 +93,45 @@ function selfTest() {
   let failed = 0;
   for (const [text, id] of cases) {
     const hit = FORBIDDEN.filter((f) => f.re.test(text)).map((f) => f.id);
-    if (!hit.includes(id)) { console.error(`  SELF-TEST FAIL: ${id} not caught in ${JSON.stringify(text)}`); failed++; }
-    else console.log(`  ok  negative fixture caught: ${id}`);
+    if (!hit.includes(id)) {
+      console.error(`  SELF-TEST FAIL: ${id} not caught in ${JSON.stringify(text)}`);
+      failed++;
+    } else console.log(`  ok  negative fixture caught: ${id}`);
   }
-  const clean = 'const n=document.createElement("p");n.textContent=x;await crypto.subtle.digest("SHA-256",b);';
+  // A bare Function() constructor that is NOT the known probe must be rejected.
+  const unknownCtor = 'const x=Function("return 1");';
+  const unknownHits = bareFunctionConstructors(unknownCtor).filter(
+    (c) => !isKnownCapabilityProbe(c)
+  );
+  if (unknownHits.length !== 1) {
+    console.error('  SELF-TEST FAIL: bare Function() constructor not caught');
+    failed++;
+  } else console.log('  ok  negative fixture caught: bare Function() constructor');
+  // The known capability probe is recognised and does not fail the gate.
+  const probe =
+    'if(navigator?.userAgent?.includes(`Cloudflare`))return!1;try{return Function(``),!0}catch{return!1}';
+  const probeHits = bareFunctionConstructors(probe);
+  if (probeHits.length !== 1 || !isKnownCapabilityProbe(probeHits[0])) {
+    console.error('  SELF-TEST FAIL: capability probe not recognised');
+    failed++;
+  } else console.log('  ok  capability probe recognised (allowed, unexecuted)');
+  const clean =
+    'const n=document.createElement("p");n.textContent=x;await crypto.subtle.digest("SHA-256",b);';
   const bad = FORBIDDEN.filter((f) => f.re.test(clean));
-  if (bad.length) { console.error('  SELF-TEST FAIL: clean fixture flagged: ' + bad.map((b) => b.id).join(',')); failed++; }
-  else console.log('  ok  clean fixture passes (createElement + textContent + subtle.digest)');
+  if (bad.length) {
+    console.error('  SELF-TEST FAIL: clean fixture flagged: ' + bad.map((b) => b.id).join(','));
+    failed++;
+  } else console.log('  ok  clean fixture passes (createElement + textContent + subtle.digest)');
   return failed;
 }
 
 if (process.argv.includes('--self-test')) {
   const failed = selfTest();
-  console.log(failed ? `verifier bundle self-test: ${failed} FAILED` : 'verifier bundle self-test: all negative fixtures caught');
+  console.log(
+    failed
+      ? `verifier bundle self-test: ${failed} FAILED`
+      : 'verifier bundle self-test: all negative fixtures caught'
+  );
   process.exit(failed ? 1 : 0);
 }
 
@@ -94,10 +158,15 @@ if (js.length === 0) {
 }
 
 const violations = [];
+let knownProbeCount = 0;
 for (const f of js) {
   const text = readFileSync(f, 'utf8');
   for (const rule of FORBIDDEN) {
     if (rule.re.test(text)) violations.push(`${relative(ROOT, f)}: ${rule.msg}`);
+  }
+  for (const context of bareFunctionConstructors(text)) {
+    if (isKnownCapabilityProbe(context)) knownProbeCount += 1;
+    else violations.push(`${relative(ROOT, f)}: unrecognised Function() constructor`);
   }
 }
 
@@ -116,11 +185,18 @@ if (violations.length) {
   for (const v of violations) console.error('  - ' + v);
   process.exit(1);
 }
+const probeNote =
+  knownProbeCount > 0
+    ? `the only Function() constructor present is a dependency capability probe (x${knownProbeCount}), ` +
+      'disabled application-wide and proven unexecuted by the browser matrix; '
+    : '';
 console.log(
   `verifier bundle: OK -- ${js.length} emitted JS asset(s), ${html.length} HTML; ` +
-    'no forbidden pattern detected in the emitted output (Node builtin, browser-external stub, ' +
-    'network, storage, service-worker, HTML-injection or dynamic-code path). ' +
-    'This is a static scan of what was emitted; the real-browser smoke test provides the runtime ' +
-    'observation. Framing protection (frame-ancestors, X-Frame-Options) is not expressible in the ' +
-    'emitted HTML and remains a response-header requirement at the serving origin.'
+    'no forbidden pattern in the emitted output (Node builtin, browser-external stub, network, ' +
+    'storage, service-worker, HTML-injection, eval or new Function); ' +
+    probeNote +
+    'no other dynamic-code construction. This is a static scan; the browser matrix observes at ' +
+    'runtime that no dynamic code executes and no policy violation is raised. Framing protection ' +
+    '(frame-ancestors, X-Frame-Options) is not expressible in the emitted HTML and remains a ' +
+    'response-header requirement at the serving origin.'
 );


### PR DESCRIPTION
## Summary

The browser verifier ships under a closed Content-Security-Policy (`script-src 'self'`, no `unsafe-eval`). Its schema-validation dependency has a fast path that compiles validators with the `Function` constructor, reached through a capability probe that itself calls `Function("")`. That probe executed during schema construction, was refused by the policy, and raised a policy violation, while the bundle-inspection gates checked only for `eval()` and `new Function()` and so reported no dynamic-code path.

## Security property

Validator compilation is disabled application-wide before any schema is constructed, so the application constructs and executes no dynamic code and raises no policy violation under the shipped CSP. The policy is unchanged; no `unsafe-eval` or `unsafe-inline` is introduced.

The emitted-bundle gate now also detects a bare `Function(...)` constructor. The dependency's probe source remains in the bundle but is never executed; it is recognised and reported as such, and any other dynamic-code construction fails the gate. The browser matrix installs a policy-violation observer before application code and requires zero violations across Chromium, Firefox and WebKit; that runtime observation is the load-bearing evidence.

## Validation

- Full repository suite (503 files); verifier suite including three added regressions (the runtime module configures the interpreted validator, both entry points load it first, and construction plus parse perform no dynamic-code construction).
- Emitted-bundle gate self-test extended with a bare-constructor negative fixture and the recognised-probe case.
- Browser matrix passes on Chromium, Firefox and WebKit plus mobile emulation with no policy violation and no console error; removing the configuration makes the matrix fail with a `script-src` violation, confirming the check is not vacuous.
- Guard, format and whitespace checks pass. No dependency version changed.

## Scope

Verifier application configuration, its emitted-bundle and browser gates, and tests. The schema-validation dependency is declared directly by the (private, unpublished) verifier application because it now uses that dependency's configuration API. No Wire, cryptographic profile, schema, public API, protocol behaviour, dependency version or release-state change.
