### PR TITLE
docs(protocol): kid validation

### DIFF
--- a/packages/protocol/src/issue.ts
+++ b/packages/protocol/src/issue.ts
@@ -420,7 +420,7 @@ export interface IssueWire02Options {
   /** Ed25519 private key (32 bytes) */
   privateKey: Uint8Array;
 
-  /** Key ID (max 256 chars per JOSE hardening rules) */
+  /** Key ID: non-empty, well-formed Unicode, at most 256 UTF-8 bytes (a PEAC constraint; RFC 7515 leaves kid structure unspecified) */
   kid: string;
 
   /**


### PR DESCRIPTION
## Summary

Corrects the `kid` field documentation on the record-issuing options. The rule is a PEAC application-level constraint (non-empty, well-formed Unicode, at most 256 UTF-8 bytes), not a JOSE requirement measured in characters; RFC 7515 leaves the structure of `kid` unspecified. This matches the enforced validation.

## Scope

Documentation comment only. No behaviour, wire format, schema, cryptographic, API or dependency change.
