### PR TITLE
docs(specs): profile-defined digests; fix Cloudflare discovery path

### DIFF
--- a/docs/SOLUTIONS/cloudflare-x402-peac.md
+++ b/docs/SOLUTIONS/cloudflare-x402-peac.md
@@ -62,7 +62,7 @@ const jsonDigest = await computeX402TermsDigest({
 // uri without bytes returns 'unavailable'
 const uriDigest = await computeX402TermsDigest({
   representation: 'uri',
-  uri: 'https://api.example.com/.well-known/peac-terms.txt',
+  uri: 'https://api.example.com/.well-known/peac.txt',
 });
 ```
 

--- a/docs/specs/AGENT-ACTION-RECORDS.md
+++ b/docs/specs/AGENT-ACTION-RECORDS.md
@@ -71,6 +71,10 @@ The type URI in the PEAC record envelope (`type` field) MUST match the `event_ki
 | `upstream_artifact_digest` | sha256-hex | Digest of an upstream artifact           |
 | `parent_ref`               | OpaqueRef  | Parent action or task                    |
 
+These fields carry a format contract only: `sha256:` followed by 64 lowercase hexadecimal characters. The preimage is profile-defined and out of scope for this schema, so generic verification treats these values as caller-asserted references and does not recompute them.
+
+Document binding is a separate mechanism. `bindings.policy`, `bindings.documents` and `bindings.terms` have a normative preimage and are recomputed; see [DOCUMENT-BINDING.md](DOCUMENT-BINDING.md). The extension field `policy_digest` is not part of that mechanism.
+
 ### 4.3 Per-event-kind additional fields
 
 | Event kind                        | Additional required            | Additional optional               |

--- a/docs/specs/COMMERCE-MANDATE-RECORDS.md
+++ b/docs/specs/COMMERCE-MANDATE-RECORDS.md
@@ -73,6 +73,10 @@ The type URI in the PEAC record envelope (`type` field) MUST match the `event_ki
 | `scheme_id`                | string     | Bounded scheme identifier (see Section 6)                      |
 | `scheme_ref`               | OpaqueRef  | Opaque scheme reference (mutually exclusive with `scheme_id`)  |
 
+These fields carry a format contract only: `sha256:` followed by 64 lowercase hexadecimal characters. The preimage is profile-defined and out of scope for this schema, so generic verification treats these values as caller-asserted references and does not recompute them.
+
+Document binding is a separate mechanism. `bindings.policy`, `bindings.documents` and `bindings.terms` have a normative preimage and are recomputed; see [DOCUMENT-BINDING.md](DOCUMENT-BINDING.md). The extension field `policy_digest` is not part of that mechanism.
+
 ### 4.3 Per-event-kind additional fields
 
 | Event kind                        | Additional required                                              | Additional optional                                                             |

--- a/docs/specs/GATEWAY-EXPORT-RECORDS.md
+++ b/docs/specs/GATEWAY-EXPORT-RECORDS.md
@@ -92,6 +92,10 @@ Profile boundary rules:
 | `payer_ref`                 | OpaqueRef         | Caller-reported EIP-3009 four-tuple `payer` reference                                                                                                                         |
 | `pay_to_ref`                | OpaqueRef         | Caller-reported EIP-3009 four-tuple `payTo` reference                                                                                                                         |
 
+This field carries a format contract only: `sha256:` followed by 64 lowercase hexadecimal characters. The preimage is profile-defined and out of scope for this schema, so generic verification treats the value as a caller-asserted reference and does not recompute it.
+
+Document binding, specified in [DOCUMENT-BINDING.md](DOCUMENT-BINDING.md), is a separate mechanism with a normative preimage.
+
 ### 4.3 Per-event-kind additional fields
 
 | Event kind                                       | Additional required                                                        | Additional optional                                                                                                                               |

--- a/docs/specs/LIFECYCLE-OBSERVATION-PROFILE.md
+++ b/docs/specs/LIFECYCLE-OBSERVATION-PROFILE.md
@@ -93,6 +93,10 @@ Every event kind carries:
 | `score_ref`                | OpaqueRef       | OPTIONAL    | Opaque reference to a stored score artifact (score values are NEVER inlined; see §6)                     |
 | `result_digest`            | sha256 string   | OPTIONAL    | Canonical digest of the result artifact                                                                  |
 
+These fields carry a format contract only: `sha256:` followed by 64 lowercase hexadecimal characters. The preimage is profile-defined and out of scope for this schema, so generic verification treats these values as caller-asserted references and does not recompute them.
+
+Document binding is a separate mechanism. `bindings.policy`, `bindings.documents` and `bindings.terms` have a normative preimage and are recomputed; see [DOCUMENT-BINDING.md](DOCUMENT-BINDING.md). The extension field `policy_digest` is not part of that mechanism.
+
 ### 5.2 Per-event-kind required fields
 
 | `event_kind`                     | Additional REQUIRED fields                                                                                 |

--- a/docs/specs/PROVISIONING-LIFECYCLE-PROFILE.md
+++ b/docs/specs/PROVISIONING-LIFECYCLE-PROFILE.md
@@ -66,6 +66,10 @@ Every record carries a closed-enum discriminator at `event_kind` whose value mat
 
 `observed_at` is required on every event family. Optional metadata: `observed_by_ref`, `upstream_event_ref`, `upstream_artifact_digest`.
 
+This field carries a format contract only: `sha256:` followed by 64 lowercase hexadecimal characters. The preimage is profile-defined and out of scope for this schema, so generic verification treats the value as a caller-asserted reference and does not recompute it.
+
+Document binding, specified in [DOCUMENT-BINDING.md](DOCUMENT-BINDING.md), is a separate mechanism with a normative preimage.
+
 `credential.storage_surface` is REQUIRED for `credential.sub_event` values that handle credential material directly (`issued`, `rotated`, `synced`) and OPTIONAL for `revoked`. When the caller cannot capture or describe the storage surface safely, the placeholder `{ "kind": "unknown", "material_redaction": "never_capture" }` satisfies the invariant.
 
 ## 6. Schema (NORMATIVE)


### PR DESCRIPTION
Depends on #972.

## Summary
Several spec docs describe `*_digest` extension fields (`policy_digest`, `upstream_artifact_digest`, `result_digest`) only as "sha256-hex" without stating what the digest is a hash of, or whether verifiers recompute it. This PR adds one clarifying sentence per affected spec, and fixes a stale example discovery path in the Cloudflare x402 solution doc.

## Changes
- `docs/specs/AGENT-ACTION-RECORDS.md`, `docs/specs/COMMERCE-MANDATE-RECORDS.md`, `docs/specs/GATEWAY-EXPORT-RECORDS.md`, `docs/specs/LIFECYCLE-OBSERVATION-PROFILE.md`, `docs/specs/PROVISIONING-LIFECYCLE-PROFILE.md`: state that the digest preimage is defined by the issuing profile or integration, that the wire schema only validates the `sha256:<hex>` grammar, and that verifiers do not recompute the binding unless a separately documented check names the preimage (pointing to DOCUMENT-BINDING.md, which defines a recomputed binding).
- `docs/SOLUTIONS/cloudflare-x402-peac.md`: fixed a stale example path — `/.well-known/peac-terms.txt` does not match any resolver in the codebase; the correct discovery path for policy/terms documents is `/.well-known/peac.txt` (see `packages/kernel/src/constants.ts` and `packages/cli/src/lib/policy-document-discovery.ts`).

## Compatibility
Docs-only clarification. No schema, conformance-vector, or normative MUST/SHOULD change.

## Verification
- `npx prettier --check` on all changed files → pass
- `npx vitest run tests/tooling/repo-links-doc-truth.test.ts tests/tooling/provisioning-lifecycle-profile-doc-truth.test.ts tests/tooling/execution-surface-doc-truth.test.ts tests/tooling/runtime-composition-doc-truth.test.ts tests/tooling/erc8126-ap2-composition-doc-truth.test.ts tests/tooling/verification-artifacts-doc-truth.test.ts` → 478 passed
