### PR TITLE
feat(verifier): accessible verification guidance and state announcement

### DIFF
--- a/apps/verifier/src/styles/main.css
+++ b/apps/verifier/src/styles/main.css
@@ -1,4 +1,11 @@
-/* PEAC Receipt Verifier -- Minimal vanilla CSS */
+/*
+ * Local record verifier styling.
+ *
+ * Visual language follows peacprotocol.org: a neutral monochrome base with an emerald accent for
+ * verified state, generous whitespace, subtle card shadows and rounded corners. Fonts use the same
+ * system fallback stacks the site declares for Inter and JetBrains Mono; no font is fetched or
+ * bundled, so the page stays within its no-network content-security policy.
+ */
 
 *,
 *::before,
@@ -9,338 +16,376 @@
 }
 
 :root {
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace;
+
   --bg: #fafafa;
-  --fg: #1a1a1a;
-  --border: #ddd;
-  --accent: #2563eb;
-  --valid: #16a34a;
-  --invalid: #dc2626;
-  --warn: #ca8a04;
-  --mono: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
+  --surface: #ffffff;
+  --code-bg: #171717;
+  --code-fg: #d4d4d4;
+
+  --fg: #171717;
+  --fg-muted: #525252;
+  --fg-subtle: #737373;
+
+  --border: #e5e5e5;
+  --border-strong: #d4d4d4;
+
+  --accent: #047857;
+  --accent-strong: #065f46;
+  --accent-bg: #ecfdf5;
+  --accent-border: #a7f3d0;
+
+  --danger: #b91c1c;
+  --danger-bg: #fef2f2;
+  --danger-border: #fecaca;
+
+  --focus: #a3a3a3;
+
+  --radius-lg: 12px;
+  --radius-md: 8px;
+  --radius-sm: 6px;
+
+  --shadow-card: 0 1px 3px 0 rgb(0 0 0 / 0.04), 0 1px 2px -1px rgb(0 0 0 / 0.04);
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
 }
 
 body {
-  font-family:
-    system-ui,
-    -apple-system,
-    sans-serif;
+  font-family: var(--font-sans);
   background: var(--bg);
   color: var(--fg);
-  max-width: 800px;
-  margin: 0 auto;
-  padding: 2rem 1rem;
   line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-header {
-  margin-bottom: 2rem;
+#app {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 2.5rem 1.25rem 4rem;
 }
 
-header h1 {
-  font-size: 1.5rem;
-  font-weight: 600;
-}
-
-header p {
-  color: #666;
-  font-size: 0.875rem;
-}
-
-/* Tabs */
-.tabs {
+main {
   display: flex;
-  gap: 0;
-  border-bottom: 2px solid var(--border);
-  margin-bottom: 1.5rem;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
-.tab {
-  padding: 0.5rem 1.5rem;
-  border: none;
-  background: none;
-  cursor: pointer;
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: #666;
-  border-bottom: 2px solid transparent;
-  margin-bottom: -2px;
+/* Header */
+
+h1 {
+  font-size: clamp(1.6rem, 4vw, 2rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
 }
 
-.tab.active {
-  color: var(--accent);
-  border-bottom-color: var(--accent);
+h1 + p {
+  margin-top: 0.5rem;
+  color: var(--fg-muted);
+  font-size: 1rem;
+  max-width: 60ch;
 }
 
-.tab-content {
+/* Input group and result panels share a card surface. */
+
+[role='group'],
+section[aria-label='Verification result']:not(:empty),
+section[aria-label='Verification report']:not(:empty),
+section[aria-label='What verification proves'] {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+  padding: 1.5rem;
+}
+
+/* Empty result and report panels take no space until they hold an outcome. */
+section[aria-label='Verification result']:empty,
+section[aria-label='Verification report']:empty {
   display: none;
 }
 
-.tab-content.active {
-  display: block;
+[role='group'] {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
 }
 
-/* Paste + Verify */
+[role='group'] > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
 label {
-  display: block;
-  font-weight: 500;
-  font-size: 0.875rem;
-  margin-bottom: 0.25rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--fg);
 }
 
-textarea,
-input[type='url'] {
+textarea {
   width: 100%;
-  padding: 0.75rem;
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  font-family: var(--mono);
-  font-size: 0.8125rem;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--fg);
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  padding: 0.7rem 0.8rem;
   resize: vertical;
-  margin-bottom: 0.75rem;
+  min-height: 6.5rem;
 }
+
+textarea:focus-visible {
+  outline: none;
+  border-color: var(--fg-subtle);
+  box-shadow: 0 0 0 3px rgb(115 115 115 / 0.18);
+}
+
+input[type='file'] {
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  color: var(--fg-muted);
+}
+
+input[type='file']::file-selector-button {
+  font-family: inherit;
+  font-size: 0.85rem;
+  color: var(--fg);
+  background: #f5f5f5;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  padding: 0.4rem 0.75rem;
+  margin-right: 0.75rem;
+  cursor: pointer;
+}
+
+input[type='file']::file-selector-button:hover {
+  background: #ededed;
+}
+
+/* Field hint text. */
+[role='group'] > div > p {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--fg-subtle);
+}
+
+/* Primary action */
 
 button {
-  padding: 0.5rem 1.25rem;
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  background: var(--accent);
-  color: white;
+  align-self: flex-start;
+  font-family: inherit;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #ffffff;
+  background: var(--fg);
+  border: 1px solid var(--fg);
+  border-radius: var(--radius-md);
+  padding: 0.6rem 1.5rem;
   cursor: pointer;
-  font-size: 0.875rem;
-  font-weight: 500;
+  transition:
+    background-color 0.15s ease,
+    transform 0.1s ease;
 }
 
-button:hover {
-  opacity: 0.9;
+button:hover:not(:disabled) {
+  background: #262626;
+}
+
+button:active:not(:disabled) {
+  transform: scale(0.98);
 }
 
 button:disabled {
-  opacity: 0.5;
+  opacity: 0.45;
   cursor: not-allowed;
 }
 
-#verify-btn {
-  margin-bottom: 1.5rem;
+:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
 }
 
-/* File upload */
-.drop-zone {
-  border: 2px dashed var(--border);
-  border-radius: 4px;
-  padding: 1.5rem;
-  text-align: center;
-  margin-bottom: 1.5rem;
-  transition: border-color 0.2s;
+/* Result panel */
+
+section[aria-label='Verification result'] {
+  border-left: 4px solid var(--border-strong);
 }
 
-.drop-zone.drag-over {
-  border-color: var(--accent);
-  background: #f0f5ff;
+section[aria-label='Verification result'].result--ok {
+  border-left-color: var(--accent);
+  background: linear-gradient(0deg, var(--surface), var(--surface)), var(--accent-bg);
 }
 
-.drop-zone p {
-  color: #666;
-  font-size: 0.875rem;
-  margin-bottom: 0.5rem;
+section[aria-label='Verification result'].result--fail {
+  border-left-color: var(--danger);
 }
 
-/* Results */
-.result {
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 1rem;
-  margin-top: 1rem;
-}
-
-.result.valid {
-  border-color: var(--valid);
-}
-
-.result.invalid {
-  border-color: var(--invalid);
-}
-
-.result.error {
-  border-color: var(--invalid);
-}
-
-.result.no-key {
-  border-color: var(--warn);
-}
-
-.result-status {
+section[aria-label='Verification result'] h2 {
+  font-size: 1.25rem;
   font-weight: 700;
-  font-size: 1.125rem;
-  margin-bottom: 0.25rem;
+  letter-spacing: -0.01em;
 }
 
-.valid .result-status {
-  color: var(--valid);
-}
-.invalid .result-status,
-.error .result-status {
-  color: var(--invalid);
-}
-.no-key .result-status {
-  color: var(--warn);
+section[aria-label='Verification result'].result--ok h2 {
+  color: var(--accent-strong);
 }
 
-.result-message {
-  font-size: 0.875rem;
-  color: #444;
-  margin-bottom: 0.5rem;
+section[aria-label='Verification result'].result--fail h2 {
+  color: var(--danger);
 }
 
-.result-kid {
-  font-size: 0.75rem;
-  color: #666;
-  font-family: var(--mono);
-  margin-bottom: 0.75rem;
-}
-
-/* Claims table */
-.claims-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.8125rem;
-}
-
-.claims-table th,
-.claims-table td {
-  padding: 0.375rem 0.5rem;
-  text-align: left;
-  border-bottom: 1px solid var(--border);
-}
-
-.claims-table th {
-  font-weight: 600;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  color: #666;
-}
-
-.claim-label {
-  font-weight: 500;
-  white-space: nowrap;
-  width: 120px;
-}
-
-.claim-value {
-  font-family: var(--mono);
-  word-break: break-all;
-}
-
-.claim-value.json {
-  white-space: pre-wrap;
-}
-
-/* Trust config */
-.trust-actions {
-  display: flex;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
-}
-
-.trust-actions button {
-  font-size: 0.8125rem;
-}
-
-#load-sandbox {
-  background: var(--accent);
-}
-
-#load-local {
-  background: white;
-  color: var(--fg);
-  font-size: 0.75rem;
-}
-
-#add-manual {
-  background: white;
-  color: var(--fg);
-}
-
-.trust-message {
-  font-size: 0.875rem;
-  padding: 0.5rem 0.75rem;
-  border-radius: 4px;
-  margin-bottom: 0.75rem;
-}
-
-.trust-message:empty {
-  display: none;
-}
-
-.trust-message.error {
-  background: #fef2f2;
-  color: var(--invalid);
-  border: 1px solid #fecaca;
-}
-
-.trust-message.success {
-  background: #f0fdf4;
-  color: var(--valid);
-  border: 1px solid #bbf7d0;
-}
-
-.empty {
-  color: #666;
-  font-size: 0.875rem;
-  font-style: italic;
-}
-
-.issuer-list {
-  list-style: none;
-}
-
-.issuer-item {
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 0.75rem;
-  margin-bottom: 0.5rem;
-}
-
-.issuer-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.remove-btn {
-  background: white;
-  color: var(--invalid);
-  border-color: var(--invalid);
-  font-size: 0.75rem;
-  padding: 0.25rem 0.5rem;
-}
-
-.key-list {
-  list-style: none;
+section[aria-label='Verification result'] > p {
   margin-top: 0.5rem;
-  font-family: var(--mono);
-  font-size: 0.75rem;
-  color: #666;
+  color: var(--fg-muted);
+  font-size: 0.92rem;
 }
 
-.manual-form {
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 1rem;
+section[aria-label='Verification result'] h3 {
+  margin-top: 1.25rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+/* Assessment and claim rows. */
+dl {
+  margin-top: 0.75rem;
+  display: grid;
+  grid-template-columns: minmax(9rem, auto) 1fr;
+  gap: 0.35rem 1rem;
+  font-size: 0.88rem;
+}
+
+dt {
+  color: var(--fg-subtle);
+  font-weight: 500;
+}
+
+dd {
+  color: var(--fg);
+  font-family: var(--font-mono);
+  font-size: 0.83rem;
+  word-break: break-word;
+}
+
+/* Report panel */
+
+section[aria-label='Verification report'] h3 {
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+section[aria-label='Verification report'] > p {
+  margin-top: 0.5rem;
+  color: var(--fg-muted);
+  font-size: 0.85rem;
+  max-width: 62ch;
+}
+
+pre {
   margin-top: 1rem;
+  background: var(--code-bg);
+  color: var(--code-fg);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  line-height: 1.55;
 }
 
-.manual-form h3 {
-  font-size: 0.875rem;
-  margin-bottom: 0.75rem;
+section[aria-label='Verification report'] a {
+  display: inline-block;
+  margin-top: 1rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--fg);
+  text-decoration: none;
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  padding: 0.5rem 1.1rem;
 }
 
-/* Responsive */
-@media (max-width: 600px) {
-  body {
-    padding: 1rem 0.5rem;
-  }
+section[aria-label='Verification report'] a:hover {
+  background: #f5f5f5;
+  border-color: var(--fg-subtle);
+}
 
-  .tabs {
-    overflow-x: auto;
+/* Guidance: what verification does and does not establish. */
+
+section[aria-label='What verification proves'] {
+  background: #fbfbfa;
+}
+
+section[aria-label='What verification proves'] h2 {
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+section[aria-label='What verification proves'] h3 {
+  margin-top: 1.1rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--fg-muted);
+}
+
+section[aria-label='What verification proves'] ul {
+  margin-top: 0.5rem;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+section[aria-label='What verification proves'] li {
+  position: relative;
+  padding-left: 1.6rem;
+  font-size: 0.9rem;
+  color: var(--fg);
+}
+
+section[aria-label='What verification proves'] li::before {
+  position: absolute;
+  left: 0;
+  top: 0;
+  font-weight: 700;
+}
+
+/* First list establishes; second does not. Marker plus wording, never colour alone. */
+section[aria-label='What verification proves'] h3:nth-of-type(1) + ul li::before {
+  content: '\2713';
+  color: var(--accent);
+}
+
+section[aria-label='What verification proves'] h3:nth-of-type(2) + ul li::before {
+  content: '\2013';
+  color: var(--fg-subtle);
+}
+
+/* Visually hidden but exposed to assistive technology: the polite status announcer. */
+.sr-status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    transition: none !important;
   }
 }

--- a/apps/verifier/src/styles/main.css
+++ b/apps/verifier/src/styles/main.css
@@ -371,6 +371,32 @@ section[aria-label='What verification proves'] h3:nth-of-type(2) + ul li::before
   color: var(--fg-subtle);
 }
 
+/* Footer: canonical project links. */
+
+footer {
+  margin-top: 2.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border);
+}
+
+footer nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+footer a {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--fg-muted);
+  text-decoration: none;
+}
+
+footer a:hover {
+  color: var(--fg);
+  text-decoration: underline;
+}
+
 /* Visually hidden but exposed to assistive technology: the polite status announcer. */
 .sr-status {
   position: absolute;

--- a/apps/verifier/src/ui/app.ts
+++ b/apps/verifier/src/ui/app.ts
@@ -98,6 +98,25 @@ export async function initApp(root: HTMLElement): Promise<void> {
   }
   main.appendChild(guidance);
 
+  // Footer: canonical project links. Sibling of main so it is the page contentinfo landmark.
+  const footer = document.createElement('footer');
+  const nav = document.createElement('nav');
+  nav.setAttribute('aria-label', 'PEAC Protocol');
+  for (const [text, href] of [
+    ['PEAC Protocol', 'https://peacprotocol.org'],
+    ['Source', 'https://github.com/peacprotocol/peac'],
+  ] as const) {
+    const a = document.createElement('a');
+    a.href = href;
+    a.textContent = text;
+    a.rel = 'noopener noreferrer';
+    a.target = '_blank';
+    a.setAttribute('aria-label', `${text} (opens in a new tab)`);
+    nav.appendChild(a);
+  }
+  footer.appendChild(nav);
+  root.appendChild(footer);
+
   let verifier: LocalVerifier;
   try {
     verifier = await initializeLocalVerifier({ verifierBuild: verifierBuildFromEnvironment() });

--- a/apps/verifier/src/ui/app.ts
+++ b/apps/verifier/src/ui/app.ts
@@ -103,7 +103,7 @@ export async function initApp(root: HTMLElement): Promise<void> {
   const nav = document.createElement('nav');
   nav.setAttribute('aria-label', 'PEAC Protocol');
   for (const [text, href] of [
-    ['PEAC Protocol', 'https://peacprotocol.org'],
+    ['PEAC Protocol', 'https://www.peacprotocol.org/'],
     ['Source', 'https://github.com/peacprotocol/peac'],
   ] as const) {
     const a = document.createElement('a');

--- a/apps/verifier/src/ui/app.ts
+++ b/apps/verifier/src/ui/app.ts
@@ -1,9 +1,10 @@
 /**
- * Minimal text-only operability shim.
+ * Text-only local verification page.
  *
- * Deliberately minimal rather than designed. This exists so the no-network,
- * no-persistence and CSP gates run against a built application that actually verifies, rather than
- * against an empty shell.
+ * The page verifies a PEAC record in the browser and explains, in plain terms, what a successful
+ * verification does and does not establish. It uses landmark and heading structure, associates
+ * each input with its label, announces state changes through a live region, and moves focus to the
+ * outcome once a run completes.
  *
  * A displayed result always describes the exact inputs submitted for that run. Verification and
  * file reads are both asynchronous, so a run is bound to a monotonic run token and to the input
@@ -16,8 +17,30 @@ import { renderResults } from './results.js';
 import { renderReport } from './report-panel.js';
 import { DEFAULT_MAX_CLOCK_SKEW_SECONDS } from '../lib/limits.js';
 
+/** What a successful cryptographic verification does, and does not, establish. */
+const PROVES = [
+  'the record was signed by the private key matching the public key you supplied',
+  'the record has not changed since it was signed',
+  'the record satisfied the checks this verifier performed, at the evaluation time shown',
+];
+const DOES_NOT_PROVE = [
+  'that the key, or its holder, is one you should trust',
+  'that the statements inside the record are factually true',
+  'that any external event the record refers to actually occurred',
+];
+
+function fatalMessage(root: HTMLElement, status: HTMLElement, text: string): void {
+  status.textContent = text;
+  const p = document.createElement('p');
+  p.textContent = text;
+  root.appendChild(p);
+}
+
 export async function initApp(root: HTMLElement): Promise<void> {
   root.replaceChildren();
+
+  const main = document.createElement('main');
+  root.appendChild(main);
 
   const h1 = document.createElement('h1');
   h1.textContent = 'Verify a PEAC record locally';
@@ -26,37 +49,75 @@ export async function initApp(root: HTMLElement): Promise<void> {
     'Paste a compact PEAC record and a public JWK or JWKS, and optionally a set of verification ' +
     'expectations. Verification runs in this browser. The application does not upload, resolve or ' +
     'store your inputs.';
-  root.append(h1, intro);
+  main.append(h1, intro);
 
-  const form = document.createElement('div');
-  root.appendChild(form);
-  const fields = renderInputs(form);
+  // A polite live region so assistive technology announces state changes without stealing focus.
+  const status = document.createElement('p');
+  status.setAttribute('role', 'status');
+  status.setAttribute('aria-live', 'polite');
+  status.className = 'sr-status';
+  main.appendChild(status);
+
+  const group = document.createElement('div');
+  group.setAttribute('role', 'group');
+  group.setAttribute('aria-label', 'PEAC record verification');
+  main.appendChild(group);
+  const fields = renderInputs(group);
 
   const button = document.createElement('button');
   button.type = 'button';
   button.textContent = 'Verify';
-  root.appendChild(button);
+  group.appendChild(button);
 
   const results = document.createElement('section');
+  results.setAttribute('aria-label', 'Verification result');
+  results.tabIndex = -1;
   const reportPanel = document.createElement('section');
-  root.append(results, reportPanel);
+  reportPanel.setAttribute('aria-label', 'Verification report');
+  main.append(results, reportPanel);
+
+  // Guidance: what verification proves and does not prove. Static, neutral, always available.
+  const guidance = document.createElement('section');
+  guidance.setAttribute('aria-label', 'What verification proves');
+  const gh = document.createElement('h2');
+  gh.textContent = 'What a successful verification means';
+  guidance.appendChild(gh);
+  for (const [heading, items] of [
+    ['It establishes', PROVES],
+    ['It does not establish', DOES_NOT_PROVE],
+  ] as const) {
+    const h3 = document.createElement('h3');
+    h3.textContent = heading;
+    const ul = document.createElement('ul');
+    for (const item of items) {
+      const li = document.createElement('li');
+      li.textContent = item;
+      ul.appendChild(li);
+    }
+    guidance.append(h3, ul);
+  }
+  main.appendChild(guidance);
 
   let verifier: LocalVerifier;
   try {
     verifier = await initializeLocalVerifier({ verifierBuild: verifierBuildFromEnvironment() });
   } catch {
-    const p = document.createElement('p');
-    p.textContent = 'The verifier could not start because its build identifier is missing.';
-    root.appendChild(p);
+    fatalMessage(
+      main,
+      status,
+      'The verifier could not start because its build identifier is missing.'
+    );
+    button.disabled = true;
     return;
   }
 
   if (!verifier.supported) {
-    const p = document.createElement('p');
-    p.textContent =
+    fatalMessage(
+      main,
+      status,
       'This browser cannot perform the Ed25519 verification profile required by PEAC. ' +
-      'Use a current browser, or verify with the PEAC CLI.';
-    root.appendChild(p);
+        'Use a current browser, or verify with the PEAC CLI.'
+    );
     button.disabled = true;
     return;
   }
@@ -80,6 +141,7 @@ export async function initApp(root: HTMLElement): Promise<void> {
     const p = document.createElement('p');
     p.textContent = 'The verifier failed unexpectedly. No verification outcome was established.';
     results.appendChild(p);
+    status.textContent = 'The verifier failed unexpectedly.';
     // Clear any report from a previous run: leaving it visible beside a failure invites reading it
     // as the outcome of this one.
     renderReport(undefined, reportPanel);
@@ -89,6 +151,7 @@ export async function initApp(root: HTMLElement): Promise<void> {
     updateAvailability();
     // The inputs no longer match anything on screen.
     clearOutputs();
+    status.textContent = '';
   });
   updateAvailability();
 
@@ -110,6 +173,7 @@ export async function initApp(root: HTMLElement): Promise<void> {
     running = true;
     fields.setDisabled(true);
     updateAvailability();
+    status.textContent = 'Verifying.';
 
     void verifier
       .verify(input)
@@ -117,12 +181,17 @@ export async function initApp(root: HTMLElement): Promise<void> {
         if (token !== runToken || revision !== fields.revision()) return;
         renderResults(result, results);
         renderReport(result.report, reportPanel);
+        // Announce the outcome and move focus to the result region, so a keyboard or screen-reader
+        // user lands on what changed rather than hunting for it. Focus moves only on a current run.
+        status.textContent = result.ok ? 'Verification succeeded.' : 'Verification failed.';
+        results.focus();
       })
       .catch(() => {
         // verify() is a total boundary and should not reject. If it does, the operator must still
         // see that the run failed rather than face a control that silently does nothing.
         if (token !== runToken || revision !== fields.revision()) return;
         showRunFailure();
+        results.focus();
       })
       .finally(() => {
         // A superseded run must not restore controls a newer run is holding.

--- a/apps/verifier/src/ui/inputs.ts
+++ b/apps/verifier/src/ui/inputs.ts
@@ -46,10 +46,13 @@ function field(
   const ta = document.createElement('textarea');
   ta.id = id;
   ta.rows = 6;
+  ta.setAttribute('aria-describedby', `${id}-hint`);
   const p = document.createElement('p');
+  p.id = `${id}-hint`;
   p.textContent = hint;
   const file = document.createElement('input');
   file.type = 'file';
+  file.setAttribute('aria-label', `Load ${label} from a file`);
   shared.register(ta);
   shared.register(file);
 

--- a/apps/verifier/src/ui/results.ts
+++ b/apps/verifier/src/ui/results.ts
@@ -33,12 +33,14 @@ export function renderResults(result: BrowserVerificationResult, container: HTML
   container.replaceChildren();
 
   if ('capability' in result) {
+    container.className = 'result--capability';
     container.appendChild(el('h2', 'This browser cannot verify'));
     container.appendChild(el('p', result.message));
     return;
   }
 
   if (result.ok) {
+    container.className = 'result--ok';
     container.appendChild(el('h2', 'Verification succeeded'));
     container.appendChild(el('p', MODE_COPY[result.mode]));
     container.appendChild(el('p', `Mode: ${result.mode}`));
@@ -63,6 +65,7 @@ export function renderResults(result: BrowserVerificationResult, container: HTML
   }
 
   // Failure: code and a neutral message only. No claims, no stack, no raw key, no echoed record.
+  container.className = 'result--fail';
   container.appendChild(el('h2', 'Verification failed'));
   container.appendChild(el('p', result.message));
   const d = el('dl');

--- a/apps/verifier/tests/accessibility.test.ts
+++ b/apps/verifier/tests/accessibility.test.ts
@@ -92,7 +92,7 @@ describe('footer', () => {
     expect(footers).toHaveLength(1);
     const links = footers[0].querySelectorAll('a');
     const hrefs = links.map((a) => a.href);
-    expect(hrefs).toContain('https://peacprotocol.org');
+    expect(hrefs).toContain('https://www.peacprotocol.org/');
     expect(hrefs).toContain('https://github.com/peacprotocol/peac');
     for (const a of links) {
       expect(a.getAttribute('aria-label')).toMatch(/opens in a new tab/i);

--- a/apps/verifier/tests/accessibility.test.ts
+++ b/apps/verifier/tests/accessibility.test.ts
@@ -85,6 +85,21 @@ describe('landmark and heading structure', () => {
   });
 });
 
+describe('footer', () => {
+  it('links to the project site and source with safe external attributes', async () => {
+    const root = await mount(async () => accepted);
+    const footers = root.querySelectorAll('footer');
+    expect(footers).toHaveLength(1);
+    const links = footers[0].querySelectorAll('a');
+    const hrefs = links.map((a) => a.href);
+    expect(hrefs).toContain('https://peacprotocol.org');
+    expect(hrefs).toContain('https://github.com/peacprotocol/peac');
+    for (const a of links) {
+      expect(a.getAttribute('aria-label')).toMatch(/opens in a new tab/i);
+    }
+  });
+});
+
 describe('control names and descriptions', () => {
   it('associates every textarea with a label and a description', async () => {
     const root = await mount(async () => accepted);

--- a/apps/verifier/tests/accessibility.test.ts
+++ b/apps/verifier/tests/accessibility.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Accessible structure and state announcement.
+ *
+ * The verification surface must be operable and understandable without sight: a single main
+ * landmark, each control with a programmatic name and description, a polite live region that
+ * announces state transitions, and focus moved to the outcome once a run completes. These are the
+ * DOM-level guarantees; real assistive-technology behaviour is exercised by the browser smoke test.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  installMiniDom,
+  uninstallMiniDom,
+  createContainer,
+  findByText,
+} from './helpers/mini-dom.js';
+import type { MiniNode } from './helpers/mini-dom.js';
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  uninstallMiniDom();
+});
+
+const accepted = {
+  ok: true as const,
+  mode: 'integrity-only' as const,
+  signature: 'valid_under_supplied_key' as const,
+  recordValidation: 'valid' as const,
+  trustedKey: 'not_provided' as const,
+  issuerConstraint: 'not_provided' as const,
+  kidConstraint: 'not_provided' as const,
+  recordTypeConstraint: 'not_provided' as const,
+  claimTruth: 'not_evaluated' as const,
+  claims: {} as never,
+  limitations: [] as string[],
+  report: { reportVersion: '1', outcome: 'accepted' } as never,
+};
+
+async function mount(verify: (input: unknown) => Promise<unknown>) {
+  installMiniDom();
+  const verifyModule = await import('../src/verify.js');
+  vi.spyOn(verifyModule, 'initializeLocalVerifier').mockResolvedValue({
+    supported: true,
+    verify,
+  } as never);
+  const { initApp } = await import('../src/ui/app.js');
+  const root = createContainer() as unknown as HTMLElement;
+  await initApp(root);
+  await flush();
+  return root as unknown as MiniNode;
+}
+
+function byAttr(root: MiniNode, tag: string, name: string, value: string): MiniNode | undefined {
+  return root.querySelectorAll(tag).find((n) => {
+    try {
+      return n.getAttribute(name) === value;
+    } catch {
+      return false;
+    }
+  });
+}
+
+describe('landmark and heading structure', () => {
+  it('mounts a single main landmark holding the page heading', async () => {
+    const root = await mount(async () => accepted);
+    const mains = root.querySelectorAll('main');
+    expect(mains).toHaveLength(1);
+    const h1 = mains[0].querySelectorAll('h1');
+    expect(h1).toHaveLength(1);
+    expect(h1[0].textContent).toMatch(/verify a peac record/i);
+  });
+
+  it('states, always, what a successful verification does and does not establish', async () => {
+    const root = await mount(async () => accepted);
+    const items = root.querySelectorAll('li').map((n) => n.textContent);
+    // Present without running anything: guidance is not gated on a result.
+    expect(items.some((t) => /matching the public key you supplied/i.test(t))).toBe(true);
+    expect(items.some((t) => /not changed since it was signed/i.test(t))).toBe(true);
+    expect(items.some((t) => /the key, or its holder, is one you should trust/i.test(t))).toBe(
+      true
+    );
+    expect(items.some((t) => /factually true/i.test(t))).toBe(true);
+  });
+});
+
+describe('control names and descriptions', () => {
+  it('associates every textarea with a label and a description', async () => {
+    const root = await mount(async () => accepted);
+    const labels = root.querySelectorAll('label');
+    for (const textarea of root.querySelectorAll('textarea')) {
+      const id = textarea.id;
+      expect(id).toBeTruthy();
+      expect(labels.some((l) => l.htmlFor === id)).toBe(true);
+      const describedby = textarea.getAttribute('aria-describedby');
+      expect(describedby).toBe(`${id}-hint`);
+      expect(byAttr(root, 'p', 'id', describedby as string)).toBeDefined();
+    }
+  });
+
+  it('gives every file control an accessible name', async () => {
+    const root = await mount(async () => accepted);
+    const files = root.querySelectorAll('input').filter((n) => n.type === 'file');
+    expect(files.length).toBeGreaterThan(0);
+    for (const file of files) {
+      expect(file.getAttribute('aria-label')).toMatch(/load .* from a file/i);
+    }
+  });
+});
+
+describe('state announcement and focus', () => {
+  it('exposes a polite status region', async () => {
+    const root = await mount(async () => accepted);
+    const status = byAttr(root, 'p', 'role', 'status');
+    expect(status).toBeDefined();
+    expect((status as MiniNode).getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('announces progress then outcome, and moves focus to the result', async () => {
+    let release: () => void = () => {};
+    const gate = new Promise<void>((r) => (release = r));
+    const root = await mount(async () => {
+      await gate;
+      return accepted;
+    });
+    const status = byAttr(root, 'p', 'role', 'status') as MiniNode;
+    const results = byAttr(root, 'section', 'aria-label', 'Verification result') as MiniNode;
+    expect(results.tabIndex).toBe(-1);
+    let focusMoves = 0;
+    results.focus = () => {
+      focusMoves += 1;
+    };
+
+    const button = findByText(root, 'button', /verify/i) as MiniNode;
+    button.dispatchEvent('click');
+    await flush();
+    expect(status.textContent).toMatch(/verifying/i);
+    expect(focusMoves).toBe(0);
+
+    release();
+    await flush();
+    await flush();
+    expect(status.textContent).toMatch(/verification succeeded/i);
+    expect(focusMoves).toBe(1);
+  });
+
+  it('clears the announcement when inputs change', async () => {
+    const root = await mount(async () => accepted);
+    const status = byAttr(root, 'p', 'role', 'status') as MiniNode;
+    const button = findByText(root, 'button', /verify/i) as MiniNode;
+    button.dispatchEvent('click');
+    await flush();
+    expect(status.textContent).toMatch(/verification succeeded/i);
+
+    const textarea = root.querySelectorAll('textarea')[0];
+    textarea.value = 'changed';
+    textarea.dispatchEvent('input');
+    expect(status.textContent).toBe('');
+  });
+});

--- a/apps/verifier/tests/browser/run-browser-matrix.mjs
+++ b/apps/verifier/tests/browser/run-browser-matrix.mjs
@@ -282,16 +282,16 @@ async function runFlow(page, flow) {
   if (flow.context) await page.fill('#context', flow.context);
   await page.waitForSelector('button:enabled', { timeout: 15000 });
   await page.click('button:has-text("Verify")');
-  const heading = page.locator('section h2').first();
+  const heading = page.locator('section[aria-label="Verification result"] h2').first();
   await heading.waitFor({ state: 'visible', timeout: 15000 });
   return {
     heading: await heading.textContent(),
-    body: await page.locator('section').first().textContent(),
+    body: await page.locator('section[aria-label="Verification result"]').first().textContent(),
   };
 }
 
 async function reportJson(page) {
-  const pre = page.locator('section pre').first();
+  const pre = page.locator('section[aria-label="Verification report"] pre').first();
   await pre.waitFor({ state: 'visible', timeout: 15000 });
   return pre.textContent();
 }
@@ -360,7 +360,7 @@ async function checkReadSupersession(page, fixtures, problems) {
   if (value !== fixtures.record) {
     problems.push('supersession: a superseded file read replaced newer manual input');
   }
-  const stale = await page.locator('section h2').count();
+  const stale = await page.locator('section[aria-label="Verification result"] h2').count();
   if (stale !== 0) problems.push('supersession: a superseded read produced a result');
   await page
     .waitForSelector('button:enabled', { timeout: 5000 })
@@ -384,7 +384,7 @@ async function checkFileInput(page, fixtures, problems) {
   await page.fill('#key', fixtures.bareJwk);
   await page.waitForSelector('button:enabled', { timeout: 15000 });
   await page.click('button:has-text("Verify")');
-  const heading = page.locator('section h2').first();
+  const heading = page.locator('section[aria-label="Verification result"] h2').first();
   await heading.waitFor({ state: 'visible', timeout: 15000 });
   const text = await heading.textContent();
   if (text !== ACCEPT) problems.push(`file-input: expected "${ACCEPT}", saw "${text}"`);
@@ -424,7 +424,7 @@ async function runSession(page, fixtures, origin, flowIds) {
     await checkDeterministicReport(page, flows(fixtures)[0], problems);
 
     await page.fill('#record', fixtures.record + ' ');
-    const headings = await page.locator('section h2').count();
+    const headings = await page.locator('section[aria-label="Verification result"] h2').count();
     if (headings !== 0)
       problems.push('input-snapshot: an edited input left a stale result visible');
 
@@ -510,7 +510,7 @@ async function collectParityReports(browser, origin, fixtures) {
     await page.clock.setFixedTime(fixtures.parityEvaluationTime);
     await page.goto(`${origin}/`, { waitUntil: 'networkidle' });
     await runFlow(page, flowById[scenario.flowId]);
-    const report = page.locator('section pre').first();
+    const report = page.locator('section[aria-label="Verification report"] pre').first();
     await report.waitFor({ state: 'visible', timeout: 15000 });
     byFlow[scenario.flowId] = await report.textContent();
     await context.close();

--- a/apps/verifier/tests/helpers/mini-dom.ts
+++ b/apps/verifier/tests/helpers/mini-dom.ts
@@ -33,16 +33,25 @@ export interface MiniNode {
   getAttribute(name: string): string | undefined;
   querySelector(sel: string): MiniNode | undefined;
   querySelectorAll(sel: string): MiniNode[];
+  setAttribute(name: string, value: string): void;
+  tabIndex?: number;
+  className?: string;
+  focus(): void;
 }
 
 function node(tagName: string): MiniNode {
   const listeners = new Map<string, Array<() => void>>();
+  const attrs = new Map<string, string>();
   const self: MiniNode = {
     tagName,
     textContent: '',
     value: '',
     disabled: false,
     childNodes: [],
+    setAttribute(name, value) {
+      attrs.set(name, value);
+    },
+    focus() {},
     appendChild(n) {
       self.childNodes.push(n);
       return n;
@@ -66,6 +75,7 @@ function node(tagName: string): MiniNode {
       if (name === 'download') return self.download;
       if (name === 'id') return self.id;
       if (name === 'type') return self.type;
+      if (attrs.has(name)) return attrs.get(name);
       throw new Error(`mini-dom: unsupported attribute ${name}`);
     },
     querySelector(sel) {


### PR DESCRIPTION
## Summary

Gives the local record verification page an accessible structure, a plain-language explanation of what a successful verification does and does not establish, and a visual design consistent with the protocol site. No verification logic, protocol surface, package or wire behaviour changes.

## Changes

**Accessibility**
- Wrap the page in a single `main` landmark with a heading hierarchy, and add a `contentinfo` footer.
- Associate each textarea with its label and a programmatic description (`aria-describedby`); give each file control an accessible name.
- Add a polite live region (`role=status`, `aria-live=polite`) that announces progress and outcome, and move focus to the result region once a run completes.

**Guidance**
- A static section stating what a valid signature proves (signed by the matching key, unchanged since signing, checks satisfied at the evaluation time shown) and does not prove (key or holder trustworthiness, claim truth, external events).

**Visual design**
- Theme the page to match the protocol site: neutral monochrome base, an emerald accent for verified state, card surfaces, rounded corners and a dark report code block. Verified and failed results carry a coloured accent alongside the existing text, so state is never conveyed by colour alone.
- Fonts use the system fallback stacks the site declares; no font is fetched or bundled, so the page stays within its no-network content-security policy.
- A footer links the project site (`https://www.peacprotocol.org/`) and the source repository, opening in a new tab with `rel=noopener noreferrer`.

The run-token and input-revision binding that ties a displayed result to the exact inputs submitted for that run is unchanged.

## Validation

- `apps/verifier` typecheck (`tsc --noEmit`), tests (380 passed, 1 skipped), and production build all pass.
- The browser matrix passes on Chromium, Firefox and WebKit (plus mobile emulation and cross-engine report parity): no network, no persistence, no service worker, no CSP unsafe-eval violation.
- Browser-verifier boundary and emitted-bundle gates pass: no network, storage, service-worker, HTML-injection or dynamic-code sink.
- The result and report regions are located by accessible name in the browser matrix; the test DOM stub gains `setAttribute`, `tabIndex` and `focus` support, leaving the existing concurrency and input-snapshot assertions unaltered.

## Scope

Accessibility, guidance and visual theme for the verification surface. No change to `verifyLocal`, the report schema, sentinels, or any published package.
