### PR TITLE
chore(security): update nanoid override to 3.3.17+

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,8 @@
       "vite@<6.4.2": ">=8.0.16",
       "ws@>=8.0.0 <8.21.0": "8.21.0",
       "js-yaml@>=4.0.0 <4.3.1": "4.3.1",
-      "js-yaml@>=3.0.0 <3.15.1": "3.15.1"
+      "js-yaml@>=3.0.0 <3.15.1": "3.15.1",
+      "nanoid@<3.3.17": ">=3.3.17 <4"
     },
     "overridesComments": {
       "minimatch": "Cross-major pin to 10.2.4: typescript-estree requires ^9.0.4 but 9.x has no patch for GHSA-3ppc-4f35-3m26. minimatch 10.x is API-compatible (same globbing interface). 10.2.4 patches GHSA-7r86-cg39-jmmj and GHSA-23c5-xmqv-rm74 (ReDoS). Drops Node 18 (fine: repo baseline is >=22.0.0). Lint verified clean.",
@@ -200,7 +201,8 @@
       "ip-address@<=10.3.0": "Range-scoped to <=10.3.0 only (forces patched 10.3.1+). Retains the CVE-2026-42338 fix (XSS in Address6 HTML-emitting methods, patched 10.1.1) and adds GHSA-mwp4-54f8-5fhr (Address4 decodes leading-zero octets as decimal while resolvers decode them as octal, patched 10.3.1). The prior selector stopped at <=10.1.0, so the newly disclosed range left the resolved 10.2.0 unpatched. Transitive prod dep via @modelcontextprotocol/sdk -> express-rate-limit.",
       "js-yaml@>=4.0.0 <4.3.0": "Range-scoped to the v4 line below 4.3.0 only, pinned to the patched 4.3.0. Fixes GHSA-52cp-r559-cp3m (YAML merge-key chains force quadratic CPU; 4.x vulnerable >=4.0.0 <4.3.0). Dev-only: root devDependency used by repo tooling; not in any published package. Same-major minor bump preserves the js-yaml 4.x API.",
       "js-yaml@>=3.0.0 <3.15.0": "Range-scoped to the v3 line below 3.15.0 only, pinned to the patched 3.15.0. Fixes GHSA-52cp-r559-cp3m (YAML merge-key chains force quadratic CPU; 3.x vulnerable >=3.0.0 <3.15.0). Dev/test-only via apps/api -> jest -> babel-plugin-istanbul -> @istanbuljs/load-nyc-config -> js-yaml@3.14.2; not in any published package. Same-major patch bump preserves the js-yaml 3.x API that istanbul expects.",
-      "sharp@<0.35.0": "Pins vulnerable sharp releases below 0.35.0 to the tested patched 0.35.3 release for GHSA-f88m-g3jw-g9cj. The affected copies are optional dependencies of Next 15.5.x and Wrangler 3.114.x, whose declared 0.x ranges cannot resolve the patched minor. The exact pin avoids admitting future native releases without compatibility review."
+      "sharp@<0.35.0": "Pins vulnerable sharp releases below 0.35.0 to the tested patched 0.35.3 release for GHSA-f88m-g3jw-g9cj. The affected copies are optional dependencies of Next 15.5.x and Wrangler 3.114.x, whose declared 0.x ranges cannot resolve the patched minor. The exact pin avoids admitting future native releases without compatibility review.",
+      "nanoid@<3.3.17": "Range-scoped to the nanoid 3.x line below 3.3.17 only (forces >=3.3.17 <4). Fixes GHSA-2v37-7h3g-55p8 / CVE-2026-67213 (custom generators can loop indefinitely when size is zero, a DoS in nanoid's custom-alphabet API). Dev-only via vitest / @vitest/coverage-v8 -> vite -> postcss, which declares ^3.3.16; not in any published package. Same-major patch bump (resolves to 3.3.18) preserves the nanoid 3.x API; upper bound <4 prevents an unreviewed major."
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,7 @@ overrides:
   ws@>=8.0.0 <8.21.0: 8.21.0
   js-yaml@>=4.0.0 <4.3.1: 4.3.1
   js-yaml@>=3.0.0 <3.15.1: 3.15.1
+  nanoid@<3.3.17: '>=3.3.17 <4'
 
 importers:
 
@@ -8324,8 +8325,8 @@ packages:
       thenify-all: 1.6.0
     dev: true
 
-  /nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  /nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
     dev: true
@@ -8686,7 +8687,7 @@ packages:
     resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
     dev: true


### PR DESCRIPTION
## Summary

Add a `pnpm` override forcing `nanoid` to a patched release for GHSA-2v37-7h3g-55p8 / CVE-2026-67213 (custom generators can loop indefinitely when `size` is zero), which surfaces as a high-severity finding in the strict audit gate.

## Changes

- `pnpm.overrides`: `"nanoid@<3.3.17": ">=3.3.17 <4"` (resolves to `3.3.18`), with a matching `overridesComments` entry.
- Lockfile regenerated: the only resolution change is `nanoid 3.3.16 -> 3.3.18` (and its single consumer, `postcss`).

`nanoid` is a development-only transitive dependency via `vitest` / `@vitest/coverage-v8` -> `vite` -> `postcss` (which declares `^3.3.16`); no published package depends on it. The bump is same-major and inside the consumer's declared range, and the upper bound `<4` prevents an unreviewed major.

## Validation

- Audit gate passes in default and strict mode (previously strict reported `FAIL: 1 high`); production audit remains 0 high / 0 critical.
- Audit-gate unit tests pass; the dev build toolchain (vite/postcss) builds unchanged with `nanoid 3.3.18`.
- Lockfile changes are confined to the `nanoid` resolution.

## Scope

Development-dependency security remediation only. No published package version, runtime dependency, source, or release-state change.
