### PR TITLE
docs(guides): cross-organization verification handoff

### DIFF
--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -39,8 +39,9 @@ You have a receipt (JWS string) and want to verify it offline with a public key.
 1. Install: `pnpm add @peac/protocol @peac/crypto`
 2. Follow the [Agent Operator Quickstart](guides/quickstart-agent-operator.md) (5 minutes)
 3. Compare the CLI, browser, and self-host paths in [Verification options](guides/verification-options.md), and try them on the shipped records in the [Offline sample index](guides/offline-sample-index.md)
-4. See [examples/minimal](../examples/minimal/) for typed accessor helpers
-5. Self-host the reference verifier: recipes under [`surfaces/reference-verifier/`](../surfaces/reference-verifier/)
+4. Verify a record another organization issued: [Cross-organization verification handoff](guides/cross-org-verification-handoff.md)
+5. See [examples/minimal](../examples/minimal/) for typed accessor helpers
+6. Self-host the reference verifier: recipes under [`surfaces/reference-verifier/`](../surfaces/reference-verifier/)
 
 Key packages: `@peac/protocol`, `@peac/crypto`.
 

--- a/docs/guides/cross-org-verification-handoff.md
+++ b/docs/guides/cross-org-verification-handoff.md
@@ -1,18 +1,18 @@
 # Cross-organization verification handoff
 
-A PEAC record is a signed, self-contained JWS. One organization issues it; another organization
-verifies it locally, without calling back to the issuer, without an account, and without any shared
-online service. This guide walks through that handoff end to end and states precisely what a
+A Wire 0.2 PEAC record is carried as a signed compact JWS. The recipient verifies it locally using
+independently supplied public-key material, with no issuer callback, no account, and no shared online
+verification service. This guide walks through that handoff end to end and states precisely what a
 successful verification does and does not establish.
 
 The shape is always the same: **organization A issues a record and shares it, along with the public
-key, with organization B; organization B verifies it locally.** Nothing in the middle needs to be
-online.
+key, with organization B; organization B verifies it locally.** Verification requires no issuer
+callback or shared online verification service.
 
 ## 1. Organization A issues a record and exports the public key
 
 Records are produced with `issue()` from `@peac/protocol` (see [`docs/VERIFY.md`](../VERIFY.md) for
-the library form). The signing (private) key never leaves organization A. What A shares is:
+the library form). The signing (private) key is not part of the handoff. What A shares is:
 
 - the **compact record** (a JWS string), and
 - the **public key** as a JWK or a JWKS (never the private key).
@@ -25,19 +25,23 @@ pnpm dlx @peac/cli samples generate -o ./s
 # ./s/bundles/sandbox-jwks.json   the public JWKS
 ```
 
-A ready-made pair also ships with the browser verifier under
+The repository includes a ready-made pair under
 [`apps/verifier/samples/`](../../apps/verifier/samples/): `record.jws` and `key.jwk.json`.
 
 ## 2. Organization A transfers the record and key to organization B
 
-Send the record and the public key over any channel: an email attachment, a ticket, a file drop, a
-message. Neither is secret; the security of the handoff does not depend on the transport, because
-verification checks the signature, not the channel.
+Transfer the record and public key using a channel appropriate to the information being exchanged and
+the organizations' requirements. The public key is not secret, but a signed record is not encrypted
+merely because it is a JWS. Signature verification detects changes to the record relative to the
+supplied key; it does not establish how that key reached organization B or whether it is the expected
+key. Transfer the compact JWS byte for byte: whitespace or line-ending normalization that changes the
+supplied string will cause it to be rejected.
 
-If organization B intends to check that the record was signed by a **specific expected key** (not
-merely any key A supplies alongside the record), A also communicates the key's RFC 7638 JWK
-thumbprint **out of band** so B can pin it. That thumbprint is the only independent trust anchor;
-see step 4.
+If organization B needs to establish that the supplied key is the expected key (not merely a key A
+sent alongside the record), B obtains or confirms the expected RFC 7638 JWK thumbprint independently
+of the record-and-key handoff, for example through pre-established configuration, a previously
+recorded expected thumbprint, or a separately authenticated channel. B then supplies that value as a
+trust anchor; see step 4.
 
 ## 3. Organization B verifies locally
 
@@ -66,28 +70,32 @@ matches the public key I used, and is it unchanged?_ It does not answer _should 
 Those are kept deliberately separate. In the browser verifier, organization B can supply a
 **verification context** (a `VerificationContextV1` document) alongside the record and key:
 
-- a **trusted JWK thumbprint** is the only independent trust anchor. When B supplies the thumbprint it
-  obtained out of band in step 2 and it matches the selected key, the result is reported as
-  trusted-key rather than integrity-only.
-- **expected issuer**, **allowed key ids**, and **allowed record types** are claim constraints over
-  values inside the record. They are useful routing and policy checks, but they are attacker-
-  controllable payload values, not trust anchors.
+- Within the browser verifier's current `VerificationContextV1` model, an independently established
+  **trusted JWK thumbprint** is the supported trust-anchor input. When B supplies the thumbprint it
+  confirmed independently in step 2 and it matches the selected key, the result is reported as
+  trusted-key rather than integrity-only. The thumbprint identifies the key; its trust comes from B's
+  independent provenance decision, not from the thumbprint format itself.
+- **expected issuer**, **allowed key ids**, and **allowed record types** are record-supplied signed
+  or protected values. They constrain what organization B accepts, but they do not independently
+  establish key provenance and are not trust anchors.
 
 Supplying no context is a valid, integrity-only verification: the signature is checked, and the
 result says plainly that the key was not independently established as expected.
 
 ## 5. Tamper is detected
 
-Change any byte of the record and verify again. Verification fails at the signature stage with
-`E_INVALID_SIGNATURE`: the record no longer matches the signature. The browser verifier ships a
-`record-tampered.jws` sample that demonstrates exactly this.
+For the included `record-tampered.jws` example, which changes a byte in the signature segment,
+verification fails at the signature stage with `E_INVALID_SIGNATURE`: the record no longer matches
+the signature. More generally, any modification to a record is rejected when it violates the checks
+the verifier applies; depending on what changed, that may be the signature check or an earlier
+structural, encoding, or content check.
 
 ## 6. A deterministic report
 
 The browser verifier can export a deterministic, unsigned verification report for a completed run.
-The same inputs and evaluation time produce a byte-identical report, and its hash makes it
-reproducible and tamper-evident against a retained reference. The report records the outcome; it does
-not, on its own, establish who produced it.
+Given identical verification inputs and evaluation time, the report is byte-identical, so a
+separately retained report hash can be used to detect later changes. The unsigned report records the
+verification outcome; it does not establish who produced the report.
 
 ## What a successful verification establishes, and what it does not
 

--- a/docs/guides/cross-org-verification-handoff.md
+++ b/docs/guides/cross-org-verification-handoff.md
@@ -1,0 +1,111 @@
+# Cross-organization verification handoff
+
+A PEAC record is a signed, self-contained JWS. One organization issues it; another organization
+verifies it locally, without calling back to the issuer, without an account, and without any shared
+online service. This guide walks through that handoff end to end and states precisely what a
+successful verification does and does not establish.
+
+The shape is always the same: **organization A issues a record and shares it, along with the public
+key, with organization B; organization B verifies it locally.** Nothing in the middle needs to be
+online.
+
+## 1. Organization A issues a record and exports the public key
+
+Records are produced with `issue()` from `@peac/protocol` (see [`docs/VERIFY.md`](../VERIFY.md) for
+the library form). The signing (private) key never leaves organization A. What A shares is:
+
+- the **compact record** (a JWS string), and
+- the **public key** as a JWK or a JWKS (never the private key).
+
+To try the flow without writing any code, generate a sample record and its public key bundle:
+
+```bash
+pnpm dlx @peac/cli samples generate -o ./s
+# ./s/valid/*.jws            the records
+# ./s/bundles/sandbox-jwks.json   the public JWKS
+```
+
+A ready-made pair also ships with the browser verifier under
+[`apps/verifier/samples/`](../../apps/verifier/samples/): `record.jws` and `key.jwk.json`.
+
+## 2. Organization A transfers the record and key to organization B
+
+Send the record and the public key over any channel: an email attachment, a ticket, a file drop, a
+message. Neither is secret; the security of the handoff does not depend on the transport, because
+verification checks the signature, not the channel.
+
+If organization B intends to check that the record was signed by a **specific expected key** (not
+merely any key A supplies alongside the record), A also communicates the key's RFC 7638 JWK
+thumbprint **out of band** so B can pin it. That thumbprint is the only independent trust anchor;
+see step 4.
+
+## 3. Organization B verifies locally
+
+Organization B verifies with the public key it received. Every path runs entirely on B's side, with
+no network call to A:
+
+- **Browser verifier** ([`apps/verifier/`](../../apps/verifier/)): paste the record into "PEAC
+  record" and the public key into "Public key", then choose Verify. Nothing is uploaded, fetched, or
+  stored.
+- **Command line**:
+
+  ```bash
+  pnpm dlx @peac/cli verify ./record.jws --public-key ./key.jwk.json
+  ```
+
+- **Library**: `verifyLocal(record, publicKey)` from `@peac/protocol`.
+
+A valid record reports success. See [Verification options](verification-options.md) for the full set
+of paths.
+
+## 4. Trust context is separate from cryptographic validity
+
+A successful signature check answers one question: _was this record signed by the private key that
+matches the public key I used, and is it unchanged?_ It does not answer _should I trust that key?_
+
+Those are kept deliberately separate. In the browser verifier, organization B can supply a
+**verification context** (a `VerificationContextV1` document) alongside the record and key:
+
+- a **trusted JWK thumbprint** is the only independent trust anchor. When B supplies the thumbprint it
+  obtained out of band in step 2 and it matches the selected key, the result is reported as
+  trusted-key rather than integrity-only.
+- **expected issuer**, **allowed key ids**, and **allowed record types** are claim constraints over
+  values inside the record. They are useful routing and policy checks, but they are attacker-
+  controllable payload values, not trust anchors.
+
+Supplying no context is a valid, integrity-only verification: the signature is checked, and the
+result says plainly that the key was not independently established as expected.
+
+## 5. Tamper is detected
+
+Change any byte of the record and verify again. Verification fails at the signature stage with
+`E_INVALID_SIGNATURE`: the record no longer matches the signature. The browser verifier ships a
+`record-tampered.jws` sample that demonstrates exactly this.
+
+## 6. A deterministic report
+
+The browser verifier can export a deterministic, unsigned verification report for a completed run.
+The same inputs and evaluation time produce a byte-identical report, and its hash makes it
+reproducible and tamper-evident against a retained reference. The report records the outcome; it does
+not, on its own, establish who produced it.
+
+## What a successful verification establishes, and what it does not
+
+It establishes:
+
+- the record was signed by the private key matching the public key organization B used;
+- the record has not changed since it was signed;
+- the record satisfied the checks the verifier performed, at the evaluation time shown.
+
+It does not establish:
+
+- that the key, or its holder, is one organization B should trust (that is the separate trust
+  decision in step 4);
+- that the statements inside the record are factually true;
+- that any external event the record refers to actually occurred.
+
+## Related
+
+- [Verification options](verification-options.md) — CLI, browser, and self-host verification paths.
+- [`apps/verifier/README.md`](../../apps/verifier/README.md) — the browser verifier and its sample walkthrough.
+- [`docs/VERIFY.md`](../VERIFY.md) — command-line and library verification, including issuance.

--- a/docs/guides/verification-options.md
+++ b/docs/guides/verification-options.md
@@ -29,7 +29,7 @@ No network calls are made when `--public-key` is supplied. See [`docs/VERIFY.md`
 
 ### 2. Browser verifier
 
-[`apps/verifier/`](../../apps/verifier/) is a client-side browser verifier. All verification runs locally with `verifyLocal()` from `@peac/protocol`; no record is sent to any server. Add the trusted issuer public key to its trust store, then paste or drop a record.
+[`apps/verifier/`](../../apps/verifier/) is a client-side browser verifier. Paste a record and the public key material (a JWK or JWKS), and optionally a set of verification expectations; verification runs locally with `verifyLocal()` from `@peac/protocol`. Nothing is fetched, uploaded or stored, and the application registers no service worker. A supplied trusted JWK thumbprint is the only trust anchor; issuer, key id and record type expectations are claim constraints, not trust anchors.
 
 ```bash
 # from apps/verifier/
@@ -38,7 +38,7 @@ pnpm dev
 # opens on http://localhost:5173
 ```
 
-See [`apps/verifier/README.md`](../../apps/verifier/README.md) for the trust-store and build details.
+See [`apps/verifier/README.md`](../../apps/verifier/README.md) for the build details and a sample walkthrough, and the [cross-organization verification handoff](cross-org-verification-handoff.md) for the end-to-end flow between two organizations.
 
 ### 3. Self-host HTTP
 
@@ -58,6 +58,7 @@ Every path above can verify the shipped sample records. See the [Offline sample 
 
 ## Related
 
+- [Cross-organization verification handoff](cross-org-verification-handoff.md) — the end-to-end flow where one organization issues a record and another verifies it locally.
 - [`docs/VERIFY.md`](../VERIFY.md) — command-line and library verification walkthrough.
 - [`docs/guides/offline-sample-index.md`](offline-sample-index.md) — the shipped valid and invalid sample records.
 - [`docs/START_HERE.md`](../START_HERE.md) — entry path by role.


### PR DESCRIPTION
## Summary

Documents the cross-organization verification handoff and corrects the browser-verifier guidance to the supplied-key model.

## Changes

- **New guide** `docs/guides/cross-org-verification-handoff.md`: local cross-organization verification where one organization issues a record and another verifies it with supplied public-key material. It covers an independently established optional trusted-key context, a tamper demonstration, and the deterministic report, and states plainly what a valid signature does and does not establish. Verification requires no issuer callback, account, or shared online verification service.
- **Corrected** `docs/guides/verification-options.md`: the browser verifier takes a supplied public key and optional verification expectations per run; it has no persistent trust store, fetches nothing, and stores nothing.
- Linked the new guide from `verification-options.md` and `START_HERE.md`.

## Validation

Prettier, the repo-wide and entry Markdown link gates, and the execution-surface CLI doc-truth gate all pass.

## Scope

Documentation only. No code, dependency, or verification-behavior change.
