### PR TITLE
fix(go): accept and normalize the full media-type form

### DIFF
--- a/sdks/go/constants.go
+++ b/sdks/go/constants.go
@@ -3,6 +3,11 @@ package peac
 // InteractionRecordTyp is the JWS typ header for Interaction Record format.
 const InteractionRecordTyp = "interaction-record+jwt"
 
+// InteractionRecordTypMediaType is the full media-type form of the Wire 0.2 typ.
+// Verifiers accept it and normalize it to the compact InteractionRecordTyp; issuers
+// emit the compact form and MUST NOT emit this one.
+const InteractionRecordTypMediaType = "application/interaction-record+jwt"
+
 // PeacVersion is the PEAC protocol version for Interaction Record format.
 const PeacVersion = "0.2"
 

--- a/sdks/go/media_type_test.go
+++ b/sdks/go/media_type_test.go
@@ -1,0 +1,80 @@
+package peac
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/peacprotocol/peac/sdks/go/jws"
+)
+
+func TestNormalizeWire02Typ(t *testing.T) {
+	cases := map[string]string{
+		InteractionRecordTyp:                      InteractionRecordTyp,
+		InteractionRecordTypMediaType:             InteractionRecordTyp,
+		"application/interaction-record+jwt; x=1": "application/interaction-record+jwt; x=1", // parameters not parsed
+		"peac-receipt/0.1":                        "peac-receipt/0.1",
+		"":                                        "",
+	}
+	for in, want := range cases {
+		if got := normalizeWire02Typ(in); got != want {
+			t.Fatalf("normalizeWire02Typ(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// A verifier must accept the full media-type form and treat it as the compact form.
+// Built by signing valid claims under the full typ, which issuers do not emit.
+func TestVerifyLocal_AcceptsFullMediaType(t *testing.T) {
+	key := testSigningKey(t)
+	result, err := Issue(IssueOptions{Iss: "https://example.com", Kind: KindEvidence, Type: "org.peacprotocol/test", SigningKey: key})
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	payload, err := jws.Decode(strings.Split(result.JWS, ".")[1])
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	full, err := key.SignWithType(payload, InteractionRecordTypMediaType)
+	if err != nil {
+		t.Fatalf("sign full media type: %v", err)
+	}
+	vr := VerifyLocal(full, VerifyLocalOptions{PublicKey: key.PublicKey()})
+	if !vr.Valid {
+		t.Fatalf("full media-type record should verify: %s %s", vr.ErrorCode, vr.ErrorMessage)
+	}
+}
+
+// The compact form still verifies (regression).
+func TestVerifyLocal_AcceptsCompactTyp(t *testing.T) {
+	key := testSigningKey(t)
+	result, err := Issue(IssueOptions{Iss: "https://example.com", Kind: KindEvidence, Type: "org.peacprotocol/test", SigningKey: key})
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	vr := VerifyLocal(result.JWS, VerifyLocalOptions{PublicKey: key.PublicKey()})
+	if !vr.Valid {
+		t.Fatalf("compact record should verify: %s %s", vr.ErrorCode, vr.ErrorMessage)
+	}
+}
+
+// A parameterized media type is not accepted: parameters are not parsed, so it is an
+// unrecognized typ and the record is rejected.
+func TestVerifyLocal_RejectsParameterizedMediaType(t *testing.T) {
+	key := testSigningKey(t)
+	result, err := Issue(IssueOptions{Iss: "https://example.com", Kind: KindEvidence, Type: "org.peacprotocol/test", SigningKey: key})
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	payload, err := jws.Decode(strings.Split(result.JWS, ".")[1])
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	param, err := key.SignWithType(payload, InteractionRecordTypMediaType+"; charset=utf-8")
+	if err != nil {
+		t.Fatalf("sign parameterized typ: %v", err)
+	}
+	vr := VerifyLocal(param, VerifyLocalOptions{PublicKey: key.PublicKey()})
+	if vr.Valid {
+		t.Fatal("parameterized media type should be rejected")
+	}
+}

--- a/sdks/go/media_type_test.go
+++ b/sdks/go/media_type_test.go
@@ -9,9 +9,14 @@ import (
 
 func TestNormalizeWire02Typ(t *testing.T) {
 	cases := map[string]string{
-		InteractionRecordTyp:                      InteractionRecordTyp,
-		InteractionRecordTypMediaType:             InteractionRecordTyp,
-		"application/interaction-record+jwt; x=1": "application/interaction-record+jwt; x=1", // parameters not parsed
+		// Both accepted spellings normalize to the canonical compact form, case-insensitively.
+		InteractionRecordTyp:                 InteractionRecordTyp,
+		"Interaction-Record+JWT":             InteractionRecordTyp,
+		InteractionRecordTypMediaType:        InteractionRecordTyp,
+		"Application/Interaction-Record+JWT": InteractionRecordTyp,
+		// Not accepted: parameters not parsed, whitespace not normalized, other typ unchanged.
+		"application/interaction-record+jwt; x=1": "application/interaction-record+jwt; x=1",
+		" interaction-record+jwt ":                " interaction-record+jwt ",
 		"peac-receipt/0.1":                        "peac-receipt/0.1",
 		"":                                        "",
 	}
@@ -22,8 +27,26 @@ func TestNormalizeWire02Typ(t *testing.T) {
 	}
 }
 
+// The comparison is ASCII case folding, not Unicode case folding: the Kelvin sign
+// (U+212A) folds to 'k' under Unicode but must not match ASCII 'k' here. A non-ASCII
+// typ is therefore never accepted.
+func TestNormalizeWire02Typ_IsASCIIFoldNotUnicode(t *testing.T) {
+	const kelvin = "\u212a"
+	if asciiEqualFold(kelvin, "k") {
+		t.Fatal("asciiEqualFold must not fold the Kelvin sign to ASCII k")
+	}
+	if !strings.EqualFold(kelvin, "k") {
+		t.Fatal("precondition: strings.EqualFold folds Kelvin to k (Unicode folding)")
+	}
+	nonASCII := "\u212anteraction-record+jwt" // Kelvin sign in place of leading 'i'-ish
+	if got := normalizeWire02Typ(nonASCII); got != nonASCII {
+		t.Fatalf("a non-ASCII typ must be returned unchanged, got %q", got)
+	}
+}
+
 // A verifier must accept the full media-type form and treat it as the compact form.
-// Built by signing valid claims under the full typ, which issuers do not emit.
+// A mixed-case full form exercises the case-insensitive ASCII comparison end to end.
+// Built by signing valid claims under that typ, which issuers do not emit.
 func TestVerifyLocal_AcceptsFullMediaType(t *testing.T) {
 	key := testSigningKey(t)
 	result, err := Issue(IssueOptions{Iss: "https://example.com", Kind: KindEvidence, Type: "org.peacprotocol/test", SigningKey: key})
@@ -34,13 +57,13 @@ func TestVerifyLocal_AcceptsFullMediaType(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decode payload: %v", err)
 	}
-	full, err := key.SignWithType(payload, InteractionRecordTypMediaType)
+	full, err := key.SignWithType(payload, "Application/Interaction-Record+JWT")
 	if err != nil {
 		t.Fatalf("sign full media type: %v", err)
 	}
 	vr := VerifyLocal(full, VerifyLocalOptions{PublicKey: key.PublicKey()})
 	if !vr.Valid {
-		t.Fatalf("full media-type record should verify: %s %s", vr.ErrorCode, vr.ErrorMessage)
+		t.Fatalf("mixed-case full media-type record should verify: %s %s", vr.ErrorCode, vr.ErrorMessage)
 	}
 }
 

--- a/sdks/go/verify_local.go
+++ b/sdks/go/verify_local.go
@@ -92,6 +92,17 @@ type VerificationWarning struct {
 	Pointer string `json:"pointer,omitempty"`
 }
 
+// normalizeWire02Typ maps the accepted full media-type form of the Wire 0.2 typ to
+// the compact form by exact string match. Verifiers accept both forms; any other
+// value is returned unchanged. It does not parse content-type parameters, so a
+// parameterized value is not accepted.
+func normalizeWire02Typ(typ string) string {
+	if typ == InteractionRecordTypMediaType {
+		return InteractionRecordTyp
+	}
+	return typ
+}
+
 // VerifyLocal verifies a signed interaction record locally with a provided public key.
 //
 // Enforces the current stable Interaction Record format (interaction-record+jwt)
@@ -136,6 +147,12 @@ func VerifyLocal(receiptJWS string, opts VerifyLocalOptions) *VerifyLocalResult 
 		result.ErrorMessage = fmt.Sprintf("invalid JWS: %v", err)
 		return result
 	}
+
+	// Accept the full media-type form of the Wire 0.2 typ and normalize it to the
+	// compact form before any header validation, so both forms are treated identically
+	// and the decoded header carries the compact form. The match is exact: no
+	// content-type parameter parsing.
+	parsed.Header.Type = normalizeWire02Typ(parsed.Header.Type)
 
 	// Low-level header validation (typ-agnostic)
 	if err := jws.ValidateHeader(parsed.Header); err != nil {

--- a/sdks/go/verify_local.go
+++ b/sdks/go/verify_local.go
@@ -92,15 +92,42 @@ type VerificationWarning struct {
 	Pointer string `json:"pointer,omitempty"`
 }
 
-// normalizeWire02Typ maps the accepted full media-type form of the Wire 0.2 typ to
-// the compact form by exact string match. Verifiers accept both forms; any other
-// value is returned unchanged. It does not parse content-type parameters, so a
-// parameterized value is not accepted.
+// normalizeWire02Typ maps either accepted Wire 0.2 typ spelling, the compact form or
+// the full media-type form, to the canonical compact form. The comparison is
+// case-insensitive ASCII string equality; it does not parse content-type parameters
+// or normalize whitespace, so a parameterized or whitespace-padded value is not
+// accepted. Any other value is returned unchanged and rejected by the later typ check.
 func normalizeWire02Typ(typ string) string {
-	if typ == InteractionRecordTypMediaType {
+	if asciiEqualFold(typ, InteractionRecordTyp) || asciiEqualFold(typ, InteractionRecordTypMediaType) {
 		return InteractionRecordTyp
 	}
 	return typ
+}
+
+// asciiEqualFold reports whether a and b are equal under ASCII case folding: equal
+// length, every byte in the ASCII range, with A-Z folded to a-z. It is deliberately
+// ASCII-only, not Unicode case folding (strings.EqualFold), because the Wire 0.2 typ
+// comparison is defined over ASCII; a non-ASCII byte never matches.
+func asciiEqualFold(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		ca, cb := a[i], b[i]
+		if ca >= 0x80 || cb >= 0x80 {
+			return false
+		}
+		if 'A' <= ca && ca <= 'Z' {
+			ca += 'a' - 'A'
+		}
+		if 'A' <= cb && cb <= 'Z' {
+			cb += 'a' - 'A'
+		}
+		if ca != cb {
+			return false
+		}
+	}
+	return true
 }
 
 // VerifyLocal verifies a signed interaction record locally with a provided public key.


### PR DESCRIPTION
## Summary

The Wire 0.2 profile requires verifiers to accept both the compact typ `interaction-record+jwt` and the full media-type form `application/interaction-record+jwt`, using case-insensitive ASCII string equality, and to normalize either accepted spelling to the canonical compact form (WIRE02-MEDIA-002 / WIRE02-MEDIA-003 / WIRE02-IDENT-002, and RFC 7515 media type/subtype case-insensitivity). The Go verifier accepted only the compact form and compared case-sensitively, so records from a conforming external issuer using the media-type form, or any case-varied spelling, were rejected — directly on the cross-organization verification path.

## Change

`VerifyLocal` normalizes either accepted spelling to the canonical compact form before header validation, using ASCII case-insensitive equality via a small ASCII-only case-folding comparator (not `strings.EqualFold`, whose Unicode folding is broader than the ASCII rule). It does not perform content-type parameter parsing, whitespace normalization, or Unicode case folding, so parameterized or whitespace-padded values are not accepted. Issuer output is unchanged (issuers emit the compact form), and typ/peac_version coherence is preserved.

## Validation

`gofmt`, `go build ./...`, `go vet ./...`, `go test ./... -count=1`, `go test -race ./...`, and `golangci-lint v2.9.0` all pass. Tests: the normalize mapping (compact, mixed-case compact, full, mixed-case full, parameterized, whitespace, other); an ASCII-not-Unicode fold check (the Kelvin sign does not match ASCII `k`); a mixed-case full-media-type record verifies end to end; the compact form still verifies; a parameterized media type is rejected.

## Scope

Verifier typ acceptance only. No change to issuer output, validation ordering, error model, or JWS internals; no content-type parameter parsing introduced.
