### PR TITLE
fix(go): enforce I-JSON on issuance

### DIFF
--- a/sdks/go/errors.go
+++ b/sdks/go/errors.go
@@ -24,4 +24,14 @@ const (
 	ErrCodeInvalidPillar = "INVALID_PILLAR"
 	ErrCodeSignFailed    = "SIGN_FAILED"
 	ErrCodeIDGenFailed   = "ID_GEN_FAILED"
+
+	// ErrCodeInvalidUTF8 indicates a caller-controlled claim string is not valid
+	// UTF-8. It is detected before json.Marshal, which would otherwise silently
+	// replace the invalid bytes with U+FFFD and sign a mutated identifier.
+	ErrCodeInvalidUTF8 = "INVALID_UTF8"
+
+	// ErrCodeNonIJSONPayload indicates the marshaled claims payload violates the
+	// raw-bytes I-JSON (RFC 7493) gate the verifier applies. The underlying
+	// canonical code (E_IJSON_*) is preserved in the message.
+	ErrCodeNonIJSONPayload = "NON_IJSON_PAYLOAD"
 )

--- a/sdks/go/errors.go
+++ b/sdks/go/errors.go
@@ -30,8 +30,12 @@ const (
 	// replace the invalid bytes with U+FFFD and sign a mutated identifier.
 	ErrCodeInvalidUTF8 = "INVALID_UTF8"
 
-	// ErrCodeNonIJSONPayload indicates the marshaled claims payload violates the
-	// raw-bytes I-JSON (RFC 7493) gate the verifier applies. The underlying
-	// canonical code (E_IJSON_*) is preserved in the message.
-	ErrCodeNonIJSONPayload = "NON_IJSON_PAYLOAD"
+	// ErrCodeInvalidJSONProfile indicates the marshaled claims payload failed the
+	// PEAC raw JSON admission profile the verifier applies. That profile combines
+	// RFC 7493 requirements (UTF-8, no surrogates or noncharacters, unique member
+	// names) with PEAC's stricter safe-numeric-range rule, which rejects numbers
+	// whose magnitude exceeds 2^53-1 (RFC 7493 treats that bound as SHOULD-NOT, not
+	// a MUST). The underlying canonical code (E_IJSON_* / E_INVALID_FORMAT) is
+	// preserved in the message.
+	ErrCodeInvalidJSONProfile = "INVALID_JSON_PROFILE"
 )

--- a/sdks/go/issue.go
+++ b/sdks/go/issue.go
@@ -186,10 +186,29 @@ func Issue(opts IssueOptions) (*IssueResult, error) {
 		claims.Exp = opts.Exp
 	}
 
+	// Reject invalid UTF-8 in any caller-controlled claim string BEFORE marshaling, because
+	// encoding/json would silently replace it with U+FFFD and sign a mutated identifier. Run on the
+	// built claims so a caller-supplied receipt-ID generator is covered too.
+	if err := validateClaimUTF8(&claims); err != nil {
+		return nil, err
+	}
+
 	// Marshal and sign
 	payload, err := json.Marshal(claims)
 	if err != nil {
 		return nil, &IssueError{Code: ErrCodeSignFailed, Message: fmt.Sprintf("failed to marshal claims: %v", err)}
+	}
+
+	// Enforce the same raw-bytes I-JSON gate the verifier applies, on the exact bytes about to be
+	// signed. This is the sole gate for classes that survive marshaling as valid JSON: Unicode
+	// noncharacters and numbers whose magnitude exceeds the safe range. Without it the issuer could
+	// emit a payload its own VerifyLocal rejects.
+	if ijErr := assertIJSON(payload); ijErr != nil {
+		msg := ijErr.Error()
+		if ije, ok := ijErr.(*ijsonError); ok {
+			msg = ije.Code + ": " + ije.Msg
+		}
+		return nil, &IssueError{Code: ErrCodeNonIJSONPayload, Message: msg}
 	}
 
 	jwsString, err := opts.SigningKey.SignWithType(payload, InteractionRecordTyp)

--- a/sdks/go/issue.go
+++ b/sdks/go/issue.go
@@ -143,9 +143,12 @@ func Issue(opts IssueOptions) (*IssueResult, error) {
 		}
 	}
 
+	// Resolve the effective evidence limits once so extension validation and the extension UTF-8
+	// walk below share one authoritative node ceiling instead of a second hard-coded value.
+	limits := opts.EvidenceLimits.WithDefaults()
+
 	// Validate extensions if provided
 	if opts.Extensions != nil {
-		limits := opts.EvidenceLimits.WithDefaults()
 		if err := evidence.ValidateValue(opts.Extensions, limits); err != nil {
 			return nil, &IssueError{Code: ErrCodeInvalidType, Message: fmt.Sprintf("extension validation failed: %v", err), Field: "Extensions"}
 		}
@@ -186,10 +189,11 @@ func Issue(opts IssueOptions) (*IssueResult, error) {
 		claims.Exp = opts.Exp
 	}
 
-	// Reject invalid UTF-8 in any caller-controlled claim string BEFORE marshaling, because
+	// Reject invalid UTF-8 in any caller-controlled claim string before marshaling, because
 	// encoding/json would silently replace it with U+FFFD and sign a mutated identifier. Run on the
-	// built claims so a caller-supplied receipt-ID generator is covered too.
-	if err := validateClaimUTF8(&claims); err != nil {
+	// built claims so a caller-supplied receipt-ID generator is covered too, and share the resolved
+	// node ceiling so the extension walk does not impose a second, unrelated limit.
+	if err := validateClaimUTF8(&claims, limits.MaxTotalNodes); err != nil {
 		return nil, err
 	}
 
@@ -199,16 +203,16 @@ func Issue(opts IssueOptions) (*IssueResult, error) {
 		return nil, &IssueError{Code: ErrCodeSignFailed, Message: fmt.Sprintf("failed to marshal claims: %v", err)}
 	}
 
-	// Enforce the same raw-bytes I-JSON gate the verifier applies, on the exact bytes about to be
-	// signed. This is the sole gate for classes that survive marshaling as valid JSON: Unicode
-	// noncharacters and numbers whose magnitude exceeds the safe range. Without it the issuer could
+	// Enforce the PEAC raw JSON/I-JSON admission profile the verifier applies, on the exact bytes
+	// about to be signed. This is the sole gate for classes that survive marshaling as valid JSON:
+	// Unicode noncharacters and numbers outside the safe numeric range. Without it the issuer could
 	// emit a payload its own VerifyLocal rejects.
 	if ijErr := assertIJSON(payload); ijErr != nil {
 		msg := ijErr.Error()
 		if ije, ok := ijErr.(*ijsonError); ok {
 			msg = ije.Code + ": " + ije.Msg
 		}
-		return nil, &IssueError{Code: ErrCodeNonIJSONPayload, Message: msg}
+		return nil, &IssueError{Code: ErrCodeInvalidJSONProfile, Message: msg}
 	}
 
 	jwsString, err := opts.SigningKey.SignWithType(payload, InteractionRecordTyp)

--- a/sdks/go/issue_ijson.go
+++ b/sdks/go/issue_ijson.go
@@ -14,25 +14,22 @@ import (
 //
 //   - Invalid UTF-8 in a Go string is silently replaced with U+FFFD by encoding/json. U+FFFD is a
 //     valid character, so a post-marshal scan cannot recover the original invalidity. This class
-//     MUST be detected before json.Marshal runs, on the Go values themselves. That is the sole job
+//     must be detected before json.Marshal runs, on the Go values themselves. That is the sole job
 //     of the pre-marshal walk below.
 //   - Unicode noncharacters and out-of-range numbers survive marshaling as valid UTF-8 / literal
-//     digits, so they are caught after marshaling by assertIJSON over the exact signed bytes. The
-//     pre-marshal walk deliberately does not re-implement that logic.
+//     digits, so they are caught after marshaling by the raw JSON admission gate over the exact
+//     signed bytes. The pre-marshal walk deliberately does not re-implement that logic.
 //
 // The walk covers every caller-controlled string reachable in the marshaled payload: the typed
 // top-level fields (including the generated or caller-supplied rid), the pillar list, the optional
 // actor and policy blocks, and every string value and string member name inside the extension map.
 
-// maxClaimGraphNodes bounds the extension-map traversal so the walk terminates on any input,
-// independent of whether evidence.ValidateValue (which enforces its own node and depth bounds) ran
-// first. It matches the evidence validator's default node ceiling.
-const maxClaimGraphNodes = 100000
-
 // validateClaimUTF8 rejects any caller-controlled claim string that is not valid UTF-8, before the
 // claims are marshaled and signed. It operates on the built claims struct so a caller-supplied
 // receipt-ID generator or actor/policy/extension value cannot introduce bytes it does not see.
-func validateClaimUTF8(claims *InteractionRecordClaims) error {
+// maxNodes bounds the extension traversal; callers pass the same effective evidence node ceiling
+// used for extension validation so the walk does not impose a second, unrelated limit.
+func validateClaimUTF8(claims *InteractionRecordClaims, maxNodes int) error {
 	typed := []struct {
 		field string
 		value string
@@ -79,7 +76,7 @@ func validateClaimUTF8(claims *InteractionRecordClaims) error {
 		}
 	}
 	if claims.Ext != nil {
-		if err := validateExtUTF8(claims.Ext); err != nil {
+		if err := validateExtUTF8(claims.Ext, maxNodes); err != nil {
 			return err
 		}
 	}
@@ -99,10 +96,10 @@ func checkClaimStringUTF8(s, field string) error {
 }
 
 // validateExtUTF8 walks the extension graph and rejects any string value or member name that is not
-// valid UTF-8. The traversal is iterative and self-bounded: it carries its own node ceiling and
+// valid UTF-8. The traversal is iterative and self-bounded: it honors the supplied node ceiling and
 // fails closed on any value type outside the JSON builtins, so it terminates and cannot panic even
 // if it is ever reached without evidence.ValidateValue having constrained the graph first.
-func validateExtUTF8(ext map[string]any) error {
+func validateExtUTF8(ext map[string]any, maxNodes int) error {
 	type frame struct {
 		value any
 		path  string
@@ -114,10 +111,10 @@ func validateExtUTF8(ext map[string]any) error {
 		stack = stack[:len(stack)-1]
 
 		nodes++
-		if nodes > maxClaimGraphNodes {
+		if nodes > maxNodes {
 			return &IssueError{
 				Code:    ErrCodeInvalidType,
-				Message: fmt.Sprintf("extension graph exceeds %d nodes", maxClaimGraphNodes),
+				Message: fmt.Sprintf("extension graph exceeds %d nodes", maxNodes),
 				Field:   "Extensions",
 			}
 		}

--- a/sdks/go/issue_ijson.go
+++ b/sdks/go/issue_ijson.go
@@ -1,0 +1,158 @@
+package peac
+
+import (
+	"fmt"
+	"sort"
+	"unicode/utf8"
+)
+
+// Issuance/verification I-JSON symmetry (payload).
+//
+// The verifier applies the raw-bytes I-JSON gate (assertIJSON, RFC 7493) to the decoded payload
+// before parsing. The issuer must not emit a payload that gate would reject. Two problems can arise
+// when a caller-supplied Go value is marshaled:
+//
+//   - Invalid UTF-8 in a Go string is silently replaced with U+FFFD by encoding/json. U+FFFD is a
+//     valid character, so a post-marshal scan cannot recover the original invalidity. This class
+//     MUST be detected before json.Marshal runs, on the Go values themselves. That is the sole job
+//     of the pre-marshal walk below.
+//   - Unicode noncharacters and out-of-range numbers survive marshaling as valid UTF-8 / literal
+//     digits, so they are caught after marshaling by assertIJSON over the exact signed bytes. The
+//     pre-marshal walk deliberately does not re-implement that logic.
+//
+// The walk covers every caller-controlled string reachable in the marshaled payload: the typed
+// top-level fields (including the generated or caller-supplied rid), the pillar list, the optional
+// actor and policy blocks, and every string value and string member name inside the extension map.
+
+// maxClaimGraphNodes bounds the extension-map traversal so the walk terminates on any input,
+// independent of whether evidence.ValidateValue (which enforces its own node and depth bounds) ran
+// first. It matches the evidence validator's default node ceiling.
+const maxClaimGraphNodes = 100000
+
+// validateClaimUTF8 rejects any caller-controlled claim string that is not valid UTF-8, before the
+// claims are marshaled and signed. It operates on the built claims struct so a caller-supplied
+// receipt-ID generator or actor/policy/extension value cannot introduce bytes it does not see.
+func validateClaimUTF8(claims *InteractionRecordClaims) error {
+	typed := []struct {
+		field string
+		value string
+	}{
+		{"iss", claims.Iss},
+		{"sub", claims.Sub},
+		{"rid", claims.Rid},
+		{"kind", claims.Kind},
+		{"type", claims.Type},
+		{"peac_version", claims.PeacVersion},
+	}
+	for _, t := range typed {
+		if err := checkClaimStringUTF8(t.value, t.field); err != nil {
+			return err
+		}
+	}
+	for i, p := range claims.Pillars {
+		if err := checkClaimStringUTF8(p, fmt.Sprintf("pillars[%d]", i)); err != nil {
+			return err
+		}
+	}
+	if claims.Actor != nil {
+		if err := checkClaimStringUTF8(claims.Actor.ID, "actor.id"); err != nil {
+			return err
+		}
+		if err := checkClaimStringUTF8(claims.Actor.Role, "actor.role"); err != nil {
+			return err
+		}
+		for i, pt := range claims.Actor.ProofTypes {
+			if err := checkClaimStringUTF8(pt, fmt.Sprintf("actor.proof_types[%d]", i)); err != nil {
+				return err
+			}
+		}
+	}
+	if claims.Peac != nil {
+		if err := checkClaimStringUTF8(claims.Peac.Digest, "policy.digest"); err != nil {
+			return err
+		}
+		if err := checkClaimStringUTF8(claims.Peac.URI, "policy.uri"); err != nil {
+			return err
+		}
+		if err := checkClaimStringUTF8(claims.Peac.Version, "policy.version"); err != nil {
+			return err
+		}
+	}
+	if claims.Ext != nil {
+		if err := validateExtUTF8(claims.Ext); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checkClaimStringUTF8 returns an *IssueError if s is not valid UTF-8.
+func checkClaimStringUTF8(s, field string) error {
+	if !utf8.ValidString(s) {
+		return &IssueError{
+			Code:    ErrCodeInvalidUTF8,
+			Message: "claim string is not valid UTF-8",
+			Field:   field,
+		}
+	}
+	return nil
+}
+
+// validateExtUTF8 walks the extension graph and rejects any string value or member name that is not
+// valid UTF-8. The traversal is iterative and self-bounded: it carries its own node ceiling and
+// fails closed on any value type outside the JSON builtins, so it terminates and cannot panic even
+// if it is ever reached without evidence.ValidateValue having constrained the graph first.
+func validateExtUTF8(ext map[string]any) error {
+	type frame struct {
+		value any
+		path  string
+	}
+	stack := []frame{{value: ext, path: "ext"}}
+	nodes := 0
+	for len(stack) > 0 {
+		item := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+
+		nodes++
+		if nodes > maxClaimGraphNodes {
+			return &IssueError{
+				Code:    ErrCodeInvalidType,
+				Message: fmt.Sprintf("extension graph exceeds %d nodes", maxClaimGraphNodes),
+				Field:   "Extensions",
+			}
+		}
+
+		switch v := item.value.(type) {
+		case nil, bool, float64:
+			// Scalars that cannot carry invalid UTF-8.
+		case string:
+			if err := checkClaimStringUTF8(v, item.path); err != nil {
+				return err
+			}
+		case []any:
+			for i := len(v) - 1; i >= 0; i-- {
+				stack = append(stack, frame{value: v[i], path: fmt.Sprintf("%s[%d]", item.path, i)})
+			}
+		case map[string]any:
+			keys := make([]string, 0, len(v))
+			for k := range v {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for i := len(keys) - 1; i >= 0; i-- {
+				k := keys[i]
+				if err := checkClaimStringUTF8(k, item.path+" (member name)"); err != nil {
+					return err
+				}
+				stack = append(stack, frame{value: v[k], path: item.path + "." + k})
+			}
+		default:
+			return &IssueError{
+				Code:    ErrCodeInvalidType,
+				Message: fmt.Sprintf("unexpected extension value type %T", v),
+				Field:   item.path,
+			}
+		}
+	}
+	return nil
+}

--- a/sdks/go/issue_ijson_test.go
+++ b/sdks/go/issue_ijson_test.go
@@ -1,0 +1,167 @@
+package peac
+
+import (
+	"testing"
+)
+
+// A record the issuer accepts must be admitted by the same SDK's verifier. Non-ASCII but
+// well-formed values (accented text, CJK, an emoji) round-trip. Written with escapes so the code
+// points do not depend on source encoding.
+func TestIssue_UTF8RoundTripSymmetry(t *testing.T) {
+	key := testSigningKey(t)
+	result, err := Issue(IssueOptions{
+		Iss:        "https://example.com",
+		Kind:       KindEvidence,
+		Type:       "org.peacprotocol/test",
+		SigningKey: key,
+		Kid:        "test-key-1",
+		Sub:        "https://sub.example.com/caf\u00e9",
+		Extensions: map[string]any{
+			"note":   "caf\u00e9 \U0001F600",
+			"\u00e9": "value",
+			"nested": map[string]any{
+				"list": []any{"a", "\u4e2d\u6587", true, float64(42)},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("valid non-ASCII issuance failed: %v", err)
+	}
+	vr := VerifyLocal(result.JWS, VerifyLocalOptions{PublicKey: key.PublicKey()})
+	if !vr.Valid {
+		t.Fatalf("issued record did not verify: %s %s", vr.ErrorCode, vr.ErrorMessage)
+	}
+}
+
+// Invalid UTF-8 in any caller-controlled claim string is rejected before marshaling, with the field
+// path, so encoding/json cannot silently replace it with U+FFFD and sign a mutated identifier.
+func TestIssue_RejectsInvalidUTF8(t *testing.T) {
+	key := testSigningKey(t)
+	const badByte = "\xff" // a lone 0xFF is not valid UTF-8
+
+	base := func() IssueOptions {
+		return IssueOptions{
+			Iss:        "https://example.com",
+			Kind:       KindEvidence,
+			Type:       "org.peacprotocol/test",
+			SigningKey: key,
+			Kid:        "test-key-1",
+		}
+	}
+
+	cases := []struct {
+		name   string
+		field  string
+		mutate func(*IssueOptions)
+	}{
+		{"iss", "iss", func(o *IssueOptions) { o.Iss = "https://example.com/" + badByte }},
+		{"sub", "sub", func(o *IssueOptions) { o.Sub = "https://sub.example.com/" + badByte }},
+		{"type", "type", func(o *IssueOptions) { o.Type = "org.peacprotocol/" + badByte }},
+		{"actor.id", "actor.id", func(o *IssueOptions) { o.Actor = &ActorBinding{ID: "urn:actor:" + badByte} }},
+		{"policy.digest", "policy.digest", func(o *IssueOptions) { o.Policy = &PolicyBlock{Digest: badByte} }},
+		{"ext value", "ext.k", func(o *IssueOptions) { o.Extensions = map[string]any{"k": badByte} }},
+		{"ext member name", "ext (member name)", func(o *IssueOptions) { o.Extensions = map[string]any{badByte: "v"} }},
+		{"rid via custom generator", "rid", func(o *IssueOptions) { o.IDGen = NewFixedIDGenerator("rid-" + badByte) }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := base()
+			tc.mutate(&opts)
+			_, err := Issue(opts)
+			ie := requireIssueError(t, err)
+			if ie.Code != ErrCodeInvalidUTF8 {
+				t.Fatalf("code = %q, want %q", ie.Code, ErrCodeInvalidUTF8)
+			}
+			if ie.Field != tc.field {
+				t.Fatalf("field = %q, want %q", ie.Field, tc.field)
+			}
+		})
+	}
+}
+
+// Classes that survive marshaling as valid JSON (Unicode noncharacters and numbers whose magnitude
+// exceeds the safe range) are rejected by the post-marshal I-JSON gate, the same gate the verifier
+// applies. Without it the issuer could emit a payload its own VerifyLocal rejects.
+func TestIssue_RejectsNonIJSONPayload(t *testing.T) {
+	key := testSigningKey(t)
+	base := func() IssueOptions {
+		return IssueOptions{
+			Iss:        "https://example.com",
+			Kind:       KindEvidence,
+			Type:       "org.peacprotocol/test",
+			SigningKey: key,
+			Kid:        "test-key-1",
+		}
+	}
+
+	cases := []struct {
+		name   string
+		mutate func(*IssueOptions)
+	}{
+		{"noncharacter in ext string (valid UTF-8, not I-JSON)", func(o *IssueOptions) {
+			o.Extensions = map[string]any{"k": "x\ufdd0"}
+		}},
+		{"noncharacter in type", func(o *IssueOptions) {
+			o.Type = "org.peacprotocol/x\uffff"
+		}},
+		{"ext float64 magnitude above the safe range", func(o *IssueOptions) {
+			o.Extensions = map[string]any{"n": 1e300}
+		}},
+		{"exp int64 above the safe range", func(o *IssueOptions) {
+			o.Exp = int64(1) << 60
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := base()
+			tc.mutate(&opts)
+			_, err := Issue(opts)
+			ie := requireIssueError(t, err)
+			if ie.Code != ErrCodeNonIJSONPayload {
+				t.Fatalf("code = %q, want %q (msg: %s)", ie.Code, ErrCodeNonIJSONPayload, ie.Message)
+			}
+		})
+	}
+}
+
+// A record that would previously verify only because its identifier was mutated to U+FFFD now fails
+// closed at issuance instead. The symmetry guarantee: no emitted record, no silent mutation.
+func TestIssue_InvalidUTF8NeverEmitsMutatedRecord(t *testing.T) {
+	key := testSigningKey(t)
+	_, err := Issue(IssueOptions{
+		Iss:        "https://example.com",
+		Kind:       KindEvidence,
+		Type:       "org.peacprotocol/test",
+		SigningKey: key,
+		Kid:        "test-key-1",
+		IDGen:      NewFixedIDGenerator("rid-\xff-mutated"),
+	})
+	if err == nil {
+		t.Fatal("expected issuance to reject an invalid-UTF-8 rid, but it succeeded")
+	}
+}
+
+// The extension walk fails closed on any value type outside the JSON builtins. In the Issue() flow
+// evidence.ValidateValue rejects such types first; this exercises the walk's own defensive branch
+// directly so it cannot be silently skipped.
+func TestValidateExtUTF8_FailsClosedOnUnexpectedType(t *testing.T) {
+	err := validateExtUTF8(map[string]any{"x": 42}) // Go int, not a JSON builtin
+	ie := requireIssueError(t, err)
+	if ie.Code != ErrCodeInvalidType {
+		t.Fatalf("code = %q, want %q", ie.Code, ErrCodeInvalidType)
+	}
+}
+
+func requireIssueError(t *testing.T, err error) *IssueError {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	ie, ok := err.(*IssueError)
+	if !ok {
+		t.Fatalf("error type = %T, want *IssueError (%v)", err, err)
+	}
+	return ie
+}

--- a/sdks/go/issue_ijson_test.go
+++ b/sdks/go/issue_ijson_test.go
@@ -2,6 +2,7 @@ package peac
 
 import (
 	"testing"
+	"time"
 )
 
 // A record the issuer accepts must be admitted by the same SDK's verifier. Non-ASCII but
@@ -58,9 +59,27 @@ func TestIssue_RejectsInvalidUTF8(t *testing.T) {
 		{"sub", "sub", func(o *IssueOptions) { o.Sub = "https://sub.example.com/" + badByte }},
 		{"type", "type", func(o *IssueOptions) { o.Type = "org.peacprotocol/" + badByte }},
 		{"actor.id", "actor.id", func(o *IssueOptions) { o.Actor = &ActorBinding{ID: "urn:actor:" + badByte} }},
+		{"actor.role", "actor.role", func(o *IssueOptions) {
+			o.Actor = &ActorBinding{ID: "urn:actor:ok", Role: badByte}
+		}},
+		{"actor.proof_types[0]", "actor.proof_types[0]", func(o *IssueOptions) {
+			o.Actor = &ActorBinding{ID: "urn:actor:ok", ProofTypes: []string{badByte}}
+		}},
 		{"policy.digest", "policy.digest", func(o *IssueOptions) { o.Policy = &PolicyBlock{Digest: badByte} }},
+		{"policy.uri", "policy.uri", func(o *IssueOptions) {
+			o.Policy = &PolicyBlock{Digest: "sha-256:ok", URI: badByte}
+		}},
+		{"policy.version", "policy.version", func(o *IssueOptions) {
+			o.Policy = &PolicyBlock{Digest: "sha-256:ok", Version: badByte}
+		}},
 		{"ext value", "ext.k", func(o *IssueOptions) { o.Extensions = map[string]any{"k": badByte} }},
 		{"ext member name", "ext (member name)", func(o *IssueOptions) { o.Extensions = map[string]any{badByte: "v"} }},
+		{"nested ext value", "ext.outer.inner", func(o *IssueOptions) {
+			o.Extensions = map[string]any{"outer": map[string]any{"inner": badByte}}
+		}},
+		{"nested ext member name", "ext.outer (member name)", func(o *IssueOptions) {
+			o.Extensions = map[string]any{"outer": map[string]any{badByte: "v"}}
+		}},
 		{"rid via custom generator", "rid", func(o *IssueOptions) { o.IDGen = NewFixedIDGenerator("rid-" + badByte) }},
 	}
 
@@ -80,10 +99,12 @@ func TestIssue_RejectsInvalidUTF8(t *testing.T) {
 	}
 }
 
-// Classes that survive marshaling as valid JSON (Unicode noncharacters and numbers whose magnitude
-// exceeds the safe range) are rejected by the post-marshal I-JSON gate, the same gate the verifier
-// applies. Without it the issuer could emit a payload its own VerifyLocal rejects.
-func TestIssue_RejectsNonIJSONPayload(t *testing.T) {
+// Classes that survive marshaling as valid JSON (Unicode noncharacters, which RFC 7493 forbids, and
+// numbers outside the safe numeric range, which PEAC's stricter admission rule rejects) fail the
+// PEAC raw JSON admission profile gate, the same gate the verifier applies. Without it the issuer
+// could emit a payload its own VerifyLocal rejects. The injectable clock and exp cases show a
+// generated numeric input reaching the gate, the numeric analogue of the custom rid generator.
+func TestIssue_RejectsInvalidJSONProfile(t *testing.T) {
 	key := testSigningKey(t)
 	base := func() IssueOptions {
 		return IssueOptions{
@@ -111,6 +132,9 @@ func TestIssue_RejectsNonIJSONPayload(t *testing.T) {
 		{"exp int64 above the safe range", func(o *IssueOptions) {
 			o.Exp = int64(1) << 60
 		}},
+		{"iat above the safe range via a custom clock", func(o *IssueOptions) {
+			o.Clock = FixedClock{Time: time.Unix(int64(1)<<60, 0)}
+		}},
 	}
 
 	for _, tc := range cases {
@@ -119,8 +143,8 @@ func TestIssue_RejectsNonIJSONPayload(t *testing.T) {
 			tc.mutate(&opts)
 			_, err := Issue(opts)
 			ie := requireIssueError(t, err)
-			if ie.Code != ErrCodeNonIJSONPayload {
-				t.Fatalf("code = %q, want %q (msg: %s)", ie.Code, ErrCodeNonIJSONPayload, ie.Message)
+			if ie.Code != ErrCodeInvalidJSONProfile {
+				t.Fatalf("code = %q, want %q (msg: %s)", ie.Code, ErrCodeInvalidJSONProfile, ie.Message)
 			}
 		})
 	}
@@ -147,7 +171,23 @@ func TestIssue_InvalidUTF8NeverEmitsMutatedRecord(t *testing.T) {
 // evidence.ValidateValue rejects such types first; this exercises the walk's own defensive branch
 // directly so it cannot be silently skipped.
 func TestValidateExtUTF8_FailsClosedOnUnexpectedType(t *testing.T) {
-	err := validateExtUTF8(map[string]any{"x": 42}) // Go int, not a JSON builtin
+	err := validateExtUTF8(map[string]any{"x": 42}, 100000) // Go int, not a JSON builtin
+	ie := requireIssueError(t, err)
+	if ie.Code != ErrCodeInvalidType {
+		t.Fatalf("code = %q, want %q", ie.Code, ErrCodeInvalidType)
+	}
+}
+
+// The walk honors the node ceiling it is given rather than an internal default, so a caller that
+// raises EvidenceLimits.MaxTotalNodes is not silently capped by a second constant.
+func TestValidateExtUTF8_HonorsSuppliedNodeLimit(t *testing.T) {
+	ext := map[string]any{"a": "x", "b": "y", "c": "z"} // root map plus three entries
+
+	if err := validateExtUTF8(ext, 100000); err != nil {
+		t.Fatalf("a generous limit should accept a small valid graph: %v", err)
+	}
+
+	err := validateExtUTF8(ext, 1) // one node allowed; the graph has more
 	ie := requireIssueError(t, err)
 	if ie.Code != ErrCodeInvalidType {
 		t.Fatalf("code = %q, want %q", ie.Code, ErrCodeInvalidType)


### PR DESCRIPTION
## Summary

The Go issuer could produce an interaction record its own `VerifyLocal` rejects. `encoding/json` silently replaces invalid UTF-8 in a Go string with U+FFFD before signing, mutating the caller's identifier, and it emits Unicode noncharacters and numbers outside the safe numeric range unchanged, all of which the PEAC raw JSON admission profile the verifier applies rejects. This makes `Issue()` symmetric with `VerifyLocal()`.

## Invariant

A record `Issue()` (and `IssueJWS()`) returns is admitted by the same SDK's `VerifyLocal()`, and no record is emitted with a silently mutated identifier.

- Before marshaling, every caller-controlled claim string is checked for valid UTF-8 on the built claims: the typed fields (`iss`, `sub`, `rid`, `kind`, `type`, `peac_version`), the pillar list, the optional actor and policy blocks, and every string value and member name in the extension map. Invalid UTF-8 must be caught here because a post-marshal scan cannot recover bytes `json.Marshal` has already turned into U+FFFD; errors carry a field path. Running on the built claims covers a caller-supplied receipt-ID generator.
- The extension traversal is iterative, honors the effective `EvidenceLimits.MaxTotalNodes` shared with extension validation, and fails closed on any value type outside the JSON builtins.
- After marshaling, the exact bytes about to be signed are run through the same raw JSON admission profile gate the verifier uses (it owns Unicode noncharacters, numeric range, and structural validity), then signed.
- New `IssueError` codes: `INVALID_UTF8` (pre-marshal, with field path) and `INVALID_JSON_PROFILE` (post-marshal; the canonical `E_IJSON_*` / `E_INVALID_FORMAT` code is preserved in the message). Marshal failures continue to surface as `SIGN_FAILED`. RFC 7493 makes the UTF-8, noncharacter, and duplicate-member rules a MUST; the 2^53-1 numeric bound is PEAC's stricter admission rule (RFC 7493 treats it as SHOULD-NOT).

## Validation

`gofmt`, `go build ./...`, `go vet ./...`, `go test ./... -count=1`, `go test -race ./...`, and `golangci-lint v2.9.0` (the CI set) all pass. Tests cover: well-formed non-ASCII round-trip through `Issue()` to `VerifyLocal()`; invalid UTF-8 rejected per field (`iss`, `sub`, `type`, `actor.id`, `actor.role`, `actor.proof_types[0]`, `policy.digest`, `policy.uri`, `policy.version`, extension value and member name including nested, and a custom receipt-ID generator); the admission-profile gate reached by a noncharacter, an out-of-range `float64` extension, an out-of-range `exp`, and an out-of-range `iat` from a custom clock; the extension walk honoring a supplied node limit; and its fail-closed branch.

## Scope

`Issue()` and `IssueJWS()` only. The low-level `jws.SignClaims` and `jws.SignWithType` remain raw JWS primitives that sign caller-supplied bytes and make no interaction-record claim. No verifier or JWS header (`kid`) change.
