### PR TITLE
chore(release): stamp v0.16.4 publish state

### DIFF
--- a/REPO_SURFACE_STATUS.json
+++ b/REPO_SURFACE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable surface classification for PEAC Protocol workspace. CI fails if any workspace member is missing. See docs/PACKAGE_STATUS.md for human-readable view.",
   "version": "0.13.0",
-  "updated": "2026-07-21",
+  "updated": "2026-08-09",
   "states": {
     "default": "Current recommended path. Actively maintained, Wire 0.2 native.",
     "supported": "Actively maintained, published, production-ready. May not be on default quickstart path.",

--- a/docs/SURFACE_STATUS.md
+++ b/docs/SURFACE_STATUS.md
@@ -2,7 +2,7 @@
 
 Do not edit manually. Source: `REPO_SURFACE_STATUS.json`. Rebuild via `node scripts/generate-surface-status.mjs`.
 
-**Version:** 0.13.0 | **Updated:** 2026-07-21
+**Version:** 0.13.0 | **Updated:** 2026-08-09
 
 ## Layer 1
 

--- a/docs/releases/facts.json
+++ b/docs/releases/facts.json
@@ -4,7 +4,7 @@
   "version": "0.16.4",
   "wire_format_version": "0.2",
   "dist_tag": "latest",
-  "release_date": "2026-07-21",
+  "release_date": "2026-08-09",
   "metrics": {
     "tests": 13149,
     "test_files": 506,


### PR DESCRIPTION
## Summary

Stamp the v0.16.4 release-state fields after publishing to the `next` dist-tag.

## Changes

- `docs/releases/facts.json`: `release_date` set to the publish date.
- `REPO_SURFACE_STATUS.json`: `updated` set to the publish date.
- `docs/SURFACE_STATUS.md`: regenerated from `REPO_SURFACE_STATUS.json`.

## Scope

Release-state stamp only. `dist_tag` is stamped at promotion to `latest`. No code,
schema, or dependency change.
