### PR TITLE
fix(verifier): own-property lookup in the canonical stage map

### DIFF
--- a/apps/verifier/src/lib/stage-map.ts
+++ b/apps/verifier/src/lib/stage-map.ts
@@ -52,7 +52,14 @@ export const STAGE_BY_CODE = {
 /**
  * Look up a stage. An unmapped code returns undefined so the caller can fail CLOSED at the
  * internal-error stage; it must never be treated as a post-signature validation failure.
+ *
+ * OWN-property lookup only. `STAGE_BY_CODE` is an ordinary object, so a plain index would resolve
+ * inherited members for strings such as "constructor", "toString" or "__proto__" and return a
+ * function or object instead of undefined -- which the caller would then treat as a mapped stage.
+ * `satisfies` pins the key set at compile time; it says nothing about runtime lookups with
+ * arbitrary strings, so the guard has to be here.
  */
 export function stageForCanonicalCode(code: string): CanonicalStage | undefined {
+  if (!Object.hasOwn(STAGE_BY_CODE, code)) return undefined;
   return (STAGE_BY_CODE as Record<string, CanonicalStage>)[code];
 }

--- a/apps/verifier/tests/stage-map.test.ts
+++ b/apps/verifier/tests/stage-map.test.ts
@@ -32,6 +32,15 @@ describe('coverage against the real union', () => {
   it('has no default branch: an unknown code returns undefined', () => {
     expect(stageForCanonicalCode('E_TOTALLY_NEW_CODE')).toBeUndefined();
   });
+
+  it.each(['constructor', 'toString', '__proto__', 'hasOwnProperty', 'valueOf', 'isPrototypeOf'])(
+    'inherited Object member %s is NOT a stage (own-property lookup only)',
+    (code) => {
+      // Without the own-property guard these resolve to inherited functions/objects, which are
+      // truthy and would be treated as a mapped stage by a caller that only rejects `undefined`.
+      expect(stageForCanonicalCode(code)).toBeUndefined();
+    }
+  );
 });
 
 describe('stage assignment', () => {

--- a/apps/verifier/tests/stage-map.unmapped-codes.test.ts
+++ b/apps/verifier/tests/stage-map.unmapped-codes.test.ts
@@ -30,17 +30,30 @@ describe('unmapped canonical codes fail closed end to end', () => {
       });
       expect(r.ok).toBe(false);
       if (r.ok) return;
+      // Narrow past the `ok: false` union: CapabilityFailure carries no `failureStage` at all, so
+      // an `in` check (rather than a bare property read) is required before the discriminant read
+      // below is safe. Once `failureStage` is known to be present, its value is the discriminant
+      // that narrows the remaining variants down to exactly `InternalError`.
+      if (!('failureStage' in r)) throw new Error('expected a failureStage-bearing failure');
       expect(r.failureStage).toBe('internal_error');
+      if (r.failureStage !== 'internal_error') return;
       expect(r.code).toBe('E_VERIFIER_UNMAPPED_CANONICAL_CODE');
       expect(r.signature).toBe('not_evaluated');
       expect(r.recordValidation).toBe('not_evaluated');
-      expect(r.report.outcome).toBe('rejected');
-      expect(r.report.failureStage).toBe('internal_error');
-      expect(r.report.failureCode).toBe('E_VERIFIER_UNMAPPED_CANONICAL_CODE');
-      expect(r.report.signatureResult).toBe('not_evaluated');
-      expect(r.report.recordValidationResult).toBe('not_evaluated');
-      expect((r.report as { recordType?: unknown }).recordType).toBeUndefined();
-      expect((r.report as { reportedIssuer?: unknown }).reportedIssuer).toBeUndefined();
+      // `InternalError.report` is optional (an internal error before a report could be built has
+      // none); this path always produces one, so require it explicitly rather than reading through
+      // a possibly-undefined value.
+      expect(r.report).toBeDefined();
+      if (!r.report) return;
+      expect(r.report).toMatchObject({
+        outcome: 'rejected',
+        failureStage: 'internal_error',
+        failureCode: 'E_VERIFIER_UNMAPPED_CANONICAL_CODE',
+        signatureResult: 'not_evaluated',
+        recordValidationResult: 'not_evaluated',
+      });
+      expect(r.report.recordType).toBeUndefined();
+      expect(r.report.reportedIssuer).toBeUndefined();
     }
   );
 });

--- a/apps/verifier/tests/stage-map.unmapped-codes.test.ts
+++ b/apps/verifier/tests/stage-map.unmapped-codes.test.ts
@@ -1,0 +1,46 @@
+/**
+ * End-to-end: every string the canonical stage map does not OWN reaches the fail-closed
+ * internal-error path, with no positive signature or validation claim in the result or report.
+ *
+ * The canonical verifier is stubbed through the `verifyLocal` injection point so the orchestrator
+ * sees a rejected result carrying an arbitrary code. Inherited Object member names are the cases
+ * that used to escape: a plain object index resolved them to inherited functions, which the caller
+ * accepted as a mapped stage and classified as a post-signature failure -- i.e. it asserted
+ * "signature valid under supplied key" with no evidence.
+ */
+import { describe, it, expect } from 'vitest';
+import { initializeLocalVerifier } from '../src/verify.js';
+import { makeFixture } from './helpers/fixtures.js';
+
+const BUILD = 'test-build';
+
+describe('unmapped canonical codes fail closed end to end', () => {
+  it.each(['constructor', 'toString', '__proto__', 'hasOwnProperty', 'valueOf', 'E_FUTURE_CODE'])(
+    'code %s -> internal_error / E_VERIFIER_UNMAPPED_CANONICAL_CODE, nothing evaluated',
+    async (code) => {
+      const verifier = await initializeLocalVerifier({
+        verifierBuild: BUILD,
+        verifyLocal: (async () => ({ valid: false, code, message: 'stubbed' })) as never,
+      });
+      const f = await makeFixture();
+      const r = await verifier.verify({
+        record: f.record,
+        keyDocument: f.keyDocument,
+        evaluationTimeUnixSeconds: f.evaluationTime,
+      });
+      expect(r.ok).toBe(false);
+      if (r.ok) return;
+      expect(r.failureStage).toBe('internal_error');
+      expect(r.code).toBe('E_VERIFIER_UNMAPPED_CANONICAL_CODE');
+      expect(r.signature).toBe('not_evaluated');
+      expect(r.recordValidation).toBe('not_evaluated');
+      expect(r.report.outcome).toBe('rejected');
+      expect(r.report.failureStage).toBe('internal_error');
+      expect(r.report.failureCode).toBe('E_VERIFIER_UNMAPPED_CANONICAL_CODE');
+      expect(r.report.signatureResult).toBe('not_evaluated');
+      expect(r.report.recordValidationResult).toBe('not_evaluated');
+      expect((r.report as { recordType?: unknown }).recordType).toBeUndefined();
+      expect((r.report as { reportedIssuer?: unknown }).reportedIssuer).toBeUndefined();
+    }
+  );
+});


### PR DESCRIPTION
Depends on #972.

## Summary
`stageForCanonicalCode` indexed `STAGE_BY_CODE` with plain bracket access on an ordinary object, so a small set of strings that happen to be inherited `Object.prototype` member names (`constructor`, `toString`, `__proto__`, `hasOwnProperty`, `valueOf`, `isPrototypeOf`) resolved to the inherited function or object instead of `undefined`. The caller only checks for `undefined` before treating the result as a mapped stage, so an inherited member value could have been accepted as a stage rather than rejected.

## Changes
- `apps/verifier` stage map: the lookup now checks `Object.hasOwn(STAGE_BY_CODE, code)` before indexing, so only codes actually present in the canonical map resolve to a stage; every other string, including the inherited-name cases, returns `undefined`. Unmapped codes continue to fail closed exactly as before — `verify.ts` treats `undefined` as `E_VERIFIER_UNMAPPED_CANONICAL_CODE` with `failureStage: 'internal_error'` and both `signature` and `recordValidation` set to `not_evaluated`.
- `apps/verifier/tests/stage-map.test.ts`: parametrized case asserting each inherited `Object.prototype` member name returns `undefined` from `stageForCanonicalCode`.
- `apps/verifier/tests/stage-map.unmapped-codes.test.ts` (new): end-to-end coverage through `initializeLocalVerifier` with a stubbed canonical verifier result, confirming every one of those codes (plus an arbitrary future code) reaches the fail-closed `E_VERIFIER_UNMAPPED_CANONICAL_CODE` / `internal_error` path with no `recordType`/`reportedIssuer` present on the report.
- Follow-up commit narrows the result union read in `stage-map.unmapped-codes.test.ts` itself (an `'failureStage' in r` guard before any discriminant read, explicit `report` guard) to remove unchecked reads through the discriminated `verifier.verify()` result type; no `any`/cast; `stage-map.ts` and `verify.ts` untouched by this commit.

## Compatibility
No wire, schema, or public API change; no change to record validation or signature logic. This is a helper-contract hardening — no path in the current canonical verifier emits any of the affected strings as an error code today, so this closes a latent gap rather than fixing a live bypass.

## Verification
- `pnpm --filter ./apps/verifier run typecheck` → exit 0
- `apps/verifier` full suite → 397 passed / 1 skipped (398 total) across 31 test files
