### PR TITLE
fix(go): enforce the Wire 0.2 kid UTF-8 byte bound in the local verifier

### DIFF
--- a/sdks/go/verify_local.go
+++ b/sdks/go/verify_local.go
@@ -90,6 +90,10 @@ type VerificationWarning struct {
 	Pointer string `json:"pointer,omitempty"`
 }
 
+// maxKidUTF8Bytes is the Wire 0.2 JOSE hardening bound on kid length (WIRE02-JOSE-008): a kid MUST
+// NOT exceed 256 UTF-8 bytes. RFC 7515 leaves kid structure unspecified; this is a PEAC constraint.
+const maxKidUTF8Bytes = 256
+
 // VerifyLocal verifies a signed interaction record locally with a provided public key.
 //
 // Enforces the current stable Interaction Record format (interaction-record+jwt)
@@ -278,6 +282,17 @@ func checkJOSEHardening(headerRaw []byte) error {
 	// Reject zip
 	if _, ok := raw["zip"]; ok {
 		return fmt.Errorf("JOSE hardening: zip header is not allowed")
+	}
+
+	// Reject kid exceeding the PEAC bound (WIRE02-JOSE-008). The bound is 256 UTF-8 bytes of the
+	// decoded kid; len on a Go string counts bytes, which is exactly that unit. Raw-header I-JSON
+	// validity (no surrogates or noncharacters) is already enforced upstream, so the decoded string
+	// is well-formed here. kid presence and non-emptiness stay in jws.ValidateHeader.
+	if kidRaw, ok := raw["kid"]; ok {
+		var kid string
+		if err := json.Unmarshal(kidRaw, &kid); err == nil && len(kid) > maxKidUTF8Bytes {
+			return fmt.Errorf("JOSE hardening: kid exceeds %d UTF-8 bytes", maxKidUTF8Bytes)
+		}
 	}
 
 	return nil

--- a/sdks/go/verify_local_test.go
+++ b/sdks/go/verify_local_test.go
@@ -1,6 +1,8 @@
 package peac
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -192,6 +194,45 @@ func TestVerifyLocal_JOSEHardening(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			err := checkJOSEHardening([]byte(tc.header))
+			if (err != nil) != tc.wantErr {
+				t.Errorf("checkJOSEHardening() err = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestVerifyLocal_JOSEHardening_KidByteBound(t *testing.T) {
+	// WIRE02-JOSE-008: kid MUST NOT exceed 256 UTF-8 bytes. The bound is measured in UTF-8 bytes,
+	// not characters or UTF-16 code units, so ASCII fixtures alone cannot prove it. Each kid is
+	// built from escape sequences via json.Marshal, so the header bytes stay ASCII.
+	mkHeader := func(kid string) string {
+		b, err := json.Marshal(map[string]any{
+			"alg": "EdDSA",
+			"kid": kid,
+			"typ": "interaction-record+jwt",
+		})
+		if err != nil {
+			t.Fatalf("marshal header: %v", err)
+		}
+		return string(b)
+	}
+	astral := "\U0001F600" // one supplementary-plane code point: 2 UTF-16 code units, 4 UTF-8 bytes
+	tests := []struct {
+		name    string
+		kid     string
+		wantErr bool
+	}{
+		{"256 UTF-8 bytes (ascii)", strings.Repeat("a", 256), false},
+		{"257 UTF-8 bytes (ascii)", strings.Repeat("a", 257), true},
+		{"256 UTF-8 bytes (astral)", strings.Repeat(astral, 64), false},
+		{"512 UTF-8 bytes, 256 UTF-16 units (astral)", strings.Repeat(astral, 128), true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := len(tc.kid); (got > maxKidUTF8Bytes) != tc.wantErr {
+				t.Fatalf("fixture kid is %d UTF-8 bytes, inconsistent with wantErr=%v", got, tc.wantErr)
+			}
+			err := checkJOSEHardening([]byte(mkHeader(tc.kid)))
 			if (err != nil) != tc.wantErr {
 				t.Errorf("checkJOSEHardening() err = %v, wantErr %v", err, tc.wantErr)
 			}


### PR DESCRIPTION
## Summary

The Go Wire 0.2 local verifier did not enforce the normative `kid` length bound (WIRE02-JOSE-008): a record with a `kid` over 256 UTF-8 bytes verified successfully in Go, while the specification and the TypeScript verifier reject it. This aligns Go with the normative rule.

## Changes

- `checkJOSEHardening` now rejects a `kid` exceeding 256 UTF-8 bytes. The check is placed here, after the `interaction-record+jwt` type is known, so `jws.ValidateHeader` stays typ-agnostic (it also serves the legacy typ). `kid` presence and non-emptiness remain in `jws.ValidateHeader`.
- Go string length is a UTF-8 byte count, which is the normative unit; raw-header I-JSON validity is already enforced upstream, so the decoded string is well-formed at this point.
- Added a dedicated test asserting the boundaries in bytes: 256 ASCII (accept), 257 ASCII (reject), 64 supplementary-plane code points = 256 UTF-8 bytes (accept), 128 supplementary-plane code points = 256 UTF-16 code units / 512 UTF-8 bytes (reject). `kid` values are built via `json.Marshal`, so the header bytes stay ASCII.

## Validation

- `go build`, `go vet`, `gofmt` clean; the full `sdks/go` test suite passes; the new discriminating test passes all four boundary cases.

## Scope

Go local-verifier conformance to the existing Wire 0.2 `kid` bound. No spec, wire-format, or API-shape change; no other language surface is touched.
