### PR TITLE
ci(verifier): harden browser compatibility gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -742,8 +742,8 @@ jobs:
     name: Verifier Browser Matrix
     needs: detect-changes
     # The verifier bundles kernel/schema/crypto/protocol and is built with the root toolchain, so
-    # a change to any of those can alter its browser behaviour. Activation therefore matches the
-    # verifier unit lane: verifier-owned paths, core, or root build/test configuration.
+    # verifier-owned paths, core packages, root build/config changes, and the main branch all run
+    # browser validation. The required aggregate enforces the same condition.
     if: >-
       needs.detect-changes.outputs.verifier_ci == 'true' ||
       needs.detect-changes.outputs.core == 'true' ||
@@ -774,7 +774,7 @@ jobs:
           pnpm exec playwright install --with-deps chromium firefox webkit
 
       - name: Browser matrix
-        run: node apps/verifier/tests/browser/run-browser-matrix.mjs --deps "$RUNNER_TEMP/browser-deps"
+        run: node apps/verifier/tests/browser/run-browser-matrix.mjs --deps "$RUNNER_TEMP/browser-deps" --engines chromium,firefox,webkit
 
   ci:
     name: Build, Lint, Test
@@ -857,14 +857,19 @@ jobs:
             echo "FAIL: verifier-affecting paths changed but the verifier lane did not succeed (result: ${{ needs.examples-apps.result }})"; exit 1
           fi
 
-          # browser-matrix: a failure or cancellation always blocks; when a verifier-reachable
-          # path changed (verifier-owned, core, or root config) the matrix must have actually
-          # succeeded, since a skipped job reports success to its dependents.
+          # browser-matrix: the required condition mirrors the job's own activation so enforcement
+          # cannot drift from when the job runs. A failure or cancellation always blocks; when the
+          # matrix was required it must have succeeded, since a skipped job reports success to its
+          # dependents.
+          BROWSER_REQUIRED=false
+          if [[ "${{ github.ref }}" == "refs/heads/main" || "${{ needs.detect-changes.outputs.verifier_ci }}" == "true" || "${{ needs.detect-changes.outputs.core }}" == "true" || "${{ needs.detect-changes.outputs.root_config }}" == "true" ]]; then
+            BROWSER_REQUIRED=true
+          fi
           if [[ "${{ needs.browser-matrix.result }}" == "failure" || "${{ needs.browser-matrix.result }}" == "cancelled" ]]; then
             echo "FAIL: browser-matrix failed"; exit 1
           fi
-          if [[ ( "${{ needs.detect-changes.outputs.verifier_ci }}" == "true" || "${{ needs.detect-changes.outputs.core }}" == "true" || "${{ needs.detect-changes.outputs.root_config }}" == "true" ) && "${{ needs.browser-matrix.result }}" != "success" ]]; then
-            echo "FAIL: a verifier-reachable path changed but the browser matrix did not succeed (result: ${{ needs.browser-matrix.result }})"; exit 1
+          if [[ "$BROWSER_REQUIRED" == "true" && "${{ needs.browser-matrix.result }}" != "success" ]]; then
+            echo "FAIL: browser validation was required but the matrix did not succeed (result: ${{ needs.browser-matrix.result }})"; exit 1
           fi
 
           # node-compat: the runtime compatibility matrix. Membership in `needs` alone does

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Install actionlint (pinned v1.7.11 with checksum)
+      - name: Install actionlint (pinned v1.7.12 with checksum)
         run: |
           ACTIONLINT_VERSION="1.7.12"
           ACTIONLINT_CHECKSUM="8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
@@ -770,7 +770,7 @@ jobs:
           mkdir -p "$DEPS"
           cd "$DEPS"
           pnpm init > /dev/null
-          pnpm add playwright@1.62.1
+          pnpm add --save-exact playwright@1.62.1
           pnpm exec playwright install --with-deps chromium firefox webkit
 
       - name: Browser matrix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
               - 'scripts/check-browser-verifier-boundary.mjs'
               - 'scripts/check-verifier-bundle.mjs'
               - '.github/workflows/ci.yml'
+              - '.github/actions/setup-env/**'
               - 'tests/tooling/verifier-ci-coverage.test.ts'
             published:
               - 'packages/*/package.json'
@@ -141,8 +142,8 @@ jobs:
 
       - name: Install actionlint (pinned v1.7.11 with checksum)
         run: |
-          ACTIONLINT_VERSION="1.7.11"
-          ACTIONLINT_CHECKSUM="900919a84f2229bac68ca9cd4103ea297abc35e9689ebb842c6e34a3d1b01b0a"
+          ACTIONLINT_VERSION="1.7.12"
+          ACTIONLINT_CHECKSUM="8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
           curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" -o /tmp/actionlint.tar.gz
           echo "${ACTIONLINT_CHECKSUM}  /tmp/actionlint.tar.gz" | sha256sum -c -
           tar xzf /tmp/actionlint.tar.gz -C /tmp actionlint
@@ -740,8 +741,13 @@ jobs:
   browser-matrix:
     name: Verifier Browser Matrix
     needs: detect-changes
+    # The verifier bundles kernel/schema/crypto/protocol and is built with the root toolchain, so
+    # a change to any of those can alter its browser behaviour. Activation therefore matches the
+    # verifier unit lane: verifier-owned paths, core, or root build/test configuration.
     if: >-
       needs.detect-changes.outputs.verifier_ci == 'true' ||
+      needs.detect-changes.outputs.core == 'true' ||
+      needs.detect-changes.outputs.root_config == 'true' ||
       github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -851,13 +857,14 @@ jobs:
             echo "FAIL: verifier-affecting paths changed but the verifier lane did not succeed (result: ${{ needs.examples-apps.result }})"; exit 1
           fi
 
-          # browser-matrix: same activation rule as the verifier lane. A failure always blocks;
-          # when verifier-affecting paths changed the matrix must have actually succeeded.
+          # browser-matrix: a failure or cancellation always blocks; when a verifier-reachable
+          # path changed (verifier-owned, core, or root config) the matrix must have actually
+          # succeeded, since a skipped job reports success to its dependents.
           if [[ "${{ needs.browser-matrix.result }}" == "failure" || "${{ needs.browser-matrix.result }}" == "cancelled" ]]; then
             echo "FAIL: browser-matrix failed"; exit 1
           fi
-          if [[ "${{ needs.detect-changes.outputs.verifier_ci }}" == "true" && "${{ needs.browser-matrix.result }}" != "success" ]]; then
-            echo "FAIL: verifier-affecting paths changed but the browser matrix did not succeed (result: ${{ needs.browser-matrix.result }})"; exit 1
+          if [[ ( "${{ needs.detect-changes.outputs.verifier_ci }}" == "true" || "${{ needs.detect-changes.outputs.core }}" == "true" || "${{ needs.detect-changes.outputs.root_config }}" == "true" ) && "${{ needs.browser-matrix.result }}" != "success" ]]; then
+            echo "FAIL: a verifier-reachable path changed but the browser matrix did not succeed (result: ${{ needs.browser-matrix.result }})"; exit 1
           fi
 
           # node-compat: the runtime compatibility matrix. Membership in `needs` alone does

--- a/apps/verifier/tests/browser-matrix-wiring.test.ts
+++ b/apps/verifier/tests/browser-matrix-wiring.test.ts
@@ -62,14 +62,22 @@ describe('the browser matrix CI lane', () => {
     }
   });
 
-  it('activates on verifier-affecting paths and is required by the aggregate', () => {
+  it('activates on verifier-reachable paths and is required by the aggregate', () => {
     const job = CI.slice(CI.indexOf('browser-matrix:'), CI.indexOf('\n  ci:'));
-    expect(job).toContain("needs.detect-changes.outputs.verifier_ci == 'true'");
+    for (const output of ['verifier_ci', 'core', 'root_config']) {
+      expect(job, `matrix activates on ${output}`).toContain(
+        `needs.detect-changes.outputs.${output} == 'true'`
+      );
+    }
     const aggregate = CI.slice(CI.indexOf('\n  ci:'));
     expect(aggregate).toContain('browser-matrix,');
     expect(aggregate).toContain('needs.browser-matrix.result');
-    expect(aggregate).toMatch(
-      /verifier_ci }}" == "true" && "\$\{\{ needs\.browser-matrix\.result }}" != "success"/
-    );
+    // The aggregate requires the matrix to have succeeded when any verifier-reachable path changed.
+    for (const output of ['verifier_ci', 'core', 'root_config']) {
+      expect(aggregate, `aggregate requires the matrix on ${output}`).toContain(
+        `needs.detect-changes.outputs.${output} }}" == "true"`
+      );
+    }
+    expect(aggregate).toContain('needs.browser-matrix.result }}" != "success"');
   });
 });

--- a/apps/verifier/tests/browser-matrix-wiring.test.ts
+++ b/apps/verifier/tests/browser-matrix-wiring.test.ts
@@ -66,7 +66,7 @@ describe('the browser matrix CI lane', () => {
   it('routes every verifier-reachable path to the matrix and leaves docs unaffected', () => {
     // The change filters that the matrix activation reads. Losing any pattern would silently
     // reopen the coverage hole this lane closes.
-    const filterBlock = (name) => {
+    const filterBlock = (name: string) => {
       const start = CI.indexOf(`\n            ${name}:\n`);
       expect(start, `${name} filter present`).toBeGreaterThan(-1);
       // End at the next sibling filter key (12-space indent, a word, a colon), not a deeper entry.

--- a/apps/verifier/tests/browser-matrix-wiring.test.ts
+++ b/apps/verifier/tests/browser-matrix-wiring.test.ts
@@ -75,6 +75,9 @@ describe('the browser matrix CI lane', () => {
     };
     const required = {
       'apps/verifier/**': 'verifier_ci',
+      'scripts/check-browser-verifier-boundary.mjs': 'verifier_ci',
+      'scripts/check-verifier-bundle.mjs': 'verifier_ci',
+      '.github/workflows/ci.yml': 'verifier_ci',
       '.github/actions/setup-env/**': 'verifier_ci',
       'packages/kernel/**': 'core',
       'packages/schema/**': 'core',
@@ -82,6 +85,8 @@ describe('the browser matrix CI lane', () => {
       'packages/protocol/**': 'core',
       'package.json': 'root_config',
       'pnpm-lock.yaml': 'root_config',
+      'tsconfig*.json': 'root_config',
+      'vitest*.config.*': 'root_config',
     };
     for (const [path, filter] of Object.entries(required)) {
       expect(filterBlock(filter), `${path} in ${filter}`).toContain(`'${path}'`);
@@ -90,6 +95,17 @@ describe('the browser matrix CI lane', () => {
     for (const filter of ['verifier_ci', 'core', 'root_config']) {
       expect(filterBlock(filter)).not.toContain("'docs/**'");
     }
+  });
+
+  it('runs the release engine contract of Chromium, Firefox and WebKit explicitly', () => {
+    const job = CI.slice(CI.indexOf('browser-matrix:'), CI.indexOf('\n  ci:'));
+    expect(job).toContain('--engines chromium,firefox,webkit');
+  });
+
+  it('requires the browser matrix on the main branch as well as on verifier-reachable paths', () => {
+    const aggregate = CI.slice(CI.indexOf('\n  ci:'));
+    expect(aggregate).toContain('github.ref }}" == "refs/heads/main"');
+    expect(aggregate).toContain('BROWSER_REQUIRED');
   });
 
   it('activates on verifier-reachable paths and is required by the aggregate', () => {

--- a/apps/verifier/tests/browser-matrix-wiring.test.ts
+++ b/apps/verifier/tests/browser-matrix-wiring.test.ts
@@ -54,11 +54,41 @@ describe('the browser matrix CI lane', () => {
     expect(CI).toContain('run-browser-matrix.mjs --deps');
   });
 
-  it('pins an exact stable Playwright release', () => {
+  it('pins an exact stable Playwright release recorded exactly in the ephemeral manifest', () => {
     const pins = [...CI.matchAll(/playwright@(\S+)/g)].map((m) => m[1]);
     expect(pins.length).toBeGreaterThan(0);
     for (const pin of pins) {
       expect(pin, 'exact release, no range or pre-release tag').toMatch(/^\d+\.\d+\.\d+$/);
+    }
+    expect(CI).toContain('pnpm add --save-exact playwright@');
+  });
+
+  it('routes every verifier-reachable path to the matrix and leaves docs unaffected', () => {
+    // The change filters that the matrix activation reads. Losing any pattern would silently
+    // reopen the coverage hole this lane closes.
+    const filterBlock = (name) => {
+      const start = CI.indexOf(`\n            ${name}:\n`);
+      expect(start, `${name} filter present`).toBeGreaterThan(-1);
+      // End at the next sibling filter key (12-space indent, a word, a colon), not a deeper entry.
+      const next = CI.slice(start + 1).search(/\n {12}\w+:\n/);
+      return CI.slice(start, next === -1 ? undefined : start + 1 + next);
+    };
+    const required = {
+      'apps/verifier/**': 'verifier_ci',
+      '.github/actions/setup-env/**': 'verifier_ci',
+      'packages/kernel/**': 'core',
+      'packages/schema/**': 'core',
+      'packages/crypto/**': 'core',
+      'packages/protocol/**': 'core',
+      'package.json': 'root_config',
+      'pnpm-lock.yaml': 'root_config',
+    };
+    for (const [path, filter] of Object.entries(required)) {
+      expect(filterBlock(filter), `${path} in ${filter}`).toContain(`'${path}'`);
+    }
+    // Documentation is in none of the three matrix-activating filters.
+    for (const filter of ['verifier_ci', 'core', 'root_config']) {
+      expect(filterBlock(filter)).not.toContain("'docs/**'");
     }
   });
 

--- a/apps/verifier/tests/browser/run-browser-matrix.mjs
+++ b/apps/verifier/tests/browser/run-browser-matrix.mjs
@@ -158,15 +158,17 @@ async function makeFixtures() {
   }
   const tampered = [segments[0], segments[1], base64urlEncode(tamperedSig)].join('.');
 
-  // The record's issued-at is the real issuance instant. Parity pins the evaluation time to it so
-  // the record is within its validity window and every engine reports the same evaluation second.
+  // Parity pins the evaluation time one second after the record's issued-at, so it is
+  // unambiguously after issuance and identical across engines, without testing the temporal
+  // boundary itself.
   const iat = JSON.parse(new TextDecoder().decode(base64urlDecode(segments[1]))).iat;
   if (!Number.isInteger(iat)) throw new Error('fixture record has no integer iat');
+  const parityEvaluationSecond = iat + 1;
 
   return {
     record: issued.jws,
-    parityEvaluationSecond: iat,
-    parityEvaluationTime: new Date(iat * 1000),
+    parityEvaluationSecond,
+    parityEvaluationTime: new Date(parityEvaluationSecond * 1000),
     unicodeRecord: unicodeIssued.jws,
     tampered,
     bareJwk: JSON.stringify(jwk),

--- a/apps/verifier/tests/browser/run-browser-matrix.mjs
+++ b/apps/verifier/tests/browser/run-browser-matrix.mjs
@@ -146,19 +146,27 @@ async function makeFixtures() {
     x: otherJwk.x,
   });
 
-  // Tamper by flipping one decoded payload byte and re-encoding, keeping the signature, so the
-  // signed bytes provably change.
+  // Tamper by flipping one signature byte, leaving the header and payload well-formed and exactly
+  // as signed, so the record reaches signature verification and fails there (rather than a
+  // structural or I-JSON failure before it). The signature bytes provably change.
   const segments = issued.jws.split('.');
-  const payloadBytes = base64urlDecode(segments[1]);
-  const tamperedBytes = Uint8Array.from(payloadBytes);
-  tamperedBytes[0] ^= 0x01;
-  if (Buffer.from(payloadBytes).equals(Buffer.from(tamperedBytes))) {
-    throw new Error('tamper fixture failed to change the signed bytes');
+  const sigBytes = base64urlDecode(segments[2]);
+  const tamperedSig = Uint8Array.from(sigBytes);
+  tamperedSig[0] ^= 0x01;
+  if (Buffer.from(sigBytes).equals(Buffer.from(tamperedSig))) {
+    throw new Error('tamper fixture failed to change the signature bytes');
   }
-  const tampered = [segments[0], base64urlEncode(tamperedBytes), segments[2]].join('.');
+  const tampered = [segments[0], segments[1], base64urlEncode(tamperedSig)].join('.');
+
+  // The record's issued-at is the real issuance instant. Parity pins the evaluation time to it so
+  // the record is within its validity window and every engine reports the same evaluation second.
+  const iat = JSON.parse(new TextDecoder().decode(base64urlDecode(segments[1]))).iat;
+  if (!Number.isInteger(iat)) throw new Error('fixture record has no integer iat');
 
   return {
     record: issued.jws,
+    parityEvaluationSecond: iat,
+    parityEvaluationTime: new Date(iat * 1000),
     unicodeRecord: unicodeIssued.jws,
     tampered,
     bareJwk: JSON.stringify(jwk),
@@ -471,26 +479,38 @@ async function runObserverControl(browser, origin) {
   return recorded ? [] : ['csp-observer: no violation recorded for a deliberate blocked eval'];
 }
 
-// A fixed instant so the report's evaluation-time input is identical across engines. The UI reads
-// the wall clock at verification time, so the clock is pinned before load.
-const PARITY_CLOCK_MS = 1_700_000_000_000;
-const PARITY_FLOWS = ['accept-bare-jwk', 'tamper', 'trusted-key-mismatch'];
+// Expected semantics per scenario, so parity proves "same correct report", not merely "same
+// bytes": three engines can be identically wrong. Codes and stages are the verifier's own.
+const PARITY_SCENARIOS = [
+  { flowId: 'accept-bare-jwk', outcome: 'accepted' },
+  {
+    flowId: 'tamper',
+    outcome: 'rejected',
+    failureStage: 'signature',
+    failureCode: 'E_INVALID_SIGNATURE',
+  },
+  {
+    flowId: 'trusted-key-mismatch',
+    outcome: 'rejected',
+    failureStage: 'trusted_key',
+    failureCode: 'E_VERIFIER_TRUSTED_KEY_MISMATCH',
+  },
+];
 
-// Collects the rendered report for each parity flow under a pinned clock. Identical record, key,
-// context and evaluation time must yield a byte-identical report in every engine. Each flow runs
-// on a fresh page so the report panel cannot carry a prior flow's render, and the report element
-// is awaited before it is read.
+// Collects the rendered report for each parity scenario under a pinned evaluation time, on a fresh
+// context and page per scenario. The report element is awaited before it is read.
 async function collectParityReports(browser, origin, fixtures) {
   const byFlow = {};
-  for (const flow of flows(fixtures).filter((f) => PARITY_FLOWS.includes(f.id))) {
+  const flowById = Object.fromEntries(flows(fixtures).map((f) => [f.id, f]));
+  for (const scenario of PARITY_SCENARIOS) {
     const context = await browser.newContext();
     const page = await context.newPage();
-    await page.clock.install({ time: PARITY_CLOCK_MS });
+    await page.clock.setFixedTime(fixtures.parityEvaluationTime);
     await page.goto(`${origin}/`, { waitUntil: 'networkidle' });
-    await runFlow(page, flow);
+    await runFlow(page, flowById[scenario.flowId]);
     const report = page.locator('section pre').first();
     await report.waitFor({ state: 'visible', timeout: 15000 });
-    byFlow[flow.id] = await report.textContent();
+    byFlow[scenario.flowId] = await report.textContent();
     await context.close();
   }
   return byFlow;
@@ -585,22 +605,50 @@ try {
       await browser.close();
     }
     const problems = [];
-    for (const flowId of PARITY_FLOWS) {
-      const reports = parityEngines.map((n) => perEngine[n][flowId]);
+    const firstEngine = parityEngines[0];
+    for (const scenario of PARITY_SCENARIOS) {
+      const reports = parityEngines.map((n) => perEngine[n][scenario.flowId]);
+      // Semantics first: prove the report says what it should before comparing engines, so
+      // identically-wrong output cannot satisfy parity.
+      const parsed = JSON.parse(reports[0]);
+      if (parsed.outcome !== scenario.outcome) {
+        problems.push(
+          `${scenario.flowId}: outcome ${parsed.outcome}, expected ${scenario.outcome}`
+        );
+      }
+      if (parsed.failureStage !== scenario.failureStage) {
+        problems.push(
+          `${scenario.flowId}: stage ${parsed.failureStage}, expected ${scenario.failureStage}`
+        );
+      }
+      if (parsed.failureCode !== scenario.failureCode) {
+        problems.push(
+          `${scenario.flowId}: code ${parsed.failureCode}, expected ${scenario.failureCode}`
+        );
+      }
+      if (parsed.evaluationTimeUnixSeconds !== fixtures.parityEvaluationSecond) {
+        problems.push(
+          `${scenario.flowId}: evaluation time not pinned to ${fixtures.parityEvaluationSecond}`
+        );
+      }
+      if (!parsed.reportSha256) problems.push(`${scenario.flowId}: reportSha256 absent`);
+      // Then engine equality: exact bytes and hash, unmodified.
       if (new Set(reports).size !== 1) {
-        problems.push(`${flowId}: report differs across engines`);
-        continue;
+        problems.push(`${scenario.flowId}: report differs across engines`);
       }
-      const hash = JSON.parse(reports[0]).reportSha256;
-      const hashes = reports.map((r) => JSON.parse(r).reportSha256);
-      if (!hash || new Set(hashes).size !== 1) {
-        problems.push(`${flowId}: reportSha256 differs across engines`);
+      if (new Set(reports.map((r) => JSON.parse(r).reportSha256)).size !== 1) {
+        problems.push(`${scenario.flowId}: reportSha256 differs across engines`);
       }
+    }
+    // The three scenarios must not collapse to one report, or a shared-wrong-output bug would pass.
+    const distinct = new Set(PARITY_SCENARIOS.map((s) => perEngine[firstEngine][s.flowId]));
+    if (distinct.size !== PARITY_SCENARIOS.length) {
+      problems.push('parity scenarios produced fewer than three distinct reports');
     }
     report(
       'cross-engine-parity',
       problems,
-      `${parityEngines.join(', ')} x ${PARITY_FLOWS.join(', ')}`
+      `${parityEngines.join(', ')} x ${PARITY_SCENARIOS.map((s) => s.flowId).join(', ')}`
     );
   }
 

--- a/apps/verifier/tests/browser/run-browser-matrix.mjs
+++ b/apps/verifier/tests/browser/run-browser-matrix.mjs
@@ -471,6 +471,31 @@ async function runObserverControl(browser, origin) {
   return recorded ? [] : ['csp-observer: no violation recorded for a deliberate blocked eval'];
 }
 
+// A fixed instant so the report's evaluation-time input is identical across engines. The UI reads
+// the wall clock at verification time, so the clock is pinned before load.
+const PARITY_CLOCK_MS = 1_700_000_000_000;
+const PARITY_FLOWS = ['accept-bare-jwk', 'tamper', 'trusted-key-mismatch'];
+
+// Collects the rendered report for each parity flow under a pinned clock. Identical record, key,
+// context and evaluation time must yield a byte-identical report in every engine. Each flow runs
+// on a fresh page so the report panel cannot carry a prior flow's render, and the report element
+// is awaited before it is read.
+async function collectParityReports(browser, origin, fixtures) {
+  const byFlow = {};
+  for (const flow of flows(fixtures).filter((f) => PARITY_FLOWS.includes(f.id))) {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.clock.install({ time: PARITY_CLOCK_MS });
+    await page.goto(`${origin}/`, { waitUntil: 'networkidle' });
+    await runFlow(page, flow);
+    const report = page.locator('section pre').first();
+    await report.waitFor({ state: 'visible', timeout: 15000 });
+    byFlow[flow.id] = await report.textContent();
+    await context.close();
+  }
+  return byFlow;
+}
+
 // A runtime without WebCrypto Ed25519 must present a capability message, not a cryptic failure.
 async function runCapabilityCheck(browser, origin) {
   const context = await browser.newContext();
@@ -546,6 +571,36 @@ try {
       `${version}; ${flows(fixtures).length} flows + report determinism + snapshot + ` +
         `supersession + file input + capability + CSP-observer control; no network, no persistence, ` +
         `no application CSP unsafe-eval violation`
+    );
+  }
+
+  // Cross-engine report parity: the same inputs and pinned evaluation time must produce a
+  // byte-identical report, including its hash, in every desktop engine.
+  const parityEngines = engines.filter((n) => playwright[n]);
+  if (parityEngines.length > 1) {
+    const perEngine = {};
+    for (const name of parityEngines) {
+      const browser = await playwright[name].launch();
+      perEngine[name] = await collectParityReports(browser, origin, fixtures);
+      await browser.close();
+    }
+    const problems = [];
+    for (const flowId of PARITY_FLOWS) {
+      const reports = parityEngines.map((n) => perEngine[n][flowId]);
+      if (new Set(reports).size !== 1) {
+        problems.push(`${flowId}: report differs across engines`);
+        continue;
+      }
+      const hash = JSON.parse(reports[0]).reportSha256;
+      const hashes = reports.map((r) => JSON.parse(r).reportSha256);
+      if (!hash || new Set(hashes).size !== 1) {
+        problems.push(`${flowId}: reportSha256 differs across engines`);
+      }
+    }
+    report(
+      'cross-engine-parity',
+      problems,
+      `${parityEngines.join(', ')} x ${PARITY_FLOWS.join(', ')}`
     );
   }
 

--- a/tests/tooling/verifier-lane-aggregation.test.ts
+++ b/tests/tooling/verifier-lane-aggregation.test.ts
@@ -153,3 +153,25 @@ describe('core and root-config changes also require the browser matrix', () => {
     expect(evaluate(lanes({ browserMatrix: 'skipped' }))).toBe(0);
   });
 });
+
+// GitHub exposes needs.<job>.result as exactly success | failure | cancelled | skipped. The full
+// state table: when required, only success passes; when not required, success and skipped pass.
+describe('the browser-matrix state table is exhaustive over result values', () => {
+  for (const activator of ['verifier_ci', 'core', 'root_config']) {
+    const key =
+      activator === 'verifier_ci' ? 'verifierCi' : activator === 'core' ? 'core' : 'rootConfig';
+    it(`required via ${activator}: success passes, skipped/failure/cancelled fail`, () => {
+      expect(evaluate(lanes({ [key]: 'true', browserMatrix: 'success' }))).toBe(0);
+      for (const result of ['skipped', 'failure', 'cancelled']) {
+        expect(evaluate(lanes({ [key]: 'true', browserMatrix: result })), result).not.toBe(0);
+      }
+    });
+  }
+
+  it('not required: success and skipped pass, failure and cancelled fail', () => {
+    expect(evaluate(lanes({ browserMatrix: 'success' }))).toBe(0);
+    expect(evaluate(lanes({ browserMatrix: 'skipped' }))).toBe(0);
+    expect(evaluate(lanes({ browserMatrix: 'failure' }))).not.toBe(0);
+    expect(evaluate(lanes({ browserMatrix: 'cancelled' }))).not.toBe(0);
+  });
+});

--- a/tests/tooling/verifier-lane-aggregation.test.ts
+++ b/tests/tooling/verifier-lane-aggregation.test.ts
@@ -53,6 +53,7 @@ interface LaneOptions {
   verifierCi?: string;
   core?: string;
   rootConfig?: string;
+  ref?: string;
   examplesApps?: string;
   browserMatrix?: string;
 }
@@ -61,6 +62,8 @@ interface LaneOptions {
 function lanes(opts: LaneOptions = {}): Record<string, string> {
   const examplesApps = opts.examplesApps ?? 'success';
   return {
+    // A pull-request ref by default, so main-branch activation is only exercised when requested.
+    'github.ref': opts.ref ?? 'refs/pull/1/merge',
     'needs.detect-changes.outputs.verifier_ci': opts.verifierCi ?? 'false',
     'needs.detect-changes.outputs.core': opts.core ?? 'false',
     'needs.detect-changes.outputs.root_config': opts.rootConfig ?? 'false',
@@ -167,6 +170,14 @@ describe('the browser-matrix state table is exhaustive over result values', () =
       }
     });
   }
+
+  it('required on the main branch: success passes, skipped/failure/cancelled fail', () => {
+    const onMain = { ref: 'refs/heads/main' };
+    expect(evaluate(lanes({ ...onMain, browserMatrix: 'success' }))).toBe(0);
+    for (const result of ['skipped', 'failure', 'cancelled']) {
+      expect(evaluate(lanes({ ...onMain, browserMatrix: result })), result).not.toBe(0);
+    }
+  });
 
   it('not required: success and skipped pass, failure and cancelled fail', () => {
     expect(evaluate(lanes({ browserMatrix: 'success' }))).toBe(0);

--- a/tests/tooling/verifier-lane-aggregation.test.ts
+++ b/tests/tooling/verifier-lane-aggregation.test.ts
@@ -49,16 +49,23 @@ function evaluate(values: Record<string, string>): number {
   }
 }
 
-/** All lanes passing, with the verifier activation flag and lane results under test. */
-function lanes(
-  verifierCi: string,
-  examplesApps: string,
-  browserMatrix = examplesApps
-): Record<string, string> {
+interface LaneOptions {
+  verifierCi?: string;
+  core?: string;
+  rootConfig?: string;
+  examplesApps?: string;
+  browserMatrix?: string;
+}
+
+/** All lanes passing, with the activation flags and lane results under test. */
+function lanes(opts: LaneOptions = {}): Record<string, string> {
+  const examplesApps = opts.examplesApps ?? 'success';
   return {
-    'needs.detect-changes.outputs.verifier_ci': verifierCi,
+    'needs.detect-changes.outputs.verifier_ci': opts.verifierCi ?? 'false',
+    'needs.detect-changes.outputs.core': opts.core ?? 'false',
+    'needs.detect-changes.outputs.root_config': opts.rootConfig ?? 'false',
     // Unrelated activation outputs, held at values that keep the other rules satisfied so each
-    // test isolates the verifier rule.
+    // test isolates the rule under examination.
     'needs.detect-changes.outputs.stamp_any': 'false',
     'needs.detect-changes.outputs.non_stamp': 'true',
     'needs.workflow-lint.result': 'success',
@@ -69,53 +76,80 @@ function lanes(
     'needs.examples-apps.result': examplesApps,
     'needs.pack-smoke.result': 'success',
     'needs.node-compat.result': 'success',
-    'needs.browser-matrix.result': browserMatrix,
+    'needs.browser-matrix.result': opts.browserMatrix ?? examplesApps,
   };
 }
 
 describe('a verifier lane that did not run cannot pass the aggregate', () => {
   it('verifier paths changed and the lane succeeded: accepted', () => {
-    expect(evaluate(lanes('true', 'success'))).toBe(0);
+    expect(evaluate(lanes({ verifierCi: 'true', examplesApps: 'success' }))).toBe(0);
   });
 
   it('verifier paths changed and the lane was SKIPPED: rejected', () => {
     // The exact defect this exists to prevent: skipped reads as success to dependents.
-    expect(evaluate(lanes('true', 'skipped'))).not.toBe(0);
+    expect(evaluate(lanes({ verifierCi: 'true', examplesApps: 'skipped' }))).not.toBe(0);
   });
 
   it('verifier paths changed and the lane failed: rejected', () => {
-    expect(evaluate(lanes('true', 'failure'))).not.toBe(0);
+    expect(evaluate(lanes({ verifierCi: 'true', examplesApps: 'failure' }))).not.toBe(0);
   });
 
   it('verifier paths unchanged and the lane was skipped: allowed', () => {
     // Unrelated changes must not be forced through the application lane.
-    expect(evaluate(lanes('false', 'skipped'))).toBe(0);
+    expect(evaluate(lanes({ verifierCi: 'false', examplesApps: 'skipped' }))).toBe(0);
   });
 
   it('verifier paths unchanged and the lane failed: still rejected', () => {
     // The pre-existing generic failure handling must survive the added rule.
-    expect(evaluate(lanes('false', 'failure'))).not.toBe(0);
+    expect(evaluate(lanes({ verifierCi: 'false', examplesApps: 'failure' }))).not.toBe(0);
   });
 });
 
 describe('a browser matrix that did not run cannot pass the aggregate', () => {
   it('verifier paths changed and the matrix succeeded: accepted', () => {
-    expect(evaluate(lanes('true', 'success', 'success'))).toBe(0);
+    expect(evaluate(lanes({ verifierCi: 'true', browserMatrix: 'success' }))).toBe(0);
   });
 
   it('verifier paths changed and the matrix was SKIPPED: rejected', () => {
-    expect(evaluate(lanes('true', 'success', 'skipped'))).not.toBe(0);
+    expect(evaluate(lanes({ verifierCi: 'true', browserMatrix: 'skipped' }))).not.toBe(0);
   });
 
   it('verifier paths changed and the matrix failed: rejected', () => {
-    expect(evaluate(lanes('true', 'success', 'failure'))).not.toBe(0);
+    expect(evaluate(lanes({ verifierCi: 'true', browserMatrix: 'failure' }))).not.toBe(0);
   });
 
   it('verifier paths unchanged and the matrix was skipped: allowed', () => {
-    expect(evaluate(lanes('false', 'success', 'skipped'))).toBe(0);
+    expect(evaluate(lanes({ verifierCi: 'false', browserMatrix: 'skipped' }))).toBe(0);
   });
 
   it('verifier paths unchanged and the matrix failed: still rejected', () => {
-    expect(evaluate(lanes('false', 'success', 'failure'))).not.toBe(0);
+    expect(evaluate(lanes({ verifierCi: 'false', browserMatrix: 'failure' }))).not.toBe(0);
+  });
+});
+
+describe('core and root-config changes also require the browser matrix', () => {
+  it('a core change with the matrix skipped is rejected', () => {
+    expect(evaluate(lanes({ core: 'true', browserMatrix: 'skipped' }))).not.toBe(0);
+  });
+
+  it('a core change with the matrix succeeded is accepted', () => {
+    expect(evaluate(lanes({ core: 'true', browserMatrix: 'success' }))).toBe(0);
+  });
+
+  it('a root-config change with the matrix skipped is rejected', () => {
+    expect(evaluate(lanes({ rootConfig: 'true', browserMatrix: 'skipped' }))).not.toBe(0);
+  });
+
+  it('a root-config change with the matrix succeeded is accepted', () => {
+    expect(evaluate(lanes({ rootConfig: 'true', browserMatrix: 'success' }))).toBe(0);
+  });
+
+  it('a matrix failure blocks regardless of which path activated it', () => {
+    expect(evaluate(lanes({ core: 'true', browserMatrix: 'failure' }))).not.toBe(0);
+    expect(evaluate(lanes({ rootConfig: 'true', browserMatrix: 'failure' }))).not.toBe(0);
+  });
+
+  it('an unrelated change with the matrix skipped is allowed', () => {
+    expect(evaluate(lanes({ browserMatrix: 'skipped' }))).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Strengthens the verifier's browser compatibility gates so a change that can alter browser behaviour cannot merge without the browser matrix having run, and so the matrix proves portability across engines rather than only within each engine.

## Changes

- The browser matrix activates on verifier-owned paths, core packages, root build and configuration changes, and the main branch; the shared setup action is included. The required aggregate enforces the same condition, refusing a skipped matrix whenever browser validation was required.
- The matrix adds a cross-engine report parity check: under a pinned evaluation time, the same record, key and context must produce a byte-identical report, including its hash, in Chromium, Firefox and WebKit, for an accepted verification, a signature failure and a trusted-key mismatch, with each scenario's outcome asserted before the comparison.
- actionlint is updated to 1.7.12 with its published checksum; the isolated Playwright tool installation is pinned exactly.

## Validation

Full repository suite. The aggregate decision table is exercised for verifier, core, root-config and main-branch activation across success, skipped, failed and cancelled matrix results. The browser matrix passes on Chromium, Firefox and WebKit plus mobile emulation, including cross-engine report equality and a per-engine policy-observer control. actionlint 1.7.12 lints the workflow clean. Guard, format and whitespace checks pass.

## Scope

CI workflow and verifier test tooling only. No protocol, wire format, cryptographic, schema, public API, or workspace/runtime package dependency change.
