### PR TITLE
fix(conformance): bind Ed25519 observation applicability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,12 +392,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history so the Ed25519 runtime-observation applicability gates can resolve the
+          # measurement source revision instead of silently skipping.
+          fetch-depth: 0
       - uses: ./.github/actions/setup-env
 
       - name: Build all packages
         run: pnpm build
 
       - name: Core tests
+        # Fail closed rather than skip: require the measurement-revision history and the built
+        # artifact so the build-input drift and built-export known-answer gates always run.
+        env:
+          PEAC_REQUIRE_PROVENANCE_HISTORY: '1'
+          PEAC_REQUIRE_BUILT_ARTIFACT: '1'
         run: pnpm test:core
 
       - name: Schema meta-validation

--- a/packages/crypto/tests/observation-integrity.test.ts
+++ b/packages/crypto/tests/observation-integrity.test.ts
@@ -204,6 +204,45 @@ describe('the committed runtime observations', () => {
     }
   });
 
+  it('the runtime-JS build inputs match the measurement revision', () => {
+    // A behavioural corpus pass does not prove the build configuration is unchanged: a build-config
+    // change can alter the emitted wrapper. Bind the first-party runtime-JS build inputs to the
+    // measurement revision so a build change (for example tsup.config.ts) fails applicability closed.
+    // These files are byte-identical at the measurement revision, so this is an exact drift check,
+    // not a rewrite of provenance. (Transitive bundler versions and the measurement-tool helper
+    // closure are recorded as follow-ups: the helper evolved after the measurement revision and so
+    // cannot be pinned to it without a false failure.)
+    const revision = document.measurement_source_revision;
+    const buildConfig = fileAtRevision(REPO_ROOT, revision, 'packages/crypto/tsup.config.ts');
+    if (buildConfig === null) {
+      // Shallow clones and source archives cannot resolve the recorded revision.
+      expect(
+        process.env.PEAC_REQUIRE_PROVENANCE_HISTORY,
+        `revision ${revision} is not resolvable here; audit the build inputs from a full-history checkout`
+      ).toBeUndefined();
+      return;
+    }
+    expect(
+      sha256(readRepositoryFile(REPO_ROOT, 'packages/crypto/tsup.config.ts')),
+      'tsup.config.ts drift from the measurement revision'
+    ).toBe(sha256(buildConfig));
+
+    // Only the build-script projection of package.json is causally relevant to the emitted JS; the
+    // rest (version, description) is not, and must not invalidate evidence.
+    const buildScripts = (buf: Buffer): string => {
+      const pkg = JSON.parse(buf.toString('utf8')) as { scripts?: Record<string, string> };
+      return JSON.stringify({
+        build: pkg.scripts?.build,
+        'build:js': pkg.scripts?.['build:js'],
+      });
+    };
+    const historicalPkg = fileAtRevision(REPO_ROOT, revision, 'packages/crypto/package.json');
+    expect(
+      buildScripts(readRepositoryFile(REPO_ROOT, 'packages/crypto/package.json')),
+      'crypto build-script projection drift from the measurement revision'
+    ).toBe(buildScripts(historicalPkg as Buffer));
+  });
+
   it('the built ed25519Verify decides the corpus as recorded, through the public export', async () => {
     // Known-answer check on the BUILT public wrapper: re-pointing the alias, or a build change that
     // alters the decision, is caught behaviourally here. Requires the package to be built.

--- a/packages/crypto/tests/observation-integrity.test.ts
+++ b/packages/crypto/tests/observation-integrity.test.ts
@@ -209,9 +209,9 @@ describe('the committed runtime observations', () => {
     // change can alter the emitted wrapper. Bind the first-party runtime-JS build inputs to the
     // measurement revision so a build change (for example tsup.config.ts) fails applicability closed.
     // These files are byte-identical at the measurement revision, so this is an exact drift check,
-    // not a rewrite of provenance. (Transitive bundler versions and the measurement-tool helper
-    // closure are recorded as follow-ups: the helper evolved after the measurement revision and so
-    // cannot be pinned to it without a false failure.)
+    // not a rewrite of provenance. This assertion binds the first-party runtime-JS build
+    // configuration; transitive build-tool versions and measurement-tool helper source history are
+    // outside it.
     const revision = document.measurement_source_revision;
     const buildConfig = fileAtRevision(REPO_ROOT, revision, 'packages/crypto/tsup.config.ts');
     if (buildConfig === null) {

--- a/packages/crypto/tests/observation-integrity.test.ts
+++ b/packages/crypto/tests/observation-integrity.test.ts
@@ -6,8 +6,9 @@
  */
 import { describe, it, expect } from 'vitest';
 import Ajv2020 from 'ajv/dist/2020.js';
-import { readFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { join, resolve, dirname, relative } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import {
   CORPUS_PATH,
   LOCKFILE_PATH,
@@ -163,32 +164,86 @@ describe('the committed runtime observations', () => {
     }
   });
 
-  it('scopes current applicability to the measured Ed25519 surface', () => {
-    // The measured surface is the Ed25519 verification decision, not the whole crypto package.
-    expect(PRODUCTION_SOURCES).toContain('packages/crypto/src/ed25519.ts');
-    expect(PRODUCTION_SOURCES).toContain('packages/crypto/src/internal/ed25519-admissibility.ts');
-    // The JWS/signing layer is outside the measured surface: a change there must not invalidate
-    // Ed25519 applicability, and it is not a named production source.
-    expect(PRODUCTION_SOURCES).not.toContain('packages/crypto/src/jws.ts');
+  // The measured browser wrapper imports the public `ed25519Verify` alias. Applicability must fail
+  // closed on any change to the verify decision surface reached through that alias, and stay green
+  // for unrelated package code. The three checks below bind that surface behaviourally rather than
+  // by asserting membership of a hand-curated list.
 
-    const base = productionSourceManifestDigest(REPO_ROOT, PRODUCTION_SOURCES);
-    // Every named production source binds: dropping one changes the manifest, so an ed25519.ts or
-    // admissibility.ts change does invalidate applicability.
-    for (let i = 0; i < PRODUCTION_SOURCES.length; i++) {
-      const without = PRODUCTION_SOURCES.filter((_, j) => j !== i);
-      expect(
-        productionSourceManifestDigest(REPO_ROOT, without),
-        `dropping ${PRODUCTION_SOURCES[i]} must change the manifest`
-      ).not.toBe(base);
+  it('binds the exported ed25519Verify to the measured verify implementation', async () => {
+    // Re-pointing the export glue in src/index.ts changes the measured wrapper while leaving the
+    // production source manifest untouched, so the alias identity itself is asserted.
+    const [index, ed25519] = await Promise.all([import('../src/index'), import('../src/ed25519')]);
+    expect(index.ed25519Verify, 'ed25519Verify is the ed25519 verify implementation').toBe(
+      ed25519.verify
+    );
+  });
+
+  it('names every first-party source reachable from the verify implementation', () => {
+    // Derive the first-party closure statically from the verify entrypoint so a new import cannot
+    // silently drop out of the attestation. The export glue (src/index.ts) is bound by the identity
+    // test above and is not a byte-attested implementation source.
+    const SRC = join(REPO_ROOT, 'packages/crypto/src') + '/';
+    const seen = new Set<string>();
+    const walk = (absFile: string): void => {
+      const rel = relative(REPO_ROOT, absFile).replace(/\\/g, '/');
+      if (seen.has(rel)) return;
+      seen.add(rel);
+      for (const m of readFileSync(absFile, 'utf8').matchAll(/from\s+'(\.[^']+)'/g)) {
+        let target = resolve(dirname(absFile), m[1]);
+        if (!target.endsWith('.ts')) target += '.ts';
+        if (existsSync(target) && (target + '/').startsWith(SRC)) walk(target);
+      }
+    };
+    walk(join(REPO_ROOT, 'packages/crypto/src/ed25519.ts'));
+    const closure = [...seen].sort();
+    for (const f of closure) {
+      expect(PRODUCTION_SOURCES, `${f} is reachable from verify but not attested`).toContain(f);
     }
-    // A file outside the measured surface would change the manifest only if it were named; its
-    // exclusion is what keeps unrelated package changes from invalidating the evidence.
-    expect(
-      productionSourceManifestDigest(REPO_ROOT, [
-        ...PRODUCTION_SOURCES,
-        'packages/crypto/src/jws.ts',
-      ])
-    ).not.toBe(base);
+    for (const f of PRODUCTION_SOURCES) {
+      expect(closure, `${f} is attested but not in the verify closure`).toContain(f);
+    }
+  });
+
+  it('the built ed25519Verify decides the corpus as recorded, through the public export', async () => {
+    // Known-answer check on the BUILT public wrapper: re-pointing the alias, or a build change that
+    // alters the decision, is caught behaviourally here. Requires the package to be built.
+    const distPath = join(CRYPTO_ROOT, 'dist', 'index.mjs');
+    if (!existsSync(distPath)) {
+      expect(
+        process.env.PEAC_REQUIRE_BUILT_ARTIFACT,
+        'dist/index.mjs is absent; build @peac/crypto before asserting the known-answer decisions'
+      ).toBeUndefined();
+      return;
+    }
+    const { ed25519Verify } = (await import(pathToFileURL(distPath).href)) as {
+      ed25519Verify: (s: Uint8Array, m: Uint8Array, k: Uint8Array) => Promise<boolean>;
+    };
+    const corpus = JSON.parse(readFileSync(join(CORPUS_DIR, 'vectors.json'), 'utf8')) as {
+      vectors: {
+        id: string;
+        description: string;
+        message_hex: string;
+        public_key_hex: string;
+        signature_hex: string;
+        peac_expected: { accepted: boolean | null };
+      }[];
+    };
+    const hex = (s: string) => Uint8Array.from(Buffer.from(s, 'hex'));
+    let acceptedSeen = false;
+    let rejectedSeen = false;
+    for (const v of corpus.vectors) {
+      if (typeof v.peac_expected.accepted !== 'boolean') continue;
+      const got = await ed25519Verify(
+        hex(v.signature_hex),
+        hex(v.message_hex),
+        hex(v.public_key_hex)
+      );
+      expect(got, `${v.id}: ${v.description}`).toBe(v.peac_expected.accepted);
+      acceptedSeen ||= v.peac_expected.accepted;
+      rejectedSeen ||= !v.peac_expected.accepted;
+    }
+    // Both outcomes must be exercised, so neither a constant-true nor a constant-false wrapper passes.
+    expect(acceptedSeen && rejectedSeen, 'corpus exercises both accept and reject').toBe(true);
   });
 
   it('does not claim to recompute the wrapper bundle', () => {

--- a/packages/crypto/tests/observation-integrity.test.ts
+++ b/packages/crypto/tests/observation-integrity.test.ts
@@ -6,12 +6,11 @@
  */
 import { describe, it, expect } from 'vitest';
 import Ajv2020 from 'ajv/dist/2020.js';
-import { existsSync, readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import {
   CORPUS_PATH,
   LOCKFILE_PATH,
-  MEASURED_ARTIFACT_PATH,
   PRODUCTION_SOURCES,
   fileAtRevision,
   fileDigest,
@@ -147,23 +146,49 @@ describe('the committed runtime observations', () => {
     }
   });
 
-  it('recomputes the measured artifact digest when the package has been built', () => {
-    // The artifact exists only after a build; its absence is reported rather than passing.
-    const artifact = join(REPO_ROOT, MEASURED_ARTIFACT_PATH);
+  it('treats the measured artifact digest as historical provenance, not a current-tree lock', () => {
+    // measured_artifact_sha256 records the complete built package artifact that existed at the
+    // measurement revision. Unrelated package code (for example the JWS layer) legitimately changes
+    // the built crypto bundle without changing the measured Ed25519 decision surface, so this digest
+    // is provenance and is not asserted against the current build. Current applicability is governed
+    // by the production source manifest and measurement dependencies checked above.
     const wrappers = Object.entries(document.environments).filter(
       ([, e]) => e.surface === 'peac-wrapper'
     );
-    if (!existsSync(artifact)) {
-      expect(
-        process.env.PEAC_REQUIRE_BUILT_ARTIFACT,
-        `${MEASURED_ARTIFACT_PATH} is absent; run the build before asserting the artifact digest`
-      ).toBeUndefined();
-      return;
-    }
-    const expected = fileDigest(REPO_ROOT, MEASURED_ARTIFACT_PATH);
+    expect(wrappers.length, 'wrapper environments are present').toBeGreaterThan(0);
     for (const [id, environment] of wrappers) {
-      expect(environment.measured_artifact_sha256, `${id}: measured artifact`).toBe(expected);
+      expect(environment.measured_artifact_sha256, `${id}: measured artifact provenance`).toMatch(
+        /^[0-9a-f]{64}$/
+      );
     }
+  });
+
+  it('scopes current applicability to the measured Ed25519 surface', () => {
+    // The measured surface is the Ed25519 verification decision, not the whole crypto package.
+    expect(PRODUCTION_SOURCES).toContain('packages/crypto/src/ed25519.ts');
+    expect(PRODUCTION_SOURCES).toContain('packages/crypto/src/internal/ed25519-admissibility.ts');
+    // The JWS/signing layer is outside the measured surface: a change there must not invalidate
+    // Ed25519 applicability, and it is not a named production source.
+    expect(PRODUCTION_SOURCES).not.toContain('packages/crypto/src/jws.ts');
+
+    const base = productionSourceManifestDigest(REPO_ROOT, PRODUCTION_SOURCES);
+    // Every named production source binds: dropping one changes the manifest, so an ed25519.ts or
+    // admissibility.ts change does invalidate applicability.
+    for (let i = 0; i < PRODUCTION_SOURCES.length; i++) {
+      const without = PRODUCTION_SOURCES.filter((_, j) => j !== i);
+      expect(
+        productionSourceManifestDigest(REPO_ROOT, without),
+        `dropping ${PRODUCTION_SOURCES[i]} must change the manifest`
+      ).not.toBe(base);
+    }
+    // A file outside the measured surface would change the manifest only if it were named; its
+    // exclusion is what keeps unrelated package changes from invalidating the evidence.
+    expect(
+      productionSourceManifestDigest(REPO_ROOT, [
+        ...PRODUCTION_SOURCES,
+        'packages/crypto/src/jws.ts',
+      ])
+    ).not.toBe(base);
   });
 
   it('does not claim to recompute the wrapper bundle', () => {


### PR DESCRIPTION
## Summary

The runtime-observation integrity test asserted the committed measured artifact digest against the digest of the entire built crypto bundle, which conflated historical provenance with current applicability: an unrelated change (for example the JWS layer) invalidated the Ed25519 evidence even though the measured verification decision was unchanged. This replaces that single coarse gate with a set of independent checks that fail closed on the measured decision surface and stay green for unrelated package code.

## Invariant

`measured_artifact_sha256` is historical provenance (immutable, format-checked), not a current-tree lock. Current applicability is established by independent layers:

- **Decision-source manifest** — the byte digest of the Ed25519 decision implementation (`ed25519.ts`, `ed25519-admissibility.ts`); a change there fails closed.
- **Public-export binding** — the exported `ed25519Verify` must be the `ed25519.ts` verify implementation, so re-pointing the export glue in `src/index.ts` fails closed.
- **Build-input drift** — the first-party runtime-JS build inputs (`tsup.config.ts`, the crypto build-script projection of `package.json`) are bound to the measurement revision, so a build-config change fails closed even when corpus outcomes are unchanged.
- **Measurement-dependency, corpus, and harness** checks remain fail-closed.
- **Known-answer behaviour** — the corpus is run through the *built* public `ed25519Verify`, exercising both accept and reject, so a constant-true/false wrapper cannot pass. This is behavioural defence in depth, not build provenance.
- **Regeneration completeness** — the first-party closure reachable from the verify entrypoint is derived statically and must be attested, so a new decision-relevant import cannot silently drop out.

## Validation

- `@peac/crypto` suite passes (547); observation-integrity passes (26). Adversarially confirmed fail-closed: re-pointing the `ed25519Verify` alias fails the binding-identity check; a `tsup.config.ts` change fails the build-input gate; a new first-party value import fails the completeness gate; a manifest-source change fails the manifest check; an unrelated JWS-layer change stays green. typecheck, prettier, Unicode/Trojan-Source, and the safety guard are clean.

## CI

The `tests-core` job fetches full history and sets `PEAC_REQUIRE_PROVENANCE_HISTORY` and `PEAC_REQUIRE_BUILT_ARTIFACT`, so the build-input drift and built-export known-answer gates run fail-closed rather than skipping.

## Scope

Test and CI validation only; no runtime, wire, schema, API, or observation-outcome change. This binds the first-party runtime-JS build configuration represented by the current evidence model; transitive build-tool and measurement-helper source history are outside these assertions.
