### PR TITLE
fix(go): enforce the Wire 0.2 kid profile on issuance and verification

### DIFF
--- a/.github/workflows/go-sdk.yml
+++ b/.github/workflows/go-sdk.yml
@@ -53,7 +53,7 @@ jobs:
           GOWORK: 'off'
         run: |
           go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0
-          golangci-lint run --timeout=5m ./. ./jws/... ./evidence/... ./conformance/... ./policy/...
+          golangci-lint run --timeout=5m ./. ./jws/... ./evidence/... ./conformance/... ./policy/... ./internal/...
 
   test:
     name: Build + Test + Race

--- a/sdks/go/errors.go
+++ b/sdks/go/errors.go
@@ -25,6 +25,16 @@ const (
 	ErrCodeSignFailed    = "SIGN_FAILED"
 	ErrCodeIDGenFailed   = "ID_GEN_FAILED"
 
+	// ErrCodeKeyIDMismatch indicates IssueOptions.Kid was set to a non-empty value
+	// that differs from the signing key's own key ID. The signing key's ID is
+	// authoritative; a conflicting Kid is rejected rather than silently ignored.
+	ErrCodeKeyIDMismatch = "KEY_ID_MISMATCH"
+
+	// ErrCodeInvalidKeyID indicates the authoritative key ID does not satisfy the
+	// Wire 0.2 kid rule (non-empty, valid UTF-8, no Unicode noncharacters, at most
+	// 256 UTF-8 bytes), so a record signed with it would be rejected by the verifier.
+	ErrCodeInvalidKeyID = "INVALID_KEY_ID"
+
 	// ErrCodeInvalidUTF8 indicates a caller-controlled claim string is not valid
 	// UTF-8. It is detected before json.Marshal, which would otherwise silently
 	// replace the invalid bytes with U+FFFD and sign a mutated identifier.

--- a/sdks/go/errors.go
+++ b/sdks/go/errors.go
@@ -32,7 +32,9 @@ const (
 
 	// ErrCodeInvalidKeyID indicates the authoritative key ID does not satisfy the
 	// Wire 0.2 kid rule (non-empty, valid UTF-8, no Unicode noncharacters, at most
-	// 256 UTF-8 bytes), so a record signed with it would be rejected by the verifier.
+	// 256 UTF-8 bytes). It is rejected before header serialization to prevent either
+	// silent UTF-8 replacement (encoding/json substitutes U+FFFD for invalid bytes)
+	// or emission of a header that VerifyLocal would reject.
 	ErrCodeInvalidKeyID = "INVALID_KEY_ID"
 
 	// ErrCodeInvalidUTF8 indicates a caller-controlled claim string is not valid

--- a/sdks/go/internal/kid/kid.go
+++ b/sdks/go/internal/kid/kid.go
@@ -1,5 +1,12 @@
 // Package kid validates the PEAC Wire 0.2 JWS key identifier (kid) against the
 // profile shared by issuance and verification, so both sides apply one rule.
+//
+// The rule composes three layers: the base JWS kid semantics (RFC 7515 §4.1.4: an
+// optional, case-sensitive string of unspecified structure), the PEAC Wire 0.2 kid
+// profile (required, non-empty, at most 256 UTF-8 bytes), and I-JSON protected-header
+// admission (RFC 7493: a JSON string must be well-formed UTF-8 with no surrogates or
+// Unicode noncharacters). This validator preserves the kid exactly; it does not trim,
+// case-fold, or normalize.
 package kid
 
 import (
@@ -19,10 +26,7 @@ const MaxUTF8Bytes = 256
 // own error surface. At the verifier the raw I-JSON gate runs on the header bytes
 // first, so ErrInvalidUTF8 and ErrNoncharacter are unreachable there and only
 // ErrEmpty and ErrTooLong can fire; at issuance there is no such gate, so this
-// predicate is the sole check and all four are reachable. TypeScript enforces the
-// same accept/reject decision, catching the UTF-8 and noncharacter classes through
-// its header I-JSON gate rather than a kid rule, so the decision matches across
-// languages even though the issuance error surface differs.
+// predicate is the sole check and all four are reachable.
 var (
 	ErrEmpty        = errors.New("kid is empty")
 	ErrInvalidUTF8  = errors.New("kid is not valid UTF-8")

--- a/sdks/go/internal/kid/kid.go
+++ b/sdks/go/internal/kid/kid.go
@@ -1,0 +1,62 @@
+// Package kid validates the PEAC Wire 0.2 JWS key identifier (kid) against the
+// profile shared by issuance and verification, so both sides apply one rule.
+package kid
+
+import (
+	"errors"
+	"unicode/utf8"
+)
+
+// MaxUTF8Bytes is the maximum kid length, measured in UTF-8 bytes of the string.
+// RFC 7515 leaves the kid structure unspecified; the bound and well-formedness are
+// PEAC Wire 0.2 application constraints. The unit is UTF-8 bytes because that is
+// what bounds the serialized protected header and is the only unit independent
+// implementations agree on (a bound stated in characters counts UTF-16 code units
+// in JavaScript, bytes in Go, and code points in JSON Schema).
+const MaxUTF8Bytes = 256
+
+// Classified reasons a kid fails the Wire 0.2 profile, so each caller maps to its
+// own error surface. At the verifier the raw I-JSON gate runs on the header bytes
+// first, so ErrInvalidUTF8 and ErrNoncharacter are unreachable there and only
+// ErrEmpty and ErrTooLong can fire; at issuance there is no such gate, so this
+// predicate is the sole check and all four are reachable. TypeScript enforces the
+// same accept/reject decision, catching the UTF-8 and noncharacter classes through
+// its header I-JSON gate rather than a kid rule, so the decision matches across
+// languages even though the issuance error surface differs.
+var (
+	ErrEmpty        = errors.New("kid is empty")
+	ErrInvalidUTF8  = errors.New("kid is not valid UTF-8")
+	ErrNoncharacter = errors.New("kid contains a Unicode noncharacter")
+	ErrTooLong      = errors.New("kid exceeds the maximum UTF-8 byte length")
+)
+
+// Validate reports whether kid satisfies the Wire 0.2 profile: non-empty,
+// well-formed UTF-8, free of Unicode noncharacters, and at most MaxUTF8Bytes UTF-8
+// bytes. It returns one of the classified sentinel errors, or nil. Well-formedness
+// is checked before length so the classification is deterministic.
+func Validate(kid string) error {
+	if kid == "" {
+		return ErrEmpty
+	}
+	if !utf8.ValidString(kid) {
+		return ErrInvalidUTF8
+	}
+	for _, r := range kid {
+		if IsNoncharacter(r) {
+			return ErrNoncharacter
+		}
+	}
+	if len(kid) > MaxUTF8Bytes {
+		return ErrTooLong
+	}
+	return nil
+}
+
+// IsNoncharacter reports whether r is one of the 66 Unicode noncharacters
+// (U+FDD0..U+FDEF and the last two code points of every plane, U+xFFFE and
+// U+xFFFF). RFC 7493 forbids these in JSON strings and member names. It mirrors
+// the noncharacter predicate in the raw I-JSON gate; a parity test pins the two.
+func IsNoncharacter(r rune) bool {
+	return (r >= 0xFDD0 && r <= 0xFDEF) ||
+		(r >= 0xFFFE && r <= 0x10FFFF && (r&0xFFFF == 0xFFFE || r&0xFFFF == 0xFFFF))
+}

--- a/sdks/go/internal/kid/kid_test.go
+++ b/sdks/go/internal/kid/kid_test.go
@@ -47,6 +47,30 @@ func TestValidate_Rejects(t *testing.T) {
 	}
 }
 
+// The profile preserves the kid: it does not case-fold, trim, Unicode-normalize, or
+// restrict to ASCII, and it permits NUL, BOM, and zero-width characters (none are
+// noncharacters). These inputs must be accepted so the rule invents no restriction
+// beyond well-formed UTF-8, no noncharacters, and the byte bound.
+func TestValidate_NoNormalizationOrInventedRestrictions(t *testing.T) {
+	accepted := map[string]string{
+		"mixed case preserved":   "Key-1",
+		"leading/trailing space": "  key  ",
+		"precomposed acute":      "cl\u00e9",
+		"decomposed acute":       "cle\u0301",
+		"zero-width space":       "k\u200bk",
+		"byte order mark":        "k\ufeff",
+		"NUL":                    "k\x00k",
+		"non-ASCII CJK":          "\u4e2d\u6587",
+	}
+	for name, k := range accepted {
+		t.Run(name, func(t *testing.T) {
+			if err := Validate(k); err != nil {
+				t.Fatalf("Validate(%s) = %v, want nil (no invented restriction)", name, err)
+			}
+		})
+	}
+}
+
 // The byte bound is exact at 256: 256 accepted, 257 rejected, for ASCII and for
 // supplementary-plane code points (four bytes each).
 func TestValidate_ByteBoundaryIsExact(t *testing.T) {

--- a/sdks/go/internal/kid/kid_test.go
+++ b/sdks/go/internal/kid/kid_test.go
@@ -1,0 +1,65 @@
+package kid
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestValidate_Accepts(t *testing.T) {
+	cases := map[string]string{
+		"ascii":                 "key-1",
+		"256 ascii bytes":       strings.Repeat("a", 256),
+		"64 astral = 256 bytes": strings.Repeat("\U0001F600", 64),
+		"well-formed non-ASCII": "cl\u00e9-\u4e2d\u6587",
+	}
+	for name, k := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := Validate(k); err != nil {
+				t.Fatalf("Validate(%q) = %v, want nil", name, err)
+			}
+		})
+	}
+}
+
+func TestValidate_Rejects(t *testing.T) {
+	cases := []struct {
+		name string
+		kid  string
+		want error
+	}{
+		{"empty", "", ErrEmpty},
+		{"lone 0xFF byte", "k\xff", ErrInvalidUTF8},
+		{"lone surrogate bytes", "k\xed\xa0\x80", ErrInvalidUTF8},
+		{"noncharacter U+FDD0", "k\ufdd0", ErrNoncharacter},
+		{"noncharacter U+FFFF", "k\uffff", ErrNoncharacter},
+		{"noncharacter U+1FFFE", "k\U0001FFFE", ErrNoncharacter},
+		{"257 ascii bytes", strings.Repeat("a", 257), ErrTooLong},
+		{"65 astral = 260 bytes", strings.Repeat("\U0001F600", 65), ErrTooLong},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Validate(tc.kid)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("Validate(%s) = %v, want %v", tc.name, err, tc.want)
+			}
+		})
+	}
+}
+
+// The byte bound is exact at 256: 256 accepted, 257 rejected, for ASCII and for
+// supplementary-plane code points (four bytes each).
+func TestValidate_ByteBoundaryIsExact(t *testing.T) {
+	if err := Validate(strings.Repeat("a", 256)); err != nil {
+		t.Fatalf("256 ASCII bytes should be accepted: %v", err)
+	}
+	if err := Validate(strings.Repeat("a", 257)); !errors.Is(err, ErrTooLong) {
+		t.Fatalf("257 ASCII bytes = %v, want ErrTooLong", err)
+	}
+	if err := Validate(strings.Repeat("\U0001F600", 64)); err != nil {
+		t.Fatalf("64 astral (256 bytes) should be accepted: %v", err)
+	}
+	if err := Validate(strings.Repeat("\U0001F600", 65)); !errors.Is(err, ErrTooLong) {
+		t.Fatalf("65 astral (260 bytes) = %v, want ErrTooLong", err)
+	}
+}

--- a/sdks/go/issue.go
+++ b/sdks/go/issue.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/peacprotocol/peac/sdks/go/evidence"
+	"github.com/peacprotocol/peac/sdks/go/internal/kid"
 	"github.com/peacprotocol/peac/sdks/go/jws"
 )
 
@@ -25,7 +26,10 @@ type IssueOptions struct {
 	// SigningKey for Ed25519 signing (required).
 	SigningKey *jws.SigningKey
 
-	// Kid is the key identifier for the JWS header (required).
+	// Kid is an optional key identifier for the JWS header.
+	//
+	// Deprecated: the signing key's own key ID is authoritative. Leave Kid empty,
+	// or set it equal to SigningKey.KeyID(); a conflicting value is rejected.
 	Kid string
 
 	// Sub is the optional subject URI.
@@ -128,12 +132,20 @@ func Issue(opts IssueOptions) (*IssueResult, error) {
 		return nil, &IssueError{Code: ErrCodeMissingKey, Message: "signing key is required", Field: "SigningKey"}
 	}
 
-	kid := opts.Kid
-	if kid == "" {
-		kid = opts.SigningKey.KeyID()
+	// Wire 0.2 kid contract. The signing key's own key ID is authoritative. An
+	// explicit IssueOptions.Kid must be empty (use the key ID) or equal to it; a
+	// conflicting value is rejected rather than silently ignored. The authoritative
+	// key ID is then validated against the Wire 0.2 kid rule before emission, so the
+	// issuer never signs a kid its own verifier would reject.
+	authoritativeKid := opts.SigningKey.KeyID()
+	if authoritativeKid == "" {
+		return nil, &IssueError{Code: ErrCodeMissingKid, Message: "signing key has no key ID", Field: "SigningKey"}
 	}
-	if kid == "" {
-		return nil, &IssueError{Code: ErrCodeMissingKid, Message: "kid is required", Field: "Kid"}
+	if opts.Kid != "" && opts.Kid != authoritativeKid {
+		return nil, &IssueError{Code: ErrCodeKeyIDMismatch, Message: "Kid conflicts with the signing key's key ID; leave it empty or set it equal", Field: "Kid"}
+	}
+	if err := kid.Validate(authoritativeKid); err != nil {
+		return nil, &IssueError{Code: ErrCodeInvalidKeyID, Message: fmt.Sprintf("signing key ID is not a valid Wire 0.2 kid: %v", err), Field: "SigningKey"}
 	}
 
 	// Validate pillars if provided

--- a/sdks/go/jws/jws.go
+++ b/sdks/go/jws/jws.go
@@ -9,11 +9,10 @@ import (
 	"strings"
 )
 
-// ErrMissingKid is returned by ValidateHeader when the header has no kid. It is
-// exported so a protocol-layer caller can classify a Wire 0.2 missing-kid failure
-// distinctly (as E_JWS_MISSING_KID) without changing this generic, typ-agnostic
-// layer. Accept and reject behavior is unchanged; this only makes the reason
-// inspectable via errors.Is.
+// ErrMissingKid identifies a protected header with a missing or empty kid. It is
+// exported so a caller can classify this reason via errors.Is without changing this
+// generic, typ-agnostic layer; any protocol error-code mapping is owned by the
+// protocol layer.
 var ErrMissingKid = errors.New("missing key ID (kid) in header")
 
 // Header represents a JWS header.
@@ -97,10 +96,11 @@ func ValidateHeader(header Header) error {
 	return nil
 }
 
-// IsWire02Typ reports whether typ identifies the PEAC Wire 0.2 profile. It is the
-// single decision point so no alternate accepted spelling can bypass the Wire 0.2
-// header rules; Go accepts only the compact form.
-func IsWire02Typ(typ string) bool {
+// isWire02IssuerTyp reports whether typ is the Wire 0.2 form a PEAC issuer is
+// allowed to emit, which is the compact form only. It is the single decision point
+// for issuer-side kid enforcement so no alternate spelling can bypass it. It is
+// deliberately issuer-scoped and does not describe every typ a verifier accepts.
+func isWire02IssuerTyp(typ string) bool {
 	return typ == InteractionRecordTyp
 }
 

--- a/sdks/go/jws/jws.go
+++ b/sdks/go/jws/jws.go
@@ -4,9 +4,17 @@ package jws
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 )
+
+// ErrMissingKid is returned by ValidateHeader when the header has no kid. It is
+// exported so a protocol-layer caller can classify a Wire 0.2 missing-kid failure
+// distinctly (as E_JWS_MISSING_KID) without changing this generic, typ-agnostic
+// layer. Accept and reject behavior is unchanged; this only makes the reason
+// inspectable via errors.Is.
+var ErrMissingKid = errors.New("missing key ID (kid) in header")
 
 // Header represents a JWS header.
 type Header struct {
@@ -83,10 +91,17 @@ func ValidateHeader(header Header) error {
 	}
 
 	if header.KeyID == "" {
-		return fmt.Errorf("missing key ID (kid) in header")
+		return ErrMissingKid
 	}
 
 	return nil
+}
+
+// IsWire02Typ reports whether typ identifies the PEAC Wire 0.2 profile. It is the
+// single decision point so no alternate accepted spelling can bypass the Wire 0.2
+// header rules; Go accepts only the compact form.
+func IsWire02Typ(typ string) bool {
+	return typ == InteractionRecordTyp
 }
 
 // Encode encodes data as base64url without padding.

--- a/sdks/go/jws/sign.go
+++ b/sdks/go/jws/sign.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
+	"github.com/peacprotocol/peac/sdks/go/internal/kid"
 )
 
 // InteractionRecordTyp is the JWS typ for the current stable Interaction Record format.
@@ -74,13 +76,24 @@ func (k *SigningKey) PublicKey() ed25519.PublicKey {
 }
 
 // Sign creates a JWS compact serialization for the given payload.
-// The typ header is set to DefaultReceiptTyp ("peac-receipt/0.1").
+// The typ header is set to DefaultReceiptTyp ("interaction-record+jwt").
 func (k *SigningKey) Sign(payload []byte) (string, error) {
 	return k.SignWithType(payload, DefaultReceiptTyp)
 }
 
-// SignWithType creates a JWS compact serialization with a custom type header.
+// SignWithType creates a JWS compact serialization with a custom type header. It
+// signs the caller-supplied payload bytes as raw JWS and does not assert those
+// bytes are a valid PEAC Interaction Record. When the selected typ identifies the
+// Wire 0.2 profile, the kid it emits must satisfy the Wire 0.2 kid rule, so a
+// direct caller cannot mint a record the verifier rejects; other typ values are
+// left as raw construction.
 func (k *SigningKey) SignWithType(payload []byte, typ string) (string, error) {
+	if IsWire02Typ(typ) {
+		if err := kid.Validate(k.keyID); err != nil {
+			return "", fmt.Errorf("wire 0.2 kid invalid: %w", err)
+		}
+	}
+
 	header := Header{
 		Algorithm: "EdDSA",
 		Type:      typ,

--- a/sdks/go/jws/sign.go
+++ b/sdks/go/jws/sign.go
@@ -83,12 +83,12 @@ func (k *SigningKey) Sign(payload []byte) (string, error) {
 
 // SignWithType creates a JWS compact serialization with a custom type header. It
 // signs the caller-supplied payload bytes as raw JWS and does not assert those
-// bytes are a valid PEAC Interaction Record. When the selected typ identifies the
-// Wire 0.2 profile, the kid it emits must satisfy the Wire 0.2 kid rule, so a
-// direct caller cannot mint a record the verifier rejects; other typ values are
-// left as raw construction.
+// bytes are a valid PEAC Interaction Record. When typ selects the Wire 0.2 issuer
+// profile, the emitted kid is validated so direct callers cannot bypass the Wire
+// 0.2 kid constraint; the payload bytes remain caller-controlled at this layer, and
+// other typ values are left as raw construction.
 func (k *SigningKey) SignWithType(payload []byte, typ string) (string, error) {
-	if IsWire02Typ(typ) {
+	if isWire02IssuerTyp(typ) {
 		if err := kid.Validate(k.keyID); err != nil {
 			return "", fmt.Errorf("wire 0.2 kid invalid: %w", err)
 		}

--- a/sdks/go/kid_profile_test.go
+++ b/sdks/go/kid_profile_test.go
@@ -166,3 +166,123 @@ func TestKidNoncharacterMatchesIJSONGate(t *testing.T) {
 		}
 	}
 }
+
+// craftRawHeaderJWS builds a compact JWS whose protected-header segment is exactly
+// the supplied raw bytes, so a test can place malformed UTF-8 in the header that
+// json.Marshal would otherwise repair.
+func craftRawHeaderJWS(t *testing.T, headerBytes []byte) string {
+	t.Helper()
+	return jws.Encode(headerBytes) + "." + jws.Encode([]byte(`{"a":"b"}`)) + "." + jws.Encode([]byte("sig"))
+}
+
+// The root and jws packages each declare the Wire 0.2 issuer typ constant; they must
+// not drift apart.
+func TestInteractionRecordTypConstantsAgree(t *testing.T) {
+	if InteractionRecordTyp != jws.InteractionRecordTyp {
+		t.Fatalf("typ constants differ: peac=%q jws=%q", InteractionRecordTyp, jws.InteractionRecordTyp)
+	}
+}
+
+// A malformed-UTF-8 kid in the raw protected header is rejected by the raw I-JSON
+// gate as an I-JSON string error and is not remapped to the kid class. Built from raw
+// bytes because json.Marshal would repair the invalid byte to U+FFFD first.
+func TestVerifyLocal_MalformedUTF8KidIsIJSONError(t *testing.T) {
+	raw := []byte("{\"alg\":\"EdDSA\",\"typ\":\"interaction-record+jwt\",\"kid\":\"k\xff\"}")
+	vr := VerifyLocal(craftRawHeaderJWS(t, raw), VerifyLocalOptions{PublicKey: make([]byte, 32)})
+	if vr.ErrorCode != "E_IJSON_INVALID_STRING" {
+		t.Fatalf("code = %q, want E_IJSON_INVALID_STRING (%s)", vr.ErrorCode, vr.ErrorMessage)
+	}
+}
+
+// Both an absent kid and an explicitly empty kid produce E_JWS_MISSING_KID.
+func TestVerifyLocal_ExplicitEmptyKidIsMissingKid(t *testing.T) {
+	j := craftWire02JWS(t, map[string]any{"alg": "EdDSA", "typ": InteractionRecordTyp, "kid": ""})
+	vr := VerifyLocal(j, VerifyLocalOptions{PublicKey: make([]byte, 32)})
+	if vr.ErrorCode != "E_JWS_MISSING_KID" {
+		t.Fatalf("code = %q, want E_JWS_MISSING_KID (%s)", vr.ErrorCode, vr.ErrorMessage)
+	}
+}
+
+// The bound is UTF-8 bytes, not code points or Go string length: 64 four-byte
+// supplementary-plane code points (256 bytes) issue and verify with the kid preserved
+// exactly, while 65 (260 bytes) fail issuance and, crafted externally, classify as
+// E_JWS_MISSING_KID.
+func TestKidByteBoundary_EndToEnd(t *testing.T) {
+	kid256 := strings.Repeat("\U0001F600", 64)
+	kid260 := strings.Repeat("\U0001F600", 65)
+	opts := func(k *jws.SigningKey) IssueOptions {
+		return IssueOptions{Iss: "https://example.com", Kind: KindEvidence, Type: "org.peacprotocol/test", SigningKey: k}
+	}
+
+	t.Run("256-byte astral key ID issues and verifies with kid preserved", func(t *testing.T) {
+		k, err := jws.GenerateSigningKey(kid256)
+		if err != nil {
+			t.Fatalf("generate key: %v", err)
+		}
+		result, err := Issue(opts(k))
+		if err != nil {
+			t.Fatalf("issue: %v", err)
+		}
+		vr := VerifyLocal(result.JWS, VerifyLocalOptions{PublicKey: k.PublicKey()})
+		if !vr.Valid {
+			t.Fatalf("verify: %s %s", vr.ErrorCode, vr.ErrorMessage)
+		}
+		if vr.Kid != kid256 {
+			t.Fatalf("kid not preserved exactly")
+		}
+	})
+
+	t.Run("260-byte astral key ID fails issuance as INVALID_KEY_ID", func(t *testing.T) {
+		k, err := jws.GenerateSigningKey(kid260)
+		if err != nil {
+			t.Fatalf("generate key: %v", err)
+		}
+		_, err = Issue(opts(k))
+		ie := requireIssueError(t, err)
+		if ie.Code != ErrCodeInvalidKeyID {
+			t.Fatalf("code = %q, want %q", ie.Code, ErrCodeInvalidKeyID)
+		}
+	})
+
+	t.Run("externally crafted 260-byte astral kid is E_JWS_MISSING_KID", func(t *testing.T) {
+		j := craftWire02JWS(t, map[string]any{"alg": "EdDSA", "typ": InteractionRecordTyp, "kid": kid260})
+		vr := VerifyLocal(j, VerifyLocalOptions{PublicKey: make([]byte, 32)})
+		if vr.ErrorCode != "E_JWS_MISSING_KID" {
+			t.Fatalf("code = %q, want E_JWS_MISSING_KID (%s)", vr.ErrorCode, vr.ErrorMessage)
+		}
+	})
+}
+
+// Issuance and direct Wire 0.2 signing refuse an authoritative key ID with invalid
+// UTF-8 or a Unicode noncharacter, while a legacy typ is not subject to the rule.
+func TestKidWiring_InvalidUTF8AndNoncharacter(t *testing.T) {
+	badKeyIDs := map[string]string{
+		"invalid UTF-8": "k\xff",
+		"noncharacter":  "k\ufdd0",
+	}
+	for name, keyID := range badKeyIDs {
+		t.Run("Issue refuses "+name, func(t *testing.T) {
+			k, err := jws.GenerateSigningKey(keyID)
+			if err != nil {
+				t.Fatalf("generate key: %v", err)
+			}
+			_, err = Issue(IssueOptions{Iss: "https://example.com", Kind: KindEvidence, Type: "org.peacprotocol/test", SigningKey: k})
+			ie := requireIssueError(t, err)
+			if ie.Code != ErrCodeInvalidKeyID {
+				t.Fatalf("code = %q, want %q", ie.Code, ErrCodeInvalidKeyID)
+			}
+		})
+		t.Run("SignWithType(Wire 0.2) refuses "+name, func(t *testing.T) {
+			k, err := jws.GenerateSigningKey(keyID)
+			if err != nil {
+				t.Fatalf("generate key: %v", err)
+			}
+			if _, err := k.SignWithType([]byte(`{"a":"b"}`), InteractionRecordTyp); err == nil {
+				t.Fatalf("SignWithType(Wire 0.2) with %s key ID should refuse emission", name)
+			}
+			if _, err := k.SignWithType([]byte(`{"a":"b"}`), jws.LegacyReceiptTyp); err != nil {
+				t.Fatalf("legacy typ should not enforce the Wire 0.2 kid rule (%s): %v", name, err)
+			}
+		})
+	}
+}

--- a/sdks/go/kid_profile_test.go
+++ b/sdks/go/kid_profile_test.go
@@ -1,0 +1,168 @@
+package peac
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/peacprotocol/peac/sdks/go/internal/kid"
+	"github.com/peacprotocol/peac/sdks/go/jws"
+)
+
+// craftWire02JWS builds a compact JWS with a caller-chosen protected header and a
+// minimal valid-I-JSON payload and a placeholder signature. It exists to reach the
+// verifier's kid classification with kids the issuer would refuse to emit; the
+// signature is never checked because kid classification precedes signature
+// verification.
+func craftWire02JWS(t *testing.T, header map[string]any) string {
+	t.Helper()
+	hb, err := json.Marshal(header)
+	if err != nil {
+		t.Fatalf("marshal header: %v", err)
+	}
+	return jws.Encode(hb) + "." + jws.Encode([]byte(`{"a":"b"}`)) + "." + jws.Encode([]byte("sig"))
+}
+
+func TestIssue_KidContract(t *testing.T) {
+	key := testSigningKey(t) // key ID "test-key-1"
+	base := func() IssueOptions {
+		return IssueOptions{
+			Iss:        "https://example.com",
+			Kind:       KindEvidence,
+			Type:       "org.peacprotocol/test",
+			SigningKey: key,
+		}
+	}
+
+	t.Run("empty Kid uses the signing key ID and verifies", func(t *testing.T) {
+		opts := base() // Kid unset
+		result, err := Issue(opts)
+		if err != nil {
+			t.Fatalf("issue: %v", err)
+		}
+		vr := VerifyLocal(result.JWS, VerifyLocalOptions{PublicKey: key.PublicKey()})
+		if !vr.Valid {
+			t.Fatalf("verify: %s %s", vr.ErrorCode, vr.ErrorMessage)
+		}
+		if vr.Kid != "test-key-1" {
+			t.Fatalf("kid = %q, want test-key-1", vr.Kid)
+		}
+	})
+
+	t.Run("matching Kid is accepted", func(t *testing.T) {
+		opts := base()
+		opts.Kid = "test-key-1"
+		if _, err := Issue(opts); err != nil {
+			t.Fatalf("matching Kid should be accepted: %v", err)
+		}
+	})
+
+	t.Run("conflicting Kid is rejected as KEY_ID_MISMATCH", func(t *testing.T) {
+		opts := base()
+		opts.Kid = "some-other-id"
+		_, err := Issue(opts)
+		ie := requireIssueError(t, err)
+		if ie.Code != ErrCodeKeyIDMismatch {
+			t.Fatalf("code = %q, want %q", ie.Code, ErrCodeKeyIDMismatch)
+		}
+	})
+}
+
+func TestIssue_AuthoritativeKeyIDMustSatisfyKidRule(t *testing.T) {
+	base := func(k *jws.SigningKey) IssueOptions {
+		return IssueOptions{
+			Iss:        "https://example.com",
+			Kind:       KindEvidence,
+			Type:       "org.peacprotocol/test",
+			SigningKey: k,
+		}
+	}
+
+	t.Run("256-byte key ID is accepted and verifies", func(t *testing.T) {
+		k, err := jws.GenerateSigningKey(strings.Repeat("a", 256))
+		if err != nil {
+			t.Fatalf("generate key: %v", err)
+		}
+		result, err := Issue(base(k))
+		if err != nil {
+			t.Fatalf("256-byte key ID should be accepted: %v", err)
+		}
+		vr := VerifyLocal(result.JWS, VerifyLocalOptions{PublicKey: k.PublicKey()})
+		if !vr.Valid {
+			t.Fatalf("verify: %s %s", vr.ErrorCode, vr.ErrorMessage)
+		}
+	})
+
+	t.Run("257-byte key ID is rejected as INVALID_KEY_ID", func(t *testing.T) {
+		k, err := jws.GenerateSigningKey(strings.Repeat("a", 257))
+		if err != nil {
+			t.Fatalf("generate key: %v", err)
+		}
+		_, err = Issue(base(k))
+		ie := requireIssueError(t, err)
+		if ie.Code != ErrCodeInvalidKeyID {
+			t.Fatalf("code = %q, want %q", ie.Code, ErrCodeInvalidKeyID)
+		}
+	})
+
+	t.Run("signing key with no key ID is rejected as MISSING_KEY_ID", func(t *testing.T) {
+		_, err := Issue(base(&jws.SigningKey{})) // zero value: KeyID() == ""
+		ie := requireIssueError(t, err)
+		if ie.Code != ErrCodeMissingKid { // "MISSING_KEY_ID"
+			t.Fatalf("code = %q, want %q", ie.Code, ErrCodeMissingKid)
+		}
+	})
+}
+
+func TestVerifyLocal_KidProfile(t *testing.T) {
+	t.Run("missing kid is E_JWS_MISSING_KID", func(t *testing.T) {
+		j := craftWire02JWS(t, map[string]any{"alg": "EdDSA", "typ": InteractionRecordTyp})
+		vr := VerifyLocal(j, VerifyLocalOptions{PublicKey: make([]byte, 32)})
+		if vr.ErrorCode != "E_JWS_MISSING_KID" {
+			t.Fatalf("code = %q, want E_JWS_MISSING_KID (%s)", vr.ErrorCode, vr.ErrorMessage)
+		}
+	})
+
+	t.Run("oversized well-formed kid is E_JWS_MISSING_KID", func(t *testing.T) {
+		j := craftWire02JWS(t, map[string]any{"alg": "EdDSA", "typ": InteractionRecordTyp, "kid": strings.Repeat("a", 257)})
+		vr := VerifyLocal(j, VerifyLocalOptions{PublicKey: make([]byte, 32)})
+		if vr.ErrorCode != "E_JWS_MISSING_KID" {
+			t.Fatalf("code = %q, want E_JWS_MISSING_KID (%s)", vr.ErrorCode, vr.ErrorMessage)
+		}
+	})
+
+	t.Run("noncharacter kid is an I-JSON error, not a kid error", func(t *testing.T) {
+		j := craftWire02JWS(t, map[string]any{"alg": "EdDSA", "typ": InteractionRecordTyp, "kid": "k\ufdd0"})
+		vr := VerifyLocal(j, VerifyLocalOptions{PublicKey: make([]byte, 32)})
+		if vr.ErrorCode != "E_IJSON_INVALID_STRING" {
+			t.Fatalf("code = %q, want E_IJSON_INVALID_STRING (%s)", vr.ErrorCode, vr.ErrorMessage)
+		}
+	})
+}
+
+func TestSignWithType_Wire02KidGuard(t *testing.T) {
+	k, err := jws.GenerateSigningKey(strings.Repeat("a", 257)) // oversized key ID
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	payload := []byte(`{"a":"b"}`)
+
+	if _, err := k.SignWithType(payload, InteractionRecordTyp); err == nil {
+		t.Fatal("SignWithType with a Wire 0.2 typ and an oversized kid should error")
+	}
+	// A legacy/raw typ is not gated: SignWithType stays a raw JWS primitive there.
+	if _, err := k.SignWithType(payload, jws.LegacyReceiptTyp); err != nil {
+		t.Fatalf("SignWithType with a legacy typ should not enforce the Wire 0.2 kid rule: %v", err)
+	}
+}
+
+// The kid predicate's noncharacter table must agree with the raw I-JSON gate's, so
+// a kid the issuer accepts is never one the verifier's I-JSON gate would reject for
+// a different reason. Compare across the whole code-point range.
+func TestKidNoncharacterMatchesIJSONGate(t *testing.T) {
+	for r := rune(0); r <= 0x10FFFF; r++ {
+		if kid.IsNoncharacter(r) != isUnicodeNoncharacter(r) {
+			t.Fatalf("noncharacter disagreement at U+%04X: kid=%v ijson=%v", r, kid.IsNoncharacter(r), isUnicodeNoncharacter(r))
+		}
+	}
+}

--- a/sdks/go/verify_local.go
+++ b/sdks/go/verify_local.go
@@ -6,10 +6,12 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/peacprotocol/peac/sdks/go/internal/kid"
 	"github.com/peacprotocol/peac/sdks/go/jws"
 )
 
@@ -137,7 +139,15 @@ func VerifyLocal(receiptJWS string, opts VerifyLocalOptions) *VerifyLocalResult 
 
 	// Low-level header validation (typ-agnostic)
 	if err := jws.ValidateHeader(parsed.Header); err != nil {
-		result.ErrorCode = "E_INVALID_FORMAT"
+		// A missing or empty kid on a Wire 0.2 record is the profile's
+		// E_JWS_MISSING_KID; any other header defect, and a missing kid on a
+		// non-Wire-0.2 record, stays a generic format error. Gating on typ leaves the
+		// generic jws layer unchanged for other callers.
+		if parsed.Header.Type == InteractionRecordTyp && errors.Is(err, jws.ErrMissingKid) {
+			result.ErrorCode = "E_JWS_MISSING_KID"
+		} else {
+			result.ErrorCode = "E_INVALID_FORMAT"
+		}
 		result.ErrorMessage = fmt.Sprintf("invalid header: %v", err)
 		return result
 	}
@@ -148,6 +158,16 @@ func VerifyLocal(receiptJWS string, opts VerifyLocalOptions) *VerifyLocalResult 
 	if parsed.Header.Type != InteractionRecordTyp {
 		result.ErrorCode = "E_UNSUPPORTED_WIRE_VERSION"
 		result.ErrorMessage = fmt.Sprintf("expected typ %s, got %s", InteractionRecordTyp, parsed.Header.Type)
+		return result
+	}
+
+	// Wire 0.2 kid rule. The raw I-JSON gate above already rejected a malformed-UTF-8
+	// or noncharacter kid as E_IJSON_*, so a kid reaching here is well-formed and only
+	// the oversized case can fire (empty is handled above); it maps to the profile's
+	// E_JWS_MISSING_KID without remapping an earlier I-JSON failure.
+	if err := kid.Validate(parsed.Header.KeyID); err != nil {
+		result.ErrorCode = "E_JWS_MISSING_KID"
+		result.ErrorMessage = fmt.Sprintf("kid does not satisfy the Wire 0.2 profile: %v", err)
 		return result
 	}
 


### PR DESCRIPTION
## Summary

Aligns the Go Wire 0.2 `kid` handling across issuance and verification so the issuer cannot emit a key identifier its own `VerifyLocal` rejects, and so Go applies one `kid` rule. Previously `IssueOptions.Kid` was silently ignored when it differed from the signing key's key ID, and the verifier accepted an oversized `kid` the profile forbids.

## Invariant

One `kid` rule, defined once and applied on both sides: a `kid` is non-empty, valid UTF-8, free of Unicode noncharacters, and at most 256 UTF-8 bytes.

- **Shared predicate** `sdks/go/internal/kid` (stdlib-only) is imported by both the root package and `jws`, so the rule has a single definition. It composes the base JWS `kid` semantics (RFC 7515: an optional, case-sensitive string of unspecified structure), the PEAC Wire 0.2 profile (required, at most 256 UTF-8 bytes), and I-JSON admission (RFC 7493: no surrogates or noncharacters), and preserves the `kid` exactly (no trim, case-fold, or normalization). Its noncharacter table is pinned to the raw I-JSON gate's by a test over the whole code-point range.
- **Issuance:** the signing key's key ID is authoritative. `IssueOptions.Kid` must be empty (use the key ID) or equal to it; a conflicting value returns `KEY_ID_MISMATCH` instead of being ignored, a key with no ID returns `MISSING_KEY_ID`, and an authoritative key ID that fails the rule returns `INVALID_KEY_ID` before header serialization (which prevents both silent U+FFFD replacement of invalid UTF-8 and emission of a header the verifier would reject). `IssueOptions.Kid` is deprecated.
- **`SignWithType`** validates the emitted `kid` only when the selected `typ` is the Wire 0.2 issuer form (the compact form a PEAC issuer emits), so a direct caller cannot bypass the `kid` constraint; the payload bytes remain caller-controlled at that layer, and legacy and raw JWS construction is unchanged.
- **Verification:** a missing or empty `kid` on a Wire 0.2 record reports `E_JWS_MISSING_KID` (via an exported `jws.ErrMissingKid` sentinel, remapped only under the Wire 0.2 `typ` so the generic header layer is unchanged); a well-formed oversized `kid` reports `E_JWS_MISSING_KID` after the `typ` check. A malformed-UTF-8 or noncharacter `kid` is rejected first by the raw I-JSON gate as `E_IJSON_*`, so no earlier failure is remapped — pinned by a raw-header test.

## Validation

`gofmt`, `go build ./...`, `go vet ./...`, `go test ./... -count=1`, `go test -race ./...`, and `golangci-lint v2.9.0` (covering `./internal/...`) all pass. Tests cover: the predicate across empty / invalid-UTF-8 / lone-surrogate-bytes / noncharacter / 256-vs-257 ASCII / 64-vs-65 supplementary-plane, and that it applies no normalization (case, whitespace, composed vs decomposed, NUL, BOM, zero-width preserved); the `IssueOptions.Kid` contract (empty / match / mismatch / no-ID / invalid authoritative ID); the 256-byte bound end to end for supplementary-plane code points (issue-and-verify with the `kid` preserved, issuance rejection, and external-record classification); the verifier for absent, explicitly empty, oversized, malformed-UTF-8, and noncharacter `kid`; issuance and direct Wire 0.2 signing refusing invalid-UTF-8 and noncharacter key IDs with a legacy-typ control; the noncharacter-table parity pin; and that the two Wire 0.2 typ constants agree.

## Scope

Wire 0.2 `kid` handling in `Issue`/`IssueJWS`/`SignWithType`/`VerifyLocal`. Go issuance emits the compact `typ`. Payload admission for the low-level `jws` signing primitives, verifier acceptance of the full media-type `typ`, and the shared conformance vectors and their wording are separate changes and are not touched here.
