### PR TITLE
chore(security): prune stale audit-allowlist exceptions

### DIFF
--- a/security/audit-allowlist.json
+++ b/security/audit-allowlist.json
@@ -17,60 +17,6 @@
       "owner": "jithinraj",
       "added_at": "2026-02-19",
       "reviewed_at": "2026-08-23"
-    },
-    {
-      "advisory_id": "GHSA-p9ff-h696-f583",
-      "package": "vite",
-      "reason": "Vite dev server arbitrary file read (HIGH): dev-only via vitest@4.1.0 -> vite@6.4.1. Not exposed in production.",
-      "why_not_exploitable": "Vite dev server is only used during local test runs via vitest. Not in published packages or production deployments.",
-      "where_used": "root devDependency: @vitest/coverage-v8@4.1.0 -> vitest@4.1.0 -> vite@6.4.1",
-      "expires_at": "2026-09-20",
-      "remediation": "Update vite when vitest ships a fix or vite patches the dev server vulnerability",
-      "issue_url": "https://github.com/advisories/GHSA-p9ff-h696-f583",
-      "scope": "dev",
-      "dependency_chain": ["@vitest/coverage-v8@4.1.0", "vitest@4.1.0", "vite@6.4.1"],
-      "verified_by": "pnpm audit --prod shows no HIGH for vite; pnpm why vite confirms vitest-only path",
-      "owner": "jithinraj",
-      "added_at": "2026-04-07",
-      "reviewed_at": "2026-06-22"
-    },
-    {
-      "advisory_id": "GHSA-737v-mqg7-c878",
-      "package": "defu",
-      "reason": "defu prototype pollution via __proto__ key (HIGH): dev-only transitive dependency. Not in published packages.",
-      "why_not_exploitable": "defu is a transitive dev dependency used in build/test tooling. Not in published packages. No user-controlled input reaches defu in production.",
-      "where_used": "transitive devDependency via build/test tooling",
-      "expires_at": "2026-09-20",
-      "remediation": "Update when upstream patches or when the consuming tool updates its dependency",
-      "issue_url": "https://github.com/advisories/GHSA-737v-mqg7-c878",
-      "scope": "dev",
-      "dependency_chain": ["transitive dev dependency"],
-      "verified_by": "pnpm audit --prod shows no HIGH for defu",
-      "owner": "jithinraj",
-      "added_at": "2026-04-07",
-      "reviewed_at": "2026-06-22"
-    },
-    {
-      "advisory_id": "GHSA-gv7w-rqvm-qjhr",
-      "package": "esbuild",
-      "reason": "esbuild dev server allows any website to send requests and read responses (HIGH, GHSA-gv7w-rqvm-qjhr). esbuild >=0.17.0 <0.28.1; current resolved 0.27.3 pulled transitively by the test toolchain (vitest -> vite -> tsx -> esbuild, and tsx -> esbuild).",
-      "why_not_exploitable": "The advisory affects esbuild's HTTP dev server (serve mode). PEAC never runs esbuild's serve mode; esbuild is used only as a transpiler/bundler by tsx and vite during local test and dev runs. No published @peac/* package depends on esbuild (prod audit shows no high), so there is no production code path or shipped artifact exposure.",
-      "where_used": "devDependencies only: @vitest/coverage-v8 -> vitest -> vite -> tsx -> esbuild; and tsx -> esbuild.",
-      "expires_at": "2026-09-11",
-      "remediation": "Adopt the patched esbuild (>=0.28.1) when tsx/vite/vitest bump their transitive esbuild, or add a pnpm.overrides pin once toolchain compatibility with esbuild 0.28.x is confirmed.",
-      "issue_url": "https://github.com/advisories/GHSA-gv7w-rqvm-qjhr",
-      "scope": "dev",
-      "dependency_chain": [
-        "@vitest/coverage-v8@4.1.8",
-        "vitest@4.1.8",
-        "vite@8.0.16",
-        "tsx@4.21.0",
-        "esbuild@0.27.3"
-      ],
-      "verified_by": "pnpm audit --prod shows no high advisories; pnpm why esbuild confirms the tsx/vite/vitest dev-only resolution path.",
-      "owner": "jithinraj",
-      "added_at": "2026-06-13",
-      "reviewed_at": "2026-06-13"
     }
   ]
 }


### PR DESCRIPTION
Depends on #972.

## Summary
Removes three entries from `security/audit-allowlist.json` whose underlying advisories are no longer active exceptions to track, each verified independently against the live GitHub Advisory Database and the current resolved dependency tree.

## Changes
- `security/audit-allowlist.json`: remove `GHSA-gv7w-rqvm-qjhr` (esbuild) — withdrawn by GitHub on 2026-06-17; GitHub's withdrawal note states the affected package was misidentified (the real defect is in the Deno distribution of esbuild's binary-download integrity check, not the npm package this repo depends on).
- `security/audit-allowlist.json`: remove `GHSA-p9ff-h696-f583` (vite) — already resolved. The repo's own `pnpm.overrides["vite@<6.4.2"]` forces the single resolved `vite` instance to `8.0.16`, past the advisory's patched floor of `8.0.5`; `pnpm audit` no longer reports it.
- `security/audit-allowlist.json`: remove `GHSA-737v-mqg7-c878` (defu) — already resolved. `pnpm.overrides["defu"]` forces `defu >=6.1.5`, and the lockfile resolves it to `6.1.7`, past the advisory's patched floor of `6.1.5`; `pnpm audit` no longer reports it.
- The remaining `GHSA-2g4f-4pwh-qvx6` (ajv, transitive via eslint) entry is untouched.

## Compatibility
Metadata-only removal of stale exception records in `security/audit-allowlist.json`; no dependency, lockfile, override, or CI workflow change. No wire, schema, or public API impact.

## Verification
- `node scripts/check-audit-exception-expiry.mjs --strict` → `1 active / 0 expired / 0 invalid / 0 warning(s)`, remaining entry `GHSA-2g4f-4pwh-qvx6` expires 2026-11-20 (74d out), summary GREEN, exit 0.
- `pnpm exec vitest run tests/scripts/audit-gate.test.ts` → 1 file, 67/67 tests passed, exit 0.
- `pnpm audit --json` (full, not `--prod`) does not report any of the three removed advisory IDs in the current tree; `pnpm why vite` / `pnpm why defu` confirm `vite@8.0.16` and `defu@6.1.7` are the only resolved instances.
- `node scripts/audit-gate.mjs` (default and `AUDIT_STRICT=1`) still exits 1, unchanged by this PR: production-only phase fails on 4 HIGH advisories in `fast-uri` (transitive via `ajv@8.18.0`), and dev+prod strict phase additionally fails on 2 HIGH advisories in `browserslist` (transitive via jest/babel). Both reproduce identically on an unmodified `origin/main` checkout at the same commit, are a different package and risk class from this PR's scope, and are left for a separate security pass — no allowlist entry was added to force the gate green.
- `GHSA-g7r4-m6w7-qqqr` (esbuild, low severity, Windows-only, patched at `0.28.1`, resolved at `0.27.3`) checked against the gate logic directly: severity `low` never blocks in default or strict mode, so it does not affect this PR's status; left unlisted for the same reason.
