### PR TITLE
docs: refresh and sync

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,5 +22,5 @@ keywords:
   - content-licensing
   - agent-protocols
 license: Apache-2.0
-version: '0.15.2'
-date-released: '2026-06-22'
+version: '0.16.4'
+date-released: '2026-08-09'

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,7 +37,8 @@ kept in the loop and the disclosure calendar is coordinated.
 
 | Line                             | Status                                     | Wire format                         | Security-fix window                           |
 | -------------------------------- | ------------------------------------------ | ----------------------------------- | --------------------------------------------- |
-| `v0.15.x`                        | Active (current)                           | Wire 0.2 (`interaction-record+jwt`) | Through the next minor line                   |
+| `v0.16.x`                        | Active (current; latest release `v0.16.4`) | Wire 0.2 (`interaction-record+jwt`) | Through the next minor line                   |
+| `v0.15.x`                        | Maintenance (security fixes only)          | Wire 0.2 (`interaction-record+jwt`) | Through 2026-12-28 (6 months after `v0.16.0`) |
 | `v0.14.x`                        | Maintenance (security fixes only)          | Wire 0.2 (`interaction-record+jwt`) | Through 2026-12-01 (6 months after `v0.15.0`) |
 | `v0.13.x`                        | Maintenance (security fixes only)          | Wire 0.2 (`interaction-record+jwt`) | 6 months after the next minor line ships      |
 | `v0.12.x`                        | Maintenance (critical security fixes only) | Wire 0.2 (`interaction-record+jwt`) | Through 2026-11-03 (6 months after `v0.14.0`) |

--- a/docs/SOLUTIONS/agent-spend-attribution.md
+++ b/docs/SOLUTIONS/agent-spend-attribution.md
@@ -46,7 +46,7 @@ or participants before grouping records. Apply these rules:
 1. Verify every PEAC record and confirm that its issuer/key is accepted
    under the relying party's review policy.
 2. Establish a bounded review set and an explicit accepted-issuer or
-   participant policy. A valid signature proves control of the signing
+   participant policy. A valid signature establishes control of the signing
    key; it does not by itself establish that the issuer belongs to the
    reviewed workflow.
 3. Group only accepted records by `correlation.workflow_id`. A matching

--- a/docs/SOLUTIONS/agt-peac-composition.md
+++ b/docs/SOLUTIONS/agt-peac-composition.md
@@ -16,7 +16,7 @@ The runtime decides. PEAC records what the runtime attested. The two layers comp
 
 A runtime governance toolkit gives an organization a private control plane: policy evaluation, audit entries, authority narrowing, lifecycle transitions, trust observations, compliance assessments. Those artifacts are valuable inside the organization. Outside the organization they are unverifiable: an auditor, counterparty, downstream reviewer, or customer has no portable way to confirm what the runtime reported without trusting the runtime's read-only view of its own logs.
 
-PEAC produces a signed interaction record per runtime-attested event. The record is portable: any party with the issuer's public key can verify it offline, without calling the runtime, without depending on a particular cloud, without imitating the runtime's internal trust system. The runtime keeps owning execution; PEAC carries the proof.
+PEAC produces a signed interaction record per runtime-attested event. The record is portable: any party with the issuer's public key can verify it offline, without calling the runtime, without depending on a particular cloud, without imitating the runtime's internal trust system. The runtime keeps owning execution; PEAC carries the signed evidence.
 
 ## What PEAC does
 
@@ -102,7 +102,7 @@ The structure and signature of each record are validated; the truth of the runti
 | Audit logging              | the runtime | a runtime-internal audit chain the runtime attests                         |
 | **Portable signed record** | **PEAC**    | **`interaction-record+jwt` over Ed25519, verifiable offline by any party** |
 
-PEAC reads what the runtime reported, records it under the canonical `org.peacprotocol/runtime-governance` extension namespace (six receipt-type URIs, shipped v0.12.10), signs the record, and stops there. The runtime keeps its native exports, its dashboards, its admin UI, its in-tenant trust system. PEAC adds a portable proof artifact alongside them.
+PEAC reads what the runtime reported, records it under the canonical `org.peacprotocol/runtime-governance` extension namespace (six receipt-type URIs, shipped v0.12.10), signs the record, and stops there. The runtime keeps its native exports, its dashboards, its admin UI, its in-tenant trust system. PEAC adds a portable signed evidence artifact alongside them.
 
 ## Where to go from here
 

--- a/docs/SOLUTIONS/api-receipt-issuance.md
+++ b/docs/SOLUTIONS/api-receipt-issuance.md
@@ -8,7 +8,7 @@
 
 ## The problem
 
-An API operator wants to add portable proof to every response. Consumers may be paying partners, downstream services, auditors, or agents acting on behalf of users. Local logs are not enough — the other party needs a signed record that survives your log retention and can be checked without calling back to your service.
+An API operator wants to add portable signed evidence to every response. Consumers may be paying partners, downstream services, auditors, or agents acting on behalf of users. Local logs are not enough — the other party needs a signed record that survives your log retention and can be checked without calling back to your service.
 
 PEAC issues a compact JWS on every response, carried in the `PEAC-Receipt` HTTP header. The signature lets anyone with your public key verify offline.
 

--- a/docs/SOLUTIONS/mcp-gateway-receipts.md
+++ b/docs/SOLUTIONS/mcp-gateway-receipts.md
@@ -29,12 +29,12 @@ Two record roles, both ordinary PEAC records on the frozen wire format:
 | redaction fact            | integrator extension, `redaction_applied: true/false`                                                |
 | tool-definition reference | integrator extension, `tool_definition_ref` (see below)                                              |
 
-**Per tool-definition manifest** (registered type `org.peacprotocol/provenance-record`): the gateway signs a digest of the tool definitions it exposes (names, descriptions, schemas, risk tiers). Each per-call record references this record by `receipt_ref`. A verifier can then prove which definitions the gateway was serving when a call happened, which makes silently changed tool descriptions and schemas detectable after the fact.
+**Per tool-definition manifest** (registered type `org.peacprotocol/provenance-record`): the gateway signs a digest of the tool definitions it exposes (names, descriptions, schemas, risk tiers). Each per-call record references this record by `receipt_ref`. A verifier can then establish which definitions the gateway reported serving when a call happened, which makes silently changed tool descriptions and schemas detectable after the fact.
 
 Two rules carry the whole pattern:
 
 - **Digests, never payloads.** Arguments and results may contain customer data; the record binds hashes. Redact first, then hash, and record that redaction was applied so the verifier knows what the digest covers.
-- **Claim only what the record binds.** A valid signature proves the record was not modified. It says nothing about content the record did not bind. Binding digests is what extends the proof to the content.
+- **Claim only what the record binds.** A valid signature establishes that the record was not modified since it was signed under the supplied key. It says nothing about content the record did not bind. Binding digests is what extends that evidence to the content bytes; a digest match binds bytes, not events.
 
 ## How it is carried
 
@@ -54,12 +54,12 @@ A modified result fails check 4 even though check 2 still passes; a modified rec
 
 ## Deny records
 
-Record refusals, not just successes. A denied `tools/call` produces the same record shape with `decision: deny` and a deny reason. When a workflow later disputes why an action did not happen, the gateway can prove the refusal and the policy reference that produced it.
+Record refusals, not just successes. A denied `tools/call` produces the same record shape with `decision: deny` and a deny reason. When a workflow later disputes why an action did not happen, the gateway can present signed evidence of the refusal and the policy reference that produced it.
 
 ## What this composes with
 
 - **Auth** keeps authenticating; the record can reference the actor, it does not replace the credential.
-- **Policy engines** keep deciding; the record proves which policy reference was in force, it does not evaluate policy.
+- **Policy engines** keep deciding; the record establishes which policy reference the gateway reported as in force, it does not evaluate policy.
 - **OpenTelemetry** keeps correlating; the record carries `trace_id` through the correlation extension and a span can carry the record's `receipt_ref` attribute.
 - **The gateway itself** keeps routing, scanning, and redacting; PEAC is the artifact it emits outward.
 

--- a/docs/SOLUTIONS/verify-commerce-mandate.md
+++ b/docs/SOLUTIONS/verify-commerce-mandate.md
@@ -58,7 +58,7 @@ Prerequisites: Node 22+, pnpm 8+. No external service required.
 
 ## When to use this
 
-- An auditor needs portable proof that a mandate was reportedly bound for a merchant and payer.
+- An auditor needs portable evidence that a mandate was reportedly bound for a merchant and payer.
 - A counterparty needs to verify that an authorization, capture, a refund was reported, or a settlement state was reported without calling the rail's API.
 - A reviewer needs to verify a signed record reporting a settlement state (pending, completed, failed, reversed, partial) tied to a specific mandate.
 - A finance team needs evidence that a budget event (limit set, threshold crossed, etc.) was reportedly observed against a specific mandate.

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -12,7 +12,7 @@ New here? [Try PEAC in 5 minutes](TRY.md) or [verify a record](VERIFY.md).
 
 ## I run an API or HTTP service
 
-You want to issue signed receipts proving what terms applied and what happened on every response.
+You want to issue signed receipts that report what terms applied and what happened on every response.
 
 1. Install: `pnpm add @peac/middleware-express @peac/crypto @peac/protocol`
 2. Follow the [API Provider Quickstart](guides/quickstart-api-provider.md) (5 minutes)
@@ -133,7 +133,7 @@ Receipt-side normative profile: [`docs/specs/PRIVACY-PROFILE.md`](specs/PRIVACY-
 
 ## Core concepts
 
-- **Receipt:** a signed JWS (`interaction-record+jwt`) proving what terms applied and what happened. The JOSE header `typ` is `interaction-record+jwt`; the HTTP request or response body is `application/json` (or the `PEAC-Receipt` HTTP header) carrying the compact JWS string.
+- **Receipt:** a signed JWS (`interaction-record+jwt`) recording what terms applied and what happened. The JOSE header `typ` is `interaction-record+jwt`; the HTTP request or response body is `application/json` (or the `PEAC-Receipt` HTTP header) carrying the compact JWS string.
 - **Kind:** `evidence` (records what happened) or `challenge` (requests proof from a peer).
 - **Type:** reverse-DNS identifier for what the receipt represents (for example `org.peacprotocol/payment`).
 - **Extensions:** typed data groups (commerce, access, identity, and more) carrying domain-specific content.

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Open standard for verifiable interaction records across agent, tool, API, MCP, and cross-runtime systems.
 > Portable signed records anyone can verify offline.
-> Current release: v0.15.2
+> Current release: v0.16.4
 > Last reviewed: 2026-06-24
 
 ## What is PEAC

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -27,7 +27,39 @@ peac verify <jws>
 peac verify receipt.jws --verbose
 ```
 
-Decodes the receipt, displays claims (issuer, audience, amount, payment rail), and verifies the cryptographic signature. Exit code 0 on success, 1 on failure.
+Decodes the receipt, displays claims (issuer, audience, amount, payment rail), and verifies the cryptographic signature. Without `--public-key`, verification resolves the issuer's keys over the network via issuer discovery. Exit code 0 on success, 1 on failure.
+
+### Verify offline with a supplied public key
+
+```bash
+peac verify <jws-or-path> --public-key <jwk-or-single-key-jwks.json>
+```
+
+`--public-key <path>` verifies the record locally against the supplied public Ed25519 key using `verifyLocal()` from `@peac/protocol`. No network request, issuer discovery, or JWKS fetch is made, and there is no fallback to the network path. The record structure is validated as well as the signature.
+
+The key file must be one of:
+
+- a bare public Ed25519 JWK (`{"kty":"OKP","crv":"Ed25519","x":"..."}`), or
+- a single-key JWKS (`{"keys":[<that JWK>]}`).
+
+The loader fails closed and rejects: a file that is not valid JSON or not an object; a JWKS with no keys or with more than one key; a JWK that contains private key material (`d`); a key that is not `kty` `OKP` with `crv` `Ed25519`; a JWK missing the public value `x`, or whose `x` is not a 32-byte base64url value; and key files larger than 16 KiB. Error messages never echo key material.
+
+Try it on the shipped samples. `samples generate` writes valid records under `valid/` and the matching public key set to `bundles/sandbox-jwks.json`:
+
+```bash
+peac samples generate -o ./s
+peac verify ./s/valid/basic-record.jws --public-key ./s/bundles/sandbox-jwks.json
+```
+
+Expected output:
+
+```text
+Signature valid (offline).
+```
+
+On failure the command prints `Verification failed: <message>` with the error code (for example `E_INVALID_SIGNATURE` for a modified record) and exits 1.
+
+A valid result establishes that the record was signed by the private key matching the supplied public key and has not changed since. It does not establish that the key or its holder should be trusted, or that the statements inside the record are true.
 
 ### Decode a receipt without verification
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -102,7 +102,7 @@ const result = await handleVerify({
   input: { jws: 'eyJ...', public_key_base64url: '...' },
   policy,
   context: {
-    version: '0.15.0',
+    version: '0.16.4',
     policyHash,
     protocolVersion: '2025-11-25',
   },

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -1,6 +1,7 @@
 # PEAC Go SDK
 
-Go client library for PEAC protocol receipt issuance, verification, and policy evaluation.
+Go library for PEAC interaction record issuance, local verification, and policy evaluation
+(Wire 0.2, `interaction-record+jwt`).
 
 ## Installation
 
@@ -22,7 +23,7 @@ go get github.com/peacprotocol/peac/sdks/go/middleware/gin
 
 ## Quick Start
 
-### Issuing Receipts
+### Issuing records
 
 ```go
 package main
@@ -32,34 +33,44 @@ import (
     "log"
 
     peac "github.com/peacprotocol/peac/sdks/go"
+    "github.com/peacprotocol/peac/sdks/go/jws"
 )
 
 func main() {
-    // Create a signing key (in production, load from secure storage)
-    signingKey, err := peac.GenerateSigningKey("my-key-id")
+    // Create a signing key (in production, load from secure storage).
+    // The key ID becomes the JWS `kid` header.
+    signingKey, err := jws.GenerateSigningKey("https://api.example.com/keys/1")
     if err != nil {
         log.Fatal(err)
     }
 
     result, err := peac.Issue(peac.IssueOptions{
-        Issuer:     "https://publisher.example",
-        Audience:   "https://agent.example",
-        Amount:     1000,  // Amount in minor units (e.g., cents)
-        Currency:   "USD",
-        Rail:       "stripe",
-        Reference:  "pi_abc123",
+        Iss:     "https://api.example.com",
+        Kind:    peac.KindEvidence,
+        Type:    "org.peacprotocol/payment",
+        Pillars: []string{"commerce"},
+        Extensions: map[string]any{
+            "org.peacprotocol/commerce": map[string]any{
+                "payment_rail": "x402",
+                "amount_minor": "1000",
+                "currency":     "USD",
+            },
+        },
         SigningKey: signingKey,
     })
     if err != nil {
         log.Fatal(err)
     }
 
-    fmt.Printf("Receipt JWS: %s\n", result.JWS)
-    fmt.Printf("Receipt ID: %s\n", result.ReceiptID)
+    fmt.Printf("Record JWS: %s\n", result.JWS)
+    fmt.Printf("Record ID: %s\n", result.ReceiptID)
 }
 ```
 
-### Verifying Receipts
+### Verifying records locally
+
+Verification runs entirely locally against a supplied public key. No network request, JWKS
+discovery, or issuer callback is made.
 
 ```go
 package main
@@ -67,37 +78,83 @@ package main
 import (
     "fmt"
     "log"
-    "time"
 
     peac "github.com/peacprotocol/peac/sdks/go"
+    "github.com/peacprotocol/peac/sdks/go/jws"
 )
 
 func main() {
-    receiptJWS := "eyJhbGciOiJFZERTQSIsImtpZCI6Ii4uLiJ9..."
+    recordJWS := "eyJhbGciOiJFZERTQSIsInR5cCI6ImludGVyYWN0aW9uLXJlY29yZCtqd3QiLCJraWQiOiIuLi4ifQ..."
 
-    result, err := peac.Verify(receiptJWS, peac.VerifyOptions{
-        Issuer:   "https://publisher.example",
-        Audience: "https://agent.example",
-        MaxAge:   time.Hour,
-    })
+    // The verifier needs only the issuer's 32-byte Ed25519 public key.
+    publicKey, err := jws.ParsePublicKeyFromBytes(rawPublicKeyBytes())
     if err != nil {
         log.Fatal(err)
     }
 
-    fmt.Printf("Receipt ID: %s\n", result.Claims.ReceiptID)
-    fmt.Printf("Issued At: %d\n", result.Claims.IssuedAt)
-    fmt.Printf("Purpose: %v\n", result.Claims.PurposeDeclared)
+    result := peac.VerifyLocal(recordJWS, peac.VerifyLocalOptions{
+        PublicKey: publicKey,
+        Issuer:    "https://api.example.com", // optional: iss must match when set
+    })
+    if !result.Valid {
+        log.Fatalf("verification failed: %s: %s", result.ErrorCode, result.ErrorMessage)
+    }
+
+    fmt.Printf("Issuer: %s\n", result.Claims.Iss)
+    fmt.Printf("Kind: %s, Type: %s\n", result.Claims.Kind, result.Claims.Type)
+    fmt.Printf("Key ID: %s, Wire: %s\n", result.Kid, result.WireVersion)
 }
+
+// rawPublicKeyBytes returns the issuer's raw 32-byte Ed25519 public key, for example
+// decoded from the base64url `x` member of the issuer's public JWK.
+func rawPublicKeyBytes() []byte { /* ... */ return nil }
 ```
 
-### Evaluating Policies
+A valid result establishes that the record was signed by the private key matching the supplied
+public key and has not changed since. It does not establish that the key or its holder should be
+trusted, or that the statements inside the record are true.
+
+### Binding a policy document
+
+A record may carry a `policy` block whose `digest` is the JCS (RFC 8785) SHA-256 digest of a policy
+document. A verifier that holds its own copy of that document can check the binding:
+
+```go
+policyJSON := []byte(`{"version":"peac-policy/0.1","rules":[]}`)
+
+digest, err := peac.ComputePolicyDigest(policyJSON) // "sha256:<hex>" over RFC 8785 JCS bytes
+if err != nil {
+    log.Fatal(err)
+}
+
+issued, err := peac.Issue(peac.IssueOptions{
+    Iss:        "https://api.example.com",
+    Kind:       peac.KindEvidence,
+    Type:       "org.peacprotocol/api-call",
+    Policy:     &peac.PolicyBlock{Digest: digest, URI: "https://api.example.com/.well-known/peac.txt"},
+    SigningKey: signingKey,
+})
+if err != nil {
+    log.Fatal(err)
+}
+
+result := peac.VerifyLocal(issued.JWS, peac.VerifyLocalOptions{
+    PublicKey:   signingKey.PublicKey(),
+    PolicyBytes: policyJSON, // the verifier's own copy of the policy document
+})
+fmt.Printf("Policy binding: %s\n", result.PolicyBinding) // verified, failed, or unavailable
+```
+
+A `verified` binding means the digest in the record matches the digest of the bytes the verifier
+supplied. It binds bytes, not events: it does not establish that the policy was applied.
+
+### Evaluating policies
 
 ```go
 package main
 
 import (
     "fmt"
-    "log"
 
     "github.com/peacprotocol/peac/sdks/go/policy"
 )
@@ -158,101 +215,152 @@ The workspace file (`go.work`) links all modules for seamless local development 
 
 ## Features
 
-- Ed25519 signature signing and verification
-- Receipt issuance with UUIDv7 receipt IDs (v0.9.29+)
-- Policy evaluation with first-match-wins semantics (v0.9.29+)
-- JWKS discovery and caching
-- Purpose claims support (v0.9.24+)
-- Agent identity attestation support (v0.9.25+)
-- Thread-safe JWKS cache with stale-while-revalidate
-- Comprehensive error types with retry hints
-- Evidence validation with DoS protection (v0.9.29+)
+- Ed25519 signing and verification (RFC 8032, PEAC admissibility profile)
+- Interaction record issuance (Wire 0.2, `interaction-record+jwt`) with UUIDv7 record IDs
+- Local verification with a supplied public key (`VerifyLocal`); no network access
+- RFC 7493 I-JSON admission applied on both issuance and verification
+- JWS `kid` bounded by UTF-8 byte length (at most 256 UTF-8 bytes) on issuance and verification
+- Policy digest computation and three-state policy binding (RFC 8785 JCS + SHA-256)
+- Policy evaluation with first-match-wins semantics
+- Evidence validation with DoS protection limits on extension values
+- JWKS fetch and caching helpers (`jwks` package)
 
 ## API Reference
 
-### Issue (v0.9.29+)
+### Issue
 
 ```go
 func Issue(opts IssueOptions) (*IssueResult, error)
+func IssueJWS(opts IssueOptions) (string, error)
 ```
 
-Creates a signed PEAC receipt JWS.
+Creates a signed interaction record in the current stable format (`interaction-record+jwt`).
+Validates all inputs, generates a UUIDv7 record ID, and signs with Ed25519.
 
 #### IssueOptions
 
-| Field        | Type          | Description                                       |
-| ------------ | ------------- | ------------------------------------------------- |
-| `Issuer`     | `string`      | Issuer URL (required, must be https://)           |
-| `Audience`   | `string`      | Audience URL (required, must be https://)         |
-| `Amount`     | `int64`       | Amount in minor units (required, >= 0)            |
-| `Currency`   | `string`      | ISO 4217 currency code (required, e.g., "USD")    |
-| `Rail`       | `string`      | Payment rail identifier (required)                |
-| `Reference`  | `string`      | Payment reference (required)                      |
-| `SigningKey` | `*SigningKey` | Ed25519 signing key (required)                    |
-| `Subject`    | `string`      | Subject URL (optional, must be https://)          |
-| `Expiry`     | `int64`       | Unix timestamp for expiry (optional)              |
-| `Env`        | `string`      | Environment: "live" or "test" (default: "test")   |
-| `Network`    | `string`      | Payment network (optional)                        |
-| `Evidence`   | `any`         | Additional evidence (optional, JSON-serializable) |
+| Field            | Type                 | Description                                                                               |
+| ---------------- | -------------------- | ----------------------------------------------------------------------------------------- |
+| `Iss`            | `string`             | Issuer URI (required; must start with `https://` or `did:`)                               |
+| `Kind`           | `string`             | Structural kind (required): `peac.KindEvidence` or `peac.KindChallenge`                   |
+| `Type`           | `string`             | Semantic type (required), reverse-DNS or URI, e.g. `org.peacprotocol/mcp-tool-call`       |
+| `SigningKey`     | `*jws.SigningKey`    | Ed25519 signing key (required); its key ID becomes the JWS `kid` header                   |
+| `Kid`            | `string`             | Deprecated. Leave empty or equal to `SigningKey.KeyID()`; a conflicting value is rejected |
+| `Sub`            | `string`             | Optional subject URI                                                                      |
+| `Exp`            | `int64`              | Optional expiration (Unix seconds)                                                        |
+| `Pillars`        | `[]string`           | Optional pillar values from the closed 10-pillar taxonomy (`peac.ValidPillars`)           |
+| `Actor`          | `*ActorBinding`      | Optional top-level actor binding                                                          |
+| `Extensions`     | `map[string]any`     | Optional extension map (`ext` claim)                                                      |
+| `Policy`         | `*PolicyBlock`       | Optional policy binding block (`digest`, `uri`, `version`)                                |
+| `Clock`          | `Clock`              | Optional clock for timestamp generation (system clock if nil)                             |
+| `IDGen`          | `ReceiptIDGenerator` | Optional record-ID generator (UUIDv7 if nil)                                              |
+| `EvidenceLimits` | `evidence.Limits`    | Optional DoS-protection limits on extension values (defaults if zero)                     |
 
-#### URL Restrictions
+#### IssueResult
 
-All URL fields (`Issuer`, `Audience`, `Subject`) must:
+| Field       | Type     | Description                                    |
+| ----------- | -------- | ---------------------------------------------- |
+| `JWS`       | `string` | Compact JWS serialization of the signed record |
+| `ReceiptID` | `string` | Generated UUIDv7 record identifier             |
+| `IssuedAt`  | `int64`  | Issuance time (Unix seconds)                   |
 
-- Use the `https://` scheme
-- Have a valid host
-- **Not** contain URL fragments (e.g., `#section`)
-- **Not** contain userinfo (e.g., `user:pass@`)
+#### Issue error codes
 
-#### Evidence Structure
+Issuance failures return `*IssueError` with `Code`, `Message`, and `Field`:
 
-Evidence is placed in `payment.evidence` in the receipt claims (not at the top level):
+| Code                   | Description                                                              |
+| ---------------------- | ------------------------------------------------------------------------ |
+| `MISSING_ISSUER`       | `Iss` is empty                                                           |
+| `INVALID_ISSUER`       | `Iss` does not start with `https://` or `did:`                           |
+| `MISSING_KIND`         | `Kind` is empty                                                          |
+| `INVALID_KIND`         | `Kind` is not `evidence` or `challenge`                                  |
+| `MISSING_TYPE`         | `Type` is empty                                                          |
+| `INVALID_TYPE`         | `Type` is malformed                                                      |
+| `INVALID_PILLAR`       | A pillar value is outside the closed taxonomy                            |
+| `MISSING_SIGNING_KEY`  | No signing key provided                                                  |
+| `KEY_ID_MISMATCH`      | `Kid` set to a value that differs from the signing key's own key ID      |
+| `INVALID_KEY_ID`       | Key ID violates the Wire 0.2 `kid` rule (UTF-8, at most 256 UTF-8 bytes) |
+| `INVALID_UTF8`         | A caller-controlled claim string is not valid UTF-8                      |
+| `INVALID_JSON_PROFILE` | The marshaled payload fails the raw JSON admission profile               |
+| `SIGN_FAILED`          | Signing failed                                                           |
+| `ID_GEN_FAILED`        | Record-ID generation failed                                              |
 
-```go
-// Evidence is nested under payment
-opts := peac.IssueOptions{
-    // ...
-    Evidence: map[string]any{"custom": "data"},
-}
-
-// In the resulting receipt claims:
-// claims.payment.evidence = {"custom": "data"}
-```
-
-### Verify
-
-```go
-func Verify(receiptJWS string, opts VerifyOptions) (*VerifyResult, error)
-```
-
-Verifies a PEAC receipt JWS and returns the verified claims.
-
-#### VerifyOptions
-
-| Field       | Type              | Description                           |
-| ----------- | ----------------- | ------------------------------------- |
-| `Issuer`    | `string`          | Expected issuer (required)            |
-| `Audience`  | `string`          | Expected audience (required)          |
-| `MaxAge`    | `time.Duration`   | Maximum receipt age (default: 1 hour) |
-| `ClockSkew` | `time.Duration`   | Clock skew tolerance (default: 30s)   |
-| `JWKSURL`   | `string`          | Explicit JWKS URL (optional)          |
-| `KeySet`    | `*jwks.KeySet`    | Pre-loaded key set (optional)         |
-| `JWKSCache` | `*jwks.Cache`     | JWKS cache instance (optional)        |
-| `Context`   | `context.Context` | Request context                       |
-
-#### VerifyResult
+### VerifyLocal
 
 ```go
-type VerifyResult struct {
-    Claims          *PEACReceiptClaims
-    SubjectSnapshot *SubjectProfileSnapshot
-    KeyID           string
-    Algorithm       string
-    Perf            *VerifyPerf
-}
+func VerifyLocal(receiptJWS string, opts VerifyLocalOptions) *VerifyLocalResult
 ```
 
-### Policy Evaluation (v0.9.29+)
+Verifies a signed interaction record locally with a supplied public key. Enforces the current
+stable format (`interaction-record+jwt`; the full media-type form of `typ` is accepted and
+normalized). Never fetches keys.
+
+#### VerifyLocalOptions
+
+| Field          | Type                | Description                                                                                |
+| -------------- | ------------------- | ------------------------------------------------------------------------------------------ |
+| `PublicKey`    | `ed25519.PublicKey` | 32-byte Ed25519 public key (required)                                                      |
+| `Issuer`       | `string`            | Expected issuer URI (optional; when set, `iss` must match)                                 |
+| `MaxClockSkew` | `time.Duration`     | Clock skew tolerance (default 30s)                                                         |
+| `RequireExp`   | `bool`              | Require the `exp` claim                                                                    |
+| `PolicyBytes`  | `[]byte`            | Local policy document; when set, its JCS + SHA-256 digest is compared with `policy.digest` |
+
+#### VerifyLocalResult
+
+| Field           | Type                       | Description                             |
+| --------------- | -------------------------- | --------------------------------------- |
+| `Valid`         | `bool`                     | Whether every verification check passed |
+| `Claims`        | `*InteractionRecordClaims` | Verified claims (nil when invalid)      |
+| `Kid`           | `string`                   | Key ID from the JWS header              |
+| `Algorithm`     | `string`                   | Always `EdDSA`                          |
+| `Warnings`      | `[]VerificationWarning`    | Non-fatal warnings                      |
+| `PolicyBinding` | `PolicyBindingStatus`      | `verified`, `failed`, or `unavailable`  |
+| `WireVersion`   | `string`                   | `0.2`                                   |
+| `ReceiptRef`    | `string`                   | `sha256:<hex>` of the compact JWS bytes |
+| `ErrorCode`     | `string`                   | Error code when `Valid` is false        |
+| `ErrorMessage`  | `string`                   | Error message when `Valid` is false     |
+
+#### VerifyLocal error codes
+
+| Code                         | Description                                                |
+| ---------------------------- | ---------------------------------------------------------- |
+| `E_INVALID_FORMAT`           | Malformed JWS, header, or payload                          |
+| `E_IJSON_*`                  | Raw header or payload bytes fail RFC 7493 I-JSON admission |
+| `E_JWS_MISSING_KID`          | Protected header has no `kid`                              |
+| `E_UNSUPPORTED_WIRE_VERSION` | `typ` or `peac_version` is not Wire 0.2                    |
+| `E_INVALID_SIGNATURE`        | Signature does not verify under the supplied key           |
+| `E_NOT_YET_VALID`            | `iat` is in the future beyond the skew tolerance           |
+| `E_EXPIRED`                  | `exp` has passed                                           |
+| `E_INVALID_ISSUER`           | `iss` does not match `Issuer`                              |
+| `E_CONSTRAINT_VIOLATION`     | A required claim or constraint is missing or invalid       |
+| `E_POLICY_BINDING_FAILED`    | `policy.digest` does not match the supplied policy bytes   |
+
+### Policy binding helpers
+
+```go
+func ComputePolicyDigest(policyJSON []byte) (string, error)
+func CheckPolicyBinding(receiptDigest, localDigest string) PolicyBindingStatus
+```
+
+`ComputePolicyDigest` returns `sha256:<hex>` over the RFC 8785 JCS canonicalization of the input,
+matching the TypeScript `computePolicyDigestJcs()`. `CheckPolicyBinding` returns `verified` when both
+digests are present and equal, `failed` when both are present and differ, and `unavailable` when
+either is absent.
+
+### Keys (`jws` package)
+
+```go
+func GenerateSigningKey(keyID string) (*SigningKey, error)
+func NewSigningKey(privateKey ed25519.PrivateKey, keyID string) (*SigningKey, error)
+func NewSigningKeyFromSeed(seed []byte, keyID string) (*SigningKey, error)
+func ParsePublicKeyFromBytes(data []byte) (ed25519.PublicKey, error)
+```
+
+`SigningKey.KeyID()` returns the key identifier used as the JWS `kid`; `SigningKey.PublicKey()`
+returns the corresponding Ed25519 public key. `ParsePublicKeyFromBytes` accepts a raw 32-byte
+Ed25519 public key.
+
+### Policy Evaluation
 
 ```go
 func Evaluate(policy *PolicyDocument, context *EvaluationContext) *EvaluationResult
@@ -285,111 +393,30 @@ const (
 const ReasonNilPolicy = "nil policy"
 ```
 
-### JWKS Caching
+### Legacy Wire 0.1 API (deprecated)
 
-For production use, create a shared JWKS cache:
-
-```go
-cache := jwks.NewCache(jwks.CacheOptions{
-    TTL:                  5 * time.Minute,
-    StaleWhileRevalidate: true,
-})
-
-result, err := peac.Verify(receiptJWS, peac.VerifyOptions{
-    Issuer:    "https://publisher.example",
-    Audience:  "https://agent.example",
-    JWKSCache: cache,
-})
-```
-
-### Error Handling
-
-All errors are of type `*PEACError` with structured information:
-
-```go
-result, err := peac.Verify(receiptJWS, opts)
-if err != nil {
-    if peacErr, ok := err.(*peac.PEACError); ok {
-        fmt.Printf("Error Code: %s\n", peacErr.Code)
-        fmt.Printf("HTTP Status: %d\n", peacErr.HTTPStatus())
-        fmt.Printf("Retryable: %v\n", peacErr.IsRetryable())
-    }
-}
-```
-
-#### Error Codes
-
-| Code                  | HTTP | Description                   |
-| --------------------- | ---- | ----------------------------- |
-| `E_INVALID_SIGNATURE` | 400  | Signature verification failed |
-| `E_INVALID_FORMAT`    | 400  | Invalid JWS format            |
-| `E_EXPIRED`           | 401  | Receipt has expired           |
-| `E_NOT_YET_VALID`     | 401  | Receipt not yet valid         |
-| `E_INVALID_ISSUER`    | 400  | Issuer mismatch               |
-| `E_INVALID_AUDIENCE`  | 400  | Audience mismatch             |
-| `E_JWKS_FETCH_FAILED` | 503  | Failed to fetch JWKS          |
-| `E_KEY_NOT_FOUND`     | 400  | Key ID not in JWKS            |
-
-#### Issue Error Codes (v0.9.29+)
-
-| Code                    | Description                         |
-| ----------------------- | ----------------------------------- |
-| `E_INVALID_ISSUER`      | Invalid issuer URL                  |
-| `E_INVALID_AUDIENCE`    | Invalid audience URL                |
-| `E_INVALID_SUBJECT`     | Invalid subject URL                 |
-| `E_INVALID_CURRENCY`    | Invalid currency code               |
-| `E_INVALID_AMOUNT`      | Invalid amount (negative)           |
-| `E_INVALID_EXPIRY`      | Invalid expiry (negative)           |
-| `E_INVALID_ENV`         | Invalid env (must be "live"/"test") |
-| `E_INVALID_RAIL`        | Missing payment rail                |
-| `E_INVALID_REFERENCE`   | Missing payment reference           |
-| `E_INVALID_EVIDENCE`    | Evidence validation failed          |
-| `E_MISSING_SIGNING_KEY` | No signing key provided             |
-
-#### Identity Error Codes (v0.9.25+)
-
-| Code                     | HTTP | Description                  |
-| ------------------------ | ---- | ---------------------------- |
-| `E_IDENTITY_MISSING`     | 401  | No identity attestation      |
-| `E_IDENTITY_SIG_INVALID` | 401  | Identity signature invalid   |
-| `E_IDENTITY_EXPIRED`     | 401  | Identity attestation expired |
-| `E_IDENTITY_KEY_UNKNOWN` | 401  | Identity key not found       |
+`Verify`, `VerifyWithContext`, `VerifyOptions`, `VerifyResult`, `PEACReceiptClaims`, `ErrorCode`,
+and `PEACError` remain exported so existing middleware compiles, but they support Wire 0.1 only and
+are deprecated. `Verify` does not verify current records: it returns `E_INVALID_FORMAT` with the
+message "Wire 0.1 Verify() is deprecated; use VerifyLocal() for Interaction Record format". Use
+`VerifyLocal` for all current records.
 
 ## Claims Structure
 
 ```go
-type PEACReceiptClaims struct {
-    // Standard JWT claims
-    Issuer    string   `json:"iss"`
-    Subject   string   `json:"sub,omitempty"`
-    Audience  []string `json:"aud,omitempty"`
-    IssuedAt  int64    `json:"iat"`
-    ExpiresAt int64    `json:"exp,omitempty"`
-    JWTID     string   `json:"jti"`
-
-    // PEAC claims
-    ReceiptID       string   `json:"receipt_id"`
-    PurposeDeclared []string `json:"purpose_declared,omitempty"`
-    PurposeEnforced string   `json:"purpose_enforced,omitempty"`
-    Decision        string   `json:"decision,omitempty"`
-
-    // Evidence
-    Payment      *PaymentEvidence `json:"payment,omitempty"`
-    Attestations []Attestation    `json:"attestations,omitempty"`
-}
-```
-
-## Agent Identity (v0.9.25+)
-
-The SDK supports agent identity attestations:
-
-```go
-type AgentIdentityEvidence struct {
-    AgentID         string      `json:"agent_id"`
-    ControlType     string      `json:"control_type"`  // "operator" or "user-delegated"
-    Capabilities    []string    `json:"capabilities,omitempty"`
-    DelegationChain []string    `json:"delegation_chain,omitempty"`
-    Proof           *AgentProof `json:"proof,omitempty"`
+type InteractionRecordClaims struct {
+    Iss         string         `json:"iss"`
+    Sub         string         `json:"sub,omitempty"`
+    Iat         int64          `json:"iat"`
+    Exp         int64          `json:"exp,omitempty"`
+    Rid         string         `json:"rid"`
+    Kind        string         `json:"kind"`
+    Type        string         `json:"type"`
+    PeacVersion string         `json:"peac_version"`
+    Pillars     []string       `json:"pillars,omitempty"`
+    Actor       *ActorBinding  `json:"actor,omitempty"`
+    Ext         map[string]any `json:"ext,omitempty"`
+    Peac        *PolicyBlock   `json:"policy,omitempty"`
 }
 ```
 
@@ -424,7 +451,6 @@ For example, v0.9.29 would have tags:
 ## Requirements
 
 - Go 1.26 or later
-- `golang.org/x/crypto` for Ed25519
 
 ## License
 


### PR DESCRIPTION
## Summary

Refreshes stale version strings, corrects out-of-date API examples, documents the offline verification path, refreshes the supported-versions table, and aligns wording about what a signed record establishes with the conventions already used in the verification guides.

## Changes

- `llms.txt`, `CITATION.cff`, `packages/mcp-server/README.md`: current release is 0.16.4 (released 2026-08-09).
- `docs/START_HERE.md`: three sentences describing signed records now say "report", "establish", and "recording" instead of "prove"/"proving", matching `docs/guides/cross-org-verification-handoff.md`.
- `sdks/go/README.md`: Quick Start and API reference rewritten against the exported Go API. `IssueOptions` now lists its real fields (`Iss`, `Kind`, `Type`, `SigningKey`, ...), verification uses `VerifyLocal` with a supplied public key, a policy-binding example uses `ComputePolicyDigest`, and the Wire 0.1 `Verify` path is documented as deprecated. Every Go snippet was built and run against the current module before committing.
- `packages/cli/README.md`: documents `peac verify --public-key <path>` (bare public Ed25519 JWK or single-key JWKS, no network access, fail-closed key loading) with the sample one-liner, as implemented in `packages/cli/src/index.ts` and `packages/cli/src/lib/public-key.ts`.
- `SECURITY.md`: supported-versions table adds the `v0.16.x` line as current and moves `v0.15.x` to maintenance, following the table's existing window convention.
- `docs/SOLUTIONS/*.md`: "prove"/"proof" claims about records reworded to evidence language; a valid signature establishes issuer-reported content under a supplied key, and a digest match binds bytes, not events. Technical uses of "proof" are unchanged.

No wire format, schema, registry, public API, or normative behavior is changed.

## Compatibility

None. Documentation-only changes.

## Verification

- `go vet` and `go build` on every Go code block extracted from `sdks/go/README.md`; the issuance, verification, and policy-binding examples also executed successfully.
- `npx vitest run tests/tooling/repo-links-doc-truth.test.ts --no-color`: 356/356 passed.
- `npx prettier --check` on all changed Markdown and YAML files: clean.
