### PR TITLE
fix(crypto): enforce I-JSON on issuance so a signer cannot emit what its verifier rejects

### DIFF
--- a/packages/crypto/__tests__/jws-issuance-ijson.test.ts
+++ b/packages/crypto/__tests__/jws-issuance-ijson.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Issuance/verification I-JSON symmetry.
+ *
+ * The verifier applies the RFC 7493 I-JSON gate to the decoded header and payload bytes (Wire 0.2
+ * Section 10.6). The signer must apply the identical gate to the exact bytes it signs, so that a
+ * PEAC signing API can never emit a compact JWS its own verifier rejects as non-I-JSON. These tests
+ * assert rejection happens at issuance (the thrown code is a serialization-stage code, raised before
+ * Ed25519 signing) and that a successful sign always clears the verifier's raw I-JSON gate. Non-ASCII
+ * inputs are written with explicit escapes so their code points do not depend on file encoding.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { sign, signWire02, verify, generateKeypair } from '../src/jws';
+import { CryptoError } from '../src/errors';
+
+const payload = {
+  peac_version: '0.2',
+  kind: 'evidence',
+  type: 'org.peacprotocol/payment',
+  iss: 'https://api.example.com',
+  iat: 1709500000,
+  jti: 'issuance-ijson-001',
+} as const;
+
+// Codes raised while serializing/validating a segment, i.e. strictly before Ed25519 signing.
+const PRE_SIGN_CODES = new Set([
+  'CRYPTO_IJSON_INVALID_STRING',
+  'CRYPTO_IJSON_DUPLICATE_MEMBER_NAME',
+  'CRYPTO_IJSON_NUMBER_OUT_OF_RANGE',
+  'CRYPTO_INVALID_JWS_FORMAT',
+  'CRYPTO_JWS_MISSING_KID',
+]);
+
+let privateKey: Uint8Array;
+let publicKey: Uint8Array;
+beforeAll(async () => {
+  ({ privateKey, publicKey } = await generateKeypair());
+});
+
+const NONCHAR_FDD0 = '\uFDD0';
+const NONCHAR_FFFF = '\uFFFF';
+const LONE_SURROGATE = '\uD800';
+
+async function expectPreSignRejection(run: () => Promise<unknown>): Promise<void> {
+  try {
+    await run();
+  } catch (err) {
+    expect(err).toBeInstanceOf(CryptoError);
+    expect(PRE_SIGN_CODES.has((err as CryptoError).code), `code ${(err as CryptoError).code}`).toBe(
+      true
+    );
+    return;
+  }
+  throw new Error('expected issuance to reject, but it succeeded');
+}
+
+describe('valid issuance still signs, verifies, and clears the I-JSON gate', () => {
+  it('ordinary ASCII kid', async () => {
+    await expect(
+      verify(await signWire02(payload, privateKey, 'key-1'), publicKey)
+    ).resolves.toBeDefined();
+  });
+
+  it('supplementary-plane kid within 256 UTF-8 bytes', async () => {
+    const jws = await signWire02(payload, privateKey, '\u{1F600}'.repeat(4));
+    await expect(verify(jws, publicKey)).resolves.toBeDefined();
+  });
+
+  it('payload with a well-formed non-ASCII string', async () => {
+    const jws = await signWire02({ ...payload, jti: 'r\u00e9f-\u{1F600}' }, privateKey, 'key-1');
+    await expect(verify(jws, publicKey)).resolves.toBeDefined();
+  });
+});
+
+describe('non-I-JSON issuance is rejected at the serialization stage', () => {
+  // The thrown code is raised while serializing/validating the segment, i.e. by serializeIJsonSegment,
+  // which runs before ed25519 signing. That is asserted through the code, not by claiming zero calls.
+  it('kid containing a U+FDD0 noncharacter', () =>
+    expectPreSignRejection(() => signWire02(payload, privateKey, `k${NONCHAR_FDD0}`)));
+  it('kid containing a U+FFFF noncharacter', () =>
+    expectPreSignRejection(() => signWire02(payload, privateKey, `k${NONCHAR_FFFF}`)));
+  it('kid containing a lone surrogate', () =>
+    expectPreSignRejection(() => signWire02(payload, privateKey, `k${LONE_SURROGATE}`)));
+  it('payload string containing a noncharacter', () =>
+    expectPreSignRejection(() =>
+      signWire02({ ...payload, jti: `x${NONCHAR_FDD0}` }, privateKey, 'key-1')
+    ));
+  it('payload string containing a lone surrogate', () =>
+    expectPreSignRejection(() =>
+      signWire02({ ...payload, jti: `x${LONE_SURROGATE}` }, privateKey, 'key-1')
+    ));
+  it('Wire 0.1 payload containing a noncharacter', () =>
+    expectPreSignRejection(() => sign({ x: `y${NONCHAR_FDD0}` }, privateKey, 'key-1')));
+
+  it('payload number outside the I-JSON interoperable range is rejected', async () => {
+    // 2^53 exceeds MAX_SAFE_INTEGER; assertIJson rejects it, so the signer must too. This proves the
+    // gate is the whole I-JSON contract, not a Unicode-only check. The verifier rejects the same.
+    await expectPreSignRejection(() => sign({ n: 9007199254740992 }, privateKey, 'key-1'));
+  });
+
+  it('a payload that cannot be serialized to JSON text is rejected', async () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    const throwingToJson = {
+      toJSON() {
+        throw new Error('boom');
+      },
+    };
+    const throwingGetter = Object.defineProperty({}, 'g', {
+      enumerable: true,
+      get() {
+        throw new Error('boom');
+      },
+    });
+    // JSON.stringify returns no text (undefined/function/symbol) or throws (BigInt, cyclic, a
+    // throwing toJSON or getter). All map to a stable code with no engine or caller text leaked.
+    const bad: unknown[] = [
+      undefined,
+      () => {},
+      Symbol('x'),
+      10n,
+      cyclic,
+      throwingToJson,
+      throwingGetter,
+    ];
+    for (const value of bad) {
+      await expectPreSignRejection(() => sign(value, privateKey, 'key-1'));
+    }
+  });
+});
+
+describe('byte identity for accepted inputs', () => {
+  it('a fixed key and payload produce the exact compact JWS', async () => {
+    // Deterministic regression: Ed25519 signing is deterministic, and the refactor encodes the same
+    // serialized bytes it validates, so accepted inputs must produce byte-identical output. A change
+    // to the serialization would change this golden value.
+    const fixedKey = new Uint8Array(32).fill(7);
+    const fixed = {
+      peac_version: '0.2',
+      kind: 'evidence',
+      type: 'org.peacprotocol/payment',
+      iss: 'https://api.example.com',
+      iat: 1709500000,
+      jti: 'byte-identity-001',
+    };
+    const jws = await signWire02(fixed, fixedKey, 'golden-key');
+    expect(jws).toBe(
+      'eyJ0eXAiOiJpbnRlcmFjdGlvbi1yZWNvcmQrand0IiwiYWxnIjoiRWREU0EiLCJraWQiOiJnb2xkZW4ta2V5In0.eyJwZWFjX3ZlcnNpb24iOiIwLjIiLCJraW5kIjoiZXZpZGVuY2UiLCJ0eXBlIjoib3JnLnBlYWNwcm90b2NvbC9wYXltZW50IiwiaXNzIjoiaHR0cHM6Ly9hcGkuZXhhbXBsZS5jb20iLCJpYXQiOjE3MDk1MDAwMDAsImp0aSI6ImJ5dGUtaWRlbnRpdHktMDAxIn0.IVr_LpFbu7pMC7htTcP389u0_UP1BQLPHqduhpyBqIqS6nmybB5DDVHSog-W8H-9MplK4JBJcVZSwpeyO2j-BQ'
+    );
+  });
+});
+
+describe('round-trip invariant', () => {
+  it('every JWS a signer emits clears the verifier raw I-JSON gate', async () => {
+    const kids = ['a', 'key-1', '\u00e9', '\u{1F600}'.repeat(4), 'a'.repeat(256)];
+    for (const kid of kids) {
+      const jws = await signWire02(payload, privateKey, kid);
+      await expect(
+        verify(jws, publicKey),
+        `kid ${JSON.stringify(kid).slice(0, 20)}`
+      ).resolves.toBeDefined();
+    }
+  });
+});

--- a/packages/crypto/__tests__/jws-issuance-ijson.test.ts
+++ b/packages/crypto/__tests__/jws-issuance-ijson.test.ts
@@ -4,9 +4,12 @@
  * The verifier applies the RFC 7493 I-JSON gate to the decoded header and payload bytes (Wire 0.2
  * Section 10.6). The signer must apply the identical gate to the exact bytes it signs, so that a
  * PEAC signing API can never emit a compact JWS its own verifier rejects as non-I-JSON. These tests
- * assert rejection happens at issuance (the thrown code is a serialization-stage code, raised before
- * Ed25519 signing) and that a successful sign always clears the verifier's raw I-JSON gate. Non-ASCII
- * inputs are written with explicit escapes so their code points do not depend on file encoding.
+ * assert that non-admissible input is rejected during segment serialization/validation, with the
+ * exact stable code for each case, and that any JWS a signer does emit is admitted by the verifier
+ * AND carries a valid Ed25519 signature. The rejection code identifies which validation stage
+ * refused the input; the tests do not instrument the signer and make no claim about signing calls.
+ * Non-ASCII inputs are written with explicit escapes so their code points do not depend on file
+ * encoding.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import { sign, signWire02, verify, generateKeypair } from '../src/jws';
@@ -21,15 +24,6 @@ const payload = {
   jti: 'issuance-ijson-001',
 } as const;
 
-// Codes raised while serializing/validating a segment, i.e. strictly before Ed25519 signing.
-const PRE_SIGN_CODES = new Set([
-  'CRYPTO_IJSON_INVALID_STRING',
-  'CRYPTO_IJSON_DUPLICATE_MEMBER_NAME',
-  'CRYPTO_IJSON_NUMBER_OUT_OF_RANGE',
-  'CRYPTO_INVALID_JWS_FORMAT',
-  'CRYPTO_JWS_MISSING_KID',
-]);
-
 let privateKey: Uint8Array;
 let publicKey: Uint8Array;
 beforeAll(async () => {
@@ -40,61 +34,88 @@ const NONCHAR_FDD0 = '\uFDD0';
 const NONCHAR_FFFF = '\uFFFF';
 const LONE_SURROGATE = '\uD800';
 
-async function expectPreSignRejection(run: () => Promise<unknown>): Promise<void> {
+/**
+ * Assert that issuance is refused during segment serialization/validation with an EXACT code. An
+ * allow-set would let a regression take the wrong rejection path and still pass, so every vector
+ * pins the one code the current implementation is confirmed to raise.
+ */
+async function expectIssuanceRejection(
+  run: () => Promise<unknown>,
+  expectedCode: string
+): Promise<void> {
   try {
     await run();
   } catch (err) {
     expect(err).toBeInstanceOf(CryptoError);
-    expect(PRE_SIGN_CODES.has((err as CryptoError).code), `code ${(err as CryptoError).code}`).toBe(
-      true
-    );
+    expect((err as CryptoError).code).toBe(expectedCode);
     return;
   }
-  throw new Error('expected issuance to reject, but it succeeded');
+  throw new Error(`expected issuance to reject with ${expectedCode}, but it succeeded`);
 }
 
-describe('valid issuance still signs, verifies, and clears the I-JSON gate', () => {
+describe('valid issuance signs, is admitted by the verifier, and has a valid signature', () => {
   it('ordinary ASCII kid', async () => {
-    await expect(
-      verify(await signWire02(payload, privateKey, 'key-1'), publicKey)
-    ).resolves.toBeDefined();
+    const result = await verify(await signWire02(payload, privateKey, 'key-1'), publicKey);
+    expect(result.valid).toBe(true);
   });
 
   it('supplementary-plane kid within 256 UTF-8 bytes', async () => {
     const jws = await signWire02(payload, privateKey, '\u{1F600}'.repeat(4));
-    await expect(verify(jws, publicKey)).resolves.toBeDefined();
+    const result = await verify(jws, publicKey);
+    expect(result.valid).toBe(true);
   });
 
   it('payload with a well-formed non-ASCII string', async () => {
     const jws = await signWire02({ ...payload, jti: 'r\u00e9f-\u{1F600}' }, privateKey, 'key-1');
-    await expect(verify(jws, publicKey)).resolves.toBeDefined();
+    const result = await verify(jws, publicKey);
+    expect(result.valid).toBe(true);
   });
 });
 
-describe('non-I-JSON issuance is rejected at the serialization stage', () => {
-  // The thrown code is raised while serializing/validating the segment, i.e. by serializeIJsonSegment,
-  // which runs before ed25519 signing. That is asserted through the code, not by claiming zero calls.
+describe('non-I-JSON issuance is rejected during segment serialization/validation', () => {
+  // A noncharacter reaches the kid header and is refused by the I-JSON string gate; a lone surrogate
+  // is refused earlier by the kid rule (an unpaired surrogate is not well-formed Unicode), which is
+  // why the two kid cases carry different codes.
   it('kid containing a U+FDD0 noncharacter', () =>
-    expectPreSignRejection(() => signWire02(payload, privateKey, `k${NONCHAR_FDD0}`)));
+    expectIssuanceRejection(
+      () => signWire02(payload, privateKey, `k${NONCHAR_FDD0}`),
+      'CRYPTO_IJSON_INVALID_STRING'
+    ));
   it('kid containing a U+FFFF noncharacter', () =>
-    expectPreSignRejection(() => signWire02(payload, privateKey, `k${NONCHAR_FFFF}`)));
+    expectIssuanceRejection(
+      () => signWire02(payload, privateKey, `k${NONCHAR_FFFF}`),
+      'CRYPTO_IJSON_INVALID_STRING'
+    ));
   it('kid containing a lone surrogate', () =>
-    expectPreSignRejection(() => signWire02(payload, privateKey, `k${LONE_SURROGATE}`)));
+    expectIssuanceRejection(
+      () => signWire02(payload, privateKey, `k${LONE_SURROGATE}`),
+      'CRYPTO_JWS_MISSING_KID'
+    ));
   it('payload string containing a noncharacter', () =>
-    expectPreSignRejection(() =>
-      signWire02({ ...payload, jti: `x${NONCHAR_FDD0}` }, privateKey, 'key-1')
+    expectIssuanceRejection(
+      () => signWire02({ ...payload, jti: `x${NONCHAR_FDD0}` }, privateKey, 'key-1'),
+      'CRYPTO_IJSON_INVALID_STRING'
     ));
   it('payload string containing a lone surrogate', () =>
-    expectPreSignRejection(() =>
-      signWire02({ ...payload, jti: `x${LONE_SURROGATE}` }, privateKey, 'key-1')
+    expectIssuanceRejection(
+      () => signWire02({ ...payload, jti: `x${LONE_SURROGATE}` }, privateKey, 'key-1'),
+      'CRYPTO_IJSON_INVALID_STRING'
     ));
   it('Wire 0.1 payload containing a noncharacter', () =>
-    expectPreSignRejection(() => sign({ x: `y${NONCHAR_FDD0}` }, privateKey, 'key-1')));
+    expectIssuanceRejection(
+      () => sign({ x: `y${NONCHAR_FDD0}` }, privateKey, 'key-1'),
+      'CRYPTO_IJSON_INVALID_STRING'
+    ));
 
-  it('payload number outside the I-JSON interoperable range is rejected', async () => {
-    // 2^53 exceeds MAX_SAFE_INTEGER; assertIJson rejects it, so the signer must too. This proves the
-    // gate is the whole I-JSON contract, not a Unicode-only check. The verifier rejects the same.
-    await expectPreSignRejection(() => sign({ n: 9007199254740992 }, privateKey, 'key-1'));
+  it('payload number outside the PEAC safe-numeric-range admission rule is rejected', async () => {
+    // 2^53 exceeds MAX_SAFE_INTEGER. PEAC's existing raw JSON/I-JSON admission gate hard-rejects it
+    // (RFC 7493 recommends SHOULD NOT beyond binary64 interoperability; PEAC is stricter), so the
+    // signer must too. This proves the gate is the whole admission contract, not a Unicode-only
+    // check. The verifier rejects the identical bytes with the same code.
+    await expectIssuanceRejection(
+      () => sign({ n: 9007199254740992 }, privateKey, 'key-1'),
+      'CRYPTO_IJSON_NUMBER_OUT_OF_RANGE'
+    );
   });
 
   it('a payload that cannot be serialized to JSON text is rejected', async () => {
@@ -112,7 +133,7 @@ describe('non-I-JSON issuance is rejected at the serialization stage', () => {
       },
     });
     // JSON.stringify returns no text (undefined/function/symbol) or throws (BigInt, cyclic, a
-    // throwing toJSON or getter). All map to a stable code with no engine or caller text leaked.
+    // throwing toJSON or getter). All map to one stable code with no engine or caller text leaked.
     const bad: unknown[] = [
       undefined,
       () => {},
@@ -123,7 +144,10 @@ describe('non-I-JSON issuance is rejected at the serialization stage', () => {
       throwingGetter,
     ];
     for (const value of bad) {
-      await expectPreSignRejection(() => sign(value, privateKey, 'key-1'));
+      await expectIssuanceRejection(
+        () => sign(value, privateKey, 'key-1'),
+        'CRYPTO_INVALID_JWS_FORMAT'
+      );
     }
   });
 });
@@ -150,14 +174,12 @@ describe('byte identity for accepted inputs', () => {
 });
 
 describe('round-trip invariant', () => {
-  it('every JWS a signer emits clears the verifier raw I-JSON gate', async () => {
+  it('every JWS a signer emits is admitted by the verifier with a valid signature', async () => {
     const kids = ['a', 'key-1', '\u00e9', '\u{1F600}'.repeat(4), 'a'.repeat(256)];
     for (const kid of kids) {
       const jws = await signWire02(payload, privateKey, kid);
-      await expect(
-        verify(jws, publicKey),
-        `kid ${JSON.stringify(kid).slice(0, 20)}`
-      ).resolves.toBeDefined();
+      const result = await verify(jws, publicKey);
+      expect(result.valid, `kid ${JSON.stringify(kid).slice(0, 20)}`).toBe(true);
     }
   });
 });

--- a/packages/crypto/src/ijson.ts
+++ b/packages/crypto/src/ijson.ts
@@ -5,21 +5,28 @@
  * JSON parsers can collapse duplicate object member names, round or overflow
  * numeric values, or substitute invalid string data before higher-level
  * validation sees the original bytes. The gate also classifies string-level
- * syntax failures consistently at the raw boundary. It rejects, per I-JSON
- * (RFC 7493):
+ * syntax failures consistently at the raw boundary. It rejects:
  *
  *   - duplicate object member names  -> collapsed by JSON.parse (last wins)
  *     => CRYPTO_IJSON_DUPLICATE_MEMBER_NAME
- *   - numbers that are non-finite OR whose absolute magnitude exceeds 2^53-1
- *     (incl. large finite floats) -> rounded/overflowed by JSON.parse
- *     => CRYPTO_IJSON_NUMBER_OUT_OF_RANGE
+ *     RFC 7493 makes unique member names a MUST.
  *   - invalid string content: lone surrogates or noncharacters (directly encoded
  *     or in \u escapes), invalid escape sequences, or invalid UTF-8 bytes
  *     inside a string => CRYPTO_IJSON_INVALID_STRING
+ *     RFC 7493 makes well-formed Unicode strings (no unpaired surrogates, no
+ *     noncharacters) a MUST.
+ *   - numbers that are non-finite OR whose absolute magnitude exceeds 2^53-1
+ *     (incl. large finite floats) -> rounded/overflowed by JSON.parse
+ *     => CRYPTO_IJSON_NUMBER_OUT_OF_RANGE
+ *     This is PEAC's stricter numeric admission rule, not an RFC 7493 MUST: RFC
+ *     7493 says senders SHOULD NOT emit numbers beyond binary64 interoperability
+ *     and warns that integers beyond +/-(2^53-1) cannot be relied on to retain
+ *     exact value. PEAC hard-rejects that range at the raw boundary so a value
+ *     the recipient cannot reproduce exactly never enters a signed record.
  *
- * Escaped solidus ("\/") is valid I-JSON and MUST be accepted. String-encoded
- * large integers (inside quotes) are accepted. Valid surrogate PAIRS are
- * accepted. The numeric bound is exactly 9007199254740991 (= MAX_SAFE_INTEGER).
+ * Escaped solidus ("\/") is valid JSON and is accepted. String-encoded large
+ * integers (inside quotes) are accepted. Valid surrogate PAIRS are accepted. The
+ * numeric admission bound is exactly 9007199254740991 (= MAX_SAFE_INTEGER).
  *
  * This is a strict single-pass JSON parser operating on the RAW BYTES (it does
  * NOT pre-decode the whole document, so it can distinguish invalid UTF-8 INSIDE

--- a/packages/crypto/src/jws.ts
+++ b/packages/crypto/src/jws.ts
@@ -202,7 +202,7 @@ function buildHeader(raw: Record<string, unknown>): JWSHeader {
  *
  * @param payload - JSON-serializable payload
  * @param privateKey - Ed25519 private key (32 bytes)
- * @param kid - Key ID (ISO 8601 timestamp)
+ * @param kid - Key ID; non-empty, well-formed Unicode, at most 256 UTF-8 bytes (see kid.ts)
  * @returns JWS compact serialization (header.payload.signature)
  */
 /**

--- a/packages/crypto/src/jws.ts
+++ b/packages/crypto/src/jws.ts
@@ -16,7 +16,7 @@ import {
   PEAC_ALG,
   VERIFIER_LIMITS,
 } from '@peac/kernel';
-import { base64urlEncode, base64urlDecode, base64urlEncodeString } from './base64url';
+import { base64urlEncode, base64urlDecode } from './base64url';
 import { CryptoError } from './errors';
 import { assertIJson } from './ijson';
 import { isValidKid, MAX_KID_UTF8_BYTES } from './kid';
@@ -205,6 +205,35 @@ function buildHeader(raw: Record<string, unknown>): JWSHeader {
  * @param kid - Key ID (ISO 8601 timestamp)
  * @returns JWS compact serialization (header.payload.signature)
  */
+/**
+ * Serialize one JWS segment (header or payload) to the exact bytes that will be signed, enforcing
+ * I-JSON (RFC 7493) on those bytes before they leave the signer. The verifier applies the same
+ * `assertIJson` contract to the decoded segment bytes (Wire 0.2 Section 10.6), so validating the
+ * identical serialized bytes here keeps issuance and verification symmetric: a signer cannot emit a
+ * header or payload whose raw bytes its own verifier would reject as non-I-JSON. Encoding the same
+ * validated bytes (rather than re-serializing) leaves the signing input for valid inputs unchanged.
+ */
+function serializeIJsonSegment(value: unknown): Uint8Array {
+  let json: string | undefined;
+  try {
+    // JSON.stringify can throw: a BigInt or a circular structure raises TypeError, and a `toJSON`
+    // method or property getter can run arbitrary caller code that throws. Map any such failure to a
+    // stable code; the engine or caller exception text is not surfaced. (JSON.stringify may execute
+    // user code, so serialization is not promised to be side-effect-free.)
+    json = JSON.stringify(value);
+  } catch {
+    throw new CryptoError('CRYPTO_INVALID_JWS_FORMAT', 'JWS segment is not JSON-serializable');
+  }
+  if (typeof json !== 'string') {
+    throw new CryptoError('CRYPTO_INVALID_JWS_FORMAT', 'JWS segment is not JSON-serializable');
+  }
+  const bytes = new TextEncoder().encode(json);
+  // Not wrapped in try/catch: assertIJson raises the stable CRYPTO_IJSON_* codes the verifier also
+  // raises on the same bytes, and those must propagate unchanged.
+  assertIJson(bytes);
+  return bytes;
+}
+
 export async function sign(payload: unknown, privateKey: Uint8Array, kid: string): Promise<string> {
   if (privateKey.length !== 32) {
     throw new CryptoError('CRYPTO_INVALID_KEY_LENGTH', 'Ed25519 private key must be 32 bytes');
@@ -224,8 +253,8 @@ export async function sign(payload: unknown, privateKey: Uint8Array, kid: string
     kid,
   };
 
-  const headerB64 = base64urlEncodeString(JSON.stringify(header));
-  const payloadB64 = base64urlEncodeString(JSON.stringify(payload));
+  const headerB64 = base64urlEncode(serializeIJsonSegment(header));
+  const payloadB64 = base64urlEncode(serializeIJsonSegment(payload));
 
   const signingInput = `${headerB64}.${payloadB64}`;
   const signingInputBytes = new TextEncoder().encode(signingInput);
@@ -276,8 +305,8 @@ export async function signWire02(
     kid,
   };
 
-  const headerB64 = base64urlEncodeString(JSON.stringify(header));
-  const payloadB64 = base64urlEncodeString(JSON.stringify(payload));
+  const headerB64 = base64urlEncode(serializeIJsonSegment(header));
+  const payloadB64 = base64urlEncode(serializeIJsonSegment(payload));
 
   const signingInput = `${headerB64}.${payloadB64}`;
   const signingInputBytes = new TextEncoder().encode(signingInput);

--- a/packages/protocol/__tests__/issue-wire-02-ijson.test.ts
+++ b/packages/protocol/__tests__/issue-wire-02-ijson.test.ts
@@ -1,34 +1,63 @@
 /**
  * Higher-level issuance error surface for non-I-JSON input.
  *
- * The crypto signing boundary enforces I-JSON on the exact bytes it signs. This confirms that a
- * non-I-JSON value passed through the public `issueWire02()` API surfaces the stable structured
- * crypto error unchanged, rather than a generic exception, and that issuance fails rather than
- * emitting a record the verifier would reject. Non-ASCII inputs use explicit escapes.
+ * The crypto signing boundary enforces I-JSON (RFC 7493) and the kid rule on the exact bytes it
+ * signs. A claim value or kid that passes schema validation but is not admissible at that boundary
+ * must not be emitted. This test fixes the public error contract for that case: `issueWire02()`
+ * rejects with the protocol's structured `IssueError`, carrying the same machine-readable code the
+ * verifier reports for the identical raw bytes, and retains the underlying `CryptoError` as the
+ * cause. It is deliberately not a raw crypto error: every other issuance failure (non-canonical iss,
+ * schema violation) already surfaces as `IssueError`, and this keeps the public API consistent.
+ * Non-ASCII inputs use explicit escapes so their code points do not depend on file encoding.
  */
 import { describe, it, expect } from 'vitest';
-import { generateKeypair } from '@peac/crypto';
-import { issueWire02 } from '../src/index';
+import { generateKeypair, CryptoError } from '@peac/crypto';
+import { issueWire02, IssueError } from '../src/index';
 
 const NONCHAR_FDD0 = '\uFDD0';
+const LONE_SURROGATE = '\uD800';
 
-describe('issueWire02 rejects non-I-JSON input at issuance', () => {
-  it('surfaces the stable crypto I-JSON error for a payload noncharacter', async () => {
+const baseOptions = {
+  iss: 'https://api.example.com',
+  kind: 'evidence' as const,
+  type: 'org.peacprotocol/payment',
+  occurred_at: '2026-04-01T00:00:00Z',
+  purpose_declared: 'test',
+  pillars: ['safety'],
+  kid: 'key-1',
+};
+
+describe('issueWire02 rejects non-I-JSON input through the structured IssueError surface', () => {
+  it('maps a payload noncharacter to IssueError E_IJSON_INVALID_STRING with the crypto cause', async () => {
     const { privateKey } = await generateKeypair();
-    const options = {
-      iss: 'https://api.example.com',
-      kind: 'evidence' as const,
-      type: 'org.peacprotocol/payment',
-      occurred_at: '2026-04-01T00:00:00Z',
-      purpose_declared: 'test',
-      pillars: ['safety'],
-      privateKey,
-      kid: 'key-1',
-      jti: `x${NONCHAR_FDD0}`,
-    };
-    await expect(issueWire02(options)).rejects.toMatchObject({
-      name: 'CryptoError',
-      code: 'CRYPTO_IJSON_INVALID_STRING',
-    });
+    let thrown: unknown;
+    try {
+      await issueWire02({ ...baseOptions, privateKey, jti: `x${NONCHAR_FDD0}` });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(IssueError);
+    expect((thrown as IssueError).peacError.code).toBe('E_IJSON_INVALID_STRING');
+    // The exact crypto classification is preserved as the cause, not widened into the public code.
+    expect((thrown as { cause?: unknown }).cause).toBeInstanceOf(CryptoError);
+    expect(((thrown as { cause?: CryptoError }).cause as CryptoError).code).toBe(
+      'CRYPTO_IJSON_INVALID_STRING'
+    );
+  });
+
+  it('maps an ill-formed kid to IssueError E_JWS_MISSING_KID with the crypto cause', async () => {
+    const { privateKey } = await generateKeypair();
+    let thrown: unknown;
+    try {
+      await issueWire02({ ...baseOptions, privateKey, kid: `k${LONE_SURROGATE}` });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(IssueError);
+    expect((thrown as IssueError).peacError.code).toBe('E_JWS_MISSING_KID');
+    expect((thrown as { cause?: unknown }).cause).toBeInstanceOf(CryptoError);
+    expect(((thrown as { cause?: CryptoError }).cause as CryptoError).code).toBe(
+      'CRYPTO_JWS_MISSING_KID'
+    );
   });
 });

--- a/packages/protocol/__tests__/issue-wire-02-ijson.test.ts
+++ b/packages/protocol/__tests__/issue-wire-02-ijson.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Higher-level issuance error surface for non-I-JSON input.
+ *
+ * The crypto signing boundary enforces I-JSON on the exact bytes it signs. This confirms that a
+ * non-I-JSON value passed through the public `issueWire02()` API surfaces the stable structured
+ * crypto error unchanged, rather than a generic exception, and that issuance fails rather than
+ * emitting a record the verifier would reject. Non-ASCII inputs use explicit escapes.
+ */
+import { describe, it, expect } from 'vitest';
+import { generateKeypair } from '@peac/crypto';
+import { issueWire02 } from '../src/index';
+
+const NONCHAR_FDD0 = '\uFDD0';
+
+describe('issueWire02 rejects non-I-JSON input at issuance', () => {
+  it('surfaces the stable crypto I-JSON error for a payload noncharacter', async () => {
+    const { privateKey } = await generateKeypair();
+    const options = {
+      iss: 'https://api.example.com',
+      kind: 'evidence' as const,
+      type: 'org.peacprotocol/payment',
+      occurred_at: '2026-04-01T00:00:00Z',
+      purpose_declared: 'test',
+      pillars: ['safety'],
+      privateKey,
+      kid: 'key-1',
+      jti: `x${NONCHAR_FDD0}`,
+    };
+    await expect(issueWire02(options)).rejects.toMatchObject({
+      name: 'CryptoError',
+      code: 'CRYPTO_IJSON_INVALID_STRING',
+    });
+  });
+});

--- a/packages/protocol/src/issue.ts
+++ b/packages/protocol/src/issue.ts
@@ -4,7 +4,7 @@
  */
 
 import { uuidv7 } from 'uuidv7';
-import { sign } from '@peac/crypto';
+import { sign, CryptoError } from '@peac/crypto';
 import { defaultCodec } from './_internal/record-core/codec/jws-jwt.js';
 import { runBoundedValidatorShadow } from './_internal/record-core/bounded-validator.js';
 import { runBoundedValidationGate } from './_internal/record-core/validation-gate.js';
@@ -138,7 +138,7 @@ export interface IssueWire01Options {
   /** Ed25519 private key (32 bytes) */
   privateKey: Uint8Array;
 
-  /** Key ID (ISO 8601 timestamp) */
+  /** Key ID; non-empty, well-formed Unicode, at most 256 UTF-8 bytes */
   kid: string;
 
   /** Telemetry hook (optional, fire-and-forget) */
@@ -171,6 +171,40 @@ export class IssueError extends Error {
     this.name = 'IssueError';
     this.peacError = peacError;
   }
+}
+
+/**
+ * Protocol code for a crypto signing failure at the issuance boundary.
+ *
+ * The signer enforces the I-JSON gate (RFC 7493) and the kid rule on the exact bytes it signs, so a
+ * claim value that passed schema validation but is not I-JSON, an out-of-range number, or an invalid
+ * kid is rejected there rather than emitted. These are the crypto codes reachable when serializing a
+ * well-formed claims object, mapped to the same protocol code the verifier reports for the identical
+ * raw bytes, so issuance and verification classify the failure the same way. A well-formed claims
+ * object cannot produce duplicate member names, but the mapping is complete for robustness. Any other
+ * crypto code (for example an invalid key length) falls back to the generic validation code; the
+ * original CryptoError is always retained as the cause.
+ */
+const CRYPTO_ISSUANCE_CODE_MAP: Record<string, string> = {
+  CRYPTO_JWS_MISSING_KID: 'E_JWS_MISSING_KID',
+  CRYPTO_IJSON_INVALID_STRING: 'E_IJSON_INVALID_STRING',
+  CRYPTO_IJSON_NUMBER_OUT_OF_RANGE: 'E_IJSON_NUMBER_OUT_OF_RANGE',
+  CRYPTO_IJSON_DUPLICATE_MEMBER_NAME: 'E_IJSON_DUPLICATE_MEMBER_NAME',
+};
+
+function issueErrorFromCryptoError(err: CryptoError): IssueError {
+  const code = CRYPTO_ISSUANCE_CODE_MAP[err.code] ?? 'E_INVALID_FORMAT';
+  const issueError = new IssueError({
+    code,
+    category: 'validation',
+    severity: 'error',
+    retryable: false,
+    http_status: 400,
+    details: { message: err.message },
+  } as PEACError);
+  // Retain the exact crypto classification for diagnostics without widening the public code surface.
+  (issueError as { cause?: unknown }).cause = err;
+  return issueError;
 }
 
 /**
@@ -560,8 +594,19 @@ export async function issueWire02(options: IssueWire02Options): Promise<IssueRes
   // Sign with Wire 0.2 via the internal codec boundary (always sets
   // typ: 'interaction-record+jwt'). Default codec is a pure pass-through
   // to @peac/crypto.signWire02; serialized output is byte-identical to
-  // the prior release.
-  const jws = await defaultCodec.encode(claims, options.privateKey, options.kid);
+  // the prior release. The signer enforces the raw-bytes I-JSON gate and
+  // the kid rule; present any such failure through the same structured
+  // IssueError surface as every other issuance failure rather than leaking
+  // a raw crypto error from this public API.
+  let jws: string;
+  try {
+    jws = await defaultCodec.encode(claims, options.privateKey, options.kid);
+  } catch (err) {
+    if (err instanceof CryptoError) {
+      throw issueErrorFromCryptoError(err);
+    }
+    throw err;
+  }
 
   // Shadow scheduling fires only on the rollback branch where the
   // bounded validator is genuinely a comparison path; under the


### PR DESCRIPTION
## Summary

The verifier applies the RFC 7493 I-JSON gate to the decoded header and payload before parsing (Wire 0.2 Section 10.6), but signing serialized the header and payload and signed them without the same check. A `kid` or payload string containing a Unicode noncharacter or lone surrogate, or a number outside the interoperable range, therefore signed successfully and was then rejected by PEAC's own verifier at the recipient, indistinguishable from tampering.

## Invariant

Every compact JWS a PEAC signing API emits satisfies the same raw I-JSON contract the verifier applies to its header and payload. Each segment is serialized once through a private helper that JSON-stringifies, validates the exact serialized bytes with the existing `assertIJson` gate, and encodes those same bytes.

- `JSON.stringify` returning no JSON text (`undefined`/function/symbol) or throwing (BigInt, a circular structure, a throwing `toJSON` or property getter) maps to a stable `CryptoError`; engine and caller exception text are not surfaced. `JSON.stringify` may run user code, so serialization is not claimed to be side-effect-free.
- The `assertIJson` codes (`CRYPTO_IJSON_*`) propagate unchanged, so issuance and verification report the same failure on the same bytes.
- Covers `sign()` and `signWire02()` for Wire 0.1 and Wire 0.2.

## Validation

- `@peac/crypto` (560) and `@peac/protocol` (2144) suites pass; `typecheck:core` clean; Unicode/Trojan-Source and format clean.
- New tests: noncharacter/lone-surrogate `kid` and payload strings, an out-of-range number, and all `JSON.stringify` failure modes reject at the serialization stage (a serialization-stage `CryptoError` code, raised before Ed25519 signing); a fixed-key/payload golden proves accepted inputs are byte-identical to the previous serialization; a round-trip invariant; and `issueWire02()` surfaces the stable `CRYPTO_IJSON_INVALID_STRING` for a payload noncharacter.

## Scope

`@peac/crypto` signing boundary. No Unicode normalization, trimming, JCS, dependency, public-export, wire-format, schema, or verification-behaviour change. No new normative requirement (spec wording is handled separately).
